### PR TITLE
fix: Honor bed timing in timed_move service

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -617,7 +617,8 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                     coordinator.name,
                 )
                 pulse_delay_ms = 100  # DEFAULT_MOTOR_PULSE_DELAY_MS
-            calculated_repeat_count = max(1, duration_ms // pulse_delay_ms)
+            # Round up to honor requested duration as minimum
+            calculated_repeat_count = max(1, (duration_ms + pulse_delay_ms - 1) // pulse_delay_ms)
 
             _LOGGER.debug(
                 "Timed move: duration=%dms, pulse_delay=%dms, repeat_count=%d",

--- a/custom_components/adjustable_bed/beds/octo.py
+++ b/custom_components/adjustable_bed/beds/octo.py
@@ -910,12 +910,22 @@ class OctoStar2Controller(BedController):
             "motors stop when commands cease"
         )
 
+    def _get_pulse_settings(self) -> tuple[int, int]:
+        """Get clamped pulse settings from coordinator.
+
+        Returns:
+            Tuple of (pulse_count, pulse_delay_ms), both clamped to minimum of 1.
+        """
+        return (
+            max(1, self._coordinator.motor_pulse_count),
+            max(1, self._coordinator.motor_pulse_delay_ms),
+        )
+
     # Motor control methods using fixed Star2 commands
     # Uses coordinator's configurable pulse settings for timing
     async def move_head_up(self) -> None:
         """Move head motor up."""
-        pulse_count = max(1, self._coordinator.motor_pulse_count)
-        pulse_delay = max(1, self._coordinator.motor_pulse_delay_ms)
+        pulse_count, pulse_delay = self._get_pulse_settings()
         try:
             await self.write_command(
                 self.CMD_HEAD_UP,
@@ -927,8 +937,7 @@ class OctoStar2Controller(BedController):
 
     async def move_head_down(self) -> None:
         """Move head motor down."""
-        pulse_count = max(1, self._coordinator.motor_pulse_count)
-        pulse_delay = max(1, self._coordinator.motor_pulse_delay_ms)
+        pulse_count, pulse_delay = self._get_pulse_settings()
         try:
             await self.write_command(
                 self.CMD_HEAD_DOWN,
@@ -959,8 +968,7 @@ class OctoStar2Controller(BedController):
 
     async def move_legs_up(self) -> None:
         """Move legs motor up."""
-        pulse_count = max(1, self._coordinator.motor_pulse_count)
-        pulse_delay = max(1, self._coordinator.motor_pulse_delay_ms)
+        pulse_count, pulse_delay = self._get_pulse_settings()
         try:
             await self.write_command(
                 self.CMD_FEET_UP,
@@ -972,8 +980,7 @@ class OctoStar2Controller(BedController):
 
     async def move_legs_down(self) -> None:
         """Move legs motor down."""
-        pulse_count = max(1, self._coordinator.motor_pulse_count)
-        pulse_delay = max(1, self._coordinator.motor_pulse_delay_ms)
+        pulse_count, pulse_delay = self._get_pulse_settings()
         try:
             await self.write_command(
                 self.CMD_FEET_DOWN,
@@ -1011,8 +1018,7 @@ class OctoStar2Controller(BedController):
 
     async def preset_flat(self) -> None:
         """Go to flat position by moving both motors down."""
-        pulse_count = max(1, self._coordinator.motor_pulse_count)
-        pulse_delay = max(1, self._coordinator.motor_pulse_delay_ms)
+        pulse_count, pulse_delay = self._get_pulse_settings()
         try:
             await self.write_command(
                 self.CMD_BOTH_DOWN,


### PR DESCRIPTION
## Summary
- Fix timed_move service interrupting movements mid-cycle, causing hickups
- Calculate repeat count based on duration and bed's pulse delay
- Update Octo controllers to use configurable pulse settings

## Problem
The `timed_move` service used fixed 1500ms cycles. For beds like Octo (with ~4200ms movement cycles), this caused frequent interruptions and STOP commands being sent every 1.5 seconds, resulting in brief pauses during movement.

## Solution
Simple calculation: `repeat_count = duration_ms / pulse_delay_ms`

Example: 3500ms on Octo (350ms delay) = 10 repeats → smooth continuous movement with STOP sent only once at the end.

## Test plan
- [ ] Test `timed_move` service on Octo bed with various durations
- [ ] Verify smooth continuous movement without hickups
- [ ] Verify normal button press operations still work

Ref #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timed bed movements now complete in the requested duration with improved accuracy using dynamic timing calculations.
  * Stop behavior during timed moves is more reliable and always invoked.

* **New Features**
  * Motor timing (pulse count and delay) is configurable and applied consistently across all bed models and presets, improving consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->