### PR TITLE
fix: send SUTA preset recalls once for continuous movement

### DIFF
--- a/custom_components/adjustable_bed/beds/suta.py
+++ b/custom_components/adjustable_bed/beds/suta.py
@@ -252,14 +252,19 @@ class SutaController(BedController):
         """Stop all motor movement."""
         await self._send_stop()
 
+    async def _send_preset_recall(self, command: str) -> None:
+        """Send a preset recall command once.
+
+        SUTA firmware handles the full movement to the target preset after a
+        single MODE command; repeating the command or forcing STOP causes
+        choppy movement.
+        """
+        await self.write_command(self._build_command(command))
+
     # Preset methods
     async def preset_flat(self) -> None:
         """Go to flat position."""
-        await self._preset_with_stop(
-            self._build_command(SutaCommands.PRESET_FLAT),
-            repeat_count=100,
-            repeat_delay_ms=150,
-        )
+        await self._send_preset_recall(SutaCommands.PRESET_FLAT)
 
     async def preset_memory(self, memory_num: int) -> None:
         """Go to memory preset."""
@@ -270,11 +275,7 @@ class SutaController(BedController):
             4: SutaCommands.PRESET_MEMORY_4,
         }
         if command := commands.get(memory_num):
-            await self._preset_with_stop(
-                self._build_command(command),
-                repeat_count=100,
-                repeat_delay_ms=150,
-            )
+            await self._send_preset_recall(command)
         else:
             _LOGGER.warning("SUTA supports memory presets 1-4 only")
 
@@ -297,27 +298,15 @@ class SutaController(BedController):
 
     async def preset_zero_g(self) -> None:
         """Go to zero-g preset."""
-        await self._preset_with_stop(
-            self._build_command(SutaCommands.PRESET_ZERO_G),
-            repeat_count=100,
-            repeat_delay_ms=150,
-        )
+        await self._send_preset_recall(SutaCommands.PRESET_ZERO_G)
 
     async def preset_anti_snore(self) -> None:
         """Go to anti-snore preset."""
-        await self._preset_with_stop(
-            self._build_command(SutaCommands.PRESET_ANTI_SNORE),
-            repeat_count=100,
-            repeat_delay_ms=150,
-        )
+        await self._send_preset_recall(SutaCommands.PRESET_ANTI_SNORE)
 
     async def preset_tv(self) -> None:
         """Go to TV preset."""
-        await self._preset_with_stop(
-            self._build_command(SutaCommands.PRESET_TV),
-            repeat_count=100,
-            repeat_delay_ms=150,
-        )
+        await self._send_preset_recall(SutaCommands.PRESET_TV)
 
     # Light methods
     async def lights_on(self) -> None:

--- a/docs/beds/suta.md
+++ b/docs/beds/suta.md
@@ -103,7 +103,7 @@ Note: `head` is mapped to the same upper actuator commands as `back` for compati
 |-----------|-------------|-------|-------|
 | Motor movement (default) | 7 | 150ms | Bed-type pulse defaults |
 | Stop | 2 | 100ms | Sent after movement |
-| Preset recall | 100 | 150ms | Repeated command pattern |
+| Preset recall | 1 | n/a | Single command, bed firmware handles full move |
 | Save memory | 5 | 150ms | Program command burst |
 
 ## Notes
@@ -115,4 +115,3 @@ Note: `head` is mapped to the same upper actuator commands as `back` for compati
 ## References
 
 - `disassembly/output/com.shuta.smart_home/ANALYSIS.md`
-

--- a/tests/test_suta.py
+++ b/tests/test_suta.py
@@ -138,7 +138,7 @@ class TestSutaController:
         suta_coordinator,
         mock_bleak_client: MagicMock,
     ) -> None:
-        """Memory preset 2 should send M2 recall command."""
+        """Memory preset 2 should send one M2 recall command without STOP."""
         coordinator = await suta_coordinator(
             address="AA:BB:CC:DD:EE:04",
             name="SUTA-B505",
@@ -147,5 +147,24 @@ class TestSutaController:
 
         await coordinator.controller.preset_memory(2)
 
-        first_payload = mock_bleak_client.write_gatt_char.call_args_list[0][0][1]
-        assert first_payload == _to_packet(SutaCommands.PRESET_MEMORY_2)
+        calls = mock_bleak_client.write_gatt_char.call_args_list
+        assert len(calls) == 1
+        assert calls[0][0][1] == _to_packet(SutaCommands.PRESET_MEMORY_2)
+
+    async def test_preset_tv_sends_single_command_without_stop(
+        self,
+        suta_coordinator,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """TV preset should send one preset command and let firmware run continuously."""
+        coordinator = await suta_coordinator(
+            address="AA:BB:CC:DD:EE:06",
+            name="SUTA-B201B",
+            entry_id="suta_test_entry_6",
+        )
+
+        await coordinator.controller.preset_tv()
+
+        calls = mock_bleak_client.write_gatt_char.call_args_list
+        assert len(calls) == 1
+        assert calls[0][0][1] == _to_packet(SutaCommands.PRESET_TV)


### PR DESCRIPTION
## Summary
- send SUTA preset recall commands as single writes instead of repeated bursts
- stop forcing a cleanup STOP after preset recall for SUTA beds
- update SUTA tests and SUTA protocol docs to match single-send preset behavior

## Validation
- `uv run pytest tests/test_suta.py`

Ref #223
