### PR TITLE
Add unsupported device guidance and BLE diagnostics service

### DIFF
--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -1,0 +1,445 @@
+"""BLE diagnostic runner for capturing device protocol data."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from bleak import BleakClient
+from bleak.exc import BleakError
+from bleak_retry_connector import establish_connection
+from homeassistant.components import bluetooth
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from .coordinator import AdjustableBedCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Standard BLE Device Information Service UUIDs
+DEVICE_INFO_SERVICE_UUID = "0000180a-0000-1000-8000-00805f9b34fb"
+DEVICE_INFO_CHARS = {
+    "manufacturer_name": "00002a29-0000-1000-8000-00805f9b34fb",
+    "model_number": "00002a24-0000-1000-8000-00805f9b34fb",
+    "serial_number": "00002a25-0000-1000-8000-00805f9b34fb",
+    "hardware_revision": "00002a27-0000-1000-8000-00805f9b34fb",
+    "firmware_revision": "00002a26-0000-1000-8000-00805f9b34fb",
+    "software_revision": "00002a28-0000-1000-8000-00805f9b34fb",
+    "system_id": "00002a23-0000-1000-8000-00805f9b34fb",
+}
+
+# Connection settings
+CONNECTION_TIMEOUT = 30.0
+DEFAULT_CAPTURE_DURATION = 120  # 2 minutes
+
+
+@dataclass
+class CapturedNotification:
+    """A captured BLE notification."""
+
+    characteristic: str
+    timestamp: str
+    data_hex: str
+
+
+@dataclass
+class CharacteristicInfo:
+    """Information about a BLE characteristic."""
+
+    uuid: str
+    properties: list[str]
+    value_hex: str | None = None
+    read_error: str | None = None
+
+
+@dataclass
+class ServiceInfo:
+    """Information about a BLE service."""
+
+    uuid: str
+    characteristics: list[CharacteristicInfo] = field(default_factory=list)
+
+
+@dataclass
+class DiagnosticReport:
+    """Complete diagnostic report for a BLE device."""
+
+    metadata: dict[str, Any]
+    device: dict[str, Any]
+    advertisement: dict[str, Any]
+    gatt_services: list[dict[str, Any]]
+    device_information: dict[str, str | None]
+    notifications: list[dict[str, str]]
+    errors: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert report to dictionary for JSON serialization."""
+        return {
+            "metadata": self.metadata,
+            "device": self.device,
+            "advertisement": self.advertisement,
+            "gatt_services": self.gatt_services,
+            "device_information": self.device_information,
+            "notifications": self.notifications,
+            "errors": self.errors,
+        }
+
+
+class BLEDiagnosticRunner:
+    """Runner for BLE device diagnostics."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        address: str,
+        capture_duration: int = DEFAULT_CAPTURE_DURATION,
+        coordinator: AdjustableBedCoordinator | None = None,
+    ) -> None:
+        """Initialize the diagnostic runner."""
+        if capture_duration < 0:
+            raise ValueError("capture_duration must be non-negative")
+
+        self.hass = hass
+        self.address = address.upper()
+        self.capture_duration = capture_duration
+        self.coordinator = coordinator
+
+        self._client: BleakClient | None = None
+        self._using_coordinator_connection: bool = False
+        self._notifications: list[CapturedNotification] = []
+        self._errors: list[str] = []
+        self._notification_lock = asyncio.Lock()
+
+    async def run_diagnostics(self) -> DiagnosticReport:
+        """Run full diagnostic capture on the device."""
+        _LOGGER.info(
+            "Starting BLE diagnostics for %s (capture duration: %ds)",
+            self.address,
+            self.capture_duration,
+        )
+
+        start_time = datetime.now(timezone.utc)
+        device_info: dict[str, Any] = {"address": self.address}
+        advertisement_info: dict[str, Any] = {}
+        services_info: list[ServiceInfo] = []
+        device_information: dict[str, str | None] = {}
+
+        try:
+            # Get advertisement data from HA Bluetooth
+            service_info = bluetooth.async_last_service_info(
+                self.hass, self.address, connectable=True
+            )
+            if service_info:
+                device_info["name"] = service_info.name
+                device_info["rssi"] = getattr(service_info, "rssi", None)
+                advertisement_info["service_uuids"] = [
+                    str(uuid) for uuid in service_info.service_uuids
+                ]
+                advertisement_info["manufacturer_data"] = {
+                    str(k): bytes(v).hex()
+                    for k, v in service_info.manufacturer_data.items()
+                }
+                advertisement_info["service_data"] = {
+                    str(k): bytes(v).hex()
+                    for k, v in service_info.service_data.items()
+                }
+            else:
+                self._errors.append("No advertisement data available")
+
+            # Connect to device
+            await self._connect()
+
+            if self._client and self._client.is_connected:
+                # Enumerate GATT services and characteristics
+                services_info = await self._enumerate_services()
+
+                # Read Device Information Service
+                device_information = await self._read_device_information()
+
+                # Subscribe to all notifiable characteristics
+                await self._subscribe_to_notifications(services_info)
+
+                # Capture notifications for the specified duration
+                _LOGGER.info(
+                    "Capturing notifications for %d seconds. "
+                    "Operate the physical remote to generate data.",
+                    self.capture_duration,
+                )
+                await asyncio.sleep(self.capture_duration)
+
+                # Unsubscribe from notifications
+                await self._unsubscribe_from_notifications(services_info)
+
+        except Exception as err:
+            error_msg = f"Diagnostic error: {err}"
+            _LOGGER.error(error_msg)
+            self._errors.append(error_msg)
+        finally:
+            await self._disconnect()
+
+        end_time = datetime.now(timezone.utc)
+
+        return DiagnosticReport(
+            metadata={
+                "version": "1.0",
+                "timestamp": start_time.isoformat(),
+                "end_timestamp": end_time.isoformat(),
+                "capture_duration_seconds": self.capture_duration,
+                "integration_domain": DOMAIN,
+            },
+            device=device_info,
+            advertisement=advertisement_info,
+            gatt_services=[self._service_to_dict(s) for s in services_info],
+            device_information=device_information,
+            notifications=[
+                {
+                    "characteristic": n.characteristic,
+                    "timestamp": n.timestamp,
+                    "data_hex": n.data_hex,
+                }
+                for n in self._notifications
+            ],
+            errors=self._errors,
+        )
+
+    async def _connect(self) -> None:
+        """Connect to the BLE device."""
+        # If we have a coordinator with an active connection, use it
+        if self.coordinator and self.coordinator.client and self.coordinator.is_connected:
+            _LOGGER.info("Using existing connection from coordinator")
+            self._client = self.coordinator.client
+            self._using_coordinator_connection = True
+            return
+
+        # Otherwise, establish a new connection
+        _LOGGER.info("Establishing new BLE connection to %s", self.address)
+        self._using_coordinator_connection = False
+
+        device = bluetooth.async_ble_device_from_address(
+            self.hass, self.address, connectable=True
+        )
+        if device is None:
+            error = f"Device {self.address} not found in Bluetooth scanner"
+            self._errors.append(error)
+            raise BleakError(error)
+
+        try:
+            self._client = await establish_connection(
+                BleakClient,
+                device,
+                f"diagnostic_{self.address}",
+                max_attempts=2,
+                timeout=CONNECTION_TIMEOUT,
+            )
+            _LOGGER.info("Connected to %s", self.address)
+        except Exception as err:
+            error = f"Failed to connect: {err}"
+            self._errors.append(error)
+            raise
+
+    async def _disconnect(self) -> None:
+        """Disconnect from the BLE device."""
+        # Don't disconnect if we're using the coordinator's connection
+        if self._using_coordinator_connection:
+            _LOGGER.debug("Leaving coordinator connection intact")
+            self._client = None
+            return
+
+        if self._client and self._client.is_connected:
+            _LOGGER.info("Disconnecting from %s", self.address)
+            try:
+                await self._client.disconnect()
+            except Exception as err:
+                _LOGGER.debug("Error during disconnect: %s", err)
+            self._client = None
+            self._using_coordinator_connection = False
+
+    async def _enumerate_services(self) -> list[ServiceInfo]:
+        """Enumerate all GATT services and characteristics."""
+        if not self._client or not self._client.services:
+            return []
+
+        services: list[ServiceInfo] = []
+
+        for service in self._client.services:
+            service_info = ServiceInfo(uuid=service.uuid)
+
+            for char in service.characteristics:
+                char_info = CharacteristicInfo(
+                    uuid=char.uuid,
+                    properties=list(char.properties),
+                )
+
+                # Try to read the characteristic value if readable
+                if "read" in char.properties:
+                    try:
+                        value = await self._client.read_gatt_char(char.uuid)
+                        char_info.value_hex = value.hex()
+                    except Exception as err:
+                        char_info.read_error = str(err)
+                        _LOGGER.debug(
+                            "Could not read characteristic %s: %s",
+                            char.uuid,
+                            err,
+                        )
+
+                service_info.characteristics.append(char_info)
+
+            services.append(service_info)
+
+        _LOGGER.info("Enumerated %d GATT services", len(services))
+        return services
+
+    async def _read_device_information(self) -> dict[str, str | None]:
+        """Read standard Device Information Service if available."""
+        if not self._client or not self._client.services:
+            return {}
+
+        info: dict[str, str | None] = {}
+
+        # Check if Device Information Service exists
+        has_device_info = False
+        for service in self._client.services:
+            if service.uuid.lower() == DEVICE_INFO_SERVICE_UUID:
+                has_device_info = True
+                break
+
+        if not has_device_info:
+            _LOGGER.debug("Device Information Service not found")
+            return info
+
+        for name, uuid in DEVICE_INFO_CHARS.items():
+            try:
+                value = await self._client.read_gatt_char(uuid)
+                # Device info chars are typically strings
+                try:
+                    info[name] = value.decode("utf-8").rstrip("\x00")
+                except UnicodeDecodeError:
+                    info[name] = value.hex()
+                _LOGGER.debug("Device info %s: %s", name, info[name])
+            except Exception as err:
+                _LOGGER.debug("Could not read %s: %s", name, err)
+                info[name] = None
+
+        return info
+
+    async def _subscribe_to_notifications(
+        self, services: list[ServiceInfo]
+    ) -> None:
+        """Subscribe to all notifiable characteristics."""
+        if not self._client:
+            return
+
+        # Skip notification subscription when using coordinator's connection
+        # to avoid replacing or tearing down coordinator callbacks
+        if self._using_coordinator_connection:
+            _LOGGER.debug(
+                "Skipping notification subscription (using coordinator connection)"
+            )
+            return
+
+        for service in services:
+            for char in service.characteristics:
+                if "notify" in char.properties or "indicate" in char.properties:
+                    try:
+                        await self._client.start_notify(
+                            char.uuid,
+                            lambda sender, data, uuid=char.uuid: asyncio.create_task(
+                                self._handle_notification(uuid, data)
+                            ),
+                        )
+                        _LOGGER.debug("Subscribed to notifications on %s", char.uuid)
+                    except Exception as err:
+                        error = f"Failed to subscribe to {char.uuid}: {err}"
+                        _LOGGER.debug(error)
+                        self._errors.append(error)
+
+    async def _unsubscribe_from_notifications(
+        self, services: list[ServiceInfo]
+    ) -> None:
+        """Unsubscribe from all notifiable characteristics."""
+        if not self._client or not self._client.is_connected:
+            return
+
+        # Skip notification unsubscription when using coordinator's connection
+        # to avoid tearing down coordinator callbacks
+        if self._using_coordinator_connection:
+            _LOGGER.debug(
+                "Skipping notification unsubscription (using coordinator connection)"
+            )
+            return
+
+        for service in services:
+            for char in service.characteristics:
+                if "notify" in char.properties or "indicate" in char.properties:
+                    try:
+                        await self._client.stop_notify(char.uuid)
+                    except Exception as err:
+                        _LOGGER.debug(
+                            "Error unsubscribing from %s: %s",
+                            char.uuid,
+                            err,
+                        )
+
+    async def _handle_notification(
+        self, characteristic_uuid: str, data: bytes
+    ) -> None:
+        """Handle an incoming notification."""
+        timestamp = datetime.now(timezone.utc).isoformat()
+
+        async with self._notification_lock:
+            notification = CapturedNotification(
+                characteristic=characteristic_uuid,
+                timestamp=timestamp,
+                data_hex=data.hex(),
+            )
+            self._notifications.append(notification)
+
+        _LOGGER.debug(
+            "Notification on %s: %s",
+            characteristic_uuid,
+            data.hex(),
+        )
+
+    @staticmethod
+    def _service_to_dict(service: ServiceInfo) -> dict[str, Any]:
+        """Convert ServiceInfo to dictionary."""
+        return {
+            "uuid": service.uuid,
+            "characteristics": [
+                {
+                    "uuid": char.uuid,
+                    "properties": char.properties,
+                    "value_hex": char.value_hex,
+                    "read_error": char.read_error,
+                }
+                for char in service.characteristics
+            ],
+        }
+
+
+def save_diagnostic_report(
+    hass: HomeAssistant,
+    report: DiagnosticReport,
+    address: str,
+) -> Path:
+    """Save diagnostic report to a JSON file in the config directory."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    address_safe = address.replace(":", "").lower()
+    filename = f"adjustable_bed_diagnostic_{address_safe}_{timestamp}.json"
+
+    config_dir = Path(hass.config.config_dir)
+    filepath = config_dir / filename
+
+    with open(filepath, "w", encoding="utf-8") as f:
+        json.dump(report.to_dict(), f, indent=2)
+
+    _LOGGER.info("Diagnostic report saved to %s", filepath)
+    return filepath

