### PR TITLE
fix: Add STOP commands to preset methods and consolidate factory

### DIFF
--- a/custom_components/adjustable_bed/beds/leggett_gen2.py
+++ b/custom_components/adjustable_bed/beds/leggett_gen2.py
@@ -240,11 +240,20 @@ class LeggettGen2Controller(BedController):
     # Preset methods
     async def preset_flat(self) -> None:
         """Go to flat position."""
-        await self.write_command(
-            LeggettGen2Commands.PRESET_FLAT,
-            repeat_count=100,
-            repeat_delay_ms=300,
-        )
+        try:
+            await self.write_command(
+                LeggettGen2Commands.PRESET_FLAT,
+                repeat_count=100,
+                repeat_delay_ms=300,
+            )
+        finally:
+            try:
+                await self.write_command(
+                    LeggettGen2Commands.STOP,
+                    cancel_event=asyncio.Event(),
+                )
+            except Exception:
+                _LOGGER.debug("Failed to send STOP command during preset_flat cleanup")
 
     async def preset_memory(self, memory_num: int) -> None:
         """Go to memory preset."""
@@ -255,7 +264,16 @@ class LeggettGen2Controller(BedController):
             4: LeggettGen2Commands.PRESET_RELAX,
         }
         if command := commands.get(memory_num):
-            await self.write_command(command, repeat_count=100, repeat_delay_ms=300)
+            try:
+                await self.write_command(command, repeat_count=100, repeat_delay_ms=300)
+            finally:
+                try:
+                    await self.write_command(
+                        LeggettGen2Commands.STOP,
+                        cancel_event=asyncio.Event(),
+                    )
+                except Exception:
+                    _LOGGER.debug("Failed to send STOP command during preset_memory cleanup")
 
     async def program_memory(self, memory_num: int) -> None:
         """Program current position to memory."""
@@ -274,11 +292,20 @@ class LeggettGen2Controller(BedController):
 
     async def preset_anti_snore(self) -> None:
         """Go to anti-snore position."""
-        await self.write_command(
-            LeggettGen2Commands.PRESET_ANTI_SNORE,
-            repeat_count=100,
-            repeat_delay_ms=300,
-        )
+        try:
+            await self.write_command(
+                LeggettGen2Commands.PRESET_ANTI_SNORE,
+                repeat_count=100,
+                repeat_delay_ms=300,
+            )
+        finally:
+            try:
+                await self.write_command(
+                    LeggettGen2Commands.STOP,
+                    cancel_event=asyncio.Event(),
+                )
+            except Exception:
+                _LOGGER.debug("Failed to send STOP command during preset_anti_snore cleanup")
 
     # Light methods
     async def lights_toggle(self) -> None:

--- a/custom_components/adjustable_bed/beds/leggett_okin.py
+++ b/custom_components/adjustable_bed/beds/leggett_okin.py
@@ -276,11 +276,20 @@ class LeggettOkinController(BedController):
     # Preset methods
     async def preset_flat(self) -> None:
         """Go to flat position."""
-        await self.write_command(
-            self._build_command(LeggettOkinCommands.PRESET_FLAT),
-            repeat_count=100,
-            repeat_delay_ms=300,
-        )
+        try:
+            await self.write_command(
+                self._build_command(LeggettOkinCommands.PRESET_FLAT),
+                repeat_count=100,
+                repeat_delay_ms=300,
+            )
+        finally:
+            try:
+                await self.write_command(
+                    self._build_command(0),
+                    cancel_event=asyncio.Event(),
+                )
+            except Exception:
+                _LOGGER.debug("Failed to send STOP command during preset_flat cleanup")
 
     async def preset_memory(self, memory_num: int) -> None:
         """Go to memory preset."""
@@ -291,11 +300,20 @@ class LeggettOkinController(BedController):
             4: LeggettOkinCommands.PRESET_MEMORY_4,
         }
         if command := commands.get(memory_num):
-            await self.write_command(
-                self._build_command(command),
-                repeat_count=100,
-                repeat_delay_ms=300,
-            )
+            try:
+                await self.write_command(
+                    self._build_command(command),
+                    repeat_count=100,
+                    repeat_delay_ms=300,
+                )
+            finally:
+                try:
+                    await self.write_command(
+                        self._build_command(0),
+                        cancel_event=asyncio.Event(),
+                    )
+                except Exception:
+                    _LOGGER.debug("Failed to send STOP command during preset_memory cleanup")
 
     async def program_memory(self, memory_num: int) -> None:
         """Program current position to memory (not supported on Okin)."""
