### PR TITLE
Fix Octo PIN validation in config flow

### DIFF
--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -114,7 +114,8 @@
       "pairing_required": "This bed requires Bluetooth pairing. Pair it through your system's Bluetooth settings first.",
       "wrong_variant": "Failed to communicate with bed. Try selecting a different protocol variant.",
       "device_busy": "The bed is busy or another device is connected. Try disconnecting other controllers first.",
-      "invalid_number": "Please enter valid numbers for motor pulse count and delay."
+      "invalid_number": "Please enter valid numbers for motor pulse count and delay.",
+      "invalid_pin": "PIN must be empty or exactly 4 digits."
     }
   },
   "options": {
@@ -150,7 +151,8 @@
       }
     },
     "error": {
-      "invalid_number": "Please enter valid numbers for motor pulse count and delay."
+      "invalid_number": "Please enter valid numbers for motor pulse count and delay.",
+      "invalid_pin": "PIN must be empty or exactly 4 digits."
     }
   },
   "entity": {


### PR DESCRIPTION
## Summary
- replace Octo PIN validator with a TextSelector to avoid HA schema serialization errors
- add manual PIN validation (empty or exactly 4 digits)
- surface a user-facing invalid PIN error

## Testing
- not run (UI-only change)

Related to #73.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PIN validation for Octo adjustable beds during configuration setup.
  * Improved PIN input fields with standardized validation across configuration flows.

* **Bug Fixes**
  * Enhanced validation to prevent invalid PIN configurations from being created.
  * Added clear error messages for PIN format violations during setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->