--- a/custom_components/adjustable_bed/services.yaml
+++ b/custom_components/adjustable_bed/services.yaml
@@ -51,3 +51,33 @@ stop_all:
       selector:
         device:
           integration: adjustable_bed
+
+run_diagnostics:
+  name: Run BLE Diagnostics
+  description: Capture BLE protocol data from a device for troubleshooting and adding support for new bed models. Either provide a configured device or a target MAC address.
+  fields:
+    device_id:
+      name: Device
+      description: A configured adjustable bed device to diagnose.
+      required: false
+      selector:
+        device:
+          integration: adjustable_bed
+    target_address:
+      name: Target Address
+      description: Bluetooth MAC address of an unconfigured device (e.g., AA:BB:CC:DD:EE:FF). Use this to diagnose devices that haven't been set up yet.
+      required: false
+      example: "AA:BB:CC:DD:EE:FF"
+      selector:
+        text:
+    capture_duration:
+      name: Capture Duration
+      description: How long to capture notifications in seconds. Operate the physical remote during this time to generate data.
+      required: false
+      default: 120
+      selector:
+        number:
+          min: 10
+          max: 300
+          unit_of_measurement: seconds
+          mode: box

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -279,6 +279,30 @@
     "stop_all": {
       "name": "Stop All Motors",
       "description": "Immediately stop all bed motors."
+    },
+    "run_diagnostics": {
+      "name": "Run BLE Diagnostics",
+      "description": "Capture BLE protocol data from a device for troubleshooting and adding support for new bed models.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "A configured adjustable bed device to diagnose."
+        },
+        "target_address": {
+          "name": "Target Address",
+          "description": "Bluetooth MAC address of an unconfigured device (e.g., AA:BB:CC:DD:EE:FF)."
+        },
+        "capture_duration": {
+          "name": "Capture Duration",
+          "description": "How long to capture notifications in seconds (10-300). Operate the physical remote during this time."
+        }
+      }
+    }
+  },
+  "issues": {
+    "unsupported_device": {
+      "title": "Unsupported BLE device: {name}",
+      "description": "A Bluetooth device was detected that could not be identified as a supported adjustable bed.\n\n**Device:** {name}\n**Address:** `{address}`\n**Reason:** {reason}\n\nIf this is an adjustable bed that you'd like to see supported, please [report it on GitHub]({github_url}) with as much information as possible about your bed model.\n\nYou can also run the **Run BLE Diagnostics** service with this device's address to capture protocol data that can help us add support."
     }
   }
 }

