### PR TITLE
fix(jensen): Correct foot motor position calibration

### DIFF
--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -81,6 +81,12 @@ class BedController(ABC):
             characteristic_uuid: The UUID of the characteristic that sent the notification.
             data: The raw notification data bytes.
         """
+        _LOGGER.debug(
+            "GATT notify from %s (%s): %s",
+            self._coordinator.address,
+            characteristic_uuid,
+            data.hex(),
+        )
         if self._raw_notify_callback is not None:
             try:
                 self._raw_notify_callback(characteristic_uuid, data)
@@ -186,6 +192,16 @@ class BedController(ABC):
             raise ConnectionError("Not connected to bed")
 
         effective_cancel = cancel_event or self._coordinator.cancel_command
+
+        _LOGGER.debug(
+            "GATT write to %s (%s): %s (response=%s, repeat=%d, delay=%dms)",
+            self._coordinator.address,
+            char_uuid,
+            command.hex(),
+            response,
+            repeat_count,
+            repeat_delay_ms,
+        )
 
         for i in range(repeat_count):
             if effective_cancel is not None and effective_cancel.is_set():

--- a/custom_components/adjustable_bed/beds/jiecang.py
+++ b/custom_components/adjustable_bed/beds/jiecang.py
@@ -161,7 +161,8 @@ class JiecangController(BedController):
         effective_cancel = cancel_event or self._coordinator.cancel_command
 
         _LOGGER.debug(
-            "Writing command to Jiecang bed: %s (repeat: %d, delay: %dms)",
+            "Writing command to Jiecang bed (%s): %s (repeat: %d, delay: %dms, response=True)",
+            JIECANG_CHAR_UUID,
             command.hex(),
             repeat_count,
             repeat_delay_ms,

--- a/custom_components/adjustable_bed/beds/leggett_wilinke.py
+++ b/custom_components/adjustable_bed/beds/leggett_wilinke.py
@@ -226,7 +226,8 @@ class LeggettWilinkeController(BedController):
         effective_cancel = cancel_event or self._coordinator.cancel_command
 
         _LOGGER.debug(
-            "Writing command to L&P WiLinke bed: %s (repeat: %d, delay: %dms)",
+            "Writing command to L&P WiLinke bed (%s): %s (repeat: %d, delay: %dms, response=True)",
+            self._char_uuid,
             command.hex(),
             repeat_count,
             repeat_delay_ms,

--- a/custom_components/adjustable_bed/beds/octo.py
+++ b/custom_components/adjustable_bed/beds/octo.py
@@ -316,7 +316,8 @@ class OctoController(BedController):
         effective_cancel = cancel_event or self._coordinator.cancel_command
 
         _LOGGER.debug(
-            "Writing command to Octo bed: %s (repeat: %d, delay: %dms)",
+            "Writing command to Octo bed (%s): %s (repeat: %d, delay: %dms, response=True)",
+            OCTO_CHAR_UUID,
             command.hex(),
             repeat_count,
             repeat_delay_ms,
@@ -839,7 +840,8 @@ class OctoStar2Controller(BedController):
         effective_cancel = cancel_event or self._coordinator.cancel_command
 
         _LOGGER.debug(
-            "Writing command to Octo Star2 bed: %s (repeat: %d, delay: %dms)",
+            "Writing command to Octo Star2 bed (%s): %s (repeat: %d, delay: %dms, response=True)",
+            OCTO_STAR2_CHAR_UUID,
             command.hex(),
             repeat_count,
             repeat_delay_ms,

--- a/custom_components/adjustable_bed/beds/okin_7byte.py
+++ b/custom_components/adjustable_bed/beds/okin_7byte.py
@@ -129,7 +129,8 @@ class Okin7ByteController(BedController):
         effective_cancel = cancel_event or self._coordinator.cancel_command
 
         _LOGGER.debug(
-            "Writing command to Okin 7-byte bed: %s (repeat: %d, delay: %dms)",
+            "Writing command to Okin 7-byte bed (%s): %s (repeat: %d, delay: %dms, response=True)",
+            NECTAR_WRITE_CHAR_UUID,
             command.hex(),
             repeat_count,
             repeat_delay_ms,

--- a/custom_components/adjustable_bed/beds/okin_handle.py
+++ b/custom_components/adjustable_bed/beds/okin_handle.py
@@ -150,7 +150,7 @@ class OkinHandleController(BedController):
         effective_cancel = cancel_event or self._coordinator.cancel_command
 
         _LOGGER.debug(
-            "Writing command to Okin handle bed (handle 0x%04x): %s (repeat: %d, delay: %dms)",
+            "Writing command to Okin handle bed (handle 0x%04x): %s (repeat: %d, delay: %dms, response=True)",
             DEWERTOKIN_WRITE_HANDLE,
             command.hex(),
             repeat_count,

--- a/custom_components/adjustable_bed/beds/okin_nordic.py
+++ b/custom_components/adjustable_bed/beds/okin_nordic.py
@@ -159,10 +159,20 @@ class OkinNordicController(BedController):
                 return
             _LOGGER.debug("Sending init sequence before first command")
             try:
+                _LOGGER.debug(
+                    "Init write to %s: %s (response=True)",
+                    MATTRESSFIRM_WRITE_CHAR_UUID,
+                    OkinNordicCommands.INIT_1.hex(),
+                )
                 await self.client.write_gatt_char(
                     MATTRESSFIRM_WRITE_CHAR_UUID, OkinNordicCommands.INIT_1, response=True
                 )
                 await asyncio.sleep(0.1)  # 100ms delay between init commands
+                _LOGGER.debug(
+                    "Init write to %s: %s (response=True)",
+                    MATTRESSFIRM_WRITE_CHAR_UUID,
+                    OkinNordicCommands.INIT_2.hex(),
+                )
                 await self.client.write_gatt_char(
                     MATTRESSFIRM_WRITE_CHAR_UUID, OkinNordicCommands.INIT_2, response=True
                 )
@@ -172,7 +182,8 @@ class OkinNordicController(BedController):
                 raise
 
         _LOGGER.debug(
-            "Writing command to Okin Nordic bed: %s (repeat: %d, delay: %dms)",
+            "Writing command to Okin Nordic bed (%s): %s (repeat: %d, delay: %dms, response=True)",
+            MATTRESSFIRM_WRITE_CHAR_UUID,
             command.hex(),
             repeat_count,
             repeat_delay_ms,

--- a/custom_components/adjustable_bed/beds/okin_uuid.py
+++ b/custom_components/adjustable_bed/beds/okin_uuid.py
@@ -266,7 +266,8 @@ class OkinUuidController(BedController):
         effective_cancel = cancel_event or self._coordinator.cancel_command
 
         _LOGGER.debug(
-            "Writing command to Okin UUID bed: %s (repeat: %d, delay: %dms)",
+            "Writing command to Okin UUID bed (%s): %s (repeat: %d, delay: %dms, response=True)",
+            OKIMAT_WRITE_CHAR_UUID,
             command.hex(),
             repeat_count,
             repeat_delay_ms,

--- a/custom_components/adjustable_bed/beds/reverie.py
+++ b/custom_components/adjustable_bed/beds/reverie.py
@@ -228,7 +228,8 @@ class ReverieController(BedController):
         effective_cancel = cancel_event or self._coordinator.cancel_command
 
         _LOGGER.debug(
-            "Writing command to Reverie bed: %s (repeat: %d, delay: %dms)",
+            "Writing command to Reverie bed (%s): %s (repeat: %d, delay: %dms, response=True)",
+            REVERIE_CHAR_UUID,
             command.hex(),
             repeat_count,
             repeat_delay_ms,

--- a/custom_components/adjustable_bed/beds/reverie_nightstand.py
+++ b/custom_components/adjustable_bed/beds/reverie_nightstand.py
@@ -143,7 +143,7 @@ class ReverieNightstandController(BedController):
         command = bytes([value])
 
         _LOGGER.debug(
-            "Writing 0x%02X to %s (repeat: %d, delay: %dms)",
+            "Writing 0x%02X to %s (repeat: %d, delay: %dms, response=True)",
             value,
             char_uuid,
             repeat_count,

--- a/custom_components/adjustable_bed/beds/solace.py
+++ b/custom_components/adjustable_bed/beds/solace.py
@@ -134,7 +134,8 @@ class SolaceController(BedController):
         effective_cancel = cancel_event or self._coordinator.cancel_command
 
         _LOGGER.debug(
-            "Writing command to Solace bed: %s (repeat: %d, delay: %dms)",
+            "Writing command to Solace bed (%s): %s (repeat: %d, delay: %dms, response=True)",
+            SOLACE_CHAR_UUID,
             command.hex(),
             repeat_count,
             repeat_delay_ms,

--- a/custom_components/adjustable_bed/beds/svane.py
+++ b/custom_components/adjustable_bed/beds/svane.py
@@ -181,7 +181,7 @@ class SvaneController(BedController):
         effective_cancel = cancel_event or self._coordinator.cancel_command
 
         _LOGGER.debug(
-            "Writing %s to service %s char %s (repeat: %d, delay: %dms)",
+            "Writing %s to service %s char %s (repeat: %d, delay: %dms, response=True)",
             command.hex(),
             service_uuid[:8],
             char_uuid[:8],


### PR DESCRIPTION
## Summary

- Fix Jensen foot motor position calibration that was incorrectly inverted
- The foot control was showing 100% (45°) when flat, preventing the up arrow from working
- Both head and foot motors use the same scale (low values = flat, high values = raised)
- Add characteristic UUIDs to debug logging across all bed controllers for easier troubleshooting

## Test plan

- [ ] Jensen bed owner confirms foot position now shows 0% when flat
- [ ] Jensen bed owner confirms both up and down arrows work correctly for foot motor
- [ ] Verify head motor still works correctly

Related to #146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed position calibration for specific bed model to ensure foot and head positioning scale consistently.

* **Chores**
  * Enhanced internal debug logging for Bluetooth communication diagnostics across bed controllers to improve troubleshooting visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->