@@ -306,11 +324,20 @@ class LeggettOkinController(BedController):
 
     async def preset_zero_g(self) -> None:
         """Go to zero gravity position."""
-        await self.write_command(
-            self._build_command(LeggettOkinCommands.PRESET_ZERO_G),
-            repeat_count=100,
-            repeat_delay_ms=300,
-        )
+        try:
+            await self.write_command(
+                self._build_command(LeggettOkinCommands.PRESET_ZERO_G),
+                repeat_count=100,
+                repeat_delay_ms=300,
+            )
+        finally:
+            try:
+                await self.write_command(
+                    self._build_command(0),
+                    cancel_event=asyncio.Event(),
+                )
+            except Exception:
+                _LOGGER.debug("Failed to send STOP command during preset_zero_g cleanup")
 
     async def preset_anti_snore(self) -> None:
         """Go to anti-snore position (not supported on Okin)."""

--- a/custom_components/adjustable_bed/beds/okin_handle.py
+++ b/custom_components/adjustable_bed/beds/okin_handle.py
@@ -271,11 +271,20 @@ class OkinHandleController(BedController):
     # Preset methods
     async def preset_flat(self) -> None:
         """Go to flat position."""
-        await self.write_command(
-            OkinHandleCommands.FLAT,
-            repeat_count=100,
-            repeat_delay_ms=300,
-        )
+        try:
+            await self.write_command(
+                OkinHandleCommands.FLAT,
+                repeat_count=100,
+                repeat_delay_ms=300,
+            )
+        finally:
+            try:
+                await self.write_command(
+                    OkinHandleCommands.STOP,
+                    cancel_event=asyncio.Event(),
+                )
+            except Exception:
+                _LOGGER.debug("Failed to send STOP command during preset_flat cleanup")
 
     async def preset_memory(self, memory_num: int) -> None:
         """Go to memory preset."""
@@ -284,7 +293,16 @@ class OkinHandleController(BedController):
             2: OkinHandleCommands.MEMORY_2,
         }
         if command := commands.get(memory_num):
-            await self.write_command(command, repeat_count=100, repeat_delay_ms=300)
+            try:
+                await self.write_command(command, repeat_count=100, repeat_delay_ms=300)
+            finally:
+                try:
+                    await self.write_command(
+                        OkinHandleCommands.STOP,
+                        cancel_event=asyncio.Event(),
+                    )
+                except Exception:
+                    _LOGGER.debug("Failed to send STOP command during preset_memory cleanup")
         else:
             _LOGGER.warning("Okin handle beds only support memory presets 1 and 2")
 
@@ -297,27 +315,54 @@ class OkinHandleController(BedController):
 
     async def preset_zero_g(self) -> None:
         """Go to zero gravity position."""
-        await self.write_command(
-            OkinHandleCommands.ZERO_G,
-            repeat_count=100,
-            repeat_delay_ms=300,
-        )
+        try:
+            await self.write_command(
+                OkinHandleCommands.ZERO_G,
+                repeat_count=100,
+                repeat_delay_ms=300,
+            )
+        finally:
+            try:
+                await self.write_command(
+                    OkinHandleCommands.STOP,
+                    cancel_event=asyncio.Event(),
+                )
+            except Exception:
+                _LOGGER.debug("Failed to send STOP command during preset_zero_g cleanup")
 
     async def preset_tv(self) -> None:
         """Go to TV position."""
-        await self.write_command(
-            OkinHandleCommands.TV,
-            repeat_count=100,
-            repeat_delay_ms=300,
-        )
+        try:
+            await self.write_command(
+                OkinHandleCommands.TV,
+                repeat_count=100,
+                repeat_delay_ms=300,
+            )
+        finally:
+            try:
+                await self.write_command(
+                    OkinHandleCommands.STOP,
+                    cancel_event=asyncio.Event(),
+                )
+            except Exception:
+                _LOGGER.debug("Failed to send STOP command during preset_tv cleanup")
 
     async def preset_anti_snore(self) -> None:
         """Go to quiet sleep/anti-snore position."""
-        await self.write_command(
-            OkinHandleCommands.QUIET_SLEEP,
-            repeat_count=100,
-            repeat_delay_ms=300,
-        )
+        try:
+            await self.write_command(
+                OkinHandleCommands.QUIET_SLEEP,
+                repeat_count=100,
+                repeat_delay_ms=300,
+            )
+        finally:
+            try:
+                await self.write_command(
+                    OkinHandleCommands.STOP,
+                    cancel_event=asyncio.Event(),
+                )
+            except Exception:
+                _LOGGER.debug("Failed to send STOP command during preset_anti_snore cleanup")
 
     # Light methods
     async def lights_toggle(self) -> None:

