### PR TITLE
Fix Germany Motions (DHN-*) bed detection

### DIFF
--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -232,17 +232,26 @@ BEDTECH_SERVICE_UUID: Final = "0000fee9-0000-1000-8000-00805f9b34fb"
 BEDTECH_WRITE_CHAR_UUID: Final = "d44bc439-abfd-45a2-b575-925416129600"
 
 # WiLinke variants (5-byte commands with checksum)
+# Source: com.desarketing.gmmotor (Germany Motions) APK blutter decompilation
+# The app supports 6 BLE variants (Nordic + W1-W5), we track the WiLinke ones here
+# W1 is the default fallback when no specific service is found
+RICHMAT_WILINKE_W1_SERVICE_UUID: Final = "0000fee9-0000-1000-8000-00805f9b34fb"
 RICHMAT_WILINKE_SERVICE_UUIDS: Final = [
-    "8ebd4f76-da9d-4b5a-a96e-8ebfbeb622e7",
-    "0000fee9-0000-1000-8000-00805f9b34fb",
-    "0000fee9-0000-1000-8000-00805f9b34bb",
-    "0000fff0-0000-1000-8000-00805f9b34fb",
+    "8ebd4f76-da9d-4b5a-a96e-8ebfbeb622e7",  # Custom (legacy, index 0)
+    "0000fee9-0000-1000-8000-00805f9b34fb",  # W1 (index 1) - default fallback
+    "0000fee9-0000-1000-8000-00805f9b34bb",  # W2 (index 2) - note different base UUID suffix
+    "0000ffe0-0000-1000-8000-00805f9b34fb",  # W3 (index 3)
+    "0000fff0-0000-1000-8000-00805f9b34fb",  # W4 (index 4) - Germany Motions DHN-* beds
+    "0000e0ff-3c17-d293-8e48-14fe2e4da212",  # W5 (index 5) - custom base UUID
 ]
 RICHMAT_WILINKE_CHAR_UUIDS: Final = [
-    ("d44bc439-abfd-45a2-b575-925416129600", "d44bc439-abfd-45a2-b575-925416129601"),
-    ("d44bc439-abfd-45a2-b575-925416129600", "d44bc439-abfd-45a2-b575-925416129601"),
-    ("d44bc439-abfd-45a2-b575-925416129622", "d44bc439-abfd-45a2-b575-925416129611"),
-    ("0000fff2-0000-1000-8000-00805f9b34fb", "0000fff1-0000-1000-8000-00805f9b34fb"),
+    # (write_char, notify_char) pairs matching service UUIDs above
+    ("d44bc439-abfd-45a2-b575-925416129600", "d44bc439-abfd-45a2-b575-925416129601"),  # Custom
+    ("d44bc439-abfd-45a2-b575-925416129600", "d44bc439-abfd-45a2-b575-925416129601"),  # W1
+    ("d44bc439-abfd-45a2-b575-925416129622", "d44bc439-abfd-45a2-b575-925416129611"),  # W2
+    ("0000ffe2-0000-1000-8000-00805f9b34fb", "0000ffe1-0000-1000-8000-00805f9b34fb"),  # W3
+    ("0000fff2-0000-1000-8000-00805f9b34fb", "0000fff1-0000-1000-8000-00805f9b34fb"),  # W4
+    ("00000002-3c17-d293-8e48-14fe2e4da212", "00000003-3c17-d293-8e48-14fe2e4da212"),  # W5
 ]
 
 # Keeson specific UUIDs

--- a/custom_components/adjustable_bed/manifest.json
+++ b/custom_components/adjustable_bed/manifest.json
@@ -71,6 +71,9 @@
     },
     {
       "service_uuid": "6e403587-b5a3-f393-e0a9-e50e24dcca9e"
+    },
+    {
+      "service_uuid": "0000e0ff-3c17-d293-8e48-14fe2e4da212"
     }
   ],
   "codeowners": ["@kristofferR"],


### PR DESCRIPTION
## Summary

- Add missing W3 (FFE0) and W5 (E0FF) WiLinke service UUID variants
- Fix variant detection fallback to use W1 instead of Nordic
- Add W5 service UUID to manifest.json for BLE discovery

## Problem

Germany Motions beds (device name `DHN-*`) were detected as Richmat but commands failed with:
> the expected BLE characteristic `6e400002-...` cannot be found

The variant detection was incorrectly falling back to Nordic UART instead of W1 WiLinke.

## Root Cause

Analysis of the Germany Motions app (v3.0.5, v3.0.33, v4.6.0) revealed:
- The app supports 6 BLE variants (Nordic + W1-W5)
- DHN-* beds advertise FFF0 (W4) service with FFF2/FFF1 characteristics
- When no service matches, the app defaults to **W1**, not Nordic
- Our code was missing W3 (FFE0) and W5 (E0FF) variants entirely

## Test plan

- [ ] User re-adds Germany Motions DHN-* bed
- [ ] Debug log shows correct variant detection (W4 with FFF2 write char)
- [ ] Basic commands work (head up/down, foot up/down)
- [ ] Presets work (flat, zero-g)

Ref #163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device detection fallback for Richmat beds when WiLinke service discovery fails.

* **New Features**
  * Enhanced support for additional Richmat adjustable bed model variants.
  * Improved Bluetooth service recognition for Richmat bed compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->