### PR TITLE
fix: unblock CB24 massage while preserving OEM preset cadence

### DIFF
--- a/custom_components/adjustable_bed/button.py
+++ b/custom_components/adjustable_bed/button.py
@@ -211,6 +211,7 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         translation_key="massage_all_off",
         icon="mdi:vibrate-off",
         requires_massage=True,
+        cancel_movement=True,
         press_fn=lambda ctrl: ctrl.massage_off(),
     ),
     AdjustableBedButtonEntityDescription(
@@ -218,6 +219,7 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         translation_key="massage_all_toggle",
         icon="mdi:vibrate",
         requires_massage=True,
+        cancel_movement=True,
         press_fn=lambda ctrl: ctrl.massage_toggle(),
     ),
     AdjustableBedButtonEntityDescription(
@@ -225,6 +227,7 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         translation_key="massage_all_up",
         icon="mdi:arrow-up-bold",
         requires_massage=True,
+        cancel_movement=True,
         press_fn=lambda ctrl: ctrl.massage_intensity_up(),
     ),
     AdjustableBedButtonEntityDescription(
@@ -232,6 +235,7 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         translation_key="massage_all_down",
         icon="mdi:arrow-down-bold",
         requires_massage=True,
+        cancel_movement=True,
         press_fn=lambda ctrl: ctrl.massage_intensity_down(),
     ),
     AdjustableBedButtonEntityDescription(
@@ -239,6 +243,7 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         translation_key="massage_head_toggle",
         icon="mdi:head",
         requires_massage=True,
+        cancel_movement=True,
         press_fn=lambda ctrl: ctrl.massage_head_toggle(),
     ),
     AdjustableBedButtonEntityDescription(
@@ -246,6 +251,7 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         translation_key="massage_head_up",
         icon="mdi:arrow-up",
         requires_massage=True,
+        cancel_movement=True,
         press_fn=lambda ctrl: ctrl.massage_head_up(),
     ),
     AdjustableBedButtonEntityDescription(
@@ -253,6 +259,7 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         translation_key="massage_head_down",
         icon="mdi:arrow-down",
         requires_massage=True,
+        cancel_movement=True,
         press_fn=lambda ctrl: ctrl.massage_head_down(),
     ),
     AdjustableBedButtonEntityDescription(
@@ -260,6 +267,7 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         translation_key="massage_foot_toggle",
         icon="mdi:foot-print",
         requires_massage=True,
+        cancel_movement=True,
         press_fn=lambda ctrl: ctrl.massage_foot_toggle(),
     ),
     AdjustableBedButtonEntityDescription(
@@ -267,6 +275,7 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         translation_key="massage_foot_up",
         icon="mdi:arrow-up",
         requires_massage=True,
+        cancel_movement=True,
         press_fn=lambda ctrl: ctrl.massage_foot_up(),
     ),
     AdjustableBedButtonEntityDescription(
@@ -274,6 +283,7 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         translation_key="massage_foot_down",
         icon="mdi:arrow-down",
         requires_massage=True,
+        cancel_movement=True,
         press_fn=lambda ctrl: ctrl.massage_foot_down(),
     ),
     AdjustableBedButtonEntityDescription(
@@ -281,6 +291,7 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         translation_key="massage_mode_step",
         icon="mdi:format-list-numbered",
         requires_massage=True,
+        cancel_movement=True,
         press_fn=lambda ctrl: ctrl.massage_mode_step(),
     ),
     # Circulation massage buttons (only for beds with circulation massage support)
@@ -289,6 +300,7 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         translation_key="massage_circulation_full_body",
         icon="mdi:human",
         requires_massage=True,
+        cancel_movement=True,
         press_fn=lambda ctrl: ctrl.massage_circulation_full_body(),
         required_capability="supports_circulation_massage",
     ),
@@ -297,6 +309,7 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         translation_key="massage_circulation_head",
         icon="mdi:head",
         requires_massage=True,
+        cancel_movement=True,
         press_fn=lambda ctrl: ctrl.massage_circulation_head(),
         required_capability="supports_circulation_massage",
     ),
@@ -305,6 +318,7 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         translation_key="massage_circulation_leg",
         icon="mdi:foot-print",
         requires_massage=True,
+        cancel_movement=True,
         press_fn=lambda ctrl: ctrl.massage_circulation_leg(),
         required_capability="supports_circulation_massage",
     ),
@@ -313,6 +327,7 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         translation_key="massage_circulation_hip",
         icon="mdi:human-handsdown",
         requires_massage=True,
