### PR TITLE
feat: Add comprehensive Richmat remote code feature mapping

### DIFF
--- a/custom_components/adjustable_bed/beds/richmat.py
+++ b/custom_components/adjustable_bed/beds/richmat.py
@@ -26,10 +26,10 @@ from ..const import (
     RICHMAT_PROTOCOL_SINGLE,
     RICHMAT_PROTOCOL_WILINKE,
     RICHMAT_REMOTE_AUTO,
-    RICHMAT_REMOTE_FEATURES,
     RICHMAT_WILINKE_CHAR_UUIDS,
     RICHMAT_WILINKE_SERVICE_UUIDS,
     RichmatFeatures,
+    get_richmat_features,
 )
 from .base import BedController
 
@@ -107,9 +107,9 @@ class RichmatController(BedController):
         self._char_uuid = char_uuid or RICHMAT_NORDIC_CHAR_UUID
         self._notify_callback: Callable[[str, float], None] | None = None
         self._remote_code = remote_code or RICHMAT_REMOTE_AUTO
-        self._features = RICHMAT_REMOTE_FEATURES.get(
-            self._remote_code, RICHMAT_REMOTE_FEATURES[RICHMAT_REMOTE_AUTO]
-        )
+        # Use get_richmat_features which looks up from both manual overrides
+        # and the comprehensive 456-code generated mapping
+        self._features = get_richmat_features(self._remote_code)
 
         # Determine command protocol: explicit override > is_wilinke flag > default
         if command_protocol:

