### PR TITLE
Read manufacturer/model from BLE Device Information Service

### DIFF
--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -63,6 +63,18 @@ SUPPORTED_BED_TYPES: Final = [
     BED_TYPE_NECTAR,
 ]
 
+# Standard BLE Device Information Service UUIDs
+DEVICE_INFO_SERVICE_UUID: Final = "0000180a-0000-1000-8000-00805f9b34fb"
+DEVICE_INFO_CHARS: Final = {
+    "manufacturer_name": "00002a29-0000-1000-8000-00805f9b34fb",
+    "model_number": "00002a24-0000-1000-8000-00805f9b34fb",
+    "serial_number": "00002a25-0000-1000-8000-00805f9b34fb",
+    "hardware_revision": "00002a27-0000-1000-8000-00805f9b34fb",
+    "firmware_revision": "00002a26-0000-1000-8000-00805f9b34fb",
+    "software_revision": "00002a28-0000-1000-8000-00805f9b34fb",
+    "system_id": "00002a23-0000-1000-8000-00805f9b34fb",
+}
+
 # Linak specific UUIDs
 LINAK_CONTROL_SERVICE_UUID: Final = "99fa0001-338a-1024-8a49-009c0215f78a"
 LINAK_CONTROL_CHAR_UUID: Final = "99fa0002-338a-1024-8a49-009c0215f78a"


### PR DESCRIPTION
## Summary
- Read manufacturer name and model number from the standard BLE Device Information Service (UUID 0x180A) when available
- Fall back to hardcoded values if the service is unavailable or returns unhelpful values
- Filter out generic values like chipset manufacturer names (Nordic, TI, etc.) that don't represent the actual bed manufacturer

## Changes
- Move Device Information Service UUIDs from `ble_diagnostics.py` to `const.py` for reuse
- Add `_read_ble_device_info()` method to coordinator to read BLE device info after connection
- Add `_is_useful_ble_value()` helper to validate that BLE values are useful (not generic placeholders)
- Update `_get_manufacturer()` and `_get_model()` to prefer BLE values when available

## Test plan
- [ ] Test with a real BLE bed device that has Device Information Service
- [ ] Verify manufacturer/model appear in Home Assistant device registry from BLE data
- [ ] Test with a device that doesn't have the Device Information Service to verify fallback works
- [ ] Verify existing functionality is not affected

Fixes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BLE connection reliability by safely handling optional advertisement data fields.
  * Added explicit service discovery during BLE connection establishment.

* **New Features**
  * Device identification now reads manufacturer and model information directly from the bed's BLE Device Information Service when available, with fallback to defaults.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->