### PR TITLE
fix: Improve Octo detection and Richmat WiLinke fallback

### DIFF
--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -581,6 +581,17 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
             )
             return DetectionResult(bed_type=BED_TYPE_BEDTECH, confidence=0.9, signals=signals)
 
+    # Check for Octo by name pattern (e.g., RC2, DA1458x, etc.)
+    # MUST be before Richmat WiLinke since FFE0 (W3 variant) is in both lists
+    if any(device_name.startswith(pattern) for pattern in OCTO_NAME_PATTERNS):
+        signals.append("name:octo")
+        _LOGGER.info(
+            "Detected Octo bed at %s (name: %s) by name pattern",
+            service_info.address,
+            service_info.name,
+        )
+        return DetectionResult(bed_type=BED_TYPE_OCTO, confidence=0.9, signals=signals)
+
     # Check for Leggett & Platt MlRM variant (MlRM prefix with WiLinke UUID)
     # Must be before generic Richmat WiLinke check
     # Variant detection (mlrm) happens at controller instantiation
@@ -749,16 +760,6 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
             service_info.name,
         )
         return DetectionResult(bed_type=BED_TYPE_SERTA, confidence=0.9, signals=signals)
-
-    # Check for Octo by name pattern (e.g., DA1458x BLE chip used in some receivers)
-    if any(device_name.startswith(pattern) for pattern in OCTO_NAME_PATTERNS):
-        signals.append("name:octo")
-        _LOGGER.info(
-            "Detected Octo bed at %s (name: %s) by name pattern",
-            service_info.address,
-            service_info.name,
-        )
-        return DetectionResult(bed_type=BED_TYPE_OCTO, confidence=0.9, signals=signals)
 
     # Check for Octo Star2 variant - service UUID detection
     if OCTO_STAR2_SERVICE_UUID.lower() in service_uuids:


### PR DESCRIPTION
## Summary
- Move Octo name pattern detection before Richmat WiLinke check to prevent misdetection when FFE0 service UUID is present (appears in both bed types)
- Add fallback for Richmat WiLinke beds that use a single characteristic for both read/write/notify instead of separate write and notify characteristics (e.g., Germany Motions DHN-* beds)

## Test plan
- [ ] Test Octo bed detection with RC2/DA1458x device names
- [ ] Test Richmat WiLinke detection still works for standard configurations
- [ ] Test Germany Motions DHN-* beds can write commands via notify characteristic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a fallback to treat a notify-capable characteristic as writable to improve compatibility with Richmat beds that multiplex read/write/notify.
  * Reordered detection so the Octo name-pattern check runs earlier, improving model resolution in ambiguous or overlapping cases.
  * Both changes increase overall bed detection reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->