### PR TITLE
Add support for Octo Remote Star2 protocol variant

### DIFF
--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -70,6 +70,8 @@ from .const import (
     LEGGETT_GEN2_SERVICE_UUID,
     LEGGETT_VARIANTS,
     LINAK_CONTROL_SERVICE_UUID,
+    OCTO_STAR2_SERVICE_UUID,
+    OCTO_VARIANTS,
     OKIMAT_SERVICE_UUID,
     REVERIE_SERVICE_UUID,
     RICHMAT_NORDIC_SERVICE_UUID,
@@ -113,12 +115,14 @@ def get_variants_for_bed_type(bed_type: str) -> dict[str, str] | None:
         return LEGGETT_VARIANTS
     if bed_type == BED_TYPE_RICHMAT:
         return RICHMAT_VARIANTS
+    if bed_type == BED_TYPE_OCTO:
+        return OCTO_VARIANTS
     return None
 
 
 def bed_type_has_variants(bed_type: str) -> bool:
     """Check if a bed type has multiple protocol variants."""
-    return bed_type in (BED_TYPE_KEESON, BED_TYPE_LEGGETT_PLATT, BED_TYPE_RICHMAT)
+    return bed_type in (BED_TYPE_KEESON, BED_TYPE_LEGGETT_PLATT, BED_TYPE_OCTO, BED_TYPE_RICHMAT)
 
 
 def get_available_adapters(hass) -> dict[str, str]:
@@ -296,6 +300,15 @@ def detect_bed_type(service_info: BluetoothServiceInfoBleak) -> str | None:
             service_info.name,
         )
         return BED_TYPE_SERTA
+
+    # Check for Octo Star2 variant - service UUID detection (before name-based Octo check)
+    if OCTO_STAR2_SERVICE_UUID.lower() in service_uuids:
+        _LOGGER.info(
+            "Detected Octo Star2 bed at %s (name: %s)",
+            service_info.address,
+            service_info.name,
+        )
+        return BED_TYPE_OCTO
 
     # Check for Octo - name-based detection (before Solace since same UUID)
     if "octo" in device_name:

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -167,12 +167,21 @@ DEWERTOKIN_WRITE_HANDLE: Final = 0x0013
 SERTA_WRITE_HANDLE: Final = 0x0020
 
 # Octo specific UUIDs
+# Standard Octo variant
 OCTO_SERVICE_UUID: Final = "0000ffe0-0000-1000-8000-00805f9b34fb"
 OCTO_CHAR_UUID: Final = "0000ffe1-0000-1000-8000-00805f9b34fb"
+
+# Octo Remote Star2 variant
+OCTO_STAR2_SERVICE_UUID: Final = "0000aa5c-0000-1000-8000-00805f9b34fb"
+OCTO_STAR2_CHAR_UUID: Final = "00005a55-0000-1000-8000-00805f9b34fb"
 
 # Octo PIN keep-alive interval (seconds)
 # Octo beds drop BLE connection after ~30s without PIN re-authentication
 OCTO_PIN_KEEPALIVE_INTERVAL: Final = 25
+
+# Octo variant identifiers (dict defined later after VARIANT_AUTO)
+OCTO_VARIANT_STANDARD: Final = "standard"
+OCTO_VARIANT_STAR2: Final = "star2"
 
 # Mattress Firm 900 specific UUIDs
 # Protocol reverse-engineered by David Delahoz (https://github.com/daviddelahoz/BLEAdjustableBase)
@@ -212,6 +221,13 @@ RICHMAT_VARIANTS: Final = {
     RICHMAT_VARIANT_WILINKE: "WiLinke (5-byte commands with checksum)",
 }
 
+# Octo variants
+OCTO_VARIANTS: Final = {
+    VARIANT_AUTO: "Auto-detect (recommended)",
+    OCTO_VARIANT_STANDARD: "Standard Octo (most common)",
+    OCTO_VARIANT_STAR2: "Octo Remote Star2",
+}
+
 # Richmat command protocols (how command bytes are encoded - used internally)
 RICHMAT_PROTOCOL_WILINKE: Final = "wilinke"  # [110, 1, 0, cmd, cmd+111]
 RICHMAT_PROTOCOL_SINGLE: Final = "single"  # [cmd]
@@ -226,6 +242,8 @@ ALL_PROTOCOL_VARIANTS: Final = [
     LEGGETT_VARIANT_OKIN,
     RICHMAT_VARIANT_NORDIC,
     RICHMAT_VARIANT_WILINKE,
+    OCTO_VARIANT_STANDARD,
+    OCTO_VARIANT_STAR2,
 ]
 
 # Bed types that support angle sensing (position feedback)

--- a/custom_components/adjustable_bed/manifest.json
+++ b/custom_components/adjustable_bed/manifest.json
@@ -27,6 +27,9 @@
       "service_uuid": "0000ffe0-0000-1000-8000-00805f9b34fb"
     },
     {
+      "service_uuid": "0000aa5c-0000-1000-8000-00805f9b34fb"
+    },
+    {
       "service_uuid": "6e400001-b5a3-f393-e0a9-e50e24dcca9e",
       "connectable": true
     }


### PR DESCRIPTION
## Summary

This PR adds support for the Octo Remote Star2 protocol variant, addressing #65.

- Add Star2 service UUID (`0000aa5c-0000-1000-8000-00805f9b34fb`) to BLE discovery
- Create `OctoStar2Controller` with fixed command bytes for motor control
- Add auto-detection of Star2 variant based on service UUID
- Add variant selection option in config flow for Octo beds
- Update documentation with Star2 protocol details

### Protocol Variants

Octo beds now support two protocol variants:

| Variant | Service UUID | Detection |
|---------|--------------|-----------|
| Standard | `0000ffe0-...` | Name contains "octo" |
| Star2 | `0000aa5c-...` | Service UUID auto-detected |

### Star2 Protocol Details

Protocol reverse-engineered by [goedh452](https://community.home-assistant.io/t/how-to-setup-esphome-to-control-my-bluetooth-controlled-octocontrol-bed/540790/10):
- Service UUID: `0000aa5c-0000-1000-8000-00805f9b34fb`
- Characteristic UUID: `00005a55-0000-1000-8000-00805f9b34fb`
- Format: Fixed 15-byte commands starting with `0x68`, ending with `0x16`

Note: Star2 variant does not support under-bed lights or PIN authentication.

## Test plan

- [ ] Test with Octo Star2 bed (if available)
- [ ] Verify standard Octo beds still work
- [ ] Verify auto-detection selects correct variant
- [ ] Verify manual variant selection works in config flow

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Octo Star2 adjustable bed variant with comprehensive motor controls (head, back, legs, feet movements)
  * Implemented automatic detection of Star2 beds via Bluetooth service
  * Added manual variant selection option during configuration

* **Documentation**
  * Updated documentation with Star2 variant specifications and detection guidance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->