### PR TITLE
Add Leggett & Platt Richmat bed controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ smartbed-mqtt-discord-chats/
 
 # Lock files
 uv.lock
+
+__pycache__/

--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -452,6 +452,17 @@ class BedController(ABC):
         return True
 
     @property
+    def has_discrete_motor_control(self) -> bool:
+        """Return True if bed uses discrete (button-press) motor control.
+
+        Discrete motor control means each command moves the motor a small
+        amount (like pressing a button), rather than continuous movement
+        that requires a stop command. Beds with discrete control should
+        expose button entities instead of cover entities for motor control.
+        """
+        return False
+
+    @property
     def supports_stop_all(self) -> bool:
         """Return True if bed supports a stop-all command.
 

--- a/custom_components/adjustable_bed/beds/leggett_platt_richmat.py
+++ b/custom_components/adjustable_bed/beds/leggett_platt_richmat.py
@@ -1,0 +1,424 @@
+"""Leggett & Platt Richmat bed controller implementation.
+
+This controller is for Leggett & Platt beds that use Richmat WiLinke BLE hardware.
+These beds advertise as "MlRM*" and use the WiLinke 5-byte command protocol.
+
+Key difference from standard Richmat: This controller has discrete massage UP/DOWN
+commands (0x4c/0x4d for head, 0x4e/0x4f for foot) rather than just cycling "step" commands.
+
+Command format: [0x6e, 0x01, 0x00, command_byte, checksum]
+Where checksum = sum of first 4 bytes (truncated to 8 bits)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from bleak.exc import BleakError
+
+from ..const import LEGGETT_RICHMAT_CHAR_UUID
+from .base import BedController
+
+if TYPE_CHECKING:
+    from ..coordinator import AdjustableBedCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class LeggettPlattRichmatCommands:
+    """Command constants for Leggett & Platt Richmat beds.
+
+    These were reverse-engineered from the LP Adjustable Bed Control app.
+    Commands are the last byte of a 5-byte WiLinke packet.
+    """
+
+    # Presets
+    PRESET_FLAT = 0x31
+    PRESET_ANTI_SNORE = 0x46
+    PRESET_LOUNGE = 0x59
+    PRESET_MEMORY_1 = 0x2E
+    PRESET_MEMORY_2 = 0x2F
+    PRESET_TV = 0x58
+    PRESET_ZERO_G = 0x45
+
+    # Program presets
+    PROGRAM_ANTI_SNORE = 0x69
+    PROGRAM_LOUNGE = 0x65
+    PROGRAM_MEMORY_1 = 0x2B
+    PROGRAM_MEMORY_2 = 0x2C
+    PROGRAM_TV = 0x64
+    PROGRAM_ZERO_G = 0x66
+
+    # Massage - discrete UP/DOWN commands (from LP app decompilation)
+    MASSAGE_HEAD_UP = 0x4C      # Increase head massage intensity
+    MASSAGE_HEAD_DOWN = 0x4D    # Decrease head massage intensity
+    MASSAGE_FOOT_UP = 0x4E      # Increase foot massage intensity
+    MASSAGE_FOOT_DOWN = 0x4F    # Decrease foot massage intensity
+    MASSAGE_MOTOR_STOP = 0x47   # Stop massage motors
+
+    # Massage - additional commands
+    MASSAGE_MOTOR1_ON_OFF = 0x32  # Toggle head massage
+    MASSAGE_MOTOR2_ON_OFF = 0x33  # Toggle foot massage
+    MASSAGE_INCREASE_INTENSITY = 0x34  # Overall intensity up
+    MASSAGE_DECREASE_INTENSITY = 0x35  # Overall intensity down
+    MASSAGE_INCREASE_SPEED = 0x36
+    MASSAGE_DECREASE_SPEED = 0x37
+    MASSAGE_PATTERN_STEP = 0x38  # Cycle massage patterns
+    MASSAGE_WAVE = 0x39          # Wave massage mode
+    MASSAGE_ALWAYS_ON = 0x3A
+
+    # Massage timers
+    MASSAGE_TIMER_10M = 0x5F
+    MASSAGE_TIMER_20M = 0x63
+    MASSAGE_TIMER_30M = 0x61
+
+    # Lights
+    LIGHTS_TOGGLE = 0x3C
+
+    # Motors
+    MOTOR_PILLOW_UP = 0x3F
+    MOTOR_PILLOW_DOWN = 0x40
+    MOTOR_HEAD_UP = 0x24
+    MOTOR_HEAD_DOWN = 0x25
+    MOTOR_FEET_UP = 0x26
+    MOTOR_FEET_DOWN = 0x27
+    MOTOR_LUMBAR_UP = 0x41
+    MOTOR_LUMBAR_DOWN = 0x42
+
+    # End/Stop
+    END = 0x6E
+
+
+class LeggettPlattRichmatController(BedController):
+    """Controller for Leggett & Platt beds with Richmat WiLinke hardware."""
+
+    def __init__(
+        self,
+        coordinator: AdjustableBedCoordinator,
+        char_uuid: str | None = None,
+    ) -> None:
+        """Initialize the controller.
+
+        Args:
+            coordinator: The AdjustableBedCoordinator instance
+            char_uuid: The characteristic UUID to use for writing commands
+        """
+        super().__init__(coordinator)
+        self._char_uuid = char_uuid or LEGGETT_RICHMAT_CHAR_UUID
+        self._notify_callback: Callable[[str, float], None] | None = None
+
+        _LOGGER.debug(
+            "LeggettPlattRichmatController initialized (char: %s)",
+            self._char_uuid,
+        )
+
+    @property
+    def control_characteristic_uuid(self) -> str:
+        """Return the UUID of the control characteristic."""
+        return self._char_uuid
+
+    @property
+    def supports_preset_zero_g(self) -> bool:
+        return True
+
+    @property
+    def supports_preset_anti_snore(self) -> bool:
+        return True
+
+    @property
+    def supports_preset_tv(self) -> bool:
+        return True
+
+    @property
+    def supports_preset_lounge(self) -> bool:
+        return True
+
+    @property
+    def has_lumbar_support(self) -> bool:
+        return False  # Most L&P Richmat beds don't have lumbar
+
+    @property
+    def has_pillow_support(self) -> bool:
+        return False  # Most L&P Richmat beds don't have pillow tilt
+
+    @property
+    def supports_lights(self) -> bool:
+        """Return True if this bed supports under-bed lights."""
+        return True
+
+    @property
+    def supports_discrete_light_control(self) -> bool:
+        """Return False - only supports toggle, not discrete on/off."""
+        return False
+
+    @property
+    def supports_memory_presets(self) -> bool:
+        """Return True - supports memory presets."""
+        return True
+
+    @property
+    def memory_slot_count(self) -> int:
+        """Return 2 - supports Memory 1 and Memory 2."""
+        return 2
+
+    @property
+    def supports_memory_programming(self) -> bool:
+        """Return True - supports programming memory positions."""
+        return True
+
+    @property
+    def has_discrete_motor_control(self) -> bool:
+        """Return True - this bed uses discrete motor commands."""
+        return True
+
+    def _build_command(self, command_byte: int) -> bytes:
+        """Build WiLinke 5-byte command with checksum.
+
+        Format: [0x6e, 0x01, 0x00, command, checksum]
+        Checksum = (0x6e + 0x01 + 0x00 + command) & 0xFF = (command + 0x6F) & 0xFF
+        """
+        checksum = (0x6E + 0x01 + 0x00 + command_byte) & 0xFF
+        return bytes([0x6E, 0x01, 0x00, command_byte, checksum])
+
+    async def write_command(
+        self,
+        command: bytes,
+        repeat_count: int = 1,
+        repeat_delay_ms: int = 100,
+        cancel_event: asyncio.Event | None = None,
+    ) -> None:
+        """Write a command to the bed."""
+        if self.client is None or not self.client.is_connected:
+            _LOGGER.error("Cannot write command: BLE client not connected")
+            raise ConnectionError("Not connected to bed")
+
+        effective_cancel = cancel_event or self._coordinator.cancel_command
+
+        _LOGGER.debug(
+            "Writing command to L&P Richmat bed: %s (repeat: %d, delay: %dms)",
+            command.hex(),
+            repeat_count,
+            repeat_delay_ms,
+        )
+
+        for i in range(repeat_count):
+            if effective_cancel is not None and effective_cancel.is_set():
+                _LOGGER.info("Command cancelled after %d/%d writes", i, repeat_count)
+                return
+
+            try:
+                await self.client.write_gatt_char(
+                    self._char_uuid, command, response=True
+                )
+            except BleakError as err:
+                _LOGGER.exception("Failed to write command")
+                if "not found" in str(err).lower() or "invalid" in str(err).lower():
+                    _LOGGER.warning(
+                        "Characteristic %s may not exist on this device.",
+                        self._char_uuid,
+                    )
+                    self.log_discovered_services(level=logging.INFO)
+                raise
+
+            if i < repeat_count - 1:
+                await asyncio.sleep(repeat_delay_ms / 1000)
+
+    async def start_notify(self, callback: Callable[[str, float], None]) -> None:
+        """Start listening for position notifications."""
+        self._notify_callback = callback
+        _LOGGER.debug("L&P Richmat beds don't support position notifications")
+
+    async def stop_notify(self) -> None:
+        """Stop listening for position notifications."""
+        pass
+
+    async def read_positions(self, motor_count: int = 2) -> None:
+        """Read current position data."""
+        pass
+
+    async def _send_command(self, command_byte: int, repeat: int | None = None) -> None:
+        """Send a command to the bed."""
+        command = self._build_command(command_byte)
+        pulse_count = repeat if repeat is not None else self._coordinator.motor_pulse_count
+        pulse_delay = self._coordinator.motor_pulse_delay_ms
+        await self.write_command(command, repeat_count=pulse_count, repeat_delay_ms=pulse_delay)
+
+    async def _move_with_stop(self, command_byte: int) -> None:
+        """Execute a movement command and always send STOP at the end."""
+        try:
+            await self._send_command(command_byte)
+        finally:
+            try:
+                await self.write_command(
+                    self._build_command(LeggettPlattRichmatCommands.END),
+                    cancel_event=asyncio.Event(),
+                )
+            except Exception:
+                _LOGGER.debug("Failed to send END command during cleanup")
+
+    # Motor control methods
+    async def move_head_up(self) -> None:
+        """Move head up."""
+        await self._move_with_stop(LeggettPlattRichmatCommands.MOTOR_HEAD_UP)
+
+    async def move_head_down(self) -> None:
+        """Move head down."""
+        await self._move_with_stop(LeggettPlattRichmatCommands.MOTOR_HEAD_DOWN)
+
+    async def move_head_stop(self) -> None:
+        """Stop head motor."""
+        await self.write_command(
+            self._build_command(LeggettPlattRichmatCommands.END),
+            cancel_event=asyncio.Event(),
+        )
+
+    async def move_back_up(self) -> None:
+        """Move back up (same as head)."""
+        await self.move_head_up()
+
+    async def move_back_down(self) -> None:
+        """Move back down (same as head)."""
+        await self.move_head_down()
+
+    async def move_back_stop(self) -> None:
+        """Stop back motor."""
+        await self.move_head_stop()
+
+    async def move_legs_up(self) -> None:
+        """Move legs up."""
+        await self._move_with_stop(LeggettPlattRichmatCommands.MOTOR_FEET_UP)
+
+    async def move_legs_down(self) -> None:
+        """Move legs down."""
+        await self._move_with_stop(LeggettPlattRichmatCommands.MOTOR_FEET_DOWN)
+
+    async def move_legs_stop(self) -> None:
+        """Stop legs motor."""
+        await self.move_head_stop()
+
+    async def move_feet_up(self) -> None:
+        """Move feet up."""
+        await self._move_with_stop(LeggettPlattRichmatCommands.MOTOR_FEET_UP)
+
+    async def move_feet_down(self) -> None:
+        """Move feet down."""
+        await self._move_with_stop(LeggettPlattRichmatCommands.MOTOR_FEET_DOWN)
+
+    async def move_feet_stop(self) -> None:
+        """Stop feet motor."""
+        await self.move_head_stop()
+
+    async def stop_all(self) -> None:
+        """Stop all motors."""
+        await self.write_command(
+            self._build_command(LeggettPlattRichmatCommands.END),
+            cancel_event=asyncio.Event(),
+        )
+
+    # Preset methods
+    async def preset_flat(self) -> None:
+        """Go to flat position."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.PRESET_FLAT))
+
+    async def preset_memory(self, memory_num: int) -> None:
+        """Go to memory preset."""
+        commands = {
+            1: LeggettPlattRichmatCommands.PRESET_MEMORY_1,
+            2: LeggettPlattRichmatCommands.PRESET_MEMORY_2,
+        }
+        if command := commands.get(memory_num):
+            await self.write_command(self._build_command(command))
+        else:
+            _LOGGER.warning("Invalid memory number %d (valid: 1-2)", memory_num)
+
+    async def program_memory(self, memory_num: int) -> None:
+        """Program current position to memory."""
+        commands = {
+            1: LeggettPlattRichmatCommands.PROGRAM_MEMORY_1,
+            2: LeggettPlattRichmatCommands.PROGRAM_MEMORY_2,
+        }
+        if command := commands.get(memory_num):
+            await self.write_command(self._build_command(command))
+        else:
+            _LOGGER.warning("Invalid memory number %d (valid: 1-2)", memory_num)
+
+    async def preset_zero_g(self) -> None:
+        """Go to zero gravity position."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.PRESET_ZERO_G))
+
+    async def preset_anti_snore(self) -> None:
+        """Go to anti-snore position."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.PRESET_ANTI_SNORE))
+
+    async def preset_tv(self) -> None:
+        """Go to TV position."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.PRESET_TV))
+
+    async def preset_lounge(self) -> None:
+        """Go to lounge position."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.PRESET_LOUNGE))
+
+    # Light methods
+    async def lights_toggle(self) -> None:
+        """Toggle under-bed lights."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.LIGHTS_TOGGLE))
+
+    async def lights_on(self) -> None:
+        """Turn on under-bed lights (toggle-only)."""
+        await self.lights_toggle()
+
+    async def lights_off(self) -> None:
+        """Turn off under-bed lights (toggle-only)."""
+        await self.lights_toggle()
+
+    # Massage methods - DISCRETE UP/DOWN (the key feature of this controller!)
+    async def massage_off(self) -> None:
+        """Turn off all massage."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.MASSAGE_MOTOR_STOP))
+
+    async def massage_toggle(self) -> None:
+        """Toggle massage (head motor)."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.MASSAGE_MOTOR1_ON_OFF))
+
+    async def massage_head_toggle(self) -> None:
+        """Toggle head massage."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.MASSAGE_MOTOR1_ON_OFF))
+
+    async def massage_foot_toggle(self) -> None:
+        """Toggle foot massage."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.MASSAGE_MOTOR2_ON_OFF))
+
+    async def massage_head_up(self) -> None:
+        """Increase head massage intensity."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.MASSAGE_HEAD_UP))
+
+    async def massage_head_down(self) -> None:
+        """Decrease head massage intensity."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.MASSAGE_HEAD_DOWN))
+
+    async def massage_foot_up(self) -> None:
+        """Increase foot massage intensity."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.MASSAGE_FOOT_UP))
+
+    async def massage_foot_down(self) -> None:
+        """Decrease foot massage intensity."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.MASSAGE_FOOT_DOWN))
+
+    async def massage_intensity_up(self) -> None:
+        """Increase overall massage intensity."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.MASSAGE_INCREASE_INTENSITY))
+
+    async def massage_intensity_down(self) -> None:
+        """Decrease overall massage intensity."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.MASSAGE_DECREASE_INTENSITY))
+
+    async def massage_mode_step(self) -> None:
+        """Step through massage patterns."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.MASSAGE_PATTERN_STEP))
+
+    async def massage_wave_toggle(self) -> None:
+        """Toggle wave massage mode."""
+        await self.write_command(self._build_command(LeggettPlattRichmatCommands.MASSAGE_WAVE))

--- a/custom_components/adjustable_bed/button.py
+++ b/custom_components/adjustable_bed/button.py
@@ -281,6 +281,35 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         press_fn=lambda ctrl: ctrl.lights_on(),
         required_capability="supports_light_cycle",
     ),
+    # Motor movement buttons (for discrete motor control beds)
+    AdjustableBedButtonEntityDescription(
+        key="head_up",
+        translation_key="head_up",
+        icon="mdi:arrow-up",
+        press_fn=lambda ctrl: ctrl.move_head_up(),
+        required_capability="has_discrete_motor_control",
+    ),
+    AdjustableBedButtonEntityDescription(
+        key="head_down",
+        translation_key="head_down",
+        icon="mdi:arrow-down",
+        press_fn=lambda ctrl: ctrl.move_head_down(),
+        required_capability="has_discrete_motor_control",
+    ),
+    AdjustableBedButtonEntityDescription(
+        key="legs_up",
+        translation_key="legs_up",
+        icon="mdi:arrow-up",
+        press_fn=lambda ctrl: ctrl.move_legs_up(),
+        required_capability="has_discrete_motor_control",
+    ),
+    AdjustableBedButtonEntityDescription(
+        key="legs_down",
+        translation_key="legs_down",
+        icon="mdi:arrow-down",
+        press_fn=lambda ctrl: ctrl.move_legs_down(),
+        required_capability="has_discrete_motor_control",
+    ),
 )
 
 

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -43,6 +43,7 @@ BED_TYPE_SERTA: Final = "serta"
 BED_TYPE_OCTO: Final = "octo"
 BED_TYPE_MATTRESSFIRM: Final = "mattressfirm"
 BED_TYPE_NECTAR: Final = "nectar"
+BED_TYPE_LEGGETT_PLATT_RICHMAT: Final = "leggett_platt_richmat"
 BED_TYPE_DIAGNOSTIC: Final = "diagnostic"
 
 SUPPORTED_BED_TYPES: Final = [
@@ -61,6 +62,7 @@ SUPPORTED_BED_TYPES: Final = [
     BED_TYPE_OCTO,
     BED_TYPE_MATTRESSFIRM,
     BED_TYPE_NECTAR,
+    BED_TYPE_LEGGETT_PLATT_RICHMAT,
 ]
 
 # Standard BLE Device Information Service UUIDs
@@ -163,6 +165,11 @@ LEGGETT_GEN2_READ_CHAR_UUID: Final = "45e25103-3171-4cfc-ae89-1d83cf8d8071"
 LEGGETT_OKIN_SERVICE_UUID: Final = "62741523-52f9-8864-b1ab-3b3a8d65950b"
 LEGGETT_OKIN_CHAR_UUID: Final = "62741525-52f9-8864-b1ab-3b3a8d65950b"
 
+# Leggett & Platt Richmat variant (WiLinke protocol, discrete massage commands)
+# Uses same service/char as Richmat WiLinke but with L&P-specific features
+LEGGETT_RICHMAT_SERVICE_UUID: Final = "0000fee9-0000-1000-8000-00805f9b34fb"
+LEGGETT_RICHMAT_CHAR_UUID: Final = "d44bc439-abfd-45a2-b575-925416129600"
+
 # Reverie specific UUIDs
 REVERIE_SERVICE_UUID: Final = "1b1d9641-b942-4da8-89cc-98e6a58fbd93"
 REVERIE_CHAR_UUID: Final = "6af87926-dc79-412e-a3e0-5f85c2d55de2"
@@ -235,6 +242,7 @@ NECTAR_NOTIFY_CHAR_UUID: Final = "62741625-52f9-8864-b1ab-3b3a8d65950b"
 # - Leggett & Platt Okin variant (6-byte protocol, same as Okimat)
 # Detection priority: name patterns first, then UUID fallback to Okimat
 LEGGETT_OKIN_NAME_PATTERNS: Final = ("leggett", "l&p")
+LEGGETT_RICHMAT_NAME_PATTERNS: Final = ("mlrm",)  # MlRM prefix beds
 # Okimat devices: "Okimat", "OKIN RF", "OKIN BLE", or "OKIN-XXXXXX" (e.g., OKIN-346311)
 OKIMAT_NAME_PATTERNS: Final = ("okimat", "okin rf", "okin ble", "okin-")
 

--- a/custom_components/adjustable_bed/controller_factory.py
+++ b/custom_components/adjustable_bed/controller_factory.py
@@ -12,6 +12,7 @@ from .const import (
     BED_TYPE_JIECANG,
     BED_TYPE_KEESON,
     BED_TYPE_LEGGETT_PLATT,
+    BED_TYPE_LEGGETT_PLATT_RICHMAT,
     BED_TYPE_LINAK,
     BED_TYPE_MATTRESSFIRM,
     BED_TYPE_MOTOSLEEP,
@@ -132,6 +133,12 @@ async def create_controller(
             # Auto or gen2 variant
             _LOGGER.debug("Using Gen2 Leggett & Platt variant")
             return LeggettPlattController(coordinator, variant="gen2")
+
+    if bed_type == BED_TYPE_LEGGETT_PLATT_RICHMAT:
+        from .beds.leggett_platt_richmat import LeggettPlattRichmatController
+
+        _LOGGER.debug("Using Leggett & Platt Richmat controller")
+        return LeggettPlattRichmatController(coordinator)
 
     if bed_type == BED_TYPE_REVERIE:
         from .beds.reverie import ReverieController

--- a/custom_components/adjustable_bed/cover.py
+++ b/custom_components/adjustable_bed/cover.py
@@ -147,6 +147,14 @@ async def async_setup_entry(
         )
         return
 
+    # Skip motor cover entities if bed uses discrete motor control (buttons instead)
+    if controller is not None and controller.has_discrete_motor_control:
+        _LOGGER.debug(
+            "Skipping motor covers for %s - bed uses discrete motor control (buttons instead)",
+            coordinator.name,
+        )
+        return
+
     entities = []
 
     # Keeson and Ergomotion beds use different motor naming:

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -15,6 +15,7 @@ from .const import (
     BED_TYPE_JIECANG,
     BED_TYPE_KEESON,
     BED_TYPE_LEGGETT_PLATT,
+    BED_TYPE_LEGGETT_PLATT_RICHMAT,
     BED_TYPE_LINAK,
     BED_TYPE_MATTRESSFIRM,
     BED_TYPE_MOTOSLEEP,
@@ -30,6 +31,7 @@ from .const import (
     KEESON_NAME_PATTERNS,
     LEGGETT_GEN2_SERVICE_UUID,
     LEGGETT_OKIN_NAME_PATTERNS,
+    LEGGETT_RICHMAT_NAME_PATTERNS,
     LINAK_CONTROL_SERVICE_UUID,
     LINAK_NAME_PATTERNS,
     LINAK_POSITION_SERVICE_UUID,
@@ -82,6 +84,7 @@ BED_TYPE_DISPLAY_NAMES: dict[str, str] = {
     BED_TYPE_JIECANG: "Jiecang",
     BED_TYPE_KEESON: "Keeson",
     BED_TYPE_LEGGETT_PLATT: "Leggett & Platt",
+    BED_TYPE_LEGGETT_PLATT_RICHMAT: "Leggett & Platt (Richmat)",
     BED_TYPE_LINAK: "Linak",
     BED_TYPE_MATTRESSFIRM: "MattressFirm",
     BED_TYPE_MOTOSLEEP: "MotoSleep",
@@ -211,6 +214,18 @@ def detect_bed_type(service_info: BluetoothServiceInfoBleak) -> str | None:
             service_info.address,
         )
         return BED_TYPE_OKIMAT
+
+    # Check for Leggett & Platt Richmat (MlRM prefix with WiLinke UUID)
+    # Must be before generic Richmat WiLinke check
+    if any(device_name.startswith(pattern) for pattern in LEGGETT_RICHMAT_NAME_PATTERNS):
+        for wilinke_uuid in RICHMAT_WILINKE_SERVICE_UUIDS:
+            if wilinke_uuid.lower() in service_uuids:
+                _LOGGER.info(
+                    "Detected Leggett & Platt Richmat bed at %s (name: %s)",
+                    service_info.address,
+                    service_info.name,
+                )
+                return BED_TYPE_LEGGETT_PLATT_RICHMAT
 
     # Check for Richmat WiLinke variants
     for wilinke_uuid in RICHMAT_WILINKE_SERVICE_UUIDS:

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -311,6 +311,18 @@
       },
       "connect": {
         "name": "Connect"
+      },
+      "head_up": {
+        "name": "Head Up"
+      },
+      "head_down": {
+        "name": "Head Down"
+      },
+      "legs_up": {
+        "name": "Legs Up"
+      },
+      "legs_down": {
+        "name": "Legs Down"
       }
     },
     "cover": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -510,3 +510,26 @@ def mock_bluetooth_service_info_octo_star2() -> MagicMock:
     service_info.time = 0
     service_info.tx_power = None
     return service_info
+
+
+@pytest.fixture
+def mock_bluetooth_service_info_leggett_platt_richmat() -> MagicMock:
+    """Return mock Bluetooth service info for a Leggett & Platt Richmat bed.
+
+    These beds use Richmat WiLinke hardware but have the "MlRM" name prefix
+    and discrete massage UP/DOWN commands.
+    """
+    service_info = MagicMock()
+    service_info.name = "MlRM157052"  # Name starts with MlRM prefix
+    service_info.address = "FF:11:22:33:44:55"
+    service_info.rssi = -60
+    service_info.manufacturer_data = {}
+    service_info.service_data = {}
+    service_info.service_uuids = [RICHMAT_WILINKE_SERVICE_UUIDS[1]]  # fee9 UUID
+    service_info.source = "local"
+    service_info.device = MagicMock()
+    service_info.advertisement = MagicMock()
+    service_info.connectable = True
+    service_info.time = 0
+    service_info.tx_power = None
+    return service_info

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -20,6 +20,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_JIECANG,
     BED_TYPE_KEESON,
     BED_TYPE_LEGGETT_PLATT,
+    BED_TYPE_LEGGETT_PLATT_RICHMAT,
     BED_TYPE_LINAK,
     BED_TYPE_MOTOSLEEP,
     BED_TYPE_OCTO,
@@ -34,6 +35,7 @@ from custom_components.adjustable_bed.const import (
     CONF_MOTOR_COUNT,
     CONF_PREFERRED_ADAPTER,
     DOMAIN,
+    RICHMAT_WILINKE_SERVICE_UUIDS,
 )
 
 
@@ -343,6 +345,61 @@ class TestDetectBedType:
         """Test detection of Octo Star2 bed by service UUID (not by name)."""
         bed_type = detect_bed_type(mock_bluetooth_service_info_octo_star2)
         assert bed_type == BED_TYPE_OCTO
+
+    def test_detect_leggett_platt_richmat_bed(
+        self, mock_bluetooth_service_info_leggett_platt_richmat
+    ):
+        """Test detection of Leggett & Platt Richmat bed (MlRM prefix)."""
+        bed_type = detect_bed_type(mock_bluetooth_service_info_leggett_platt_richmat)
+        assert bed_type == BED_TYPE_LEGGETT_PLATT_RICHMAT
+
+    def test_detect_leggett_platt_richmat_case_insensitive(self):
+        """Test L&P Richmat detection is case-insensitive (name is lowercased)."""
+        # Test with uppercase MLRM
+        service_info = MagicMock()
+        service_info.name = "MLRM123456"
+        service_info.address = "AA:BB:CC:DD:EE:FF"
+        service_info.service_uuids = [RICHMAT_WILINKE_SERVICE_UUIDS[1]]
+        service_info.manufacturer_data = {}
+
+        bed_type = detect_bed_type(service_info)
+        assert bed_type == BED_TYPE_LEGGETT_PLATT_RICHMAT
+
+    def test_detect_leggett_richmat_vs_generic_richmat(self):
+        """Test L&P Richmat takes precedence over generic Richmat for mlrm prefix.
+
+        Both L&P Richmat and generic Richmat use WiLinke UUIDs, but beds with
+        'mlrm' prefix should be detected as L&P Richmat.
+        """
+        # Same UUID as generic Richmat WiLinke, but with mlrm prefix
+        service_info = MagicMock()
+        service_info.name = "mlrm157052"
+        service_info.address = "AA:BB:CC:DD:EE:FF"
+        service_info.service_uuids = [RICHMAT_WILINKE_SERVICE_UUIDS[0]]  # First WiLinke UUID
+        service_info.manufacturer_data = {}
+
+        bed_type = detect_bed_type(service_info)
+        assert bed_type == BED_TYPE_LEGGETT_PLATT_RICHMAT
+
+        # Verify generic Richmat still works for non-mlrm names
+        service_info.name = "Generic WiLinke Bed"
+        bed_type = detect_bed_type(service_info)
+        assert bed_type == BED_TYPE_RICHMAT
+
+    def test_detect_leggett_richmat_without_service_uuid(self):
+        """Test L&P Richmat needs both name pattern AND WiLinke service UUID.
+
+        If the name matches but UUID doesn't, it should not be detected as L&P Richmat.
+        """
+        service_info = MagicMock()
+        service_info.name = "MlRM157052"
+        service_info.address = "AA:BB:CC:DD:EE:FF"
+        service_info.service_uuids = []  # No service UUIDs
+        service_info.manufacturer_data = {}
+
+        bed_type = detect_bed_type(service_info)
+        # Should NOT detect as L&P Richmat without UUID
+        assert bed_type != BED_TYPE_LEGGETT_PLATT_RICHMAT
 
 
 class TestPinValidation:

--- a/tests/test_leggett_platt_richmat.py
+++ b/tests/test_leggett_platt_richmat.py
@@ -1,0 +1,972 @@
+"""Tests for Leggett & Platt Richmat bed controller."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.const import CONF_ADDRESS, CONF_NAME
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adjustable_bed.beds.leggett_platt_richmat import (
+    LeggettPlattRichmatCommands,
+)
+from custom_components.adjustable_bed.const import (
+    BED_TYPE_LEGGETT_PLATT_RICHMAT,
+    CONF_BED_TYPE,
+    CONF_DISABLE_ANGLE_SENSING,
+    CONF_HAS_MASSAGE,
+    CONF_MOTOR_COUNT,
+    CONF_PREFERRED_ADAPTER,
+    DOMAIN,
+    LEGGETT_RICHMAT_CHAR_UUID,
+)
+from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
+
+
+class TestLeggettPlattRichmatCommands:
+    """Test Leggett & Platt Richmat command constants."""
+
+    def test_preset_commands(self):
+        """Test preset command values."""
+        assert LeggettPlattRichmatCommands.PRESET_FLAT == 0x31
+        assert LeggettPlattRichmatCommands.PRESET_ANTI_SNORE == 0x46
+        assert LeggettPlattRichmatCommands.PRESET_LOUNGE == 0x59
+        assert LeggettPlattRichmatCommands.PRESET_MEMORY_1 == 0x2E
+        assert LeggettPlattRichmatCommands.PRESET_MEMORY_2 == 0x2F
+        assert LeggettPlattRichmatCommands.PRESET_TV == 0x58
+        assert LeggettPlattRichmatCommands.PRESET_ZERO_G == 0x45
+
+    def test_program_commands(self):
+        """Test program command values."""
+        assert LeggettPlattRichmatCommands.PROGRAM_ANTI_SNORE == 0x69
+        assert LeggettPlattRichmatCommands.PROGRAM_LOUNGE == 0x65
+        assert LeggettPlattRichmatCommands.PROGRAM_MEMORY_1 == 0x2B
+        assert LeggettPlattRichmatCommands.PROGRAM_MEMORY_2 == 0x2C
+        assert LeggettPlattRichmatCommands.PROGRAM_TV == 0x64
+        assert LeggettPlattRichmatCommands.PROGRAM_ZERO_G == 0x66
+
+    def test_motor_commands(self):
+        """Test motor command values."""
+        assert LeggettPlattRichmatCommands.MOTOR_PILLOW_UP == 0x3F
+        assert LeggettPlattRichmatCommands.MOTOR_PILLOW_DOWN == 0x40
+        assert LeggettPlattRichmatCommands.MOTOR_HEAD_UP == 0x24
+        assert LeggettPlattRichmatCommands.MOTOR_HEAD_DOWN == 0x25
+        assert LeggettPlattRichmatCommands.MOTOR_FEET_UP == 0x26
+        assert LeggettPlattRichmatCommands.MOTOR_FEET_DOWN == 0x27
+        assert LeggettPlattRichmatCommands.MOTOR_LUMBAR_UP == 0x41
+        assert LeggettPlattRichmatCommands.MOTOR_LUMBAR_DOWN == 0x42
+        assert LeggettPlattRichmatCommands.END == 0x6E
+
+    def test_massage_discrete_commands(self):
+        """Test discrete massage UP/DOWN command values.
+
+        This is the KEY differentiator from standard Richmat - discrete UP/DOWN
+        instead of step/toggle commands.
+        """
+        assert LeggettPlattRichmatCommands.MASSAGE_HEAD_UP == 0x4C
+        assert LeggettPlattRichmatCommands.MASSAGE_HEAD_DOWN == 0x4D
+        assert LeggettPlattRichmatCommands.MASSAGE_FOOT_UP == 0x4E
+        assert LeggettPlattRichmatCommands.MASSAGE_FOOT_DOWN == 0x4F
+        assert LeggettPlattRichmatCommands.MASSAGE_MOTOR_STOP == 0x47
+
+    def test_massage_additional_commands(self):
+        """Test additional massage command values."""
+        assert LeggettPlattRichmatCommands.MASSAGE_MOTOR1_ON_OFF == 0x32
+        assert LeggettPlattRichmatCommands.MASSAGE_MOTOR2_ON_OFF == 0x33
+        assert LeggettPlattRichmatCommands.MASSAGE_INCREASE_INTENSITY == 0x34
+        assert LeggettPlattRichmatCommands.MASSAGE_DECREASE_INTENSITY == 0x35
+        assert LeggettPlattRichmatCommands.MASSAGE_PATTERN_STEP == 0x38
+        assert LeggettPlattRichmatCommands.MASSAGE_WAVE == 0x39
+
+    def test_light_commands(self):
+        """Test light command values."""
+        assert LeggettPlattRichmatCommands.LIGHTS_TOGGLE == 0x3C
+
+
+@pytest.fixture
+def mock_leggett_richmat_config_entry_data() -> dict:
+    """Return mock config entry data for Leggett & Platt Richmat bed."""
+    return {
+        CONF_ADDRESS: "AA:BB:CC:DD:EE:FF",
+        CONF_NAME: "L&P Richmat Test Bed",
+        CONF_BED_TYPE: BED_TYPE_LEGGETT_PLATT_RICHMAT,
+        CONF_MOTOR_COUNT: 2,
+        CONF_HAS_MASSAGE: True,
+        CONF_DISABLE_ANGLE_SENSING: True,
+        CONF_PREFERRED_ADAPTER: "auto",
+    }
+
+
+@pytest.fixture
+def mock_leggett_richmat_config_entry(
+    hass: HomeAssistant, mock_leggett_richmat_config_entry_data: dict
+) -> MockConfigEntry:
+    """Return a mock config entry for Leggett & Platt Richmat bed."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="L&P Richmat Test Bed",
+        data=mock_leggett_richmat_config_entry_data,
+        unique_id="AA:BB:CC:DD:EE:FF",
+        entry_id="leggett_richmat_test_entry",
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+class TestLeggettPlattRichmatController:
+    """Test Leggett & Platt Richmat controller."""
+
+    async def test_control_characteristic_uuid(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test controller reports correct characteristic UUID."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        assert coordinator.controller.control_characteristic_uuid == LEGGETT_RICHMAT_CHAR_UUID
+
+    async def test_build_command_wilinke_format(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test command building produces correct WiLinke 5-byte format."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        command = coordinator.controller._build_command(LeggettPlattRichmatCommands.PRESET_FLAT)
+        assert len(command) == 5
+        assert command[0] == 0x6E
+        assert command[1] == 0x01
+        assert command[2] == 0x00
+        assert command[3] == LeggettPlattRichmatCommands.PRESET_FLAT
+
+    async def test_build_command_checksum(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test checksum calculation: (0x6E + 0x01 + 0x00 + cmd) & 0xFF."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        # Test with PRESET_FLAT (0x31)
+        command = coordinator.controller._build_command(LeggettPlattRichmatCommands.PRESET_FLAT)
+        expected_checksum = (0x6E + 0x01 + 0x00 + 0x31) & 0xFF
+        assert command[4] == expected_checksum
+
+        # Test with END command (0x6E) - checksum wraps around
+        command = coordinator.controller._build_command(LeggettPlattRichmatCommands.END)
+        expected_checksum = (0x6E + 0x01 + 0x00 + 0x6E) & 0xFF
+        assert command[4] == expected_checksum
+
+    async def test_write_command(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test writing a command to the bed."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        command = coordinator.controller._build_command(LeggettPlattRichmatCommands.END)
+        await coordinator.controller.write_command(command)
+
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, command, response=True
+        )
+
+    async def test_write_command_not_connected(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test writing command when not connected raises error."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        mock_bleak_client.is_connected = False
+
+        with pytest.raises(ConnectionError):
+            await coordinator.controller.write_command(
+                coordinator.controller._build_command(LeggettPlattRichmatCommands.END)
+            )
+
+
+class TestLeggettPlattRichmatCapabilities:
+    """Test controller capability properties."""
+
+    async def test_supports_preset_zero_g(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test controller reports zero gravity preset support."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+        assert coordinator.controller.supports_preset_zero_g is True
+
+    async def test_supports_preset_anti_snore(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test controller reports anti-snore preset support."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+        assert coordinator.controller.supports_preset_anti_snore is True
+
+    async def test_supports_preset_tv(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test controller reports TV preset support."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+        assert coordinator.controller.supports_preset_tv is True
+
+    async def test_supports_preset_lounge(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test controller reports lounge preset support."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+        assert coordinator.controller.supports_preset_lounge is True
+
+    async def test_has_no_lumbar_support(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test L&P Richmat beds don't have lumbar support."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+        assert coordinator.controller.has_lumbar_support is False
+
+    async def test_has_no_pillow_support(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test L&P Richmat beds don't have pillow support."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+        assert coordinator.controller.has_pillow_support is False
+
+    async def test_supports_lights(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test controller reports light support."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+        assert coordinator.controller.supports_lights is True
+
+    async def test_no_discrete_light_control(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test lights are toggle-only (no discrete on/off)."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+        assert coordinator.controller.supports_discrete_light_control is False
+
+    async def test_memory_slot_count(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test controller reports 2 memory slots."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+        assert coordinator.controller.memory_slot_count == 2
+
+    async def test_supports_memory_programming(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test controller supports memory programming."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+        assert coordinator.controller.supports_memory_programming is True
+
+    async def test_has_discrete_motor_control(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test controller reports discrete motor control (uses buttons not covers)."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+        assert coordinator.controller.has_discrete_motor_control is True
+
+
+class TestLeggettPlattRichmatMovement:
+    """Test Leggett & Platt Richmat movement commands."""
+
+    async def test_move_head_up(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test move head up sends correct command followed by END."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.move_head_up()
+
+        calls = mock_bleak_client.write_gatt_char.call_args_list
+        assert len(calls) > 1
+
+        # Last call should be END command
+        last_command = calls[-1][0][1]
+        expected_end = coordinator.controller._build_command(LeggettPlattRichmatCommands.END)
+        assert last_command == expected_end
+
+    async def test_move_head_down(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test move head down sends correct command followed by END."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.move_head_down()
+
+        calls = mock_bleak_client.write_gatt_char.call_args_list
+        assert len(calls) > 1
+
+    async def test_move_legs_up(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test move legs up sends FEET_UP command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.move_legs_up()
+
+        calls = mock_bleak_client.write_gatt_char.call_args_list
+        # First call should be FEET_UP
+        first_command = calls[0][0][1]
+        expected = coordinator.controller._build_command(LeggettPlattRichmatCommands.MOTOR_FEET_UP)
+        assert first_command == expected
+
+    async def test_move_legs_down(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test move legs down sends FEET_DOWN command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.move_legs_down()
+
+        calls = mock_bleak_client.write_gatt_char.call_args_list
+        first_command = calls[0][0][1]
+        expected = coordinator.controller._build_command(LeggettPlattRichmatCommands.MOTOR_FEET_DOWN)
+        assert first_command == expected
+
+    async def test_move_back_aliases_head(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test move_back_up is an alias for move_head_up."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.move_back_up()
+
+        calls = mock_bleak_client.write_gatt_char.call_args_list
+        first_command = calls[0][0][1]
+        expected = coordinator.controller._build_command(LeggettPlattRichmatCommands.MOTOR_HEAD_UP)
+        assert first_command == expected
+
+    async def test_move_feet_up(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test move_feet_up sends correct command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.move_feet_up()
+
+        calls = mock_bleak_client.write_gatt_char.call_args_list
+        first_command = calls[0][0][1]
+        expected = coordinator.controller._build_command(LeggettPlattRichmatCommands.MOTOR_FEET_UP)
+        assert first_command == expected
+
+    async def test_stop_all(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test stop all sends END command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.stop_all()
+
+        expected_end = coordinator.controller._build_command(LeggettPlattRichmatCommands.END)
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_end, response=True
+        )
+
+
+class TestLeggettPlattRichmatPresets:
+    """Test Leggett & Platt Richmat preset commands."""
+
+    async def test_preset_flat(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test preset flat command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.preset_flat()
+
+        expected_cmd = coordinator.controller._build_command(LeggettPlattRichmatCommands.PRESET_FLAT)
+        first_call = mock_bleak_client.write_gatt_char.call_args_list[0]
+        assert first_call[0][1] == expected_cmd
+
+    async def test_preset_zero_g(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test preset zero gravity command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.preset_zero_g()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.PRESET_ZERO_G
+        )
+        first_call = mock_bleak_client.write_gatt_char.call_args_list[0]
+        assert first_call[0][1] == expected_cmd
+
+    async def test_preset_anti_snore(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test preset anti-snore command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.preset_anti_snore()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.PRESET_ANTI_SNORE
+        )
+        first_call = mock_bleak_client.write_gatt_char.call_args_list[0]
+        assert first_call[0][1] == expected_cmd
+
+    async def test_preset_tv(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test preset TV command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.preset_tv()
+
+        expected_cmd = coordinator.controller._build_command(LeggettPlattRichmatCommands.PRESET_TV)
+        first_call = mock_bleak_client.write_gatt_char.call_args_list[0]
+        assert first_call[0][1] == expected_cmd
+
+    async def test_preset_lounge(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test preset lounge command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.preset_lounge()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.PRESET_LOUNGE
+        )
+        first_call = mock_bleak_client.write_gatt_char.call_args_list[0]
+        assert first_call[0][1] == expected_cmd
+
+    @pytest.mark.parametrize(
+        "memory_num,expected_value",
+        [
+            (1, LeggettPlattRichmatCommands.PRESET_MEMORY_1),
+            (2, LeggettPlattRichmatCommands.PRESET_MEMORY_2),
+        ],
+    )
+    async def test_preset_memory(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+        memory_num: int,
+        expected_value: int,
+    ):
+        """Test preset memory commands."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.preset_memory(memory_num)
+
+        expected_cmd = coordinator.controller._build_command(expected_value)
+        first_call = mock_bleak_client.write_gatt_char.call_args_list[0]
+        assert first_call[0][1] == expected_cmd
+
+    async def test_preset_memory_invalid(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+        caplog,
+    ):
+        """Test invalid memory number logs warning."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.preset_memory(3)
+
+        assert "Invalid memory number 3" in caplog.text
+        # Should not write any command
+        assert mock_bleak_client.write_gatt_char.call_count == 0
+
+    @pytest.mark.parametrize(
+        "memory_num,expected_value",
+        [
+            (1, LeggettPlattRichmatCommands.PROGRAM_MEMORY_1),
+            (2, LeggettPlattRichmatCommands.PROGRAM_MEMORY_2),
+        ],
+    )
+    async def test_program_memory(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+        memory_num: int,
+        expected_value: int,
+    ):
+        """Test program memory commands."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.program_memory(memory_num)
+
+        expected_cmd = coordinator.controller._build_command(expected_value)
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_cmd, response=True
+        )
+
+
+class TestLeggettPlattRichmatLights:
+    """Test Leggett & Platt Richmat light commands."""
+
+    async def test_lights_toggle(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test lights toggle command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.lights_toggle()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.LIGHTS_TOGGLE
+        )
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_cmd, response=True
+        )
+
+    async def test_lights_on_is_toggle(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test lights_on calls toggle (no discrete control)."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.lights_on()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.LIGHTS_TOGGLE
+        )
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_cmd, response=True
+        )
+
+    async def test_lights_off_is_toggle(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test lights_off calls toggle (no discrete control)."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.lights_off()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.LIGHTS_TOGGLE
+        )
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_cmd, response=True
+        )
+
+
+class TestLeggettPlattRichmatMassage:
+    """Test Leggett & Platt Richmat massage commands.
+
+    KEY DIFFERENTIATOR: This controller has discrete UP/DOWN commands for
+    massage intensity (0x4C-0x4F) instead of just step/toggle commands.
+    """
+
+    async def test_massage_head_up(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test massage head up sends discrete UP command (0x4C)."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.massage_head_up()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.MASSAGE_HEAD_UP
+        )
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_cmd, response=True
+        )
+
+    async def test_massage_head_down(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test massage head down sends discrete DOWN command (0x4D)."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.massage_head_down()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.MASSAGE_HEAD_DOWN
+        )
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_cmd, response=True
+        )
+
+    async def test_massage_foot_up(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test massage foot up sends discrete UP command (0x4E)."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.massage_foot_up()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.MASSAGE_FOOT_UP
+        )
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_cmd, response=True
+        )
+
+    async def test_massage_foot_down(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test massage foot down sends discrete DOWN command (0x4F)."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.massage_foot_down()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.MASSAGE_FOOT_DOWN
+        )
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_cmd, response=True
+        )
+
+    async def test_massage_off(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test massage off command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.massage_off()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.MASSAGE_MOTOR_STOP
+        )
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_cmd, response=True
+        )
+
+    async def test_massage_toggle(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test massage toggle command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.massage_toggle()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.MASSAGE_MOTOR1_ON_OFF
+        )
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_cmd, response=True
+        )
+
+    async def test_massage_head_toggle(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test head massage toggle command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.massage_head_toggle()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.MASSAGE_MOTOR1_ON_OFF
+        )
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_cmd, response=True
+        )
+
+    async def test_massage_foot_toggle(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test foot massage toggle command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.massage_foot_toggle()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.MASSAGE_MOTOR2_ON_OFF
+        )
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_cmd, response=True
+        )
+
+    async def test_massage_intensity_up(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test overall massage intensity up command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.massage_intensity_up()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.MASSAGE_INCREASE_INTENSITY
+        )
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_cmd, response=True
+        )
+
+    async def test_massage_intensity_down(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test overall massage intensity down command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.massage_intensity_down()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.MASSAGE_DECREASE_INTENSITY
+        )
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_cmd, response=True
+        )
+
+    async def test_massage_mode_step(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test massage mode step command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.massage_mode_step()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.MASSAGE_PATTERN_STEP
+        )
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_cmd, response=True
+        )
+
+    async def test_massage_wave_toggle(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Test massage wave toggle command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.massage_wave_toggle()
+
+        expected_cmd = coordinator.controller._build_command(
+            LeggettPlattRichmatCommands.MASSAGE_WAVE
+        )
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            LEGGETT_RICHMAT_CHAR_UUID, expected_cmd, response=True
+        )
+
+
+class TestLeggettPlattRichmatPositionNotifications:
+    """Test Leggett & Platt Richmat position notification handling."""
+
+    async def test_start_notify_no_support(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+        caplog,
+    ):
+        """Test that L&P Richmat doesn't support position notifications."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        callback = MagicMock()
+        await coordinator.controller.start_notify(callback)
+
+        assert "don't support position notifications" in caplog.text
+
+    async def test_read_positions_noop(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_richmat_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test read_positions does nothing (not supported)."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_richmat_config_entry)
+        await coordinator.async_connect()
+
+        # Should complete without error
+        await coordinator.controller.read_positions()


### PR DESCRIPTION
Hi, thanks for making this project. I seem to have a weird bed that is a combination of leggett platt and richmat. I could not get the identified bed to work well, so I had claude vibe code this new bed type. The main problem I had is that i needed to be able to send up and down signals, not just cycle. Feel free to completely ignore this. I have barely looked at the code. But if there is some value in here, and you want me to go over the code better, let me know what would be helpful.

These beds (device name prefix "mlrm") use WiLinke protocol but have incompatible massage command semantics with standard Richmat controllers.

The same command bytes mean different things:
- 0x4C: Standard Richmat = "cycle massage patterns" vs L&P Richmat = "increase head massage"
- 0x4E: Standard Richmat = "cycle massage patterns" vs L&P Richmat = "increase foot massage"

This collision required a separate controller rather than subclassing, since inheriting massage methods would produce incorrect behavior.

Includes discrete massage intensity up/down, wave mode, timers, and extended controls reverse-engineered from the LP Adjustable Bed app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Leggett & Platt Richmat adjustable beds
  * Added discrete head and legs motor control buttons
  * Added preset positions (flat, zero-G, anti-snore, TV, lounge) and memory slot support
  * Added lighting and massage control features for compatible devices

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->