### PR TITLE
fix(cb24): avoid premature adaptive promotion to continuous presets

### DIFF
--- a/tests/test_okin_cb24.py
+++ b/tests/test_okin_cb24.py
@@ -153,6 +153,15 @@ class TestOkinCB24Controller:
             adaptive_preset_fallback=True,
         )
         controller.write_command = AsyncMock()
+        current_time = 1.0
+
+        def fake_now() -> float:
+            nonlocal current_time
+            value = current_time
+            current_time += 1.0
+            return value
+
+        controller._now = fake_now
 
         await controller._send_preset(OkinCB24Commands.PRESET_MEMORY_1)
         await controller._send_preset(OkinCB24Commands.PRESET_MEMORY_1)


### PR DESCRIPTION
## Summary
- delay CB24 adaptive one-shot -> continuous preset promotion until repeated quick retries of the same preset
- keep OEM-aligned profile behavior intact:
  - `CB27New` / `CBNewProtocol`: one-shot preset writes
  - legacy CB24-family profiles: one-shot by default in auto mode, with compatibility fallback to continuous
- update tests to verify promotion occurs only after an additional retry (third same-preset tap)

## Root Cause
Issue [#185 comment 3932904574](https://github.com/kristofferR/ha-adjustable-bed/issues/185#issuecomment-3932904574) reported presets that "sometimes move an inch and then stop".

From the attached logs, the problematic sequence was:
1. one-shot preset write
2. quick second tap of same preset
3. adaptive mode immediately promoted to continuous
4. subsequent preset taps preempted/cancelled long-running continuous streams

This made behavior unstable for users frequently tapping presets while testing.

## APK Evidence Used
I re-checked the SmartBed APK decompile in `disassembly/output/com.okin.bedding.smartbedwifi/jadx/sources`:
- `BleDeviceProfileFactory` shows explicit profile matching order and first-match selection.
- `CB27NewDeviceProfile` uses `name.toLowerCase().startsWith("smartbed") && len==18` and returns `CBNewProtocol`.
- legacy profiles (`CB24/CB27/CB24AB/CB1221`) return `CB24Protocol`.
- `OREBleDeviceManager` uses one shared runnable at 300ms cadence.
- `callMemory(...)` branches by device type:
  - `DEVICE_TYPE_BLUETOOTH_NEW_PROTOCOL`: one-shot `sendCmd(data)`
  - others: continuous runnable (`mMotorRunnable`) behavior

So the app’s seamless handling is profile-based, not an immediate runtime mode flip after a single retry.

## What This PR Changes
- add retry threshold constant for adaptive promotion (`_ADAPTIVE_PRESET_PROMOTION_RETRY_COUNT = 2`)
- track same-preset retry count in adaptive mode
- only promote to continuous when the same preset is retried repeatedly within the retry window, instead of promoting on the first quick retry
- keep existing behavior for:
  - explicit `cb_old` compatibility variant (always continuous)
  - new protocol profiles (always one-shot)

## Validation
- `uv run pytest -q tests/test_okin_cb24.py`
- result: `30 passed`

Ref #185


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adaptive preset promotion retry logic for legacy bed profiles with automatic escalation after multiple attempts and enhanced diagnostic logging.

* **Tests**
  * Updated test coverage to reflect improved retry promotion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->