### PR TITLE
feat: Add support for Malouf NEW_OKIN and LEGACY_OKIN protocols

### DIFF
--- a/custom_components/adjustable_bed/beds/malouf.py
+++ b/custom_components/adjustable_bed/beds/malouf.py
@@ -1,0 +1,691 @@
+"""Malouf bed controller implementations.
+
+Reverse-engineered from Malouf Base app v2.4.3.
+
+Malouf beds use two distinct protocols:
+- NEW_OKIN: 8-byte commands via Nordic UART, advertises unique service UUID
+- LEGACY_OKIN: 9-byte commands with checksum via FFE5 service
+
+Both protocols share the same command values but differ in encoding.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from bleak.exc import BleakError
+
+from ..const import (
+    MALOUF_LEGACY_OKIN_WRITE_CHAR_UUID,
+    MALOUF_NEW_OKIN_WRITE_CHAR_UUID,
+)
+from .base import BedController
+
+if TYPE_CHECKING:
+    from ..coordinator import AdjustableBedCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MaloufCommands:
+    """Malouf command constants (32-bit values).
+
+    These values are shared by both NEW_OKIN and LEGACY_OKIN protocols.
+    The encoding differs but the command semantics are identical.
+    """
+
+    # Motors
+    HEAD_UP = 0x1
+    HEAD_DOWN = 0x2
+    FOOT_UP = 0x4
+    FOOT_DOWN = 0x8
+    HEAD_TILT_UP = 0x10
+    HEAD_TILT_DOWN = 0x20
+    LUMBAR_UP = 0x40
+    LUMBAR_DOWN = 0x80
+    DUAL_UP = 0x5  # HEAD_UP | FOOT_UP
+    DUAL_DOWN = 0xA  # HEAD_DOWN | FOOT_DOWN
+    STOP = 0x0
+
+    # Presets
+    ALL_FLAT = 0x8000000
+    ZERO_G = 0x1000
+    LOUNGE = 0x2000
+    ANTI_SNORE = 0x8000
+    TV_READ = 0x4000
+    MEMORY_1 = 0x10000
+    MEMORY_2 = 0x40000
+
+    # Lights & Massage
+    LIGHT_SWITCH = 0x20000
+    MASSAGE_HEAD = 0x800
+    MASSAGE_FOOT = 0x400
+    MASSAGE_HEAD_MINUS = 0x800000
+    MASSAGE_FOOT_MINUS = 0x1000000
+    MASSAGE_TIMER = 0x200
+    MASSAGE_OFF = 0x2000000
+
+
+class MaloufNewOkinController(BedController):
+    """Controller for Malouf beds using NEW_OKIN protocol.
+
+    Protocol characteristics:
+    - Advertised service: 01000001-0000-1000-8000-00805f9b34fb (unique identifier)
+    - Command service: Nordic UART (6e400001-b5a3-f393-e0a9-e50e24dcca9e)
+    - Write characteristic: 6e400002-b5a3-f393-e0a9-e50e24dcca9e
+    - Command format: 8 bytes, no checksum
+      [0x05, 0x02, (cmd>>24)&0xFF, (cmd>>16)&0xFF, (cmd>>8)&0xFF, cmd&0xFF, 0x00, 0x00]
+    """
+
+    def __init__(self, coordinator: AdjustableBedCoordinator) -> None:
+        """Initialize the Malouf NEW_OKIN controller."""
+        super().__init__(coordinator)
+        self._notify_callback: Callable[[str, float], None] | None = None
+        _LOGGER.debug("MaloufNewOkinController initialized")
+
+    @property
+    def control_characteristic_uuid(self) -> str:
+        """Return the UUID of the control characteristic."""
+        return MALOUF_NEW_OKIN_WRITE_CHAR_UUID
+
+    # Capability properties
+    @property
+    def supports_preset_zero_g(self) -> bool:
+        return True
+
+    @property
+    def supports_preset_anti_snore(self) -> bool:
+        return True
+
+    @property
+    def supports_preset_tv(self) -> bool:
+        return True
+
+    @property
+    def supports_preset_lounge(self) -> bool:
+        return True
+
+    @property
+    def has_lumbar_support(self) -> bool:
+        return True
+
+    @property
+    def has_tilt_support(self) -> bool:
+        return True
+
+    @property
+    def supports_lights(self) -> bool:
+        """Return True - these beds support lighting."""
+        return True
+
+    @property
+    def supports_discrete_light_control(self) -> bool:
+        """Return False - only toggle control available."""
+        return False
+
+    @property
+    def memory_slot_count(self) -> int:
+        """Return 2 - Malouf beds support memory slots 1-2."""
+        return 2
+
+    @property
+    def supports_memory_programming(self) -> bool:
+        """Return False - Malouf beds don't support programming memory positions."""
+        return False
+
+    def _build_command(self, command_value: int) -> bytes:
+        """Build an 8-byte NEW_OKIN command.
+
+        Format: [0x05, 0x02, (cmd>>24)&0xFF, (cmd>>16)&0xFF, (cmd>>8)&0xFF, cmd&0xFF, 0x00, 0x00]
+        """
+        return bytes([
+            0x05,
+            0x02,
+            (command_value >> 24) & 0xFF,
+            (command_value >> 16) & 0xFF,
+            (command_value >> 8) & 0xFF,
+            command_value & 0xFF,
+            0x00,
+            0x00,
+        ])
+
+    async def write_command(
+        self,
+        command: bytes,
+        repeat_count: int = 1,
+        repeat_delay_ms: int = 100,
+        cancel_event: asyncio.Event | None = None,
+    ) -> None:
+        """Write a command to the bed."""
+        _LOGGER.debug(
+            "Writing command to Malouf NEW_OKIN bed: %s (repeat: %d, delay: %dms)",
+            command.hex(),
+            repeat_count,
+            repeat_delay_ms,
+        )
+        await self._write_gatt_with_retry(
+            MALOUF_NEW_OKIN_WRITE_CHAR_UUID,
+            command,
+            repeat_count=repeat_count,
+            repeat_delay_ms=repeat_delay_ms,
+            cancel_event=cancel_event,
+        )
+
+    async def start_notify(self, callback: Callable[[str, float], None]) -> None:
+        """Start listening for position notifications."""
+        # These beds don't support position feedback
+        self._notify_callback = callback
+        _LOGGER.debug("Malouf NEW_OKIN beds don't support position notifications")
+
+    async def stop_notify(self) -> None:
+        """Stop listening for position notifications."""
+        self._notify_callback = None
+
+    async def read_positions(self, motor_count: int = 2) -> None:
+        """Read current motor positions - not supported."""
+        pass
+
+    async def _move_with_stop(self, command_value: int) -> None:
+        """Execute a movement command and always send STOP at the end."""
+        command = self._build_command(command_value)
+        try:
+            pulse_count = self._coordinator.motor_pulse_count
+            pulse_delay = self._coordinator.motor_pulse_delay_ms
+            await self.write_command(command, repeat_count=pulse_count, repeat_delay_ms=pulse_delay)
+        finally:
+            try:
+                await self.write_command(
+                    self._build_command(MaloufCommands.STOP),
+                    cancel_event=asyncio.Event(),
+                )
+            except (BleakError, ConnectionError):
+                _LOGGER.debug("Failed to send STOP command during cleanup", exc_info=True)
+
+    # Motor control methods
+    async def move_head_up(self) -> None:
+        """Move head up."""
+        await self._move_with_stop(MaloufCommands.HEAD_UP)
+
+    async def move_head_down(self) -> None:
+        """Move head down."""
+        await self._move_with_stop(MaloufCommands.HEAD_DOWN)
+
+    async def move_head_stop(self) -> None:
+        """Stop head movement."""
+        await self.write_command(
+            self._build_command(MaloufCommands.STOP), cancel_event=asyncio.Event()
+        )
+
+    async def move_back_up(self) -> None:
+        """Move back up (same as head)."""
+        await self.move_head_up()
+
+    async def move_back_down(self) -> None:
+        """Move back down (same as head)."""
+        await self.move_head_down()
+
+    async def move_back_stop(self) -> None:
+        """Stop back movement."""
+        await self.move_head_stop()
+
+    async def move_legs_up(self) -> None:
+        """Move legs up (same as feet)."""
+        await self.move_feet_up()
+
+    async def move_legs_down(self) -> None:
+        """Move legs down (same as feet)."""
+        await self.move_feet_down()
+
+    async def move_legs_stop(self) -> None:
+        """Stop legs movement."""
+        await self.move_feet_stop()
+
+    async def move_feet_up(self) -> None:
+        """Move feet up."""
+        await self._move_with_stop(MaloufCommands.FOOT_UP)
+
+    async def move_feet_down(self) -> None:
+        """Move feet down."""
+        await self._move_with_stop(MaloufCommands.FOOT_DOWN)
+
+    async def move_feet_stop(self) -> None:
+        """Stop feet movement."""
+        await self.write_command(
+            self._build_command(MaloufCommands.STOP), cancel_event=asyncio.Event()
+        )
+
+    # Lumbar control
+    async def move_lumbar_up(self) -> None:
+        """Move lumbar up."""
+        await self._move_with_stop(MaloufCommands.LUMBAR_UP)
+
+    async def move_lumbar_down(self) -> None:
+        """Move lumbar down."""
+        await self._move_with_stop(MaloufCommands.LUMBAR_DOWN)
+
+    async def move_lumbar_stop(self) -> None:
+        """Stop lumbar movement."""
+        await self.write_command(
+            self._build_command(MaloufCommands.STOP), cancel_event=asyncio.Event()
+        )
+
+    # Tilt control
+    async def move_tilt_up(self) -> None:
+        """Move tilt up."""
+        await self._move_with_stop(MaloufCommands.HEAD_TILT_UP)
+
+    async def move_tilt_down(self) -> None:
+        """Move tilt down."""
+        await self._move_with_stop(MaloufCommands.HEAD_TILT_DOWN)
+
+    async def move_tilt_stop(self) -> None:
+        """Stop tilt movement."""
+        await self.write_command(
+            self._build_command(MaloufCommands.STOP), cancel_event=asyncio.Event()
+        )
+
+    async def stop_all(self) -> None:
+        """Stop all movement."""
+        await self.write_command(
+            self._build_command(MaloufCommands.STOP), cancel_event=asyncio.Event()
+        )
+
+    # Preset methods
+    async def preset_flat(self) -> None:
+        """Go to flat position."""
+        await self.write_command(self._build_command(MaloufCommands.ALL_FLAT))
+
+    async def preset_zero_g(self) -> None:
+        """Go to zero-G position."""
+        await self.write_command(self._build_command(MaloufCommands.ZERO_G))
+
+    async def preset_anti_snore(self) -> None:
+        """Go to anti-snore position."""
+        await self.write_command(self._build_command(MaloufCommands.ANTI_SNORE))
+
+    async def preset_tv(self) -> None:
+        """Go to TV/reading position."""
+        await self.write_command(self._build_command(MaloufCommands.TV_READ))
+
+    async def preset_lounge(self) -> None:
+        """Go to lounge position."""
+        await self.write_command(self._build_command(MaloufCommands.LOUNGE))
+
+    async def preset_memory(self, memory_num: int) -> None:
+        """Go to memory preset."""
+        commands = {
+            1: MaloufCommands.MEMORY_1,
+            2: MaloufCommands.MEMORY_2,
+        }
+        if command := commands.get(memory_num):
+            await self.write_command(self._build_command(command))
+        else:
+            _LOGGER.warning("Memory slot %d not supported on Malouf beds", memory_num)
+
+    async def program_memory(self, memory_num: int) -> None:
+        """Program current position to memory (not supported)."""
+        _LOGGER.warning(
+            "Malouf beds don't support programming memory presets (requested: %d)", memory_num
+        )
+
+    # Light control
+    async def lights_toggle(self) -> None:
+        """Toggle lights."""
+        await self.write_command(self._build_command(MaloufCommands.LIGHT_SWITCH))
+
+    async def lights_on(self) -> None:
+        """Turn on lights (toggle only)."""
+        await self.lights_toggle()
+
+    async def lights_off(self) -> None:
+        """Turn off lights (toggle only)."""
+        await self.lights_toggle()
+
+    # Massage control
+    async def massage_head_toggle(self) -> None:
+        """Increase head massage intensity."""
+        await self.write_command(self._build_command(MaloufCommands.MASSAGE_HEAD))
+
+    async def massage_foot_toggle(self) -> None:
+        """Increase foot massage intensity."""
+        await self.write_command(self._build_command(MaloufCommands.MASSAGE_FOOT))
+
+    async def massage_head_up(self) -> None:
+        """Increase head massage intensity."""
+        await self.write_command(self._build_command(MaloufCommands.MASSAGE_HEAD))
+
+    async def massage_head_down(self) -> None:
+        """Decrease head massage intensity."""
+        await self.write_command(self._build_command(MaloufCommands.MASSAGE_HEAD_MINUS))
+
+    async def massage_foot_up(self) -> None:
+        """Increase foot massage intensity."""
+        await self.write_command(self._build_command(MaloufCommands.MASSAGE_FOOT))
+
+    async def massage_foot_down(self) -> None:
+        """Decrease foot massage intensity."""
+        await self.write_command(self._build_command(MaloufCommands.MASSAGE_FOOT_MINUS))
+
+    async def massage_off(self) -> None:
+        """Turn off massage."""
+        await self.write_command(self._build_command(MaloufCommands.MASSAGE_OFF))
+
+    async def massage_toggle(self) -> None:
+        """Toggle massage timer."""
+        await self.write_command(self._build_command(MaloufCommands.MASSAGE_TIMER))
+
+
+class MaloufLegacyOkinController(BedController):
+    """Controller for Malouf beds using LEGACY_OKIN protocol.
+
+    Protocol characteristics:
+    - Service: 0000ffe5-0000-1000-8000-00805f9b34fb
+    - Write characteristic: 0000ffe9-0000-1000-8000-00805f9b34fb
+    - Command format: 9 bytes with checksum
+      [0xE6, 0xFE, 0x16, cmd&0xFF, (cmd>>8)&0xFF, (cmd>>16)&0xFF, (cmd>>24)&0xFF, 0x00, checksum]
+    - Checksum: (~sum(bytes[0:8])) & 0xFF
+    """
+
+    def __init__(self, coordinator: AdjustableBedCoordinator) -> None:
+        """Initialize the Malouf LEGACY_OKIN controller."""
+        super().__init__(coordinator)
+        self._notify_callback: Callable[[str, float], None] | None = None
+        _LOGGER.debug("MaloufLegacyOkinController initialized")
+
+    @property
+    def control_characteristic_uuid(self) -> str:
+        """Return the UUID of the control characteristic."""
+        return MALOUF_LEGACY_OKIN_WRITE_CHAR_UUID
+
+    # Capability properties
+    @property
+    def supports_preset_zero_g(self) -> bool:
+        return True
+
+    @property
+    def supports_preset_anti_snore(self) -> bool:
+        return True
+
+    @property
+    def supports_preset_tv(self) -> bool:
+        return True
+
+    @property
+    def supports_preset_lounge(self) -> bool:
+        return True
+
+    @property
+    def has_lumbar_support(self) -> bool:
+        return True
+
+    @property
+    def has_tilt_support(self) -> bool:
+        return True
+
+    @property
+    def supports_lights(self) -> bool:
+        """Return True - these beds support lighting."""
+        return True
+
+    @property
+    def supports_discrete_light_control(self) -> bool:
+        """Return False - only toggle control available."""
+        return False
+
+    @property
+    def memory_slot_count(self) -> int:
+        """Return 2 - Malouf beds support memory slots 1-2."""
+        return 2
+
+    @property
+    def supports_memory_programming(self) -> bool:
+        """Return False - Malouf beds don't support programming memory positions."""
+        return False
+
+    def _build_command(self, command_value: int) -> bytes:
+        """Build a 9-byte LEGACY_OKIN command with checksum.
+
+        Format: [0xE6, 0xFE, 0x16, cmd&0xFF, (cmd>>8)&0xFF, (cmd>>16)&0xFF, (cmd>>24)&0xFF, 0x00, checksum]
+        Checksum: (~sum(bytes[0:8])) & 0xFF
+        """
+        data = [
+            0xE6,
+            0xFE,
+            0x16,
+            command_value & 0xFF,
+            (command_value >> 8) & 0xFF,
+            (command_value >> 16) & 0xFF,
+            (command_value >> 24) & 0xFF,
+            0x00,
+        ]
+        checksum = (~sum(data)) & 0xFF
+        data.append(checksum)
+        return bytes(data)
+
+    async def write_command(
+        self,
+        command: bytes,
+        repeat_count: int = 1,
+        repeat_delay_ms: int = 100,
+        cancel_event: asyncio.Event | None = None,
+    ) -> None:
+        """Write a command to the bed."""
+        _LOGGER.debug(
+            "Writing command to Malouf LEGACY_OKIN bed: %s (repeat: %d, delay: %dms)",
+            command.hex(),
+            repeat_count,
+            repeat_delay_ms,
+        )
+        await self._write_gatt_with_retry(
+            MALOUF_LEGACY_OKIN_WRITE_CHAR_UUID,
+            command,
+            repeat_count=repeat_count,
+            repeat_delay_ms=repeat_delay_ms,
+            cancel_event=cancel_event,
+        )
+
+    async def start_notify(self, callback: Callable[[str, float], None]) -> None:
+        """Start listening for position notifications."""
+        # These beds don't support position feedback
+        self._notify_callback = callback
+        _LOGGER.debug("Malouf LEGACY_OKIN beds don't support position notifications")
+
+    async def stop_notify(self) -> None:
+        """Stop listening for position notifications."""
+        self._notify_callback = None
+
+    async def read_positions(self, motor_count: int = 2) -> None:
+        """Read current motor positions - not supported."""
+        pass
+
+    async def _move_with_stop(self, command_value: int) -> None:
+        """Execute a movement command and always send STOP at the end."""
+        command = self._build_command(command_value)
+        try:
+            pulse_count = self._coordinator.motor_pulse_count
+            pulse_delay = self._coordinator.motor_pulse_delay_ms
+            await self.write_command(command, repeat_count=pulse_count, repeat_delay_ms=pulse_delay)
+        finally:
+            try:
+                await self.write_command(
+                    self._build_command(MaloufCommands.STOP),
+                    cancel_event=asyncio.Event(),
+                )
+            except (BleakError, ConnectionError):
+                _LOGGER.debug("Failed to send STOP command during cleanup", exc_info=True)
+
+    # Motor control methods
+    async def move_head_up(self) -> None:
+        """Move head up."""
+        await self._move_with_stop(MaloufCommands.HEAD_UP)
+
+    async def move_head_down(self) -> None:
+        """Move head down."""
+        await self._move_with_stop(MaloufCommands.HEAD_DOWN)
+
+    async def move_head_stop(self) -> None:
+        """Stop head movement."""
+        await self.write_command(
+            self._build_command(MaloufCommands.STOP), cancel_event=asyncio.Event()
+        )
+
+    async def move_back_up(self) -> None:
+        """Move back up (same as head)."""
+        await self.move_head_up()
+
+    async def move_back_down(self) -> None:
+        """Move back down (same as head)."""
+        await self.move_head_down()
+
+    async def move_back_stop(self) -> None:
+        """Stop back movement."""
+        await self.move_head_stop()
+
+    async def move_legs_up(self) -> None:
+        """Move legs up (same as feet)."""
+        await self.move_feet_up()
+
+    async def move_legs_down(self) -> None:
+        """Move legs down (same as feet)."""
+        await self.move_feet_down()
+
+    async def move_legs_stop(self) -> None:
+        """Stop legs movement."""
+        await self.move_feet_stop()
+
+    async def move_feet_up(self) -> None:
+        """Move feet up."""
+        await self._move_with_stop(MaloufCommands.FOOT_UP)
+
+    async def move_feet_down(self) -> None:
+        """Move feet down."""
+        await self._move_with_stop(MaloufCommands.FOOT_DOWN)
+
+    async def move_feet_stop(self) -> None:
+        """Stop feet movement."""
+        await self.write_command(
+            self._build_command(MaloufCommands.STOP), cancel_event=asyncio.Event()
+        )
+
+    # Lumbar control
+    async def move_lumbar_up(self) -> None:
+        """Move lumbar up."""
+        await self._move_with_stop(MaloufCommands.LUMBAR_UP)
+
+    async def move_lumbar_down(self) -> None:
+        """Move lumbar down."""
+        await self._move_with_stop(MaloufCommands.LUMBAR_DOWN)
+
+    async def move_lumbar_stop(self) -> None:
+        """Stop lumbar movement."""
+        await self.write_command(
+            self._build_command(MaloufCommands.STOP), cancel_event=asyncio.Event()
+        )
+
+    # Tilt control
+    async def move_tilt_up(self) -> None:
+        """Move tilt up."""
+        await self._move_with_stop(MaloufCommands.HEAD_TILT_UP)
+
+    async def move_tilt_down(self) -> None:
+        """Move tilt down."""
+        await self._move_with_stop(MaloufCommands.HEAD_TILT_DOWN)
+
+    async def move_tilt_stop(self) -> None:
+        """Stop tilt movement."""
+        await self.write_command(
+            self._build_command(MaloufCommands.STOP), cancel_event=asyncio.Event()
+        )
+
+    async def stop_all(self) -> None:
+        """Stop all movement."""
+        await self.write_command(
+            self._build_command(MaloufCommands.STOP), cancel_event=asyncio.Event()
+        )
+
+    # Preset methods
+    async def preset_flat(self) -> None:
+        """Go to flat position."""
+        await self.write_command(self._build_command(MaloufCommands.ALL_FLAT))
+
+    async def preset_zero_g(self) -> None:
+        """Go to zero-G position."""
+        await self.write_command(self._build_command(MaloufCommands.ZERO_G))
+
+    async def preset_anti_snore(self) -> None:
+        """Go to anti-snore position."""
+        await self.write_command(self._build_command(MaloufCommands.ANTI_SNORE))
+
+    async def preset_tv(self) -> None:
+        """Go to TV/reading position."""
+        await self.write_command(self._build_command(MaloufCommands.TV_READ))
+
+    async def preset_lounge(self) -> None:
+        """Go to lounge position."""
+        await self.write_command(self._build_command(MaloufCommands.LOUNGE))
+
+    async def preset_memory(self, memory_num: int) -> None:
+        """Go to memory preset."""
+        commands = {
+            1: MaloufCommands.MEMORY_1,
+            2: MaloufCommands.MEMORY_2,
+        }
+        if command := commands.get(memory_num):
+            await self.write_command(self._build_command(command))
+        else:
+            _LOGGER.warning("Memory slot %d not supported on Malouf beds", memory_num)
+
+    async def program_memory(self, memory_num: int) -> None:
+        """Program current position to memory (not supported)."""
+        _LOGGER.warning(
+            "Malouf beds don't support programming memory presets (requested: %d)", memory_num
+        )
+
+    # Light control
+    async def lights_toggle(self) -> None:
+        """Toggle lights."""
+        await self.write_command(self._build_command(MaloufCommands.LIGHT_SWITCH))
+
+    async def lights_on(self) -> None:
+        """Turn on lights (toggle only)."""
+        await self.lights_toggle()
+
+    async def lights_off(self) -> None:
+        """Turn off lights (toggle only)."""
+        await self.lights_toggle()
+
+    # Massage control
+    async def massage_head_toggle(self) -> None:
+        """Increase head massage intensity."""
+        await self.write_command(self._build_command(MaloufCommands.MASSAGE_HEAD))
+
+    async def massage_foot_toggle(self) -> None:
+        """Increase foot massage intensity."""
+        await self.write_command(self._build_command(MaloufCommands.MASSAGE_FOOT))
+
+    async def massage_head_up(self) -> None:
+        """Increase head massage intensity."""
+        await self.write_command(self._build_command(MaloufCommands.MASSAGE_HEAD))
+
+    async def massage_head_down(self) -> None:
+        """Decrease head massage intensity."""
+        await self.write_command(self._build_command(MaloufCommands.MASSAGE_HEAD_MINUS))
+
+    async def massage_foot_up(self) -> None:
+        """Increase foot massage intensity."""
+        await self.write_command(self._build_command(MaloufCommands.MASSAGE_FOOT))
+
+    async def massage_foot_down(self) -> None:
+        """Decrease foot massage intensity."""
+        await self.write_command(self._build_command(MaloufCommands.MASSAGE_FOOT_MINUS))
+
+    async def massage_off(self) -> None:
+        """Turn off massage."""
+        await self.write_command(self._build_command(MaloufCommands.MASSAGE_OFF))
+
+    async def massage_toggle(self) -> None:
+        """Toggle massage timer."""
+        await self.write_command(self._build_command(MaloufCommands.MASSAGE_TIMER))

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -54,6 +54,8 @@ BED_TYPE_SERTA: Final = "serta"
 BED_TYPE_OCTO: Final = "octo"
 BED_TYPE_MATTRESSFIRM: Final = "mattressfirm"  # -> okin_nordic
 BED_TYPE_NECTAR: Final = "nectar"  # -> okin_7byte
