### PR TITLE
fix: Update motor pulse timing from app disassembly analysis

### DIFF
--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -939,10 +939,46 @@ DEFAULT_OCTO_PIN: Final = ""
 DEFAULT_MOTOR_PULSE_COUNT: Final = 25  # Default for most beds
 DEFAULT_MOTOR_PULSE_DELAY_MS: Final = 50  # Default for most beds
 
-# Per-bed-type motor pulse defaults (to preserve original behavior)
+# Per-bed-type motor pulse defaults based on app disassembly analysis
+# Target: ~1.5 second total motor movement duration (repeat_count = 1500ms / delay_ms)
 BED_MOTOR_PULSE_DEFAULTS: Final = {
-    # Richmat: 30 repeats, 50ms delay (original hardcoded values)
-    BED_TYPE_RICHMAT: (30, 50),
-    # Keeson: 25 repeats, 200ms delay (original hardcoded values)
-    BED_TYPE_KEESON: (25, 200),
+    # Richmat: 150ms delay → 10 repeats = 1.5s total
+    # Source: com.richmat.sleepfunction ANALYSIS.md
+    BED_TYPE_RICHMAT: (10, 150),
+    # Keeson: 100ms delay → 15 repeats = 1.5s total
+    # Source: com.sfd.ergomotion ANALYSIS.md
+    BED_TYPE_KEESON: (15, 100),
+    # Ergomotion: 100ms delay → 15 repeats = 1.5s total
+    # Source: com.sfd.ergomotion ANALYSIS.md
+    BED_TYPE_ERGOMOTION: (15, 100),
+    # Serta: 100ms delay → 15 repeats = 1.5s total
+    # Source: com.ore.serta330 ANALYSIS.md
+    BED_TYPE_SERTA: (15, 100),
+    # Malouf Legacy OKIN: 150ms delay → 10 repeats = 1.5s total
+    # Source: com.malouf.bedbase / com.lucid.bedbase ANALYSIS.md
+    BED_TYPE_MALOUF_LEGACY_OKIN: (10, 150),
+    # Malouf New OKIN (Nordic): 100ms delay → 15 repeats = 1.5s total
+    # Source: com.malouf.bedbase / com.lucid.bedbase ANALYSIS.md
+    BED_TYPE_MALOUF_NEW_OKIN: (15, 100),
+    # OKIN FFE: 150ms delay → 10 repeats = 1.5s total
+    # Source: com.lucid.bedbase ANALYSIS.md
+    BED_TYPE_OKIN_FFE: (10, 150),
+    # OKIN Nordic: 100ms delay → 15 repeats = 1.5s total
+    # Source: com.lucid.bedbase ANALYSIS.md
+    BED_TYPE_OKIN_NORDIC: (15, 100),
+    # Leggett WiLinke: 150ms delay → 10 repeats = 1.5s total
+    # Source: com.richmat.sleepfunction ANALYSIS.md - WiLinke protocol variant
+    BED_TYPE_LEGGETT_WILINKE: (10, 150),
+    # OCTO: 350ms delay → 4 repeats = 1.4s total
+    # Source: de.octoactuators.octosmartcontrolapp ANALYSIS.md
+    BED_TYPE_OCTO: (4, 350),
+    # Jiecang: 100ms delay → 15 repeats = 1.5s total
+    # Source: com.jiecang.app.android.jiecangbed ANALYSIS.md
+    BED_TYPE_JIECANG: (15, 100),
+    # Comfort Motion: 100ms delay → 15 repeats = 1.5s total
+    # Source: com.jiecang.app.android.jiecangbed ANALYSIS.md
+    BED_TYPE_COMFORT_MOTION: (15, 100),
+    # Linak: 100ms delay → 15 repeats = 1.5s total
+    # Source: com.linak.linakbed.ble.memory ANALYSIS.md
+    BED_TYPE_LINAK: (15, 100),
 }


### PR DESCRIPTION
## Summary

- Update `BED_MOTOR_PULSE_DEFAULTS` with correct timing values from Android app reverse engineering
- Previous values (50ms for Richmat, 200ms for Keeson) were placeholders
- Add timing defaults for 11 additional bed types

## Changes

| Bed Type | Old | New | Source |
|----------|-----|-----|--------|
| Richmat | 30×50ms | 10×150ms | com.richmat.sleepfunction |
| Keeson | 25×200ms | 15×100ms | com.sfd.ergomotion |
| Ergomotion | (none) | 15×100ms | com.sfd.ergomotion |
| Serta | (none) | 15×100ms | com.ore.serta330 |
| Malouf Legacy OKIN | (none) | 10×150ms | com.malouf.bedbase |
| Malouf New OKIN | (none) | 15×100ms | com.malouf.bedbase |
| OKIN FFE | (none) | 10×150ms | com.lucid.bedbase |
| OKIN Nordic | (none) | 15×100ms | com.lucid.bedbase |
| Leggett WiLinke | (none) | 10×150ms | com.richmat.sleepfunction |
| OCTO | (none) | 4×350ms | de.octoactuators.octosmartcontrolapp |
| Jiecang | (none) | 15×100ms | com.jiecang.app.android.jiecangbed |
| Comfort Motion | (none) | 15×100ms | com.jiecang.app.android.jiecangbed |
| Linak | (none) | 15×100ms | com.linak.linakbed.ble.memory |

All timing targets ~1.5s total motor movement per button press.

## Test plan

- [ ] Verify Richmat bed motor movement feels correct
- [ ] Verify Keeson/Ergomotion bed motor movement feels correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added motor control support for additional adjustable bed models with optimized pulse timing parameters targeting approximately 1.5 second movement duration per command.
  * Updated per-bed-type motor pulse configuration for enhanced consistency and performance across all supported adjustable bed types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->