### PR TITLE
Fix BLE service discovery and Keeson/Ergomotion issues

### DIFF
--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -220,6 +220,11 @@ class KeesonController(BedController):
         return False
 
     @property
+    def supports_lights(self) -> bool:
+        """Return True - Keeson beds support under-bed/safety lighting."""
+        return True
+
+    @property
     def supports_discrete_light_control(self) -> bool:
         """Return False - Keeson only supports toggle, not discrete on/off."""
         return False
@@ -238,6 +243,11 @@ class KeesonController(BedController):
     def supports_stop_all(self) -> bool:
         """Return False - Keeson beds don't have a dedicated stop command."""
         return False
+
+    @property
+    def reports_percentage_position(self) -> bool:
+        """Return True - Keeson/Ergomotion report 0-100 percentage, not angle degrees."""
+        return True
 
     def _build_command(self, command_value: int) -> bytes:
         """Build command bytes based on protocol variant."""
@@ -618,6 +628,14 @@ class KeesonController(BedController):
         await self.write_command(self._build_command(KeesonCommands.PRESET_TV))
 
     # Light methods
+    async def lights_on(self) -> None:
+        """Turn on safety lights (toggle - no discrete control)."""
+        await self.lights_toggle()
+
+    async def lights_off(self) -> None:
+        """Turn off safety lights (toggle - no discrete control)."""
+        await self.lights_toggle()
+
     async def lights_toggle(self) -> None:
         """Toggle safety lights."""
         await self.write_command(

--- a/custom_components/adjustable_bed/beds/richmat.py
+++ b/custom_components/adjustable_bed/beds/richmat.py
@@ -418,6 +418,14 @@ class RichmatController(BedController):
         """Toggle under-bed lights."""
         await self.write_command(self._build_command(RichmatCommands.LIGHTS_TOGGLE))
 
+    async def lights_on(self) -> None:
+        """Turn on under-bed lights (toggle-only, state unknown)."""
+        await self.lights_toggle()
+
+    async def lights_off(self) -> None:
+        """Turn off under-bed lights (toggle-only, state unknown)."""
+        await self.lights_toggle()
+
     # Massage methods
     async def massage_toggle(self) -> None:
         """Toggle massage."""
@@ -442,6 +450,13 @@ async def detect_richmat_variant(client) -> tuple[bool, str | None]:
     Returns:
         Tuple of (is_wilinke, characteristic_uuid)
     """
+    # Guard against missing service discovery
+    if client.services is None:
+        _LOGGER.warning(
+            "BLE services not discovered, falling back to Nordic Richmat variant"
+        )
+        return False, RICHMAT_NORDIC_CHAR_UUID
+
     # Try WiLinke variants first
     for i, service_uuid in enumerate(RICHMAT_WILINKE_SERVICE_UUIDS):
         try:

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -591,19 +591,28 @@ class AdjustableBedCoordinator:
                     getattr(self._client, 'mtu_size', 'N/A'),
                 )
 
-                # Services are auto-discovered by HA's BleakClientWrapper during connection
-                # Just log what we have - no need to explicitly call get_services()
-                _LOGGER.debug("Checking discovered BLE services...")
+                # Explicitly discover services - not all backends auto-discover
+                _LOGGER.debug("Discovering BLE services...")
+                client = self._client  # Local reference for type narrowing
+                if client is not None:
+                    try:
+                        await client.get_services()
+                    except Exception as svc_err:
+                        _LOGGER.warning(
+                            "Service discovery failed for %s: %s",
+                            self._address,
+                            svc_err,
+                        )
 
                 # Log discovered services in detail
-                if self._client.services:
-                    services_list = list(self._client.services)
+                if client is not None and client.services:
+                    services_list = list(client.services)
                     _LOGGER.debug(
                         "Discovered %d BLE services on %s:",
                         len(services_list),
                         self._address,
                     )
-                    for service in self._client.services:
+                    for service in client.services:
                         _LOGGER.debug(
                             "  Service: %s (handle: %s)",
                             service.uuid,


### PR DESCRIPTION
## Summary
- **BLE service discovery (High)**: Explicitly call `get_services()` after connection since not all BLE backends auto-discover services. Add guard in `detect_richmat_variant()` for missing services.
- **Keeson/Ergomotion positions (Medium)**: These beds report 0-100 percentage, not angle degrees. Cover now uses percentage directly when `reports_percentage_position` is true. Angle sensors are skipped for these bed types since they don't report angles.
- **Keeson light support (Low)**: Add `supports_lights` property and `lights_on()`/`lights_off()` methods so the light switch entity is created.
- **Richmat lights**: Add `lights_on()`/`lights_off()` methods for switch compatibility.

## Test plan
- [ ] Verify BLE connection and service discovery works on various backends
- [ ] Verify Richmat variant auto-detection works with explicit service discovery
- [ ] Verify Keeson/Ergomotion cover positions display correctly as 0-100%
- [ ] Verify angle sensors are not created for Keeson/Ergomotion beds
- [ ] Verify light switch entity is created for Keeson beds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added explicit on/off light control commands for adjustable beds with safety lighting support.
  * Added support for beds reporting position as percentage (0-100%) instead of angle degrees.

* **Bug Fixes**
  * Improved bed connection reliability with enhanced service discovery and error handling.
  * Optimized sensor configuration for different bed types to prevent unnecessary angle sensors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->