--- a/custom_components/adjustable_bed/unsupported.py
+++ b/custom_components/adjustable_bed/unsupported.py
@@ -1,0 +1,172 @@
+"""Utilities for handling unsupported BLE devices."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from urllib.parse import quote
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+
+_LOGGER = logging.getLogger(__name__)
+
+GITHUB_REPO = "kristofferR/ha-adjustable-bed"
+GITHUB_NEW_ISSUE_URL = f"https://github.com/{GITHUB_REPO}/issues/new"
+
+
+@dataclass
+class UnsupportedDeviceInfo:
+    """Information about an unsupported BLE device."""
+
+    address: str
+    name: str | None
+    service_uuids: list[str]
+    manufacturer_data: dict[int, bytes]
+    rssi: int | None = None
+
+    def to_log_string(self) -> str:
+        """Format device info for logging."""
+        lines = [
+            f"Address: {self.address}",
+            f"Name: {self.name or 'Unknown'}",
+            f"RSSI: {self.rssi or 'N/A'}",
+            f"Service UUIDs: {self.service_uuids or 'None'}",
+        ]
+        if self.manufacturer_data:
+            mfr_lines = [
+                f"  {hex(k)}: {v.hex()}" for k, v in self.manufacturer_data.items()
+            ]
+            lines.append("Manufacturer data:")
+            lines.extend(mfr_lines)
+        else:
+            lines.append("Manufacturer data: None")
+        return "\n".join(lines)
+
+    def to_issue_body(self, reason: str) -> str:
+        """Format device info for GitHub issue body."""
+        mfr_str = ""
+        if self.manufacturer_data:
+            mfr_items = [
+                f"  - `{hex(k)}`: `{v.hex()}`"
+                for k, v in self.manufacturer_data.items()
+            ]
+            mfr_str = "\n".join(mfr_items)
+        else:
+            mfr_str = "  None"
+
+        uuid_str = ""
+        if self.service_uuids:
+            uuid_items = [f"  - `{uuid}`" for uuid in self.service_uuids]
+            uuid_str = "\n".join(uuid_items)
+        else:
+            uuid_str = "  None"
+
+        return f"""## Device Information
+
+**Reason for non-detection:** {reason}
+
+| Property | Value |
+|----------|-------|
+| Address | `{self.address}` |
+| Name | `{self.name or 'Unknown'}` |
+| RSSI | {self.rssi or 'N/A'} |
+
+### Service UUIDs
+{uuid_str}
+
+### Manufacturer Data
+{mfr_str}
+
+## Bed Information
+
+Please provide the following information about your bed:
+
+- **Bed manufacturer/brand:**
+- **Bed model name:**
+- **Remote control model (if visible):**
+- **App used to control the bed (if any):**
+
+## Additional Context
+
+<!-- Add any other context about your bed here -->
+
+"""
+
+
+def capture_device_info(
+    discovery_info: BluetoothServiceInfoBleak,
+) -> UnsupportedDeviceInfo:
+    """Extract device information from BluetoothServiceInfoBleak."""
+    return UnsupportedDeviceInfo(
+        address=discovery_info.address,
+        name=discovery_info.name,
+        service_uuids=[str(uuid) for uuid in discovery_info.service_uuids],
+        manufacturer_data={
+            k: bytes(v) for k, v in discovery_info.manufacturer_data.items()
+        },
+        rssi=getattr(discovery_info, "rssi", None),
+    )
+
+
+def log_unsupported_device(device_info: UnsupportedDeviceInfo, reason: str) -> None:
+    """Log detailed information about an unsupported device."""
+    _LOGGER.warning(
+        "Unsupported BLE device detected during discovery:\n"
+        "Reason: %s\n"
+        "%s\n"
+        "If this is an adjustable bed, please report it at:\n"
+        "%s",
+        reason,
+        device_info.to_log_string(),
+        _generate_github_url(device_info, reason),
+    )
+
+
+def _generate_github_url(device_info: UnsupportedDeviceInfo, reason: str) -> str:
+    """Generate a pre-filled GitHub issue URL."""
+    title = f"Support request: {device_info.name or 'Unknown device'}"
+    body = device_info.to_issue_body(reason)
+
+    # URL encode the parameters
+    params = f"?template=new-bed-support.yml&title={quote(title)}&body={quote(body)}"
+    return f"{GITHUB_NEW_ISSUE_URL}{params}"
+
+
+async def create_unsupported_device_issue(
+    hass: HomeAssistant,
+    device_info: UnsupportedDeviceInfo,
+    reason: str,
+) -> None:
+    """Create a persistent issue in the Repairs dashboard for an unsupported device."""
+    github_url = _generate_github_url(device_info, reason)
+
+    # Use address as unique identifier (normalized to avoid duplicates)
+    issue_id = f"unsupported_device_{device_info.address.replace(':', '_').lower()}"
+
+    async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        is_fixable=False,
+        is_persistent=True,
+        severity=IssueSeverity.WARNING,
+        translation_key="unsupported_device",
+        translation_placeholders={
+            "name": device_info.name or "Unknown device",
+            "address": device_info.address,
+            "reason": reason,
+            "github_url": github_url,
+        },
+    )
+
+    _LOGGER.debug(
+        "Created Repairs issue for unsupported device %s",
+        device_info.address,
+    )


### PR DESCRIPTION
## Summary

- Implements #49: Helpful guidance when unsupported devices are detected
- Implements #50: BLE diagnostic service for capturing protocol data

### New Features

**Unsupported Device Guidance:**
- When an unsupported BLE device is detected during discovery, creates a Repairs dashboard issue
- Logs detailed device info (address, name, service UUIDs, manufacturer data)
- Includes pre-filled GitHub issue link for easy reporting

**BLE Diagnostics Service (`adjustable_bed.run_diagnostics`):**
- Connects to a device and enumerates all GATT services/characteristics
- Reads Device Information Service if available
- Subscribes to all notifiable characteristics and captures data
- Supports both configured devices and unconfigured devices (via MAC address)
- Saves diagnostic report as JSON file in `/config/`

## Test plan

- [ ] Mock a BLE device with unknown service UUIDs and verify Repairs issue is created
- [ ] Verify log contains detailed device information with GitHub URL
- [ ] Call `run_diagnostics` service with a configured device
- [ ] Call `run_diagnostics` service with `target_address` for an unconfigured device
- [ ] Verify JSON diagnostic file is created in `/config/`
- [ ] Verify persistent notification is created when report is ready

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Run BLE Diagnostics" service to capture and save BLE protocol, GATT, advertisement, and notification data for troubleshooting.
  * Unsupported-device workflow now creates a Repairs dashboard issue with prefilled details and guidance.

* **Improvements**
  * Improved detection, logging, and reporting for unrecognized Bluetooth devices to streamline troubleshooting and support reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->