### PR TITLE
fix(cb24): restore one-shot presets for auto profile selection

### DIFF
--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -764,13 +764,13 @@ OKIN_CB24_VARIANT_DACHENG: Final = "dacheng"
 OKIN_CB24_VARIANT_CB27NEW: Final = "cb27new"
 OKIN_CB24_VARIANTS: Final = {
     VARIANT_AUTO: "Auto-detect (recommended)",
-    OKIN_CB24_VARIANT_OLD: "OLD protocol (CB24/CB27/CB24AB/CB1221)",
+    OKIN_CB24_VARIANT_OLD: "OLD protocol compatibility (continuous presets)",
     OKIN_CB24_VARIANT_NEW: "NEW protocol (CB27New)",
-    OKIN_CB24_VARIANT_CB24: "CB24 profile (OLD protocol)",
-    OKIN_CB24_VARIANT_CB27: "CB27 profile (OLD protocol)",
-    OKIN_CB24_VARIANT_CB24_AB: "CB24AB profile (OLD protocol, split bed)",
-    OKIN_CB24_VARIANT_CB1221: "CB1221 profile (OLD protocol)",
-    OKIN_CB24_VARIANT_DACHENG: "Dacheng profile (OLD protocol)",
+    OKIN_CB24_VARIANT_CB24: "CB24 profile (legacy packets, one-shot presets)",
+    OKIN_CB24_VARIANT_CB27: "CB27 profile (legacy packets, one-shot presets)",
+    OKIN_CB24_VARIANT_CB24_AB: "CB24AB profile (legacy packets, one-shot presets)",
+    OKIN_CB24_VARIANT_CB1221: "CB1221 profile (legacy packets, one-shot presets)",
+    OKIN_CB24_VARIANT_DACHENG: "Dacheng profile (legacy packets, one-shot presets)",
     OKIN_CB24_VARIANT_CB27NEW: "CB27New profile (NEW protocol)",
 }
 

--- a/custom_components/adjustable_bed/controller_factory.py
+++ b/custom_components/adjustable_bed/controller_factory.py
@@ -161,17 +161,17 @@ async def create_controller(
         # Detect SmartBed profile variant.
         # OEM app behavior:
         # - CB27NewDeviceProfile (NEW protocol): startswith("smartbed") and len == 18
-        # - CB24/CB27/CB24AB/CB1221/Dacheng (OLD protocol): all other CB24-family devices
-        profile_variant = OKIN_CB24_VARIANT_OLD
+        # - all other CB24-family devices: legacy packets (default to CB24 profile)
+        profile_variant = OKIN_CB24_VARIANT_CB24
         if device_name:
             name_lower = device_name.lower()
             if name_lower.startswith("smartbed") and len(device_name) == 18:
                 profile_variant = OKIN_CB24_VARIANT_CB27NEW
                 _LOGGER.debug("CB24 profile auto-detected: cb27new (name len=18)")
             else:
-                profile_variant = OKIN_CB24_VARIANT_OLD
+                profile_variant = OKIN_CB24_VARIANT_CB24
                 _LOGGER.debug(
-                    "CB24 profile auto-detected: cb_old (name len=%d)",
+                    "CB24 profile auto-detected: cb24 (name len=%d)",
                     len(device_name),
                 )
 


### PR DESCRIPTION
## Summary
- restore one-shot preset behavior for auto-selected legacy CB24 devices (cb24 profile)
- keep cb_old as explicit compatibility mode for continuous 300ms preset sends + STOP
- keep CB27New/CBNew packet switching unchanged
- add regression coverage for one-shot cb24 profile presets

## Why
v2.4.2 switched all non-CB27New legacy profiles to continuous presets, which regressed known-working devices reported in issue #185.

Ref #185


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced preset command handling with improved support for legacy bed protocols, distinguishing between continuous and one-shot preset behaviors.

* **Bug Fixes**
  * Corrected default profile selection for CB24-family devices to CB24 instead of the legacy OLD protocol.

* **Documentation**
  * Updated profile labels and initialization messages to clarify preset behavior for legacy and new protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->