+BED_TYPE_MALOUF_NEW_OKIN: Final = "malouf_new_okin"
+BED_TYPE_MALOUF_LEGACY_OKIN: Final = "malouf_legacy_okin"
 BED_TYPE_DIAGNOSTIC: Final = "diagnostic"
 
 # All supported bed types (includes both protocol-based and legacy names)
@@ -83,6 +85,9 @@ SUPPORTED_BED_TYPES: Final = [
     BED_TYPE_DEWERTOKIN,
     BED_TYPE_MATTRESSFIRM,
     BED_TYPE_NECTAR,
+    # Malouf protocols
+    BED_TYPE_MALOUF_NEW_OKIN,
+    BED_TYPE_MALOUF_LEGACY_OKIN,
 ]
 
 # Mapping from legacy bed types to their protocol-based equivalents
@@ -276,6 +281,19 @@ NECTAR_SERVICE_UUID: Final = "62741523-52f9-8864-b1ab-3b3a8d65950b"
 NECTAR_WRITE_CHAR_UUID: Final = "62741525-52f9-8864-b1ab-3b3a8d65950b"
 NECTAR_NOTIFY_CHAR_UUID: Final = "62741625-52f9-8864-b1ab-3b3a8d65950b"
 
+# Malouf NEW_OKIN specific UUIDs
+# Protocol reverse-engineered from Malouf Base app
+# Uses a unique advertised service UUID for detection plus Nordic UART for commands
+MALOUF_NEW_OKIN_ADVERTISED_SERVICE_UUID: Final = "01000001-0000-1000-8000-00805f9b34fb"
+MALOUF_NEW_OKIN_WRITE_CHAR_UUID: Final = "6e400002-b5a3-f393-e0a9-e50e24dcca9e"
+MALOUF_NEW_OKIN_NOTIFY_CHAR_UUID: Final = "6e400003-b5a3-f393-e0a9-e50e24dcca9e"
+
+# Malouf LEGACY_OKIN specific UUIDs
+# Uses FFE5 service (similar to Keeson) but with different 9-byte command format
+MALOUF_LEGACY_OKIN_SERVICE_UUID: Final = "0000ffe5-0000-1000-8000-00805f9b34fb"
+MALOUF_LEGACY_OKIN_WRITE_CHAR_UUID: Final = "0000ffe9-0000-1000-8000-00805f9b34fb"
+MALOUF_LEGACY_OKIN_NOTIFY_CHAR_UUID: Final = "0000ffe4-0000-1000-8000-00805f9b34fb"
+
 # Detection name patterns for beds sharing the OKIN service UUID
 # Multiple bed types share the same UUID (62741523-...), so name patterns help disambiguate:
 # - Nectar (7-byte protocol)
