### PR TITLE
fix(vibradorm): hold-to-run presets and fallback char discovery

### DIFF
--- a/custom_components/adjustable_bed/beds/vibradorm.py
+++ b/custom_components/adjustable_bed/beds/vibradorm.py
@@ -169,7 +169,6 @@ class VibradormController(BedController):
             return
 
         service_map = {str(service.uuid).lower(): service for service in client.services}
-        all_services = list(client.services)
         candidate_services = [
             service_map[service_uuid.lower()]
             for service_uuid in VIBRADORM_SERVICE_UUID_CANDIDATES
@@ -180,11 +179,11 @@ class VibradormController(BedController):
         # all services on the device. Some Vibradorm variants (or ESPHome proxy
         # configurations) may expose characteristics under different service UUIDs.
         if not candidate_services:
-            if force:
-                _LOGGER.debug(
-                    "No known Vibradorm services found; searching all %d services",
-                    len(all_services),
-                )
+            all_services = list(client.services)
+            _LOGGER.debug(
+                "No known Vibradorm services found; searching all %d services",
+                len(all_services),
+            )
             candidate_services = all_services
 
         selected_command_char = None
@@ -521,7 +520,7 @@ class VibradormController(BedController):
                     repeat_count=1,
                     cancel_event=asyncio.Event(),
                 )
-            except BleakError:
+            except (BleakError, ConnectionError):
                 _LOGGER.debug("Failed to send STOP command during cleanup")
 
     # Motor control methods
@@ -677,7 +676,7 @@ class VibradormController(BedController):
                     repeat_count=1,
                     cancel_event=asyncio.Event(),
                 )
-            except BleakError:
+            except (BleakError, ConnectionError):
                 _LOGGER.debug("Failed to send STOP command during preset cleanup")
 
     async def program_memory(self, memory_num: int) -> None:

--- a/tests/test_vibradorm.py
+++ b/tests/test_vibradorm.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Coroutine
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -344,7 +346,7 @@ class TestVibradormController:
         controller._characteristics_initialized = True
         controller._command_char_uuid = VIBRADORM_COMMAND_CHAR_UUID
 
-        async def _write_side_effect(char_uuid: str, *_args, **_kwargs):
+        async def _write_side_effect(char_uuid: str, *_args: Any, **_kwargs: Any) -> None:
             if str(char_uuid).lower() == VIBRADORM_COMMAND_CHAR_UUID:
                 raise BleakCharacteristicNotFoundError(char_uuid)
             return None
@@ -389,9 +391,9 @@ class TestVibradormController:
         controller._characteristics_initialized = True
         controller._command_char_uuid = VIBRADORM_COMMAND_CHAR_UUID
 
-        call_count = 0
+        call_count: int = 0
 
-        async def _write_side_effect(char_uuid: str, *_args, **_kwargs):
+        async def _write_side_effect(char_uuid: str, *_args: Any, **_kwargs: Any) -> None:
             nonlocal call_count
             call_count += 1
             if call_count == 1 and str(char_uuid).lower() == VIBRADORM_COMMAND_CHAR_UUID:
@@ -415,6 +417,8 @@ class TestVibradormController:
         mock_coordinator_connected,
     ):
         """Controller should find command characteristic on non-Vibradorm services."""
+        del mock_coordinator_connected
+
         coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
         await coordinator.async_connect()
         controller = coordinator.controller
@@ -445,6 +449,8 @@ class TestVibradormController:
         mock_coordinator_connected,
     ):
         """Controller should fall back to any writable char when no known UUIDs match."""
+        del mock_coordinator_connected
+
         coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
         await coordinator.async_connect()
         controller = coordinator.controller
@@ -604,11 +610,11 @@ class TestVibradormPresets:
     """
 
     @staticmethod
-    def _cancel_after_first_write(coordinator):
+    def _cancel_after_first_write(coordinator: Any) -> Callable[..., Coroutine[Any, Any, None]]:
         """Return a side_effect that cancels after the first write."""
-        call_count = 0
+        call_count: int = 0
 
-        async def _side_effect(*_args, **_kwargs):
+        async def _side_effect(*_args: Any, **_kwargs: Any) -> None:
             nonlocal call_count
             call_count += 1
             if call_count == 1:


### PR DESCRIPTION
## Summary
- **Memory presets / flat now use hold-to-run** (600 × 100 ms = 60 s) instead of the short motor-pulse count (~1 s). The bed auto-stops at the target position; the cancel event allows early stop via the Stop button. Ref [#162 (comment)](https://github.com/kristofferR/ha-adjustable-bed/issues/162#issuecomment-3922974764)
- **Characteristic discovery searches all device services** when the known Vibradorm service UUIDs are absent, fixing "characteristic not found" on devices with different GATT layouts (e.g. ESPHome proxy variants). Ref [#162 (comment)](https://github.com/kristofferR/ha-adjustable-bed/issues/162#issuecomment-3923041623)

## Test plan
- [x] All 42 Vibradorm tests pass (2 new tests for fallback discovery)
- [ ] @zaxxon72 tests memory preset recall moves bed to stored position
- [ ] @JoeD84 tests that commands no longer fail with "characteristic not found"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust service discovery with a fallback that scans all device services when standard identifiers are missing.
  * Improved retry behavior for command writes after refresh, with clearer warnings and error logging.
  * Ensures STOP is reliably sent during preset cleanup.

* **Improvements**
  * Presets changed to hold-to-run (up to 60s) with early cancellation support and refined movement handling.
  * Updated preset and motor command flows for more reliable operation.

* **Tests**
  * Added tests covering unknown/nonstandard service layouts, retry behavior, and hold-to-run preset semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->