### PR TITLE
Add support for complex Okimat light commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,14 +2,16 @@
 name = "ha-adjustable-bed"
 version = "1.2.0"
 description = "Home Assistant integration for adjustable beds (Linak, etc.)"
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 
 [project.optional-dependencies]
 dev = [
     "pytest>=7.4.0",
-    "pytest-asyncio>=0.24.0",
-    "pytest-homeassistant-custom-component>=0.13.0",
+    "pytest-asyncio>=0.23.5",
+    "pytest-homeassistant-custom-component>=0.13.206",
     "pytest-cov>=4.1.0",
+    "pyserial>=3.5",
+    "aiousbwatcher>=1.1.1",
 ]
 
 [tool.pytest.ini_options]
@@ -22,7 +24,7 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py313"
 line-length = 100
 
 [tool.ruff.lint]


### PR DESCRIPTION
## Summary
- Adds `OkimatComplexCommand` dataclass to support commands that require specific timing configurations (count, wait_time)
- Updates 94238 RF FLASHLINE remote to use complex commands for UBL (lights) and memory_save operations
- Extends `lights_toggle()` and `program_memory()` to handle both simple int commands and complex command objects

## Test plan
- [x] New tests for `OkimatComplexCommand` configuration verification
- [x] New test for complex light toggle on 94238 remote
- [x] New test for complex memory save on 94238 remote
- [x] Existing tests continue to pass

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Okimat 94238 remote variant with advanced timing control for memory save and light toggle commands.

* **Chores**
  * Updated Python requirement to 3.12 or later.
  * Updated development dependencies, including pytest and serial communication libraries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->