### PR TITLE
Change position Number entities from percentage to angle-based

### DIFF
--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -520,10 +520,11 @@ BEDS_WITH_POSITION_FEEDBACK: Final = frozenset({
 })
 
 # Position seeking constants
-POSITION_TOLERANCE: Final = 2.0  # Percentage tolerance for position seeking
+POSITION_TOLERANCE: Final = 3.0  # Angle tolerance in degrees for target reached
+POSITION_OVERSHOOT_TOLERANCE: Final = 6.0  # Larger tolerance for overshoot detection (prevents oscillation)
 POSITION_SEEK_TIMEOUT: Final = 60.0  # Maximum time in seconds for position seeking
 POSITION_CHECK_INTERVAL: Final = 0.3  # Interval between position checks in seconds
-POSITION_STALL_THRESHOLD: Final = 0.5  # Minimum movement percentage to not be considered stalled
+POSITION_STALL_THRESHOLD: Final = 0.5  # Minimum movement in degrees to not be considered stalled
 POSITION_STALL_COUNT: Final = 3  # Number of consecutive stall detections before stopping
 
 # Default values

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -29,7 +29,7 @@
         "data_description": {
           "bed_type": "Auto-detected bed type. Change if detection was incorrect.",
           "motor_count": "2 motors: back and legs. 3 motors: adds head. 4 motors: adds feet.",
-          "disable_angle_sensing": "When enabled, position feedback is disabled but the physical remote will continue working. Recommended for most users.",
+          "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "preferred_adapter": "Select a specific Bluetooth adapter or proxy, or let Home Assistant choose automatically.",
           "protocol_variant": "Some beds have multiple protocol variants. Auto-detect usually works, but you can override if needed.",
           "richmat_remote": "Select the Richmat remote code (use auto if unsure).",
@@ -66,7 +66,7 @@
         "data_description": {
           "protocol_variant": "Leave as 'auto' unless you know the specific protocol. Keeson: base (Member's Mark/Purple) or ksbt (older). Leggett: gen2 (most common) or okin. Richmat: auto-detected.",
           "motor_count": "2 motors: back and legs. 3 motors: adds head. 4 motors: adds feet.",
-          "disable_angle_sensing": "When enabled, position feedback is disabled but the physical remote will continue working. Recommended for most users.",
+          "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "preferred_adapter": "Select a specific Bluetooth adapter or proxy, or let Home Assistant choose automatically.",
           "motor_pulse_count": "Number of command pulses sent for motor movement (1-100). Higher = longer movement.",
           "motor_pulse_delay_ms": "Delay between command pulses in milliseconds (10-500). Lower = smoother movement.",
@@ -95,7 +95,7 @@
           "address": "MAC address in format XX:XX:XX:XX:XX:XX (found in the bed's Bluetooth settings or on a label).",
           "protocol_variant": "Leave as 'auto' unless you know the specific protocol. Keeson: base (Member's Mark/Purple) or ksbt (older). Leggett: gen2 (most common) or okin. Richmat: auto-detected.",
           "motor_count": "2 motors: back and legs. 3 motors: adds head. 4 motors: adds feet.",
-          "disable_angle_sensing": "When enabled, position feedback is disabled but the physical remote will continue working. Recommended for most users.",
+          "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "preferred_adapter": "Select a specific Bluetooth adapter or proxy, or let Home Assistant choose automatically.",
           "motor_pulse_count": "Number of command pulses sent for motor movement (1-100). Higher = longer movement.",
           "motor_pulse_delay_ms": "Delay between command pulses in milliseconds (10-500). Lower = smoother movement.",
@@ -205,7 +205,7 @@
         },
         "data_description": {
           "motor_count": "2 motors: back and legs. 3 motors: adds head. 4 motors: adds feet.",
-          "disable_angle_sensing": "When enabled, position feedback is disabled but the physical remote will continue working.",
+          "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "position_mode": "Speed: faster button response. Accuracy: extra position read after each command.",
           "preferred_adapter": "Select a specific Bluetooth adapter or proxy, or let Home Assistant choose automatically.",
           "protocol_variant": "Change the protocol variant if the bed isn't responding correctly.",

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -29,7 +29,7 @@
         "data_description": {
           "bed_type": "Auto-detected bed type. Change if detection was incorrect.",
           "motor_count": "2 motors: back and legs. 3 motors: adds head. 4 motors: adds feet.",
-          "disable_angle_sensing": "When enabled, position feedback is disabled but the physical remote will continue working. Recommended for most users.",
+          "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "preferred_adapter": "Select a specific Bluetooth adapter or proxy, or let Home Assistant choose automatically.",
           "protocol_variant": "Some beds have multiple protocol variants. Auto-detect usually works, but you can override if needed.",
           "richmat_remote": "Select the Richmat remote code (use auto if unsure).",
@@ -66,7 +66,7 @@
         "data_description": {
           "protocol_variant": "Leave as 'auto' unless you know the specific protocol. Keeson: base (Member's Mark/Purple) or ksbt (older). Leggett: gen2 (most common) or okin. Richmat: auto-detected.",
           "motor_count": "2 motors: back and legs. 3 motors: adds head. 4 motors: adds feet.",
-          "disable_angle_sensing": "When enabled, position feedback is disabled but the physical remote will continue working. Recommended for most users.",
+          "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "preferred_adapter": "Select a specific Bluetooth adapter or proxy, or let Home Assistant choose automatically.",
           "motor_pulse_count": "Number of command pulses sent for motor movement (1-100). Higher = longer movement.",
           "motor_pulse_delay_ms": "Delay between command pulses in milliseconds (10-500). Lower = smoother movement.",
@@ -95,7 +95,7 @@
           "address": "MAC address in format XX:XX:XX:XX:XX:XX (found in the bed's Bluetooth settings or on a label).",
           "protocol_variant": "Leave as 'auto' unless you know the specific protocol. Keeson: base (Member's Mark/Purple) or ksbt (older). Leggett: gen2 (most common) or okin. Richmat: auto-detected.",
           "motor_count": "2 motors: back and legs. 3 motors: adds head. 4 motors: adds feet.",
-          "disable_angle_sensing": "When enabled, position feedback is disabled but the physical remote will continue working. Recommended for most users.",
+          "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "preferred_adapter": "Select a specific Bluetooth adapter or proxy, or let Home Assistant choose automatically.",
           "motor_pulse_count": "Number of command pulses sent for motor movement (1-100). Higher = longer movement.",
           "motor_pulse_delay_ms": "Delay between command pulses in milliseconds (10-500). Lower = smoother movement.",
@@ -205,7 +205,7 @@
         },
         "data_description": {
           "motor_count": "2 motors: back and legs. 3 motors: adds head. 4 motors: adds feet.",
-          "disable_angle_sensing": "When enabled, position feedback is disabled but the physical remote will continue working.",
+          "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "position_mode": "Speed: faster button response. Accuracy: extra position read after each command.",
           "preferred_adapter": "Select a specific Bluetooth adapter or proxy, or let Home Assistant choose automatically.",
           "protocol_variant": "Change the protocol variant if the bed isn't responding correctly.",


### PR DESCRIPTION
## Summary

- Position sliders now display degrees instead of percentage for more intuitive control:
  - Back/Head: 0-68°
  - Legs/Feet: 0-45°
- Keeson/Ergomotion beds retain percentage-based UI (0-100%) since they report percentage positions
- Added separate overshoot tolerance (6°) to prevent oscillation while keeping target tolerance tight (3°)
- Updated "disable angle sensing" description to clarify it enables position sliders when unchecked

## Technical Changes

- `const.py`: Added `POSITION_OVERSHOOT_TOLERANCE` (6°), changed `POSITION_TOLERANCE` to 3°
- `number.py`: Changed `native_max_value` to use actual angles, unit to "°", removed `NumberDeviceClass.POWER_FACTOR`
- `coordinator.py`: Simplified by removing percentage conversion logic, uses angles directly

## Test plan

- [x] All 494 tests pass
- [x] Manually tested position seeking on Linak bed
- [x] Verified oscillation prevention with separate overshoot tolerance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added overshoot detection to stabilize motion control and prevent overshooting target positions.

* **Improvements**
  * Enhanced position accuracy by switching to angle-based movement control for more precise positioning.
  * Adjusted tolerance thresholds to improve detection of when target positions are reached.
  * Clarified UI descriptions for position sensor controls with clearer instructions on enabling bed position sliders.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->