### PR TITLE
feat: Add set_position service for precise motor positioning

### DIFF
--- a/custom_components/adjustable_bed/services.yaml
+++ b/custom_components/adjustable_bed/services.yaml
@@ -52,6 +52,42 @@ stop_all:
         device:
           integration: adjustable_bed
 
+set_position:
+  name: Set Motor Position
+  description: Move a motor to a specific position and stop when reached. Only works for beds with position feedback (Linak, Okimat, Reverie, Keeson, Ergomotion).
+  fields:
+    device_id:
+      name: Device
+      description: The adjustable bed device.
+      required: true
+      selector:
+        device:
+          integration: adjustable_bed
+    motor:
+      name: Motor
+      description: The motor to move.
+      required: true
+      selector:
+        select:
+          options:
+            - label: Back
+              value: back
+            - label: Legs
+              value: legs
+            - label: Head
+              value: head
+            - label: Feet
+              value: feet
+    position:
+      name: Position
+      description: Target position (0-68° for back/head, 0-45° for legs/feet, 0-100% for Keeson/Ergomotion).
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 100
+          mode: slider
+
 run_diagnostics:
   name: Run BLE Diagnostics
   description: Capture BLE protocol data from a device for troubleshooting and adding support for new bed models. Either provide a configured device or a target MAC address.

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -431,6 +431,24 @@
           "description": "Include recent log entries related to the integration."
         }
       }
+    },
+    "set_position": {
+      "name": "Set Motor Position",
+      "description": "Move a motor to a specific position and stop when reached.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The adjustable bed device."
+        },
+        "motor": {
+          "name": "Motor",
+          "description": "The motor to move (back, legs, head, or feet)."
+        },
+        "position": {
+          "name": "Position",
+          "description": "Target position (degrees or percentage depending on bed type)."
+        }
+      }
     }
   },
   "exceptions": {
@@ -448,6 +466,18 @@
     },
     "devices_not_found": {
       "message": "Could not find Adjustable Bed device(s) with ID(s): {device_ids}."
+    },
+    "position_feedback_not_supported": {
+      "message": "Device \"{device_name}\" (type: {bed_type}) does not support position feedback. Only Linak, Okimat, Reverie, Keeson, and Ergomotion beds support this feature."
+    },
+    "angle_sensing_disabled": {
+      "message": "Angle sensing is disabled for device \"{device_name}\". Enable angle sensing in the device configuration to use position control."
+    },
+    "invalid_motor_for_bed_type": {
+      "message": "Motor \"{motor}\" is not valid for device \"{device_name}\". Valid motors: {valid_motors}."
+    },
+    "invalid_position_range": {
+      "message": "Position {position} is out of range for motor \"{motor}\". Valid range: 0-{max_value}{unit}."
     }
   },
   "issues": {


### PR DESCRIPTION
## Summary
- Add new `set_position` service that moves a motor to a specific target position and stops automatically when reached
- Uses the existing `async_seek_position()` closed-loop feedback control in the coordinator
- Validates bed type supports position feedback (Linak, Okimat, Reverie, Keeson, Ergomotion)
- Validates angle sensing is enabled and motor is valid for the bed configuration
- Includes UI selectors for device, motor dropdown, and position slider

## Test plan
- [ ] Call service from Developer Tools → Services
- [ ] Verify motor moves to target position and stops
- [ ] Verify error handling for unsupported beds
- [ ] Test with automation/script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Set Motor Position" service to move adjustable bed motors to specific positions and stop when reached.
  * Supports motor selection (back, legs, head, feet) with position control via 0-100 slider.
  * Includes validation for device compatibility, angle sensing, valid motors, and position ranges with descriptive error messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->