### PR TITLE
Add bed height (Hi-Lo) and tilt support for Malouf beds

### DIFF
--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -608,6 +608,11 @@ class BedController(ABC):
         return False
 
     @property
+    def has_bed_height_support(self) -> bool:
+        """Return True if bed has bed height (Hi-Lo) control."""
+        return False
+
+    @property
     def supports_position_feedback(self) -> bool:
         """Return True if bed reports position feedback."""
         return False
@@ -815,6 +820,32 @@ class BedController(ABC):
             NotImplementedError: If the bed doesn't have hip motor
         """
         raise NotImplementedError("Hip motor not supported on this bed")
+
+    # Bed height (Hi-Lo) control (optional - raises/lowers entire bed frame)
+
+    async def move_bed_height_up(self) -> None:
+        """Raise entire bed frame (Hi-Lo up).
+
+        Raises:
+            NotImplementedError: If the bed doesn't have bed height control
+        """
+        raise NotImplementedError("Bed height control not supported on this bed")
+
+    async def move_bed_height_down(self) -> None:
+        """Lower entire bed frame (Hi-Lo down).
+
+        Raises:
+            NotImplementedError: If the bed doesn't have bed height control
+        """
+        raise NotImplementedError("Bed height control not supported on this bed")
+
+    async def move_bed_height_stop(self) -> None:
+        """Immediately stop bed height movement.
+
+        Raises:
+            NotImplementedError: If the bed doesn't have bed height control
+        """
+        raise NotImplementedError("Bed height control not supported on this bed")
 
     # Optional preset methods (may not be available on all beds)
     # These raise NotImplementedError by default. Subclasses override if supported.

--- a/custom_components/adjustable_bed/beds/malouf.py
+++ b/custom_components/adjustable_bed/beds/malouf.py
@@ -67,6 +67,10 @@ class MaloufCommands:
     MASSAGE_TIMER = 0x200
     MASSAGE_OFF = 0x2000000
 
+    # Hi-Lo (entire bed raise/lower)
+    BED_UP = 0x40000000    # Hi-Lo: raise entire bed
+    BED_DOWN = 0x80000000  # Hi-Lo: lower entire bed
+
 
 class MaloufNewOkinController(BedController):
     """Controller for Malouf beds using NEW_OKIN protocol.
@@ -112,6 +116,10 @@ class MaloufNewOkinController(BedController):
 
     @property
     def has_tilt_support(self) -> bool:
+        return True
+
+    @property
+    def has_bed_height_support(self) -> bool:
         return True
 
     @property
@@ -250,6 +258,21 @@ class MaloufNewOkinController(BedController):
 
     async def move_tilt_stop(self) -> None:
         """Stop tilt movement."""
+        await self.write_command(
+            self._build_command(MaloufCommands.STOP), cancel_event=asyncio.Event()
+        )
+
+    # Bed height (Hi-Lo) control
+    async def move_bed_height_up(self) -> None:
+        """Raise entire bed (Hi-Lo up)."""
+        await self._move_with_stop(MaloufCommands.BED_UP)
+
+    async def move_bed_height_down(self) -> None:
+        """Lower entire bed (Hi-Lo down)."""
+        await self._move_with_stop(MaloufCommands.BED_DOWN)
+
+    async def move_bed_height_stop(self) -> None:
+        """Stop Hi-Lo movement."""
         await self.write_command(
             self._build_command(MaloufCommands.STOP), cancel_event=asyncio.Event()
         )
@@ -403,6 +426,10 @@ class MaloufLegacyOkinController(BedController):
         return True
 
     @property
+    def has_bed_height_support(self) -> bool:
+        return True
+
+    @property
     def supports_lights(self) -> bool:
         """Return True - these beds support lighting."""
         return True
@@ -542,6 +569,21 @@ class MaloufLegacyOkinController(BedController):
 
     async def move_tilt_stop(self) -> None:
         """Stop tilt movement."""
+        await self.write_command(
+            self._build_command(MaloufCommands.STOP), cancel_event=asyncio.Event()
+        )
+
+    # Bed height (Hi-Lo) control
+    async def move_bed_height_up(self) -> None:
+        """Raise entire bed (Hi-Lo up)."""
+        await self._move_with_stop(MaloufCommands.BED_UP)
+
+    async def move_bed_height_down(self) -> None:
+        """Lower entire bed (Hi-Lo down)."""
+        await self._move_with_stop(MaloufCommands.BED_DOWN)
+
+    async def move_bed_height_stop(self) -> None:
+        """Stop Hi-Lo movement."""
         await self.write_command(
             self._build_command(MaloufCommands.STOP), cancel_event=asyncio.Event()
         )

--- a/custom_components/adjustable_bed/cover.py
+++ b/custom_components/adjustable_bed/cover.py
@@ -278,7 +278,7 @@ async def async_setup_entry(
                     entities.append(AdjustableBedCover(coordinator, description))
                 continue
             # Special handling for lumbar - only add if controller supports it
-            if description.key == "lumbar":
+            elif description.key == "lumbar":
                 if controller is not None and controller.has_lumbar_support:
                     entities.append(AdjustableBedCover(coordinator, description))
             # Special handling for pillow - only add if controller supports it

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -422,6 +422,9 @@
       "hip": {
         "name": "Hip"
       },
+      "bed_height": {
+        "name": "Bed Height"
+      },
       "keeson_back": {
         "name": "Back"
       },

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -429,6 +429,12 @@
       },
       "keeson_legs": {
         "name": "Legs"
+      },
+      "hip": {
+        "name": "Hip"
+      },
+      "bed_height": {
+        "name": "Bed Height"
       }
     },
     "sensor": {


### PR DESCRIPTION
## Summary

- Adds new `bed_height` infrastructure for Hi-Lo beds that raise/lower the entire bed frame (separate from the existing `hip` motor used by Solace beds)
- Adds `BED_UP` (0x40000000) / `BED_DOWN` (0x80000000) commands to Malouf protocol, exposed as a "Bed Height" cover entity
- Enables tilt cover entities for any bed declaring `has_tilt_support` (was previously restricted to Keeson/Ergomotion only), so Malouf Hi-Lo beds get both height and tilt controls
- Fixes hip translation in en.json back to "Hip" (was incorrectly set to "Bed Height")

Ref #244

## Test plan

- [ ] Verify Malouf Legacy OKIN bed shows "Bed Height" and "Tilt" cover entities
- [ ] Verify BED_UP/BED_DOWN packets are sent correctly (0x40000000 / 0x80000000)
- [ ] Verify tilt commands still use HEAD_TILT_UP/DOWN (0x10 / 0x20)
- [ ] Verify Solace beds still show "Hip" entity (unchanged)
- [ ] Verify Keeson/Ergomotion tilt behavior is unaffected (separate code path)
- [ ] Verify standard beds without tilt/bed_height support don't get extra entities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bed height adjustment controls for compatible adjustable bed models: raise, lower, and stop full-bed height movement.
  * Automatic capability detection ensures controls appear only on supported devices.
  * New cover entity for bed height integrated into device control flows when supported.

* **Documentation**
  * Added user-facing labels: "Bed Height" and a new "Hip" cover name for UI translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->