--- a/custom_components/adjustable_bed/beds/okin_nordic.py
+++ b/custom_components/adjustable_bed/beds/okin_nordic.py
@@ -136,6 +136,9 @@ class OkinNordicController(BedController):
 
         # Send init sequence on first command
         if not self._initialized:
+            if effective_cancel is not None and effective_cancel.is_set():
+                _LOGGER.info("Command cancelled before init sequence")
+                return
             _LOGGER.debug("Sending init sequence before first command")
             try:
                 await self.client.write_gatt_char(

--- a/custom_components/adjustable_bed/controller_factory.py
+++ b/custom_components/adjustable_bed/controller_factory.py
@@ -91,7 +91,7 @@ async def create_controller(
 
         return OkinHandleController(coordinator)
 
-    if bed_type == BED_TYPE_OKIN_UUID:
+    if bed_type in (BED_TYPE_OKIN_UUID, BED_TYPE_OKIMAT):
         from .beds.okin_uuid import OkinUuidController
 
         # Pass the configured variant (remote code) to the controller
@@ -248,14 +248,6 @@ async def create_controller(
         from .beds.reverie import ReverieController
 
         return ReverieController(coordinator)
-
-    if bed_type == BED_TYPE_OKIMAT:
-        from .beds.okin_uuid import OkinUuidController
-
-        # Pass the configured variant (remote code) to the controller
-        variant = protocol_variant or "auto"
-        _LOGGER.debug("Using Okin UUID variant: %s", variant)
-        return OkinUuidController(coordinator, variant=variant)
 
     if bed_type == BED_TYPE_ERGOMOTION:
         # Ergomotion uses the same protocol as Keeson with position feedback

--- a/tests/test_okin_handle.py
+++ b/tests/test_okin_handle.py
@@ -360,7 +360,7 @@ class TestOkinHandlePresets:
         assert first_call[0][1] == OkinHandleCommands.QUIET_SLEEP
 
     @pytest.mark.parametrize(
-        "memory_num,expected_command",
+        ("memory_num", "expected_command"),
         [
             (1, OkinHandleCommands.MEMORY_1),
             (2, OkinHandleCommands.MEMORY_2),

--- a/tests/test_okin_uuid.py
+++ b/tests/test_okin_uuid.py
@@ -397,11 +397,7 @@ class TestOkinUuidMovement:
 class TestOkinUuidMultiMotor:
     """Test Okin UUID multi-motor command support."""
 
-    def test_get_move_command_empty_state(
-        self,
-        hass: HomeAssistant,
-        mock_okin_uuid_config_entry,
-    ):
+    def test_get_move_command_empty_state(self):
         """Test combined command with no active motors."""
 
         # Create controller without full coordinator setup
@@ -411,11 +407,7 @@ class TestOkinUuidMultiMotor:
         controller = OkinUuidController(MockCoordinator(), OKIMAT_VARIANT_82417)
         assert controller._get_move_command() == 0
 
-    def test_get_move_command_single_motor(
-        self,
-        hass: HomeAssistant,
-        mock_okin_uuid_config_entry,
-    ):
+    def test_get_move_command_single_motor(self):
         """Test combined command with single motor."""
 
         class MockCoordinator:


### PR DESCRIPTION
## Summary

- Wrap preset methods in try/finally to always send STOP command after completion or cancellation
- Add cancellation check before init sequence in okin_nordic.py
- Consolidate duplicate OkinUuidController branches in controller_factory.py
- Fix linting issues in test files

## Changes

### Preset STOP Commands
Added try/finally blocks to ensure STOP is always sent after preset commands:
- **leggett_gen2.py**: `preset_flat`, `preset_memory`, `preset_anti_snore`
- **leggett_okin.py**: `preset_flat`, `preset_memory`, `preset_zero_g`
- **okin_handle.py**: `preset_flat`, `preset_memory`, `preset_zero_g`, `preset_tv`, `preset_anti_snore`

### okin_nordic.py
- Check cancellation event before sending init sequence to avoid unnecessary BLE writes

### controller_factory.py
- Consolidate duplicate `BED_TYPE_OKIN_UUID` and `BED_TYPE_OKIMAT` branches into single condition

### Test Fixes
- **test_okin_handle.py**: Fix PT006 - use tuple for pytest.mark.parametrize argnames
- **test_okin_uuid.py**: Remove unused fixture parameters from unit tests

## Test plan

- [x] All 556 tests pass