### PR TITLE
Fix false positive device discovery

### DIFF
--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -199,8 +199,10 @@ def _check_manufacturer_data(
 SOLACE_NAME_PATTERN = re.compile(r"^s\d+-[a-z]-\d+-[a-z0-9]+$", re.IGNORECASE)
 
 # Device name patterns that should NOT be detected as beds
-# These use generic BUIDs that beds also use, but are clearly not beds
+# These use generic BLE UUIDs that beds also use, but are clearly not beds
+# See: https://github.com/kristofferR/ha-adjustable-bed/issues/187
 EXCLUDED_DEVICE_PATTERNS: tuple[str, ...] = (
+    # Mobility devices
     "scooter",
     "ninebot",
     "segway",
@@ -210,6 +212,52 @@ EXCLUDED_DEVICE_PATTERNS: tuple[str, ...] = (
     "e-scooter",
     "skateboard",
     "hoverboard",
+    # Scales and health monitors
+    "scale",
+    "weight",
+    "wyze",
+    "withings",
+    "renpho",
+    "eufy",
+    "fitindex",
+    "greater goods",
+    "etekcity",
+    "arboleaf",
+    # Wearables and fitness trackers
+    "watch",
+    "band",
+    "tracker",
+    "fitbit",
+    "garmin",
+    "amazfit",
+    "xiaomi",
+    "mi band",
+    "miband",
+    "huawei",
+    "polar",
+    "suunto",
+    "coros",
+    "whoop",
+    # Health monitors
+    "thermometer",
+    "blood pressure",
+    "pulse ox",
+    "heart rate",
+    "glucose",
+    "oximeter",
+    # Other common BLE devices
+    "headphone",
+    "earbud",
+    "airpod",
+    "speaker",
+    "keyboard",
+    "mouse",
+    "controller",
+    "gamepad",
+    "tile",
+    "airtag",
+    "smarttag",
+    "beacon",
 )
 
 # Display names for bed types shown in the UI selector


### PR DESCRIPTION
## Summary

- Expand `EXCLUDED_DEVICE_PATTERNS` in `detection.py` to filter out common non-bed devices before they trigger the discovery UI
- Add comprehensive test coverage for all new exclusion patterns

### Devices Now Excluded

| Category | Patterns |
|----------|----------|
| Scales | scale, weight, wyze, withings, renpho, eufy, fitindex, greater goods, etekcity, arboleaf |
| Wearables | watch, band, tracker, fitbit, garmin, amazfit, xiaomi, mi band, miband, huawei, polar, suunto, coros, whoop |
| Health monitors | thermometer, blood pressure, pulse ox, heart rate, glucose, oximeter |
| Audio | headphone, earbud, airpod, speaker |
| Input devices | keyboard, mouse, controller, gamepad |
| Trackers | tile, airtag, smarttag, beacon |

## Test plan

- [x] All 153 detection tests pass
- [x] New test cases cover scales, wearables, health monitors, and other BLE devices
- [x] Tests verify exclusion works with FFE0, FFE5, and Nordic UART UUIDs

Ref #187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Significantly improved bed detection accuracy by expanding device exclusion patterns to automatically filter out mobility devices, weight scales, health monitors, wearables, fitness trackers, headphones, speakers, and other common Bluetooth devices.

* **Tests**
  * Enhanced test coverage with new exclusion scenarios covering various device types and Bluetooth profiles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->