### PR TITLE
Fix Octo light switch state after hardware auto-off

### DIFF
--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -976,6 +976,20 @@ class BedController(ABC):
         return False
 
     @property
+    def light_auto_off_seconds(self) -> int | None:
+        """Return the number of seconds before lights auto-off, or None if no auto-off.
+
+        Some beds have hardware-enforced light timeouts (e.g., Octo lights turn off
+        after 5 minutes). This property allows controllers to report this timeout
+        so the switch entity can update its assumed state accordingly.
+
+        Returns:
+            Number of seconds until lights auto-off, or None if lights stay on
+            until manually turned off.
+        """
+        return None
+
+    @property
     def light_timer_options(self) -> list[str]:
         """Return available light timer options.
 

--- a/custom_components/adjustable_bed/beds/octo.py
+++ b/custom_components/adjustable_bed/beds/octo.py
@@ -27,6 +27,7 @@ from bleak.exc import BleakError
 
 from ..const import (
     OCTO_CHAR_UUID,
+    OCTO_LIGHT_AUTO_OFF_SECONDS,
     OCTO_PIN_KEEPALIVE_INTERVAL,
     OCTO_STAR2_CHAR_UUID,
 )
@@ -411,6 +412,13 @@ class OctoController(BedController):
     def supports_discrete_light_control(self) -> bool:
         """Return True if bed has separate on/off light commands."""
         return self.supports_lights
+
+    @property
+    def light_auto_off_seconds(self) -> int | None:
+        """Octo lights auto-off after 5 minutes (hardware behavior)."""
+        if self.supports_lights:
+            return OCTO_LIGHT_AUTO_OFF_SECONDS
+        return None
 
     @property
     def supports_memory_presets(self) -> bool:

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -398,6 +398,10 @@ OCTO_STAR2_CHAR_UUID: Final = "00005a55-0000-1000-8000-00805f9b34fb"
 # Octo beds drop BLE connection after ~30s without PIN re-authentication
 OCTO_PIN_KEEPALIVE_INTERVAL: Final = 25
 
+# Octo light auto-off timeout (seconds)
+# Octo under-bed lights automatically turn off after 5 minutes (hardware behavior)
+OCTO_LIGHT_AUTO_OFF_SECONDS: Final = 300
+
 # Octo variant identifiers (dict defined later after VARIANT_AUTO)
 OCTO_VARIANT_STANDARD: Final = "standard"
 OCTO_VARIANT_STAR2: Final = "star2"


### PR DESCRIPTION
## Summary
- Fixes incorrect light switch state after Octo bed lights auto-off (hardware turns them off after 5 minutes)
- Adds timer-based state tracking to update HA switch to "off" after the 5 minute hardware timeout
- Introduces extensible `light_auto_off_seconds` property for other beds with similar behavior

## Test plan
- [ ] Configure an Octo bed with lights
- [ ] Turn on under bed lights via HA
- [ ] Verify switch shows "on"
- [ ] Wait 5 minutes (or temporarily reduce `OCTO_LIGHT_AUTO_OFF_SECONDS` for testing)
- [ ] Verify switch automatically updates to "off"
- [ ] Turn lights on again, then manually turn off before 5 min
- [ ] Verify no spurious state changes occur

Ref #176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Bed lights on compatible devices now automatically turn off after 5 minutes when activated, improving power efficiency and user convenience.
- Introduced automatic timer management for light control, featuring intelligent scheduling and cancellation mechanisms to ensure reliable auto-off behavior across supported bed models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->