+        cancel_movement=True,
         press_fn=lambda ctrl: ctrl.massage_circulation_hip(),
         required_capability="supports_circulation_massage",
     ),

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -8,6 +8,7 @@ from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
 # Import enable_custom_integrations fixture
+from custom_components.adjustable_bed.button import BUTTON_DESCRIPTIONS
 from custom_components.adjustable_bed.const import DOMAIN
 
 
@@ -107,6 +108,13 @@ class TestCoverEntities:
 
 class TestButtonEntities:
     """Test button entities."""
+
+    def test_massage_buttons_cancel_running_commands(self):
+        """Massage buttons should preempt long-running movement/preset actions."""
+        massage_buttons = [desc for desc in BUTTON_DESCRIPTIONS if desc.key.startswith("massage_")]
+
+        assert len(massage_buttons) > 0
+        assert all(desc.cancel_movement for desc in massage_buttons)
 
     async def test_button_entities_created(
         self,

--- a/tests/test_okin_cb24.py
+++ b/tests/test_okin_cb24.py
@@ -1,0 +1,50 @@
+"""Tests for Okin CB24 controller behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.adjustable_bed.beds.okin_cb24 import (
+    OkinCB24Commands,
+    OkinCB24Controller,
+)
+
+
+class TestOkinCB24Controller:
+    """Test OkinCB24Controller."""
+
+    def test_protocol_command_bytes_match_cb24_format(self) -> None:
+        """CB24 packet bytes should match OEM app command format."""
+        coordinator_default = MagicMock()
+        coordinator_default.address = "AA:BB:CC:DD:EE:FF"
+        controller_default = OkinCB24Controller(coordinator_default)
+        assert controller_default._build_command(OkinCB24Commands.PRESET_FLAT) == bytes(
+            [0x05, 0x02, 0x08, 0x00, 0x00, 0x00, 0x00]
+        )
+
+        coordinator_bed_a = MagicMock()
+        coordinator_bed_a.address = "AA:BB:CC:DD:EE:FF"
+        controller_bed_a = OkinCB24Controller(coordinator_bed_a, bed_selection=0xAA)
+        assert controller_bed_a._build_command(OkinCB24Commands.MASSAGE_ALL_TOGGLE) == bytes(
+            [0x05, 0x02, 0x00, 0x00, 0x01, 0x00, 0xAA]
+        )
+
+    def test_preset_burst_timing_constants(self) -> None:
+        """Preset burst timing should match CB24 hold-style cadence."""
+        assert OkinCB24Controller.PRESET_REPEAT_COUNT == 83
+        assert OkinCB24Controller.PRESET_REPEAT_DELAY_MS == 300
+
+    async def test_send_preset_uses_interruptible_burst_timing(self) -> None:
+        """Preset commands should use configured burst timing."""
+        coordinator = MagicMock()
+        coordinator.address = "AA:BB:CC:DD:EE:FF"
+        controller = OkinCB24Controller(coordinator)
+        controller.write_command = AsyncMock()
+
+        await controller._send_preset(OkinCB24Commands.PRESET_ZERO_G)
+
+        controller.write_command.assert_awaited_once_with(
+            controller._build_command(OkinCB24Commands.PRESET_ZERO_G),
+            repeat_count=controller.PRESET_REPEAT_COUNT,
+            repeat_delay_ms=controller.PRESET_REPEAT_DELAY_MS,
+        )


### PR DESCRIPTION
## What changed
- Keep CB24 preset resend cadence aligned with the OEM app (83 repeats at 300ms) via explicit constants.
- Make all massage-related button entities preempt running movement/preset commands (`cancel_movement=True`) so massage presses do not get starved behind long preset bursts.
- Add CB24-focused regression tests for packet bytes and preset burst timing.
- Add entity regression test to ensure all `massage_*` buttons remain preemptive.

## Why
Issue #185 reports that recent changes regressed massage behavior after preset updates. Logs showed queued massage commands being cancelled while waiting for the command lock during long preset command loops.

## Verification
- uv run pytest -n 0 tests/test_okin_cb24.py tests/test_entities.py

Ref #185


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Massage and circulation massage buttons now automatically cancel any in-progress movement commands when pressed for smoother control switching.
  * Enhanced preset command delivery with configurable repeat timing parameters.

* **Tests**
  * Added comprehensive unit tests validating preset command formatting, timing configuration, and button cancel_movement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->