@@ -309,6 +327,10 @@ ERGOMOTION_NAME_PATTERNS: Final = ("ergomotion", "ergo", "serta-i")
 # Octo name patterns
 # - "da1458x" - Dialog Semiconductor BLE SoC used in some Octo receivers
 OCTO_NAME_PATTERNS: Final = ("da1458x",)
+
+# Malouf name patterns
+# Malouf beds typically have "malouf" in the device name
+MALOUF_NAME_PATTERNS: Final = ("malouf",)
 
 # Protocol variants
 VARIANT_AUTO: Final = "auto"

--- a/custom_components/adjustable_bed/controller_factory.py
+++ b/custom_components/adjustable_bed/controller_factory.py
@@ -18,6 +18,8 @@ from .const import (
     BED_TYPE_LEGGETT_PLATT,
     BED_TYPE_LEGGETT_WILINKE,
     BED_TYPE_LINAK,
+    BED_TYPE_MALOUF_LEGACY_OKIN,
+    BED_TYPE_MALOUF_NEW_OKIN,
     BED_TYPE_MATTRESSFIRM,
     BED_TYPE_MOTOSLEEP,
     BED_TYPE_NECTAR,
@@ -108,6 +110,16 @@ async def create_controller(
         from .beds.okin_nordic import OkinNordicController
 
         return OkinNordicController(coordinator)
+
+    if bed_type == BED_TYPE_MALOUF_NEW_OKIN:
+        from .beds.malouf import MaloufNewOkinController
+
+        return MaloufNewOkinController(coordinator)
+
+    if bed_type == BED_TYPE_MALOUF_LEGACY_OKIN:
+        from .beds.malouf import MaloufLegacyOkinController
+
+        return MaloufLegacyOkinController(coordinator)
 
     if bed_type == BED_TYPE_LEGGETT_GEN2:
         from .beds.leggett_gen2 import LeggettGen2Controller


### PR DESCRIPTION
Closes #47

## Summary

- Add `MaloufNewOkinController` for beds using 8-byte commands via Nordic UART
- Add `MaloufLegacyOkinController` for beds using 9-byte commands with checksum via FFE5 service
- Add detection logic: NEW_OKIN identified by unique advertised UUID, LEGACY_OKIN by name pattern + FFE5 service

## Features supported

- Motors: head, foot, tilt, lumbar
- Presets: flat, zero-g, lounge, anti-snore, TV/reading
- Memory slots 1-2
- Light toggle
- Massage controls (head/foot up/down, timer, off)

## Test plan

- [ ] Verify type checking passes (`uv run pyright`)
- [ ] Verify linting passes (`uv run ruff check`)
- [ ] Test with actual Malouf bed using NEW_OKIN protocol
- [ ] Test with actual Malouf bed using LEGACY_OKIN protocol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Malouf adjustable beds, including NEW_OKIN and LEGACY_OKIN protocol variants.
  * Malouf bed models are now automatically detected and compatible with preset controls, lighting, and massage features.
  * Both modern and legacy Malouf bed systems are fully supported.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->