--- a/custom_components/adjustable_bed/richmat_features.py
+++ b/custom_components/adjustable_bed/richmat_features.py
@@ -1,0 +1,6735 @@
+"""Auto-generated Richmat remote code feature mapping.
+
+This file is auto-generated from decompiled Richmat app data.
+Do not edit manually - regenerate with disassembly/generate_richmat_features.py
+
+Contains feature mappings for 456 Richmat remote codes extracted from
+the official Richmat/RMControl app.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .const import RichmatFeatures
+
+_F = RichmatFeatures  # Shorthand for readability
+
+RICHMAT_REMOTE_FEATURES_GENERATED: Final[dict[str, RichmatFeatures]] = {
+    "a0rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW
+    ),
+    "a0rn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "a1rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "a2rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "a2rn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW
+    ),
+    "a3rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "a8rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "a9rn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "aarm": (
+        _F.PRESET_FLAT |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "aarn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.MOTOR_HEAD
+    ),
+    "ahrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "ajrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "anrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "aprm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "aqrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "asrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "atrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "aurm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "avrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "awrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "axrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW
+    ),
+    "ayrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ayrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "azrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "azrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "b0rm": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "b1rm": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "b2rn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "b4rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "b5rn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "b7rn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "b8rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ZERO_G |
+        _F.MASSAGE_MODE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "b8rn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "b8tt": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ZERO_G |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "b9tt": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "barm": _F.PRESET_FLAT | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "bbrm": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "bbrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "bcrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "bdrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "berm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "bfrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "bgrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "bhrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "birm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "bjrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "bkrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "blrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "bmrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "bnrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "borm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "bprm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "bqrm": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "brrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "bsrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.MOTOR_HEAD
+    ),
+    "bvrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "bxrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "bzrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "c0rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "c2rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "c2rn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "c5rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "c9rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "carm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "cbrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "cbrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "cdrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "cdrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "cerm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "cfrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "chrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "cjrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "ckrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "clrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "cmrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "cnrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "corm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "cprm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "cqrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "cxrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "cyrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "czrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "d0rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "d2rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "d3rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "d4rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "d6rm": _F.PRESET_FLAT | _F.MOTOR_LUMBAR,
+    "d7rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "d8rm": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "d9rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "darm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "dcrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "dcrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "ddrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "dfrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "dgrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "dhrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "dirm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "dmrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "dmrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "dprm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "dsrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "durm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "dvrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "dwrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "dwrn": (
+        _F.PRESET_FLAT |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "dxrm": _F.PRESET_FLAT | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "e2rm": _F.PRESET_FLAT | _F.MOTOR_HEAD,
+    "e3rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "e9rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "efrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "ejrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ekrm": _F.PRESET_FLAT | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "errm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "esrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "eurm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "evrn": (
+        _F.PRESET_FLAT |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "exrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "eyrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ezrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "f2rm": _F.PRESET_FLAT | _F.MOTOR_HEAD,
+    "f8rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "fcrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "firm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "flrm": _F.PRESET_FLAT | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "fprn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "frrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "g5rn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "g6rn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW
+    ),
+    "g7rn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "garn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "gcrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "gcrn": _F.UNDER_BED_LIGHTS,
+    "germ": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "gfrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "gfrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ggrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "gnrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "gnrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "gorm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "gurm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "gwrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "gyrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "gzrn": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD,
+    "h2rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_TV |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_TV |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "h3rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "h7rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "h8rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "hcrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "herm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "hmrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "htrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "i0rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "i1rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "i2rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "i3rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "i4rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "i5rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "i6rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_LUMBAR
+    ),
+    "i7rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "i8rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "i9rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "iarm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ibrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "icrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "ierm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ifrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "igrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "ihrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "iirm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ijrm": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD,
+    "ikrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD
+    ),
+    "ilrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD
+    ),
+    "imrm": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD,
+    "inrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "iorm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "iprm": _F.PRESET_FLAT | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "irrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "isrm": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD,
+    "j2rn": (
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G
+    ),
+    "j4rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "j5rn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "j9rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "jcrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "jdrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "jprm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "kbrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "kcrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "kerm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "kfrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "kgrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "klrn": _F.PRESET_FLAT | _F.MOTOR_HEAD,
+    "kmrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "knrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "kqrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "krrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "kwrn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "l2rn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "l9rn": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ldrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "lgrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "lxrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "lyrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "lzrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "m3rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "m4rm": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "m5rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "m6rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "m7rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "marm": (
+        _F.PRESET_FLAT |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "mlrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "mmrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "mrrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "o0rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "o1rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "o2rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "o3rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "o4rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "o5rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "o6rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "o7rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "o8rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "o9rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "oarm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "omrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "onrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "oorm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "oprm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "oqrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "orrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_TV |
+        _F.PROGRAM_TV |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "osrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "otrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ourm": _F.UNDER_BED_LIGHTS,
+    "ovrm": _F.PRESET_FLAT | _F.MOTOR_HEAD,
+    "owrm": _F.PRESET_FLAT | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "oxrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "oyrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ozrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "p0rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "p1rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "p2rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "p3rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "p4rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "p5rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "p6rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "r2rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "r5rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "r6rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "t3rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "t5rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "t7rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "t9rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "tarm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "tbrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "tdrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "term": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "thrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "u0rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "u1rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "u2rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "u3rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "u4rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "u5rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "u6rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "u7rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "u9rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "uarm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "ubrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "ucrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "udrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "uerm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "ufrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ugrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "uhrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "uirm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ujrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ukrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ulrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "umrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "unrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "uorm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "uprm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "urrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "utrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "uurm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "uvrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "uwrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "uxrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "uyrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "uzrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "v0rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "v1rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "v2rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "v4rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "v5rm": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "v6rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "v7rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "v8rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "varm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "vbrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "vcrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "vdrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "verm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "vfrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "vgrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "vhrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "virm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "vjrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "vkrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "vlrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "vmrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "vnrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "vorm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "vprm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "vqrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "vrrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "vsrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "vtrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "vurm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "vvrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "vwrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "vxrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "vyrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "vzrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_TV |
+        _F.PROGRAM_TV |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "w0rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "w1rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "w2rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "w3rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "w4rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "w5rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "w6rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "w7rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "w9rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "warm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "wbrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "wcrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "wdrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "werm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "wgrm": _F.PRESET_FLAT | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "whrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "wirm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "wjrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "wkrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "wlrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "wmrm": _F.PRESET_FLAT | _F.MOTOR_HEAD,
+    "wnrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "worm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "wprm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "wqrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD
+    ),
+    "wrrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "wsrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "wtrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "wurm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "wvrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "wwrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "wxrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "wyrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "wzrm": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "x0rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "x1rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "x2rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "x4rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "x5rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "x6rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "x7rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "x8rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "x9rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "xarm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "xdrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD
+    ),
+    "xerm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "xhrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "xirm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "xjrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "xkrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "xmrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "xnrm": _F.PRESET_FLAT | _F.PRESET_MEMORY_1 | _F.PROGRAM_MEMORY_1 | _F.UNDER_BED_LIGHTS,
+    "xorm": _F.PRESET_FLAT | _F.MOTOR_HEAD | _F.MOTOR_FEET | _F.MOTOR_LUMBAR,
+    "xprm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "xurm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "xvrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "xwrm": (
+        _F.PRESET_FLAT |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "xyrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "xzrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "y0rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "y3rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "y4rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "y5rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "y8rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ybrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ycrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ydrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "yerm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "yfrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ygrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "yhrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "yirm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "yjrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ykrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "ymrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "ynrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "yorm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "yprm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "ysrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "ytrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "yurm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "yvrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "ywrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "yyrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "yzrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "z0rm": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "z1rm": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "z2rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "z4rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "z5rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "z6rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "z7rm": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "z8rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "z9rm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "zarm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "zbrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "zcrm": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "zdrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "zerm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "zfrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "zgrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "zhrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "zirm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "zjrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "zkrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "zlrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "zprm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "zr00": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "zr01": _F.PRESET_FLAT | _F.UNDER_BED_LIGHTS | _F.MOTOR_HEAD,
+    "zr10": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "zr11": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "zr12": (
+        _F.PRESET_FLAT |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "zr21": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "zr40": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "zr50": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "zr51": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "zr60": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "zr70": _F.PRESET_FLAT | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "zr80": (
+        _F.PRESET_FLAT |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "zra0": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "zra1": _F.PRESET_FLAT | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+    "zra2": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_MEMORY_2 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_MEMORY_2 |
+        _F.PROGRAM_ZERO_G |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "zri0": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "zsrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_LUMBAR
+    ),
+    "ztrm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET |
+        _F.MOTOR_PILLOW |
+        _F.MOTOR_LUMBAR
+    ),
+    "zurm": (
+        _F.PRESET_FLAT |
+        _F.PRESET_ANTI_SNORE |
+        _F.PRESET_LOUNGE |
+        _F.PRESET_MEMORY_1 |
+        _F.PRESET_TV |
+        _F.PRESET_ZERO_G |
+        _F.PROGRAM_ANTI_SNORE |
+        _F.PROGRAM_LOUNGE |
+        _F.PROGRAM_MEMORY_1 |
+        _F.PROGRAM_TV |
+        _F.PROGRAM_ZERO_G |
+        _F.UNDER_BED_LIGHTS |
+        _F.MASSAGE_HEAD_STEP |
+        _F.MASSAGE_FOOT_STEP |
+        _F.MASSAGE_MODE |
+        _F.MASSAGE_TOGGLE |
+        _F.MOTOR_HEAD |
+        _F.MOTOR_FEET
+    ),
+    "zzrm": _F.PRESET_FLAT | _F.MOTOR_HEAD | _F.MOTOR_FEET,
+}


### PR DESCRIPTION
## Summary

- Adds auto-detection of Richmat remote codes from device names (e.g., "V1RM123456" → "v1rm")
- Provides exact feature mappings for 451 product codes extracted from the official RMControl app
- Auto-detects motor count (2, 3, or 4) based on features
- Gracefully falls back to all features for unknown codes
- Shows detected code in config UI (e.g., "Auto (detected: V1RM)")

## Details

### How it works:
1. When a Richmat bed is discovered, the system extracts the remote code from the device name
2. The code is looked up in a comprehensive mapping (451 codes) to get exact features
3. Motor count is auto-detected from features (head, feet, pillow, lumbar)
4. If the code is unknown, all features are enabled as a safe fallback
5. The config flow shows the detected code and allows manual override

### Feature mapping extracted from RMControl app:
| Feature | Codes with feature |
|---------|-------------------|
| Pillow motor | 71 |
| Lumbar motor | 151 |
| Massage | 279 |
| Under-bed lights | 377 |

### Motor configurations found:
| Motors | Count |
|--------|-------|
| 2 (head + feet) | 276 |
| 3 (head + feet + lumbar) | 82 |
| 3 (head + feet + pillow) | 4 |
| 4 (all motors) | 67 |

### Special cases:
- "Sleep Function 2.0" devices are mapped to `i7rm` code
- Manual overrides in `RICHMAT_REMOTES` take precedence over generated mappings

## Test plan

- [ ] Test auto-detection with a Richmat device name like "V1RM123456"
- [ ] Verify features are correctly limited based on detected code
- [ ] Verify motor count is auto-detected (2, 3, or 4)
- [ ] Test fallback behavior for unknown codes (should enable all features)
- [ ] Test "Sleep Function 2.0" detection maps to i7rm
- [ ] Verify existing configs continue to work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Automatic detection of Richmat remote codes from device names during configuration setup, streamlining the initial pairing process without manual remote selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->