### PR TITLE
feat: Add Sleepy's Elite bed controller support

### DIFF
--- a/custom_components/adjustable_bed/beds/sleepys.py
+++ b/custom_components/adjustable_bed/beds/sleepys.py
@@ -1,0 +1,554 @@
+"""Sleepy's Elite bed controller implementations.
+
+Reverse-engineered from MFRM Sleepy's Elite app v1.1.4 (com.okin.bedding.sleepy).
+
+Sleepy's Elite beds use two distinct protocols:
+- BOX15: 9-byte commands with checksum via FFE5 service (lumbar support)
+- BOX24: 7-byte commands via OKIN 64-bit service (no lumbar)
+
+The app auto-detects the protocol based on available BLE services.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from bleak.exc import BleakError
+
+from ..const import KEESON_BASE_WRITE_CHAR_UUID, SLEEPYS_BOX24_WRITE_CHAR_UUID
+from .base import BedController
+
+if TYPE_CHECKING:
+    from ..coordinator import AdjustableBedCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SleepysBox15Commands:
+    """BOX15 protocol command values.
+
+    9-byte packets with checksum:
+    [0xE6, 0xFE, 0x2C, motor_cmd, byte4, 0x00, byte6, 0x00, checksum]
+    """
+
+    HEADER = bytes([0xE6, 0xFE, 0x2C])
+
+    # Motor commands (byte 3)
+    STOP = 0x00
+    HEAD_UP = 0x02
+    HEAD_DOWN = 0x01
+    FOOT_UP = 0x08
+    FOOT_DOWN = 0x04
+    LUMBAR_UP = 0x20
+    LUMBAR_DOWN = 0x10
+
+    # Presets (byte 4 + byte 6 combinations)
+    FLAT_BYTE4 = 0x00
+    FLAT_BYTE6 = 0x10
+    ZERO_G_BYTE4 = 0x20
+    ZERO_G_BYTE6 = 0x00
+
+
+class SleepysBox24Commands:
+    """BOX24 protocol command values.
+
+    7-byte packets (no checksum):
+    [0xA5, 0x5A, 0x00, 0x00, 0x00, 0x40, motor_cmd]
+    """
+
+    HEADER = bytes([0xA5, 0x5A, 0x00, 0x00, 0x00, 0x40])
+
+    # Motor commands (byte 6)
+    STOP = 0x00
+    HEAD_UP = 0x02
+    HEAD_DOWN = 0x01
+    FOOT_UP = 0x06
+    FOOT_DOWN = 0x05
+
+    # Presets (byte 6)
+    FLAT = 0xCC
+    ZERO_G = 0xC0
+
+
+def _calculate_box15_checksum(data: bytes) -> int:
+    """Calculate BOX15 checksum (inverted 8-bit sum).
+
+    Args:
+        data: Bytes to checksum (should be 8 bytes)
+
+    Returns:
+        Checksum byte (one's complement of sum)
+    """
+    return (~sum(data)) & 0xFF
+
+
+class SleepysBox15Controller(BedController):
+    """Controller for Sleepy's Elite beds using BOX15 protocol.
+
+    Protocol characteristics:
+    - Service: 0000ffe5-0000-1000-8000-00805f9b34fb
+    - Write characteristic: 0000ffe9-0000-1000-8000-00805f9b34fb
+    - Command format: 9 bytes with checksum
+      [0xE6, 0xFE, 0x2C, motor_cmd, byte4, 0x00, byte6, 0x00, checksum]
+    - Checksum: (~sum(bytes[0:8])) & 0xFF
+    """
+
+    def __init__(self, coordinator: AdjustableBedCoordinator) -> None:
+        """Initialize the Sleepy's BOX15 controller."""
+        super().__init__(coordinator)
+        self._notify_callback: Callable[[str, float], None] | None = None
+        _LOGGER.debug("SleepysBox15Controller initialized")
+
+    @property
+    def control_characteristic_uuid(self) -> str:
+        """Return the UUID of the control characteristic."""
+        return KEESON_BASE_WRITE_CHAR_UUID
+
+    @property
+    def supports_preset_zero_g(self) -> bool:
+        return True
+
+    @property
+    def has_lumbar_support(self) -> bool:
+        """Return True - BOX15 protocol supports lumbar motor."""
+        return True
+
+    @property
+    def supports_stop_all(self) -> bool:
+        """Return True - BOX15 supports explicit stop command."""
+        return True
+
+    @property
+    def memory_slot_count(self) -> int:
+        """Return 0 - no memory presets available."""
+        return 0
+
+    @property
+    def supports_memory_programming(self) -> bool:
+        """Return False - no memory presets."""
+        return False
+
+    def _build_motor_command(self, motor_cmd: int) -> bytes:
+        """Build a 9-byte motor command packet.
+
+        Args:
+            motor_cmd: Motor command byte (e.g., HEAD_UP=0x02)
+
+        Returns:
+            9-byte command packet with checksum
+        """
+        data = bytearray(8)
+        data[0:3] = SleepysBox15Commands.HEADER
+        data[3] = motor_cmd
+        # bytes 4-7 are zeros for motor commands
+        checksum = _calculate_box15_checksum(bytes(data))
+        return bytes(data) + bytes([checksum])
+
+    def _build_preset_command(self, byte4: int, byte6: int) -> bytes:
+        """Build a 9-byte preset command packet.
+
+        Args:
+            byte4: Preset data for byte position 4
+            byte6: Preset data for byte position 6
+
+        Returns:
+            9-byte command packet with checksum
+        """
+        data = bytearray(8)
+        data[0:3] = SleepysBox15Commands.HEADER
+        data[3] = 0x00  # No motor command for presets
+        data[4] = byte4
+        # data[5] = 0x00
+        data[6] = byte6
+        # data[7] = 0x00
+        checksum = _calculate_box15_checksum(bytes(data))
+        return bytes(data) + bytes([checksum])
+
+    async def write_command(
+        self,
+        command: bytes,
+        repeat_count: int = 1,
+        repeat_delay_ms: int = 100,
+        cancel_event: asyncio.Event | None = None,
+    ) -> None:
+        """Write a command to the bed."""
+        _LOGGER.debug(
+            "Writing command to Sleepy's BOX15 bed: %s (repeat: %d, delay: %dms)",
+            command.hex(),
+            repeat_count,
+            repeat_delay_ms,
+        )
+        await self._write_gatt_with_retry(
+            KEESON_BASE_WRITE_CHAR_UUID,
+            command,
+            repeat_count=repeat_count,
+            repeat_delay_ms=repeat_delay_ms,
+            cancel_event=cancel_event,
+        )
+
+    async def start_notify(self, callback: Callable[[str, float], None]) -> None:
+        """Start listening for position notifications."""
+        self._notify_callback = callback
+        _LOGGER.debug("Sleepy's BOX15 beds don't support position notifications")
+
+    async def stop_notify(self) -> None:
+        """Stop listening for position notifications."""
+        self._notify_callback = None
+
+    async def read_positions(self, motor_count: int = 2) -> None:  # noqa: ARG002
+        """Read current motor positions - not supported."""
+
+    async def _move_with_stop(self, motor_cmd: int) -> None:
+        """Execute a movement command and always send STOP at the end."""
+        command = self._build_motor_command(motor_cmd)
+        try:
+            pulse_count = self._coordinator.motor_pulse_count
+            pulse_delay = self._coordinator.motor_pulse_delay_ms
+            await self.write_command(command, repeat_count=pulse_count, repeat_delay_ms=pulse_delay)
+        finally:
+            try:
+                await self.write_command(
+                    self._build_motor_command(SleepysBox15Commands.STOP),
+                    cancel_event=asyncio.Event(),
+                )
+            except (BleakError, ConnectionError):
+                _LOGGER.debug("Failed to send STOP command during cleanup", exc_info=True)
+
+    # Motor control methods
+    async def move_head_up(self) -> None:
+        """Move head up."""
+        await self._move_with_stop(SleepysBox15Commands.HEAD_UP)
+
+    async def move_head_down(self) -> None:
+        """Move head down."""
+        await self._move_with_stop(SleepysBox15Commands.HEAD_DOWN)
+
+    async def move_head_stop(self) -> None:
+        """Stop head movement."""
+        await self.write_command(
+            self._build_motor_command(SleepysBox15Commands.STOP),
+            cancel_event=asyncio.Event(),
+        )
+
+    async def move_back_up(self) -> None:
+        """Move back up (same as head)."""
+        await self.move_head_up()
+
+    async def move_back_down(self) -> None:
+        """Move back down (same as head)."""
+        await self.move_head_down()
+
+    async def move_back_stop(self) -> None:
+        """Stop back movement."""
+        await self.move_head_stop()
+
+    async def move_legs_up(self) -> None:
+        """Move legs up (same as feet)."""
+        await self.move_feet_up()
+
+    async def move_legs_down(self) -> None:
+        """Move legs down (same as feet)."""
+        await self.move_feet_down()
+
+    async def move_legs_stop(self) -> None:
+        """Stop legs movement."""
+        await self.move_feet_stop()
+
+    async def move_feet_up(self) -> None:
+        """Move feet up."""
+        await self._move_with_stop(SleepysBox15Commands.FOOT_UP)
+
+    async def move_feet_down(self) -> None:
+        """Move feet down."""
+        await self._move_with_stop(SleepysBox15Commands.FOOT_DOWN)
+
+    async def move_feet_stop(self) -> None:
+        """Stop feet movement."""
+        await self.write_command(
+            self._build_motor_command(SleepysBox15Commands.STOP),
+            cancel_event=asyncio.Event(),
+        )
+
+    # Lumbar control
+    async def move_lumbar_up(self) -> None:
+        """Move lumbar up."""
+        await self._move_with_stop(SleepysBox15Commands.LUMBAR_UP)
+
+    async def move_lumbar_down(self) -> None:
+        """Move lumbar down."""
+        await self._move_with_stop(SleepysBox15Commands.LUMBAR_DOWN)
+
+    async def move_lumbar_stop(self) -> None:
+        """Stop lumbar movement."""
+        await self.write_command(
+            self._build_motor_command(SleepysBox15Commands.STOP),
+            cancel_event=asyncio.Event(),
+        )
+
+    async def stop_all(self) -> None:
+        """Stop all movement."""
+        await self.write_command(
+            self._build_motor_command(SleepysBox15Commands.STOP),
+            cancel_event=asyncio.Event(),
+        )
+
+    # Preset methods
+    async def preset_flat(self) -> None:
+        """Go to flat position."""
+        command = self._build_preset_command(
+            SleepysBox15Commands.FLAT_BYTE4,
+            SleepysBox15Commands.FLAT_BYTE6,
+        )
+        try:
+            await self.write_command(command)
+        finally:
+            try:
+                await self.write_command(
+                    self._build_motor_command(SleepysBox15Commands.STOP),
+                    cancel_event=asyncio.Event(),
+                )
+            except (BleakError, ConnectionError):
+                _LOGGER.debug("Failed to send STOP command during preset cleanup", exc_info=True)
+
+    async def preset_zero_g(self) -> None:
+        """Go to zero gravity position."""
+        command = self._build_preset_command(
+            SleepysBox15Commands.ZERO_G_BYTE4,
+            SleepysBox15Commands.ZERO_G_BYTE6,
+        )
+        try:
+            await self.write_command(command)
+        finally:
+            try:
+                await self.write_command(
+                    self._build_motor_command(SleepysBox15Commands.STOP),
+                    cancel_event=asyncio.Event(),
+                )
+            except (BleakError, ConnectionError):
+                _LOGGER.debug("Failed to send STOP command during preset cleanup", exc_info=True)
+
+    async def preset_memory(self, memory_num: int) -> None:
+        """Go to memory preset (not supported)."""
+        _LOGGER.warning(
+            "Sleepy's BOX15 beds don't support memory presets (requested: %d)", memory_num
+        )
+
+    async def program_memory(self, memory_num: int) -> None:
+        """Program current position to memory (not supported)."""
+        _LOGGER.warning(
+            "Sleepy's BOX15 beds don't support programming memory presets (requested: %d)",
+            memory_num,
+        )
+
+
+class SleepysBox24Controller(BedController):
+    """Controller for Sleepy's Elite beds using BOX24 protocol.
+
+    Protocol characteristics:
+    - Service: 62741523-52f9-8864-b1ab-3b3a8d65950b (OKIN 64-bit)
+    - Write characteristic: 62741625-52f9-8864-b1ab-3b3a8d65950b
+    - Command format: 7 bytes (no checksum)
+      [0xA5, 0x5A, 0x00, 0x00, 0x00, 0x40, motor_cmd]
+    """
+
+    def __init__(self, coordinator: AdjustableBedCoordinator) -> None:
+        """Initialize the Sleepy's BOX24 controller."""
+        super().__init__(coordinator)
+        self._notify_callback: Callable[[str, float], None] | None = None
+        _LOGGER.debug("SleepysBox24Controller initialized")
+
+    @property
+    def control_characteristic_uuid(self) -> str:
+        """Return the UUID of the control characteristic."""
+        return SLEEPYS_BOX24_WRITE_CHAR_UUID
+
+    @property
+    def supports_preset_zero_g(self) -> bool:
+        return True
+
+    @property
+    def has_lumbar_support(self) -> bool:
+        """Return False - BOX24 protocol does not support lumbar motor."""
+        return False
+
+    @property
+    def supports_stop_all(self) -> bool:
+        """Return True - BOX24 supports explicit stop command."""
+        return True
+
+    @property
+    def memory_slot_count(self) -> int:
+        """Return 0 - no memory presets available."""
+        return 0
+
+    @property
+    def supports_memory_programming(self) -> bool:
+        """Return False - no memory presets."""
+        return False
+
+    def _build_command(self, motor_cmd: int) -> bytes:
+        """Build a 7-byte BOX24 command packet.
+
+        Args:
+            motor_cmd: Motor/preset command byte
+
+        Returns:
+            7-byte command packet
+        """
+        return SleepysBox24Commands.HEADER + bytes([motor_cmd])
+
+    async def write_command(
+        self,
+        command: bytes,
+        repeat_count: int = 1,
+        repeat_delay_ms: int = 100,
+        cancel_event: asyncio.Event | None = None,
+    ) -> None:
+        """Write a command to the bed."""
+        _LOGGER.debug(
+            "Writing command to Sleepy's BOX24 bed: %s (repeat: %d, delay: %dms)",
+            command.hex(),
+            repeat_count,
+            repeat_delay_ms,
+        )
+        await self._write_gatt_with_retry(
+            SLEEPYS_BOX24_WRITE_CHAR_UUID,
+            command,
+            repeat_count=repeat_count,
+            repeat_delay_ms=repeat_delay_ms,
+            cancel_event=cancel_event,
+            response=False,  # Fire-and-forget for BOX24
+        )
+
+    async def start_notify(self, callback: Callable[[str, float], None]) -> None:
+        """Start listening for position notifications."""
+        self._notify_callback = callback
+        _LOGGER.debug("Sleepy's BOX24 beds don't support position notifications")
+
+    async def stop_notify(self) -> None:
+        """Stop listening for position notifications."""
+        self._notify_callback = None
+
+    async def read_positions(self, motor_count: int = 2) -> None:  # noqa: ARG002
+        """Read current motor positions - not supported."""
+
+    async def _move_with_stop(self, motor_cmd: int) -> None:
+        """Execute a movement command and always send STOP at the end."""
+        command = self._build_command(motor_cmd)
+        try:
+            pulse_count = self._coordinator.motor_pulse_count
+            pulse_delay = self._coordinator.motor_pulse_delay_ms
+            await self.write_command(command, repeat_count=pulse_count, repeat_delay_ms=pulse_delay)
+        finally:
+            try:
+                await self.write_command(
+                    self._build_command(SleepysBox24Commands.STOP),
+                    cancel_event=asyncio.Event(),
+                )
+            except (BleakError, ConnectionError):
+                _LOGGER.debug("Failed to send STOP command during cleanup", exc_info=True)
+
+    # Motor control methods
+    async def move_head_up(self) -> None:
+        """Move head up."""
+        await self._move_with_stop(SleepysBox24Commands.HEAD_UP)
+
+    async def move_head_down(self) -> None:
+        """Move head down."""
+        await self._move_with_stop(SleepysBox24Commands.HEAD_DOWN)
+
+    async def move_head_stop(self) -> None:
+        """Stop head movement."""
+        await self.write_command(
+            self._build_command(SleepysBox24Commands.STOP),
+            cancel_event=asyncio.Event(),
+        )
+
+    async def move_back_up(self) -> None:
+        """Move back up (same as head)."""
+        await self.move_head_up()
+
+    async def move_back_down(self) -> None:
+        """Move back down (same as head)."""
+        await self.move_head_down()
+
+    async def move_back_stop(self) -> None:
+        """Stop back movement."""
+        await self.move_head_stop()
+
+    async def move_legs_up(self) -> None:
+        """Move legs up (same as feet)."""
+        await self.move_feet_up()
+
+    async def move_legs_down(self) -> None:
+        """Move legs down (same as feet)."""
+        await self.move_feet_down()
+
+    async def move_legs_stop(self) -> None:
+        """Stop legs movement."""
+        await self.move_feet_stop()
+
+    async def move_feet_up(self) -> None:
+        """Move feet up."""
+        await self._move_with_stop(SleepysBox24Commands.FOOT_UP)
+
+    async def move_feet_down(self) -> None:
+        """Move feet down."""
+        await self._move_with_stop(SleepysBox24Commands.FOOT_DOWN)
+
+    async def move_feet_stop(self) -> None:
+        """Stop feet movement."""
+        await self.write_command(
+            self._build_command(SleepysBox24Commands.STOP),
+            cancel_event=asyncio.Event(),
+        )
+
+    async def stop_all(self) -> None:
+        """Stop all movement."""
+        await self.write_command(
+            self._build_command(SleepysBox24Commands.STOP),
+            cancel_event=asyncio.Event(),
+        )
+
+    # Preset methods
+    async def preset_flat(self) -> None:
+        """Go to flat position."""
+        try:
+            await self.write_command(self._build_command(SleepysBox24Commands.FLAT))
+        finally:
+            try:
+                await self.write_command(
+                    self._build_command(SleepysBox24Commands.STOP),
+                    cancel_event=asyncio.Event(),
+                )
+            except (BleakError, ConnectionError):
+                _LOGGER.debug("Failed to send STOP command during preset cleanup", exc_info=True)
+
+    async def preset_zero_g(self) -> None:
+        """Go to zero gravity position."""
+        try:
+            await self.write_command(self._build_command(SleepysBox24Commands.ZERO_G))
+        finally:
+            try:
+                await self.write_command(
+                    self._build_command(SleepysBox24Commands.STOP),
+                    cancel_event=asyncio.Event(),
+                )
+            except (BleakError, ConnectionError):
+                _LOGGER.debug("Failed to send STOP command during preset cleanup", exc_info=True)
+
+    async def preset_memory(self, memory_num: int) -> None:
+        """Go to memory preset (not supported)."""
+        _LOGGER.warning(
+            "Sleepy's BOX24 beds don't support memory presets (requested: %d)", memory_num
+        )
+
+    async def program_memory(self, memory_num: int) -> None:
+        """Program current position to memory (not supported)."""
+        _LOGGER.warning(
+            "Sleepy's BOX24 beds don't support programming memory presets (requested: %d)",
+            memory_num,
+        )

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -61,6 +61,8 @@ BED_TYPE_COMFORT_MOTION: Final = "comfort_motion"  # Comfort Motion / Lierda pro
 BED_TYPE_SERTA: Final = "serta"  # Serta Motion Perfect (uses Keeson protocol with serta variant)
 BED_TYPE_BEDTECH: Final = "bedtech"  # BedTech 5-byte ASCII protocol
 BED_TYPE_OKIN_64BIT: Final = "okin_64bit"  # OKIN 64-bit protocol (10-byte commands)
+BED_TYPE_SLEEPYS_BOX15: Final = "sleepys_box15"  # Sleepy's Elite BOX15 protocol (9-byte with checksum)
+BED_TYPE_SLEEPYS_BOX24: Final = "sleepys_box24"  # Sleepy's Elite BOX24 protocol (7-byte)
 BED_TYPE_DIAGNOSTIC: Final = "diagnostic"
 
 # All supported bed types (includes both protocol-based and legacy names)
@@ -104,6 +106,9 @@ SUPPORTED_BED_TYPES: Final = [
     BED_TYPE_BEDTECH,
     # OKIN 64-bit
     BED_TYPE_OKIN_64BIT,
+    # Sleepy's Elite
+    BED_TYPE_SLEEPYS_BOX15,
+    BED_TYPE_SLEEPYS_BOX24,
 ]
 
 # Mapping from legacy bed types to their protocol-based equivalents
@@ -411,6 +416,14 @@ SOLACE_NAME_PATTERNS: Final = (
 # Malouf name patterns
 # Malouf beds typically have "malouf" in the device name
 MALOUF_NAME_PATTERNS: Final = ("malouf",)
+
+# Sleepy's Elite name patterns (MFRM = Mattress Firm)
+# These beds use the Sleepy's Elite app (com.okin.bedding.sleepy)
+SLEEPYS_NAME_PATTERNS: Final = ("sleepy", "mfrm")
+
+# Sleepy's Elite BOX24 protocol UUIDs (OKIN 64-bit service)
+SLEEPYS_BOX24_SERVICE_UUID: Final = "62741523-52f9-8864-b1ab-3b3a8d65950b"
+SLEEPYS_BOX24_WRITE_CHAR_UUID: Final = "62741625-52f9-8864-b1ab-3b3a8d65950b"
 
 # Protocol variants
 VARIANT_AUTO: Final = "auto"
@@ -1008,4 +1021,10 @@ BED_MOTOR_PULSE_DEFAULTS: Final = {
     # Linak: 100ms delay → 15 repeats = 1.5s total
     # Source: com.linak.linakbed.ble.memory ANALYSIS.md
     BED_TYPE_LINAK: (15, 100),
+    # Sleepy's BOX15: 100ms delay → 15 repeats = 1.5s total
+    # Source: com.okin.bedding.sleepy ANALYSIS.md
+    BED_TYPE_SLEEPYS_BOX15: (15, 100),
+    # Sleepy's BOX24: 100ms delay → 15 repeats = 1.5s total
+    # Source: com.okin.bedding.sleepy ANALYSIS.md
+    BED_TYPE_SLEEPYS_BOX24: (15, 100),
 }

--- a/custom_components/adjustable_bed/controller_factory.py
+++ b/custom_components/adjustable_bed/controller_factory.py
@@ -38,6 +38,8 @@ from .const import (
     BED_TYPE_REVERIE_NIGHTSTAND,
     BED_TYPE_RICHMAT,
     BED_TYPE_SERTA,
+    BED_TYPE_SLEEPYS_BOX15,
+    BED_TYPE_SLEEPYS_BOX24,
     BED_TYPE_SOLACE,
     # Variants and UUIDs
     KEESON_VARIANT_ERGOMOTION,
@@ -354,5 +356,17 @@ async def create_controller(
         variant = protocol_variant if protocol_variant and protocol_variant != "auto" else "nordic"
         _LOGGER.debug("Using OKIN 64-bit variant: %s", variant)
         return Okin64BitController(coordinator, variant=variant)
+
+    if bed_type == BED_TYPE_SLEEPYS_BOX15:
+        from .beds.sleepys import SleepysBox15Controller
+
+        _LOGGER.debug("Using Sleepy's BOX15 controller")
+        return SleepysBox15Controller(coordinator)
+
+    if bed_type == BED_TYPE_SLEEPYS_BOX24:
+        from .beds.sleepys import SleepysBox24Controller
+
+        _LOGGER.debug("Using Sleepy's BOX24 controller")
+        return SleepysBox24Controller(coordinator)
 
     raise ValueError(f"Unknown bed type: {bed_type}")

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -45,6 +45,8 @@ from .const import (
     BED_TYPE_REVERIE_NIGHTSTAND,
     BED_TYPE_RICHMAT,
     BED_TYPE_SERTA,
+    BED_TYPE_SLEEPYS_BOX15,
+    BED_TYPE_SLEEPYS_BOX24,
     BED_TYPE_SOLACE,
     # Detection constants
     COMFORT_MOTION_SERVICE_UUID,
@@ -71,6 +73,7 @@ from .const import (
     RICHMAT_NORDIC_SERVICE_UUID,
     RICHMAT_WILINKE_SERVICE_UUIDS,
     SERTA_NAME_PATTERNS,
+    SLEEPYS_NAME_PATTERNS,
     SOLACE_NAME_PATTERNS,
     SOLACE_SERVICE_UUID,
 )
@@ -176,6 +179,8 @@ BED_TYPE_DISPLAY_NAMES: dict[str, str] = {
     BED_TYPE_RICHMAT: "Richmat",
     BED_TYPE_COMFORT_MOTION: "Comfort Motion (Lierda)",
     BED_TYPE_SERTA: "Serta Motion Perfect",
+    BED_TYPE_SLEEPYS_BOX15: "Sleepy's Elite (BOX15, with lumbar)",
+    BED_TYPE_SLEEPYS_BOX24: "Sleepy's Elite (BOX24)",
     BED_TYPE_SOLACE: "Solace",
     # Diagnostic
     BED_TYPE_DIAGNOSTIC: "Diagnostic (unknown bed)",
@@ -279,6 +284,19 @@ def detect_bed_type(service_info: BluetoothServiceInfoBleak) -> str | None:
         )
         return BED_TYPE_REVERIE
 
+    # Check for Sleepy's Elite BOX24 - name-based detection (before Okimat since same UUID)
+    # Sleepy's BOX24 beds use OKIN 64-bit service UUID
+    if (
+        any(pattern in device_name for pattern in SLEEPYS_NAME_PATTERNS)
+        and OKIMAT_SERVICE_UUID.lower() in service_uuids
+    ):
+        _LOGGER.info(
+            "Detected Sleepy's Elite BOX24 bed at %s (name: %s)",
+            service_info.address,
+            service_info.name,
+        )
+        return BED_TYPE_SLEEPYS_BOX24
+
     # Check for Nectar - name-based detection (before Okimat since same UUID)
     # Nectar beds use OKIN service UUID but different command protocol
     if "nectar" in device_name and OKIMAT_SERVICE_UUID.lower() in service_uuids:
@@ -361,6 +379,19 @@ def detect_bed_type(service_info: BluetoothServiceInfoBleak) -> str | None:
             service_info.name,
         )
         return BED_TYPE_ERGOMOTION
+
+    # Check for Sleepy's Elite BOX15 - name pattern + FFE5 service (before Keeson)
+    # Sleepy's BOX15 uses FFE5 service UUID with 9-byte checksum protocol
+    if (
+        any(pattern in device_name for pattern in SLEEPYS_NAME_PATTERNS)
+        and KEESON_BASE_SERVICE_UUID.lower() in service_uuids
+    ):
+        _LOGGER.info(
+            "Detected Sleepy's Elite BOX15 bed at %s (name: %s)",
+            service_info.address,
+            service_info.name,
+        )
+        return BED_TYPE_SLEEPYS_BOX15
 
     # Check for Malouf LEGACY_OKIN - name pattern + FFE5 service (before Keeson)
     # Malouf LEGACY_OKIN uses FFE5 service UUID but different 9-byte command format

--- a/docs/SUPPORTED_ACTUATORS.md
+++ b/docs/SUPPORTED_ACTUATORS.md
@@ -20,6 +20,7 @@ This document provides an overview of supported bed brands. Click on a brand nam
 | [Nectar](beds/nectar.md) | ✅ Supported | Lumbar control, massage, lights, Zero-G/Anti-Snore/Lounge |
 | [Malouf](beds/malouf.md) | ✅ Supported | 2 memory presets, lumbar, head tilt, massage, lights |
 | [BedTech](beds/bedtech.md) | ✅ Supported | 5 presets, 4 massage modes, dual-base support |
+| [Sleepy's Elite](beds/sleepys.md) | ✅ Supported | Lumbar (BOX15), Zero-G, Flat presets |
 
 ---
 
@@ -102,6 +103,7 @@ Will not be implemented. Use the [SleepIQ](https://www.home-assistant.io/integra
    - `Octo*` → Octo (Standard variant)
    - `iFlex*` → Mattress Firm 900
    - `Malouf*`, `Structures*` → Malouf
+   - `Sleepy*` → Sleepy's Elite (try BOX24 first, BOX15 if lumbar needed)
 4. **Check service UUIDs** (using nRF Connect):
    - Service `62741523-...` → Okin family (see [Okin Protocol Family](#okin-protocol-family))
    - Service `45e25100-...` → Leggett & Platt Gen2
@@ -132,6 +134,7 @@ Community contributors who helped reverse-engineer specific protocols:
 | Malouf | [kristofferR](https://github.com/kristofferR/ha-adjustable-bed) |
 | BedTech | [kristofferR](https://github.com/kristofferR/ha-adjustable-bed) |
 | Okin 64-bit | [kristofferR](https://github.com/kristofferR/ha-adjustable-bed) |
+| Sleepy's Elite | [kristofferR](https://github.com/kristofferR/ha-adjustable-bed) |
 
 Additional contributions:
 - **Mattress Firm 900**: [David Delahoz](https://github.com/daviddelahoz) - [BLEAdjustableBase](https://github.com/daviddelahoz/BLEAdjustableBase)

--- a/docs/beds/dewertokin.md
+++ b/docs/beds/dewertokin.md
@@ -8,7 +8,7 @@
 
 Brands using DewertOkin actuators:
 
-- Mattress Firm / Sleepy's Elite
+- Mattress Firm (except Sleepy's Elite - see [Sleepy's Elite](sleepys.md))
 - Resident Adjustable Base
 - Rize (multiple models: Home, Remedy, Clarity, Contemporary, Aviada)
 - SIMMONS

--- a/docs/beds/sleepys.md
+++ b/docs/beds/sleepys.md
@@ -1,0 +1,168 @@
+# Sleepy's Elite (MFRM)
+
+**Status:** Untested
+
+**Credit:** Reverse engineering by [kristofferR](https://github.com/kristofferR/ha-adjustable-bed) from MFRM Sleepy's Elite app v1.1.4 (com.okin.bedding.sleepy)
+
+## Known Models
+
+- MFRM Sleepy's Elite adjustable beds
+- Mattress Firm adjustable beds using the Sleepy's Elite app
+
+## Apps
+
+| Analyzed | App | Package ID |
+|----------|-----|------------|
+| ✅ | [MFRM Sleepy's Elite](https://play.google.com/store/apps/details?id=com.okin.bedding.sleepy) | `com.okin.bedding.sleepy` |
+
+## Protocol Variants
+
+The Sleepy's Elite app supports multiple control box types. This integration implements the two main BLE protocols:
+
+| Variant | Packet Size | Checksum | Lumbar Support | Service UUID |
+|---------|-------------|----------|----------------|--------------|
+| BOX15 | 9 bytes | Yes | ✅ | FFE5 |
+| BOX24 | 7 bytes | No | ❌ | 62741523 (OKIN 64-bit) |
+
+**Protocol Selection:**
+
+- If your bed has **lumbar control**, use the BOX15 variant
+- If your bed has **OKIN 64-bit service UUID** (62741523-...), use BOX24
+- When in doubt, try BOX24 first (simpler protocol)
+
+## Features
+
+| Feature | BOX15 | BOX24 |
+|---------|-------|-------|
+| Motor Control | ✅ | ✅ |
+| Lumbar Motor | ✅ | ❌ |
+| Position Feedback | ❌ | ❌ |
+| Memory Presets | ❌ | ❌ |
+| Flat Preset | ✅ | ✅ |
+| Zero-G Preset | ✅ | ✅ |
+
+## Protocol Details
+
+### BOX15 Protocol (9-byte packets with checksum)
+
+**Service UUID:** `0000FFE5-0000-1000-8000-00805F9B34FB`
+
+**Write Characteristic:** `0000FFE9-0000-1000-8000-00805F9B34FB`
+
+**Packet Structure:**
+
+```text
+[0]    Header1: 0xE6
+[1]    Header2: 0xFE
+[2]    Prefix:  0x2C
+[3]    Motor command
+[4]    Preset data (byte 4)
+[5]    Reserved: 0x00
+[6]    Preset data (byte 6)
+[7]    Reserved: 0x00
+[8]    Checksum: (~sum(bytes[0:8])) & 0xFF
+```
+
+**Motor Commands (byte 3):**
+
+| Command | Hex | Description |
+|---------|-----|-------------|
+| STOP | 0x00 | Stop all motors |
+| HEAD UP | 0x02 | Raise head |
+| HEAD DOWN | 0x01 | Lower head |
+| FOOT UP | 0x08 | Raise foot |
+| FOOT DOWN | 0x04 | Lower foot |
+| LUMBAR UP | 0x20 | Raise lumbar |
+| LUMBAR DOWN | 0x10 | Lower lumbar |
+
+**Preset Commands (byte 4 + byte 6):**
+
+| Preset | Byte 4 | Byte 6 |
+|--------|--------|--------|
+| Flat | 0x00 | 0x10 |
+| Zero-G | 0x20 | 0x00 |
+
+**Example - Move Head Up:**
+
+```text
+E6 FE 2C 02 00 00 00 00 [checksum]
+```
+
+### BOX24 Protocol (7-byte packets)
+
+**Service UUID:** `62741523-52F9-8864-B1AB-3B3A8D65950B` (OKIN 64-bit)
+
+**Write Characteristic:** `62741625-52F9-8864-B1AB-3B3A8D65950B`
+
+**Packet Structure:**
+
+```text
+[0]    Header1: 0xA5
+[1]    Header2: 0x5A
+[2]    Reserved: 0x00
+[3]    Reserved: 0x00
+[4]    Reserved: 0x00
+[5]    Command type: 0x40
+[6]    Motor/Preset command
+```
+
+**Motor Commands (byte 6):**
+
+| Command | Hex | Description |
+|---------|-----|-------------|
+| STOP | 0x00 | Stop all motors |
+| HEAD UP | 0x02 | Raise head |
+| HEAD DOWN | 0x01 | Lower head |
+| FOOT UP | 0x06 | Raise foot |
+| FOOT DOWN | 0x05 | Lower foot |
+
+**Preset Commands (byte 6):**
+
+| Preset | Hex |
+|--------|-----|
+| Flat | 0xCC |
+| Zero-G | 0xC0 |
+
+**Example - Move Head Up:**
+
+```text
+A5 5A 00 00 00 40 02
+```
+
+## Checksum Calculation (BOX15 only)
+
+The BOX15 protocol uses an inverted 8-bit sum (one's complement):
+
+```python
+checksum = (~sum(bytes[0:8])) & 0xFF
+```
+
+## Command Timing
+
+From app disassembly:
+
+- **Repeat Interval:** Continuous while button held
+- **Pattern:** Send command repeatedly with ~100ms delay
+- **Stop Required:** Yes, explicit stop after motor release
+
+## Detection
+
+Sleepy's Elite beds are **auto-detected** by device name patterns:
+
+- Device names containing "sleepy" or "mfrm" (case-insensitive)
+- Protocol variant is selected based on available service UUIDs:
+  - OKIN 64-bit service (62741523-...) → BOX24
+  - FFE5 service (0000FFE5-...) → BOX15
+
+**If auto-detection fails:**
+
+1. Use nRF Connect app to scan your bed
+2. If you see service `62741523-...` → manually select BOX24
+3. If you only see service `0000FFE5-...` → manually select BOX15
+4. If BOX24 doesn't work and your bed has lumbar → try BOX15
+
+## Related Protocols
+
+- **[DewertOkin](dewertokin.md)** - Different command format, uses handle writes
+- **[Okin 64-bit](okimat.md#okin-64-bit-protocol)** - Similar service UUID but different packet format
+- **[Keeson](keeson.md)** - Same FFE5 service but different command encoding


### PR DESCRIPTION
## Summary

- Add support for MFRM Sleepy's Elite adjustable beds with two protocol variants
- BOX15: 9-byte protocol with checksum, includes lumbar motor support (FFE5 service)
- BOX24: 7-byte protocol, no lumbar (OKIN 64-bit service UUID)
- Protocol reverse-engineered from MFRM Sleepy's Elite app v1.1.4

## Test plan

- [ ] Verify syntax check passes (`python -m py_compile`)
- [ ] Test with actual Sleepy's Elite bed (BOX15 variant)
- [ ] Test with actual Sleepy's Elite bed (BOX24 variant)
- [ ] Verify head/foot motor control works
- [ ] Verify lumbar control works (BOX15 only)
- [ ] Verify Flat preset works
- [ ] Verify Zero-G preset works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Sleepy's Elite beds (BOX15 and BOX24): head and feet motor control; BOX15 adds lumbar.
  * Presets: Flat and Zero‑G; movement safety/stop behavior and write retry handling.
  * Automatic detection and device identification for both BOX15 and BOX24 variants.

* **Documentation**
  * Added comprehensive Sleepy's Elite protocol docs and updated supported actuators and brand references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->