### PR TITLE
feat: Add Keeson-specific motor labels

### DIFF
--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -486,6 +486,16 @@ class BedController(ABC):
         """
         return False
 
+    @property
+    def motor_translation_keys(self) -> dict[str, str] | None:
+        """Return custom translation keys for motor cover entities, or None for defaults.
+
+        Override in subclasses where motor labels differ from the standard naming.
+        The dict maps motor key (e.g., "head", "feet", "tilt") to a translation key
+        (e.g., "keeson_back", "keeson_legs", "keeson_head").
+        """
+        return None
+
     # Lumbar motor control (optional - only some beds have this)
 
     async def move_lumbar_up(self) -> None:

--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -326,6 +326,21 @@ class KeesonController(BedController):
         """Return True - Keeson/Ergomotion report 0-100 percentage, not angle degrees."""
         return True
 
+    @property
+    def motor_translation_keys(self) -> dict[str, str] | None:
+        """Return Keeson-specific translation keys for motor cover entities.
+
+        Keeson motor naming differs from standard naming:
+        - "head" motor → controls back/upper body → use "keeson_back"
+        - "tilt" motor → controls head/pillow → use "keeson_head"
+        - "feet" motor → controls legs → use "keeson_legs"
+        """
+        return {
+            "head": "keeson_back",
+            "tilt": "keeson_head",
+            "feet": "keeson_legs",
+        }
+
     def _build_command(self, command_value: int) -> bytes:
         """Build command bytes based on protocol variant."""
         if self._variant == "ksbt":

--- a/custom_components/adjustable_bed/cover.py
+++ b/custom_components/adjustable_bed/cover.py
@@ -169,12 +169,17 @@ async def async_setup_entry(
         # Find the specific descriptions we need
         descriptions_by_key = {d.key: d for d in COVER_DESCRIPTIONS}
 
+        # Get translation key overrides from controller
+        translation_overrides = (
+            controller.motor_translation_keys if controller is not None else None
+        ) or {}
+
         # Create Keeson-specific head description that maps to "back" position data
         # Keeson "head" motor = upper body, position reported as "back"
         head_desc = descriptions_by_key["head"]
         keeson_head_desc = AdjustableBedCoverEntityDescription(
             key=head_desc.key,
-            translation_key=head_desc.translation_key,
+            translation_key=translation_overrides.get("head", head_desc.translation_key),
             icon=head_desc.icon,
             device_class=head_desc.device_class,
             open_fn=head_desc.open_fn,
@@ -191,7 +196,7 @@ async def async_setup_entry(
         feet_desc = descriptions_by_key["feet"]
         keeson_feet_desc = AdjustableBedCoverEntityDescription(
             key=feet_desc.key,
-            translation_key=feet_desc.translation_key,
+            translation_key=translation_overrides.get("feet", feet_desc.translation_key),
             icon=feet_desc.icon,
             device_class=feet_desc.device_class,
             open_fn=feet_desc.open_fn,
@@ -210,7 +215,20 @@ async def async_setup_entry(
             and controller is not None
             and controller.has_tilt_support
         ):
-            entities.append(AdjustableBedCover(coordinator, descriptions_by_key["tilt"]))
+            tilt_desc = descriptions_by_key["tilt"]
+            keeson_tilt_desc = AdjustableBedCoverEntityDescription(
+                key=tilt_desc.key,
+                translation_key=translation_overrides.get("tilt", tilt_desc.translation_key),
+                icon=tilt_desc.icon,
+                device_class=tilt_desc.device_class,
+                open_fn=tilt_desc.open_fn,
+                close_fn=tilt_desc.close_fn,
+                stop_fn=tilt_desc.stop_fn,
+                min_motors=tilt_desc.min_motors,
+                position_key=tilt_desc.position_key,
+                max_angle=tilt_desc.max_angle,
+            )
+            entities.append(AdjustableBedCover(coordinator, keeson_tilt_desc))
 
         # Add lumbar for 4 motors if controller supports it
         if (

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -335,6 +335,15 @@
       },
       "tilt": {
         "name": "Tilt"
+      },
+      "keeson_back": {
+        "name": "Back"
+      },
+      "keeson_head": {
+        "name": "Head"
+      },
+      "keeson_legs": {
+        "name": "Legs"
       }
     },
     "sensor": {

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -347,6 +347,15 @@
       },
       "tilt": {
         "name": "Tilt"
+      },
+      "keeson_back": {
+        "name": "Back"
+      },
+      "keeson_head": {
+        "name": "Head"
+      },
+      "keeson_legs": {
+        "name": "Legs"
       }
     },
     "sensor": {


### PR DESCRIPTION
## Summary
- Adds correct motor labels for Keeson beds (Member's Mark, Purple, etc.)
- Keeson motor naming differs from standard naming:
  - "Head" motor → controls back/upper body → now labeled "Back"
  - "Tilt" motor → controls head/pillow area → now labeled "Head"
  - "Feet" motor → controls legs → now labeled "Legs"

## Implementation
- Added `motor_translation_keys` property to `BedController` base class
- Override in `KeesonController` with Keeson-specific mappings
- Updated `cover.py` to use translation overrides when creating entities

## Test plan
- [x] All 477 tests pass
- [x] Pyright type checking passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved motor position naming for Keeson adjustable beds with specialized labels for head, back, and legs positions
  * Added tilt control labeling for beds with three or more motors

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->