### PR TITLE
refactor: replace split diagnostics with support bundle

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -1007,8 +1007,8 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                 notification_id=f"adjustable_bed_support_bundle_{address.replace(':', '_').lower()}",
             )
             _LOGGER.info("Support bundle saved to %s", filepath)
-        except asyncio.TimeoutError:
-            _LOGGER.error(
+        except TimeoutError:
+            _LOGGER.exception(
                 "Support bundle generation timed out after %d seconds for %s",
                 capture_duration + 120,
                 address,
@@ -1021,6 +1021,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                 title="Adjustable Bed Support Bundle Timeout",
                 notification_id=f"adjustable_bed_support_bundle_error_{address.replace(':', '_').lower()}",
             )
+            raise
         except Exception as err:
             _LOGGER.exception("Failed to generate support bundle for %s", address)
             async_create(
@@ -1029,6 +1030,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                 title="Adjustable Bed Support Bundle Error",
                 notification_id=f"adjustable_bed_support_bundle_error_{address.replace(':', '_').lower()}",
             )
+            raise
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -53,11 +53,10 @@ from .unsupported import create_pairing_required_issue
 
 # Service constants
 SERVICE_GOTO_PRESET = "goto_preset"
+SERVICE_GENERATE_SUPPORT_BUNDLE = "generate_support_bundle"
 SERVICE_SAVE_PRESET = "save_preset"
-SERVICE_STOP_ALL = "stop_all"
-SERVICE_RUN_DIAGNOSTICS = "run_diagnostics"
-SERVICE_GENERATE_SUPPORT_REPORT = "generate_support_report"
 SERVICE_SET_POSITION = "set_position"
+SERVICE_STOP_ALL = "stop_all"
 SERVICE_TIMED_MOVE = "timed_move"
 ATTR_PRESET = "preset"
 ATTR_MOTOR = "motor"
@@ -916,211 +915,136 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         ),
     )
 
-    async def handle_run_diagnostics(call: ServiceCall) -> None:
-        """Handle run_diagnostics service call."""
+    async def handle_generate_support_bundle(call: ServiceCall) -> None:
+        """Handle generate_support_bundle service call."""
         from homeassistant.components.persistent_notification import async_create
 
-        from .ble_diagnostics import BLEDiagnosticRunner, save_diagnostic_report
+        from .support_bundle import generate_support_bundle, save_support_bundle
 
         device_ids = call.data.get(CONF_DEVICE_ID, [])
         target_address = call.data.get(ATTR_TARGET_ADDRESS)
         capture_duration = call.data.get(ATTR_CAPTURE_DURATION, DEFAULT_CAPTURE_DURATION)
+        include_logs = call.data.get(ATTR_INCLUDE_LOGS, True)
 
-        # Determine which address to use
         address: str | None = None
         coordinator: AdjustableBedCoordinator | None = None
+        entry: ConfigEntry | None = None
+        selected_device_id: str | None = None
 
         if target_address:
-            # Use the provided target address
             from .config_flow import is_valid_mac_address
 
             address = str(target_address).upper().replace("-", ":")
             if not is_valid_mac_address(address):
                 _LOGGER.error(
-                    "Invalid MAC address format for run_diagnostics: %s",
+                    "Invalid MAC address format for generate_support_bundle: %s",
                     target_address,
                 )
                 async_create(
                     hass,
-                    f"**Diagnostics Failed**\n\n"
+                    f"**Support Bundle Failed**\n\n"
                     f"Invalid MAC address format: `{target_address}`\n\n"
                     f"Please provide a valid MAC address in the format "
                     f"`XX:XX:XX:XX:XX:XX` or `XX-XX-XX-XX-XX-XX`.",
-                    title="Adjustable Bed Diagnostics Error",
-                    notification_id="adjustable_bed_diagnostics_error",
+                    title="Adjustable Bed Support Bundle Error",
+                    notification_id="adjustable_bed_support_bundle_error",
                 )
                 return
             _LOGGER.info(
-                "Running diagnostics on unconfigured device at %s",
+                "Generating support bundle for unconfigured device at %s",
                 address,
             )
         elif device_ids:
-            # Use the first device ID to get the coordinator
-            device_id = device_ids[0]
-            coordinator = await _get_coordinator_from_device(hass, device_id)
+            selected_device_id = device_ids[0]
+            coordinator = await _get_coordinator_from_device(hass, selected_device_id)
             if coordinator:
                 address = coordinator.address
+                for entry_id, coord in hass.data.get(DOMAIN, {}).items():
+                    if coord is coordinator:
+                        entry = hass.config_entries.async_get_entry(entry_id)
+                        break
                 _LOGGER.info(
-                    "Running diagnostics on configured device %s at %s",
+                    "Generating support bundle for configured device %s at %s",
                     coordinator.name,
                     address,
                 )
             else:
                 _LOGGER.error(
-                    "Could not find Adjustable Bed device with ID %s for run_diagnostics service",
-                    device_id,
+                    "Could not find Adjustable Bed device with ID %s for generate_support_bundle service",
+                    selected_device_id,
                 )
                 async_create(
                     hass,
-                    f"**Diagnostics Failed**\n\n"
-                    f"Could not find Adjustable Bed device with ID: `{device_id}`\n\n"
+                    f"**Support Bundle Failed**\n\n"
+                    f"Could not find Adjustable Bed device with ID: `{selected_device_id}`\n\n"
                     f"Please verify the device is configured and try again.",
-                    title="Adjustable Bed Diagnostics Error",
-                    notification_id="adjustable_bed_diagnostics_error",
+                    title="Adjustable Bed Support Bundle Error",
+                    notification_id="adjustable_bed_support_bundle_error",
                 )
                 return
         else:
-            _LOGGER.error("No device_id or target_address provided for run_diagnostics service")
+            _LOGGER.error(
+                "No device_id or target_address provided for generate_support_bundle service"
+            )
             async_create(
                 hass,
-                "**Diagnostics Failed**\n\n"
+                "**Support Bundle Failed**\n\n"
                 "No `device_id` or `target_address` was provided.\n\n"
                 "Please specify either a configured device or a target MAC address.",
-                title="Adjustable Bed Diagnostics Error",
-                notification_id="adjustable_bed_diagnostics_error",
+                title="Adjustable Bed Support Bundle Error",
+                notification_id="adjustable_bed_support_bundle_error",
             )
             return
 
-        # Run diagnostics (address is guaranteed to be str at this point)
         assert address is not None
         try:
-            runner = BLEDiagnosticRunner(
+            report = await generate_support_bundle(
                 hass,
-                address,
+                address=address,
                 capture_duration=capture_duration,
+                include_logs=include_logs,
                 coordinator=coordinator,
+                entry=entry,
+                device_id=selected_device_id,
             )
-            report = await runner.run_diagnostics()
-            filepath = save_diagnostic_report(hass, report, address)
+            filepath = await hass.async_add_executor_job(
+                save_support_bundle,
+                hass,
+                report,
+                address,
+            )
 
-            # Create persistent notification
             async_create(
                 hass,
-                f"BLE diagnostic report saved to:\n\n`{filepath}`\n\n"
-                f"Captured {len(report.notifications)} notifications over {capture_duration} seconds.\n\n"
-                "Please attach this file when reporting the device.",
-                title="Adjustable Bed Diagnostic Report Ready",
-                notification_id=f"adjustable_bed_diagnostic_{address.replace(':', '_').lower()}",
+                f"Support bundle saved to:\n\n`{filepath}`\n\n"
+                f"Captured {len(report.get('notifications', []))} notifications over "
+                f"{capture_duration} seconds.\n\n"
+                "Attach this JSON file when reporting unsupported or broken beds.",
+                title="Adjustable Bed Support Bundle Ready",
+                notification_id=f"adjustable_bed_support_bundle_{address.replace(':', '_').lower()}",
             )
-            _LOGGER.info("Diagnostic report saved to %s", filepath)
+            _LOGGER.info("Support bundle saved to %s", filepath)
         except Exception as err:
-            _LOGGER.exception("Failed to run diagnostics for %s", address)
+            _LOGGER.exception("Failed to generate support bundle for %s", address)
             async_create(
                 hass,
-                f"Failed to run BLE diagnostics for {address}:\n\n{err}",
-                title="Adjustable Bed Diagnostic Error",
-                notification_id=f"adjustable_bed_diagnostic_error_{address.replace(':', '_').lower()}",
+                f"Failed to generate support bundle for {address}:\n\n{err}",
+                title="Adjustable Bed Support Bundle Error",
+                notification_id=f"adjustable_bed_support_bundle_error_{address.replace(':', '_').lower()}",
             )
 
     hass.services.async_register(
         DOMAIN,
-        SERVICE_RUN_DIAGNOSTICS,
-        handle_run_diagnostics,
+        SERVICE_GENERATE_SUPPORT_BUNDLE,
+        handle_generate_support_bundle,
         schema=vol.Schema(
             {
                 vol.Exclusive(CONF_DEVICE_ID, "target"): cv.ensure_list,
                 vol.Exclusive(ATTR_TARGET_ADDRESS, "target"): cv.string,
                 vol.Optional(ATTR_CAPTURE_DURATION, default=DEFAULT_CAPTURE_DURATION): vol.All(
-                    vol.Coerce(int), vol.Range(min=MIN_CAPTURE_DURATION, max=MAX_CAPTURE_DURATION)
+                    vol.Coerce(int),
+                    vol.Range(min=MIN_CAPTURE_DURATION, max=MAX_CAPTURE_DURATION),
                 ),
-            }
-        ),
-    )
-
-    async def handle_generate_support_report(call: ServiceCall) -> None:
-        """Handle generate_support_report service call."""
-        from homeassistant.components.persistent_notification import async_create
-
-        from .support_report import generate_support_report, save_support_report
-
-        device_ids = call.data.get(CONF_DEVICE_ID, [])
-        include_logs = call.data.get(ATTR_INCLUDE_LOGS, True)
-
-        if not device_ids:
-            _LOGGER.error("No device_id provided for generate_support_report service")
-            async_create(
-                hass,
-                "No device was selected for the generate_support_report service.\n\n"
-                "Please select an Adjustable Bed device and try again.",
-                title="Adjustable Bed Support Report Error",
-                notification_id="adjustable_bed_support_report_no_device",
-            )
-            return
-
-        device_id = device_ids[0]
-        coordinator = await _get_coordinator_from_device(hass, device_id)
-        if not coordinator:
-            _LOGGER.error(
-                "Could not find Adjustable Bed device with ID %s for generate_support_report service",
-                device_id,
-            )
-            async_create(
-                hass,
-                f"Could not find Adjustable Bed device with ID:\n\n`{device_id}`\n\n"
-                "The device may have been removed or is no longer available.",
-                title="Adjustable Bed Support Report Error",
-                notification_id=f"adjustable_bed_support_report_not_found_{device_id[:8]}",
-            )
-            return
-
-        # Find the config entry for this coordinator
-        entry: ConfigEntry | None = None
-        for entry_id, coord in hass.data[DOMAIN].items():
-            if coord is coordinator:
-                entry = hass.config_entries.async_get_entry(entry_id)
-                break
-
-        if not entry:
-            _LOGGER.error("Could not find config entry for device %s", device_id)
-            return
-
-        try:
-            _LOGGER.info("Generating support report for %s", coordinator.name)
-            report = await generate_support_report(
-                hass, entry, coordinator, include_logs=include_logs
-            )
-            filepath = await hass.async_add_executor_job(
-                save_support_report, hass, report, coordinator.address
-            )
-
-            async_create(
-                hass,
-                f"Support report saved to:\n\n`{filepath}`\n\n"
-                "**How to submit a bug report:**\n"
-                "1. Go to [GitHub Issues](https://github.com/kristofferR/ha-adjustable-bed/issues/new?template=bug-report.yml)\n"
-                "2. Fill out the form\n"
-                "3. Attach this JSON file to the issue\n\n"
-                "The report contains diagnostic information with sensitive data (MAC address) redacted.",
-                title="Adjustable Bed Support Report Ready",
-                notification_id=f"adjustable_bed_support_report_{coordinator.address.replace(':', '_').lower()}",
-            )
-            _LOGGER.info("Support report saved to %s", filepath)
-        except Exception as err:
-            _LOGGER.exception("Failed to generate support report")
-            async_create(
-                hass,
-                f"Failed to generate support report:\n\n{err}",
-                title="Adjustable Bed Support Report Error",
-                notification_id="adjustable_bed_support_report_error",
-            )
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_GENERATE_SUPPORT_REPORT,
-        handle_generate_support_report,
-        schema=vol.Schema(
-            {
-                vol.Required(CONF_DEVICE_ID): cv.ensure_list,
                 vol.Optional(ATTR_INCLUDE_LOGS, default=True): cv.boolean,
             }
         ),

--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -936,20 +936,13 @@ async def _async_register_services(hass: HomeAssistant) -> None:
 
             address = str(target_address).upper().replace("-", ":")
             if not is_valid_mac_address(address):
-                _LOGGER.error(
-                    "Invalid MAC address format for generate_support_bundle: %s",
-                    target_address,
+                raise ServiceValidationError(
+                    f"Invalid MAC address format: {target_address}. "
+                    "Please provide a valid MAC address in the format "
+                    "XX:XX:XX:XX:XX:XX or XX-XX-XX-XX-XX-XX.",
+                    translation_domain=DOMAIN,
+                    translation_key="invalid_mac_address",
                 )
-                async_create(
-                    hass,
-                    f"**Support Bundle Failed**\n\n"
-                    f"Invalid MAC address format: `{target_address}`\n\n"
-                    f"Please provide a valid MAC address in the format "
-                    f"`XX:XX:XX:XX:XX:XX` or `XX-XX-XX-XX-XX-XX`.",
-                    title="Adjustable Bed Support Bundle Error",
-                    notification_id="adjustable_bed_support_bundle_error",
-                )
-                return
             _LOGGER.info(
                 "Generating support bundle for unconfigured device at %s",
                 address,
@@ -969,43 +962,33 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                     address,
                 )
             else:
-                _LOGGER.error(
-                    "Could not find Adjustable Bed device with ID %s for generate_support_bundle service",
-                    selected_device_id,
+                raise ServiceValidationError(
+                    f"Could not find Adjustable Bed device with ID: {selected_device_id}. "
+                    "Please verify the device is configured and try again.",
+                    translation_domain=DOMAIN,
+                    translation_key="device_not_found",
                 )
-                async_create(
-                    hass,
-                    f"**Support Bundle Failed**\n\n"
-                    f"Could not find Adjustable Bed device with ID: `{selected_device_id}`\n\n"
-                    f"Please verify the device is configured and try again.",
-                    title="Adjustable Bed Support Bundle Error",
-                    notification_id="adjustable_bed_support_bundle_error",
-                )
-                return
         else:
-            _LOGGER.error(
-                "No device_id or target_address provided for generate_support_bundle service"
-            )
-            async_create(
-                hass,
-                "**Support Bundle Failed**\n\n"
-                "No `device_id` or `target_address` was provided.\n\n"
+            raise ServiceValidationError(
+                "No device_id or target_address was provided. "
                 "Please specify either a configured device or a target MAC address.",
-                title="Adjustable Bed Support Bundle Error",
-                notification_id="adjustable_bed_support_bundle_error",
+                translation_domain=DOMAIN,
+                translation_key="missing_target",
             )
-            return
 
         assert address is not None
         try:
-            report = await generate_support_bundle(
-                hass,
-                address=address,
-                capture_duration=capture_duration,
-                include_logs=include_logs,
-                coordinator=coordinator,
-                entry=entry,
-                device_id=selected_device_id,
+            report = await asyncio.wait_for(
+                generate_support_bundle(
+                    hass,
+                    address=address,
+                    capture_duration=capture_duration,
+                    include_logs=include_logs,
+                    coordinator=coordinator,
+                    entry=entry,
+                    device_id=selected_device_id,
+                ),
+                timeout=capture_duration + 120,
             )
             filepath = await hass.async_add_executor_job(
                 save_support_bundle,
@@ -1024,6 +1007,20 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                 notification_id=f"adjustable_bed_support_bundle_{address.replace(':', '_').lower()}",
             )
             _LOGGER.info("Support bundle saved to %s", filepath)
+        except asyncio.TimeoutError:
+            _LOGGER.error(
+                "Support bundle generation timed out after %d seconds for %s",
+                capture_duration + 120,
+                address,
+            )
+            async_create(
+                hass,
+                f"Support bundle generation timed out after {capture_duration + 120} seconds "
+                f"for {address}.\n\n"
+                "The BLE diagnostics may be hanging. Check Bluetooth connectivity and try again.",
+                title="Adjustable Bed Support Bundle Timeout",
+                notification_id=f"adjustable_bed_support_bundle_error_{address.replace(':', '_').lower()}",
+            )
         except Exception as err:
             _LOGGER.exception("Failed to generate support bundle for %s", address)
             async_create(

--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     BED_TYPE_BEDTECH,
+    BED_TYPE_DIAGNOSTIC,
     BED_TYPE_ERGOMOTION,
     BED_TYPE_KAIDI,
     BED_TYPE_KEESON,
@@ -184,6 +185,51 @@ def _maybe_cache_kaidi_metadata(hass: HomeAssistant, entry: ConfigEntry) -> None
     )
 
 
+async def _async_finish_entry_setup(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coordinator: AdjustableBedCoordinator,
+    *,
+    schedule_initial_position_read: bool,
+) -> bool:
+    """Store coordinator, forward platforms, and finish setup."""
+    hass.data[DOMAIN][entry.entry_id] = coordinator
+
+    _LOGGER.debug("Setting up platforms: %s", PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    if schedule_initial_position_read:
+        hass.async_create_task(coordinator.async_read_initial_positions())
+
+    _LOGGER.info("Adjustable Bed integration setup complete for %s", entry.title)
+    return True
+
+
+async def _async_setup_offline_diagnostic_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coordinator: AdjustableBedCoordinator,
+    reason: str,
+) -> bool:
+    """Load a diagnostic entry even when initial BLE connection fails."""
+    from .beds.diagnostic import DiagnosticBedController
+
+    _LOGGER.warning(
+        "Loading diagnostic entry %s (%s) without an initial BLE connection so "
+        "diagnostic actions remain available: %s",
+        entry.title,
+        entry.data.get(CONF_ADDRESS),
+        reason,
+    )
+    coordinator._controller = DiagnosticBedController(coordinator)
+    return await _async_finish_entry_setup(
+        hass,
+        entry,
+        coordinator,
+        schedule_initial_position_read=False,
+    )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Adjustable Bed from a config entry."""
     hass.data.setdefault(DOMAIN, {})
@@ -256,6 +302,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             connected = await coordinator.async_connect()
     except TimeoutError:
         await _maybe_create_pairing_issue()
+        if entry.data.get(CONF_BED_TYPE) == BED_TYPE_DIAGNOSTIC:
+            return await _async_setup_offline_diagnostic_entry(
+                hass,
+                entry,
+                coordinator,
+                reason=f"initial connection timed out after {SETUP_TIMEOUT:.0f}s",
+            )
         raise ConfigEntryNotReady(
             f"Connection to bed at {entry.data.get(CONF_ADDRESS)} timed out after {SETUP_TIMEOUT:.0f}s. "
             "The integration will retry automatically."
@@ -263,23 +316,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if not connected:
         await _maybe_create_pairing_issue()
+        if entry.data.get(CONF_BED_TYPE) == BED_TYPE_DIAGNOSTIC:
+            return await _async_setup_offline_diagnostic_entry(
+                hass,
+                entry,
+                coordinator,
+                reason="device was not reachable during initial setup",
+            )
         raise ConfigEntryNotReady(
             f"Failed to connect to bed at {entry.data.get(CONF_ADDRESS)}. "
             "Check that the bed is powered on and in range of your Bluetooth adapter/proxy."
         )
 
     _LOGGER.info("Successfully connected to bed at %s", entry.data.get(CONF_ADDRESS))
-
-    # Read initial positions in background (don't block startup)
-    hass.async_create_task(coordinator.async_read_initial_positions())
-
-    hass.data[DOMAIN][entry.entry_id] = coordinator
-
-    _LOGGER.debug("Setting up platforms: %s", PLATFORMS)
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    _LOGGER.info("Adjustable Bed integration setup complete for %s", entry.title)
-    return True
+    return await _async_finish_entry_setup(
+        hass,
+        entry,
+        coordinator,
+        schedule_initial_position_read=True,
+    )
 
 
 async def _async_maybe_reclassify_legacy_bedtech_entry(

--- a/custom_components/adjustable_bed/adapter.py
+++ b/custom_components/adjustable_bed/adapter.py
@@ -100,6 +100,35 @@ def find_service_info_by_address(
     return None, False
 
 
+def get_service_info_snapshots_by_address(
+    hass: HomeAssistant,
+    address: str,
+    *,
+    allow_non_connectable: bool = False,
+) -> list[tuple[BluetoothServiceInfoBleak, bool]]:
+    """Return all current scanner snapshots for an address."""
+    normalized_address = address.upper()
+    snapshots: list[tuple[BluetoothServiceInfoBleak, bool]] = []
+
+    for service_info in get_discovered_service_info(
+        hass,
+        include_non_connectable=allow_non_connectable,
+    ):
+        if service_info.address.upper() != normalized_address:
+            continue
+        connectable = bool(getattr(service_info, "connectable", True))
+        snapshots.append((service_info, connectable))
+
+    snapshots.sort(
+        key=lambda item: (
+            item[1],
+            getattr(item[0], "rssi", RSSI_UNAVAILABLE),
+        ),
+        reverse=True,
+    )
+    return snapshots
+
+
 def get_ble_device_with_fallback(
     hass: HomeAssistant,
     address: str,
@@ -238,6 +267,7 @@ async def select_adapter(
                 except (ValueError, TypeError):
                     rssi_value = RSSI_UNAVAILABLE
                 svc_source = getattr(svc_info, "source", "unknown")
+                available_sources.append(f"{svc_source} (RSSI: {rssi_value})")
                 _LOGGER.debug("Auto-select candidate: source=%s, rssi=%s", svc_source, rssi_value)
                 if exclude_adapters and svc_source in exclude_adapters:
                     _LOGGER.debug(

--- a/custom_components/adjustable_bed/adapter.py
+++ b/custom_components/adjustable_bed/adapter.py
@@ -9,6 +9,7 @@ from bleak import BleakClient
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 from homeassistant.components import bluetooth
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.core import HomeAssistant
 
 from .const import ADAPTER_AUTO, DEVICE_INFO_CHARS, DEVICE_INFO_SERVICE_UUID
@@ -26,7 +27,116 @@ class AdapterSelectionResult:
     device: BLEDevice | None
     source: str | None
     rssi: int | None
+    connectable: bool | None
     available_sources: list[str]
+
+
+def get_discovered_service_info(
+    hass: HomeAssistant,
+    *,
+    include_non_connectable: bool = False,
+) -> list[BluetoothServiceInfoBleak]:
+    """Return discovered BLE service info, optionally including non-connectable records.
+
+    Home Assistant keeps separate snapshots for connectable and non-connectable
+    advertisements. Some proxies have been observed to classify connectable beds
+    as non-connectable, so callers can opt into a fallback merge when the strict
+    connectable view is empty.
+    """
+
+    connectable_states = (True, False) if include_non_connectable else (True,)
+    discovered: list[BluetoothServiceInfoBleak] = []
+    seen: set[tuple[str, str | None]] = set()
+
+    for connectable in connectable_states:
+        for service_info in bluetooth.async_discovered_service_info(
+            hass,
+            connectable=connectable,
+        ):
+            key = (
+                service_info.address.upper(),
+                getattr(service_info, "source", None),
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            discovered.append(service_info)
+
+    return discovered
+
+
+def find_service_info_by_address(
+    hass: HomeAssistant,
+    address: str,
+    *,
+    allow_non_connectable: bool = False,
+) -> tuple[BluetoothServiceInfoBleak | None, bool]:
+    """Return the latest service info snapshot for an address.
+
+    The boolean in the tuple indicates whether the matching snapshot came from
+    the connectable scanner view.
+    """
+
+    normalized_address = address.upper()
+    connectable_states = (True, False) if allow_non_connectable else (True,)
+
+    for connectable in connectable_states:
+        service_info = bluetooth.async_last_service_info(
+            hass,
+            normalized_address,
+            connectable=connectable,
+        )
+        if service_info is not None and service_info.address.upper() == normalized_address:
+            return service_info, connectable
+
+    if allow_non_connectable:
+        for service_info in get_discovered_service_info(
+            hass,
+            include_non_connectable=True,
+        ):
+            if service_info.address.upper() == normalized_address:
+                return service_info, bool(getattr(service_info, "connectable", False))
+
+    return None, False
+
+
+def get_ble_device_with_fallback(
+    hass: HomeAssistant,
+    address: str,
+    *,
+    allow_non_connectable: bool = False,
+) -> tuple[BLEDevice | None, bool]:
+    """Return a BLEDevice for an address, falling back to non-connectable state."""
+
+    normalized_address = address.upper()
+    device = bluetooth.async_ble_device_from_address(
+        hass,
+        normalized_address,
+        connectable=True,
+    )
+    if device is not None:
+        return device, True
+
+    if not allow_non_connectable:
+        return None, False
+
+    service_info, connectable = find_service_info_by_address(
+        hass,
+        normalized_address,
+        allow_non_connectable=True,
+    )
+    if service_info is not None and getattr(service_info, "device", None) is not None:
+        return service_info.device, connectable
+
+    device = bluetooth.async_ble_device_from_address(
+        hass,
+        normalized_address,
+        connectable=False,
+    )
+    if device is not None:
+        return device, False
+
+    return None, False
 
 
 async def select_adapter(
@@ -56,6 +166,7 @@ async def select_adapter(
     device: BLEDevice | None = None
     source: str | None = None
     rssi: int | None = None
+    connectable: bool | None = None
     available_sources: list[str] = []
 
     if preferred_adapter and preferred_adapter != ADAPTER_AUTO:
@@ -78,6 +189,7 @@ async def select_adapter(
                         device = service_info.device
                         source = svc_source
                         rssi = svc_rssi if isinstance(svc_rssi, int) else None
+                        connectable = True
                         _LOGGER.info(
                             "✓ Found device %s via preferred adapter %s (RSSI: %s)",
                             address,
@@ -147,25 +259,32 @@ async def select_adapter(
                     device = svc_info.device
                     source = best_source
                     rssi = best_rssi if best_rssi != RSSI_UNAVAILABLE else None
+                    connectable = True
                     break
 
         # Final fallback to default lookup
         if device is None:
-            device = bluetooth.async_ble_device_from_address(hass, address, connectable=True)
+            device, connectable = get_ble_device_with_fallback(
+                hass,
+                address,
+                allow_non_connectable=True,
+            )
             if device:
                 fallback_source = "unknown"
                 if hasattr(device, "details") and isinstance(device.details, dict):
                     fallback_source = device.details.get("source", "unknown")
                 source = fallback_source
-                _LOGGER.info(
-                    "Using fallback adapter selection, device found via: %s",
-                    fallback_source,
-                )
+                info_message = "Using fallback adapter selection, device found via: %s"
+                log_args: tuple[object, ...] = (fallback_source,)
+                if connectable is False:
+                    info_message += " (scanner currently marks it non-connectable)"
+                _LOGGER.info(info_message, *log_args)
 
     return AdapterSelectionResult(
         device=device,
         source=source,
         rssi=rssi,
+        connectable=connectable,
         available_sources=available_sources,
     )
 

--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -8,6 +8,7 @@ command encoding and position reading.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Coroutine
@@ -19,6 +20,8 @@ from bleak.exc import BleakError
 
 if TYPE_CHECKING:
     from ..coordinator import AdjustableBedCoordinator
+
+from ..diagnostic_payloads import format_payload
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -224,6 +227,34 @@ class BedController(ABC):
             repeat_count,
             repeat_delay_ms,
         )
+
+        characteristic_handle: int | None = None
+        if client.services:
+            for service in client.services:
+                for characteristic in service.characteristics:
+                    if characteristic.uuid == char_uuid:
+                        characteristic_handle = getattr(characteristic, "handle", None)
+                        break
+                if characteristic_handle is not None:
+                    break
+
+        caller_frame = inspect.currentframe()
+        command_origin = None
+        if caller_frame is not None and caller_frame.f_back is not None:
+            command_origin = caller_frame.f_back.f_code.co_name
+
+        payload = format_payload(command)
+        if payload is not None:
+            self._coordinator.record_command_trace(
+                payload=payload,
+                characteristic_uuid=char_uuid,
+                characteristic_handle=characteristic_handle,
+                response=response,
+                repeat_count=repeat_count,
+                repeat_delay_ms=repeat_delay_ms,
+                command_origin=command_origin,
+                controller_class=type(self).__name__,
+            )
 
         for i in range(repeat_count):
             if effective_cancel is not None and effective_cancel.is_set():

--- a/custom_components/adjustable_bed/beds/diagnostic.py
+++ b/custom_components/adjustable_bed/beds/diagnostic.py
@@ -1,9 +1,9 @@
 """Diagnostic controller for unsupported BLE devices.
 
 This controller provides a minimal implementation that allows users to add
-unsupported BLE devices to Home Assistant for diagnostic purposes. It enables
-running the run_diagnostics service to capture BLE protocol data that can
-help add support for new bed models.
+unsupported BLE devices to Home Assistant for diagnostic purposes. It exists
+for legacy entries only and helps keep support-bundle capture available even
+when the device cannot be classified yet.
 
 No motor control or position entities are created - this is purely for
 diagnostic data capture.

--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import functools
-import json
 import logging
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from bleak import BleakClient
@@ -37,6 +36,7 @@ from .detection import detect_bed_type_detailed
 from .diagnostic_payloads import (
     format_mapping_payloads,
     format_payload,
+    new_connection_attempt_details,
     payload_ascii_preview,
     summarize_repeated_payloads,
 )
@@ -49,6 +49,10 @@ _LOGGER = logging.getLogger(__name__)
 # Connection settings
 CONNECTION_TIMEOUT = 30.0
 DEFAULT_CAPTURE_DURATION = 120  # 2 minutes
+MAX_CAPTURED_NOTIFICATIONS = 5000
+
+# Timestamps above this value (approx. 2001-09-09) are treated as Unix epoch seconds
+_EPOCH_SECONDS_THRESHOLD = 1_000_000_000
 
 
 @dataclass
@@ -179,11 +183,11 @@ class BLEDiagnosticRunner:
 
         self._client: BleakClient | None = None
         self._using_coordinator_connection: bool = False
-        self._notifications: list[CapturedNotification] = []
+        self._notifications: deque[CapturedNotification] = deque(maxlen=MAX_CAPTURED_NOTIFICATIONS)
         self._errors: list[str] = []
         self._notification_lock = asyncio.Lock()
         self._diagnostic_notifications_started: bool = False
-        self._notification_payloads: dict[str, list[bytes]] = {}
+        self._notification_payloads: dict[str, deque[bytes]] = {}
         self._connection_attempt_details: list[dict[str, Any]] = []
         self._advertisement_snapshots: list[tuple[Any, bool]] = []
         self._selected_source: str | None = None
@@ -192,6 +196,7 @@ class BLEDiagnosticRunner:
         self._actual_source: str | None = None
         self._selected_ble_device: BLEDevice | None = None
         self._using_non_connectable_fallback: bool = False
+        self._background_tasks: set[asyncio.Task[None]] = set()
 
     async def run_diagnostics(self) -> DiagnosticReport:
         """Run full diagnostic capture on the device."""
@@ -308,29 +313,7 @@ class BLEDiagnosticRunner:
 
         for attempt in range(2):
             attempt_start = time.monotonic()
-            attempt_details: dict[str, Any] = {
-                "attempt": attempt + 1,
-                "started_at": datetime.now(UTC).isoformat(),
-                "preferred_adapter": preferred_adapter,
-                "selected_source": None,
-                "actual_source": None,
-                "selected_rssi": None,
-                "selected_connectable": None,
-                "non_connectable_fallback_used": False,
-                "visible_sources": [],
-                "lookup_elapsed_seconds": None,
-                "connect_elapsed_seconds": None,
-                "total_elapsed_seconds": None,
-                "error": None,
-                "error_type": None,
-                "error_category": None,
-                "service_discovery": {
-                    "attempted": False,
-                    "success": None,
-                    "service_count": None,
-                },
-                "result": "started",
-            }
+            attempt_details = new_connection_attempt_details(attempt + 1, preferred_adapter)
 
             adapter_result = await select_adapter(
                 self.hass,
@@ -526,7 +509,9 @@ class BLEDiagnosticRunner:
 
     def _raw_notify_callback(self, characteristic_uuid: str, data: bytes) -> None:
         """Handle raw notification from coordinator's controller."""
-        asyncio.create_task(self._handle_notification(characteristic_uuid, data))
+        task = asyncio.create_task(self._handle_notification(characteristic_uuid, data))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
     async def _subscribe_to_notifications(self, services: list[ServiceInfo]) -> None:
         """Subscribe to all notifiable characteristics."""
@@ -645,7 +630,9 @@ class BLEDiagnosticRunner:
                 data_hex=payload.hex(),
             )
             self._notifications.append(notification)
-            self._notification_payloads.setdefault(characteristic_uuid, []).append(payload)
+            if characteristic_uuid not in self._notification_payloads:
+                self._notification_payloads[characteristic_uuid] = deque(maxlen=MAX_CAPTURED_NOTIFICATIONS)
+            self._notification_payloads[characteristic_uuid].append(payload)
 
         _LOGGER.debug(
             "Notification on %s: %s",
@@ -953,7 +940,7 @@ class BLEDiagnosticRunner:
         if isinstance(raw_time, datetime):
             return raw_time.isoformat()
         if isinstance(raw_time, (int, float)):
-            if raw_time > 1_000_000_000:
+            if raw_time > _EPOCH_SECONDS_THRESHOLD:
                 return datetime.fromtimestamp(raw_time, tz=UTC).isoformat()
             return raw_time
         return str(raw_time)
@@ -973,21 +960,3 @@ class BLEDiagnosticRunner:
         return str(value)
 
 
-def save_diagnostic_report(
-    hass: HomeAssistant,
-    report: DiagnosticReport,
-    address: str,
-) -> Path:
-    """Save diagnostic report to a JSON file in the config directory."""
-    timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
-    address_safe = address.replace(":", "").lower()
-    filename = f"adjustable_bed_diagnostic_{address_safe}_{timestamp}.json"
-
-    config_dir = Path(hass.config.config_dir)
-    filepath = config_dir / filename
-
-    with open(filepath, "w", encoding="utf-8") as f:
-        json.dump(report.to_dict(), f, indent=2, default=str)
-
-    _LOGGER.info("Diagnostic report saved to %s", filepath)
-    return filepath

--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -14,9 +14,9 @@ from typing import TYPE_CHECKING, Any
 from bleak import BleakClient
 from bleak.exc import BleakError
 from bleak_retry_connector import establish_connection
-from homeassistant.components import bluetooth
 from homeassistant.core import HomeAssistant
 
+from .adapter import get_ble_device_with_fallback, find_service_info_by_address
 from .const import DEVICE_INFO_CHARS, DEVICE_INFO_SERVICE_UUID, DOMAIN
 
 if TYPE_CHECKING:
@@ -130,8 +130,10 @@ class BLEDiagnosticRunner:
 
         try:
             # Get advertisement data from HA Bluetooth
-            service_info = bluetooth.async_last_service_info(
-                self.hass, self.address, connectable=True
+            service_info, service_info_connectable = find_service_info_by_address(
+                self.hass,
+                self.address,
+                allow_non_connectable=True,
             )
             if service_info:
                 device_info["name"] = service_info.name
@@ -146,6 +148,7 @@ class BLEDiagnosticRunner:
                 advertisement_info["service_data"] = {
                     str(k): bytes(v).hex() for k, v in (service_info.service_data or {}).items()
                 }
+                advertisement_info["connectable"] = service_info_connectable
             else:
                 self._errors.append("No advertisement data available")
 
@@ -234,11 +237,22 @@ class BLEDiagnosticRunner:
         _LOGGER.info("Establishing new BLE connection to %s", self.address)
         self._using_coordinator_connection = False
 
-        device = bluetooth.async_ble_device_from_address(self.hass, self.address, connectable=True)
+        device, connectable = get_ble_device_with_fallback(
+            self.hass,
+            self.address,
+            allow_non_connectable=True,
+        )
         if device is None:
             error = f"Device {self.address} not found in Bluetooth scanner"
             self._errors.append(error)
             raise BleakError(error)
+        if connectable is False:
+            warning = (
+                f"Using non-connectable scanner record for {self.address}; "
+                "the Bluetooth proxy may be misclassifying the advertisement"
+            )
+            _LOGGER.warning(warning)
+            self._errors.append(warning)
 
         try:
             self._client = await establish_connection(

--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -3,21 +3,43 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import functools
 import json
 import logging
+import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from bleak import BleakClient
+from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 from bleak_retry_connector import establish_connection
+from homeassistant.components import bluetooth
 from homeassistant.core import HomeAssistant
 
-from .adapter import get_ble_device_with_fallback, find_service_info_by_address
-from .const import DEVICE_INFO_CHARS, DEVICE_INFO_SERVICE_UUID, DOMAIN
+from .adapter import (
+    find_service_info_by_address,
+    get_service_info_snapshots_by_address,
+    select_adapter,
+)
+from .const import (
+    ADAPTER_AUTO,
+    CONF_PREFERRED_ADAPTER,
+    DEVICE_INFO_CHARS,
+    DEVICE_INFO_SERVICE_UUID,
+    DOMAIN,
+    SUPPORTED_BED_TYPES,
+)
+from .detection import detect_bed_type_detailed
+from .diagnostic_payloads import (
+    format_mapping_payloads,
+    format_payload,
+    payload_ascii_preview,
+    summarize_repeated_payloads,
+)
 
 if TYPE_CHECKING:
     from .coordinator import AdjustableBedCoordinator
@@ -39,13 +61,43 @@ class CapturedNotification:
 
 
 @dataclass
+class DescriptorInfo:
+    """Information about a BLE descriptor."""
+
+    uuid: str
+    handle: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert descriptor info to a dictionary."""
+        return {
+            "uuid": self.uuid,
+            "handle": self.handle,
+        }
+
+
+@dataclass
 class CharacteristicInfo:
     """Information about a BLE characteristic."""
 
     uuid: str
+    handle: int | None
     properties: list[str]
-    value_hex: str | None = None
+    read_result: dict[str, Any] | None = None
     read_error: str | None = None
+    notify_subscription: dict[str, Any] = field(default_factory=dict)
+    descriptors: list[DescriptorInfo] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert characteristic info to a dictionary."""
+        return {
+            "uuid": self.uuid,
+            "handle": self.handle,
+            "properties": self.properties,
+            "read_result": self.read_result,
+            "read_error": self.read_error,
+            "notify_subscription": self.notify_subscription,
+            "descriptors": [descriptor.to_dict() for descriptor in self.descriptors],
+        }
 
 
 @dataclass
@@ -53,7 +105,16 @@ class ServiceInfo:
     """Information about a BLE service."""
 
     uuid: str
+    handle: int | None = None
     characteristics: list[CharacteristicInfo] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert service info to a dictionary."""
+        return {
+            "uuid": self.uuid,
+            "handle": self.handle,
+            "characteristics": [characteristic.to_dict() for characteristic in self.characteristics],
+        }
 
 
 @dataclass
@@ -63,14 +124,18 @@ class DiagnosticReport:
     metadata: dict[str, Any]
     device: dict[str, Any]
     advertisement: dict[str, Any]
+    advertisements_by_source: list[dict[str, Any]]
+    detection: dict[str, Any]
     gatt_services: list[dict[str, Any]]
+    gatt_summary: dict[str, Any]
     device_information: dict[str, str | None]
     notifications: list[dict[str, str]]
+    notification_summary: dict[str, Any]
+    adapter_details: dict[str, Any]
+    connection_history: dict[str, Any]
+    connection_attempt_details: list[dict[str, Any]]
+    command_trace: list[dict[str, Any]]
     errors: list[str]
-    # New fields for enhanced diagnostics (issue #168)
-    gatt_summary: dict[str, Any] = field(default_factory=dict)
-    adapter_details: dict[str, Any] = field(default_factory=dict)
-    connection_history: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert report to dictionary for JSON serialization."""
@@ -78,12 +143,17 @@ class DiagnosticReport:
             "metadata": self.metadata,
             "device": self.device,
             "advertisement": self.advertisement,
+            "advertisements_by_source": self.advertisements_by_source,
+            "detection": self.detection,
             "gatt_services": self.gatt_services,
             "gatt_summary": self.gatt_summary,
             "device_information": self.device_information,
             "notifications": self.notifications,
+            "notification_summary": self.notification_summary,
             "adapter_details": self.adapter_details,
             "connection_history": self.connection_history,
+            "connection_attempt_details": self.connection_attempt_details,
+            "command_trace": self.command_trace,
             "errors": self.errors,
         }
 
@@ -113,6 +183,15 @@ class BLEDiagnosticRunner:
         self._errors: list[str] = []
         self._notification_lock = asyncio.Lock()
         self._diagnostic_notifications_started: bool = False
+        self._notification_payloads: dict[str, list[bytes]] = {}
+        self._connection_attempt_details: list[dict[str, Any]] = []
+        self._advertisement_snapshots: list[tuple[Any, bool]] = []
+        self._selected_source: str | None = None
+        self._selected_rssi: int | None = None
+        self._selected_connectable: bool | None = None
+        self._actual_source: str | None = None
+        self._selected_ble_device: BLEDevice | None = None
+        self._using_non_connectable_fallback: bool = False
 
     async def run_diagnostics(self) -> DiagnosticReport:
         """Run full diagnostic capture on the device."""
@@ -123,51 +202,24 @@ class BLEDiagnosticRunner:
         )
 
         start_time = datetime.now(UTC)
-        device_info: dict[str, Any] = {"address": self.address}
-        advertisement_info: dict[str, Any] = {}
         services_info: list[ServiceInfo] = []
         device_information: dict[str, str | None] = {}
+        self._advertisement_snapshots = get_service_info_snapshots_by_address(
+            self.hass,
+            self.address,
+            allow_non_connectable=True,
+        )
 
         try:
-            # Get advertisement data from HA Bluetooth
-            service_info, service_info_connectable = find_service_info_by_address(
-                self.hass,
-                self.address,
-                allow_non_connectable=True,
-            )
-            if service_info:
-                device_info["name"] = service_info.name
-                device_info["rssi"] = getattr(service_info, "rssi", None)
-                advertisement_info["service_uuids"] = [
-                    str(uuid) for uuid in (service_info.service_uuids or [])
-                ]
-                advertisement_info["manufacturer_data"] = {
-                    str(k): bytes(v).hex()
-                    for k, v in (service_info.manufacturer_data or {}).items()
-                }
-                advertisement_info["service_data"] = {
-                    str(k): bytes(v).hex() for k, v in (service_info.service_data or {}).items()
-                }
-                advertisement_info["connectable"] = service_info_connectable
-            else:
-                self._errors.append("No advertisement data available")
-
-            # Connect to device
             await self._connect()
 
             if self._client and self._client.is_connected:
-                # Enumerate GATT services and characteristics
                 services_info = await self._enumerate_services()
-
-                # Read Device Information Service
                 device_information = await self._read_device_information()
 
-                # Subscribe to all notifiable characteristics and capture notifications
-                # Use try/finally to ensure unsubscribe runs even on timeout/cancellation
                 try:
                     await self._subscribe_to_notifications(services_info)
 
-                    # Capture notifications for the specified duration
                     _LOGGER.info(
                         "Capturing notifications for %d seconds. "
                         "Operate the physical remote to generate data.",
@@ -175,7 +227,6 @@ class BLEDiagnosticRunner:
                     )
                     await asyncio.sleep(self.capture_duration)
                 finally:
-                    # Unsubscribe from notifications (cleanup even on error)
                     await self._unsubscribe_from_notifications(services_info)
 
         except asyncio.CancelledError:
@@ -188,97 +239,198 @@ class BLEDiagnosticRunner:
             await self._disconnect()
 
         end_time = datetime.now(UTC)
+        best_snapshot = self._best_snapshot()
+        detection = self._build_detection_section(best_snapshot[0] if best_snapshot else None)
 
-        # Get coordinator data if available (issue #168)
-        adapter_details: dict[str, Any] = {}
-        connection_history: dict[str, Any] = {}
-        if self.coordinator:
-            adapter_details = self.coordinator.adapter_details
-            connection_history = self.coordinator.connection_history
+        adapter_details: dict[str, Any] = self.coordinator.adapter_details if self.coordinator else {}
+        connection_history: dict[str, Any] = (
+            self.coordinator.connection_history if self.coordinator else {}
+        )
+        connection_attempt_details = self._connection_attempt_details
+        if not connection_attempt_details and self.coordinator is not None:
+            connection_attempt_details = self.coordinator.connection_attempt_details
+
+        command_trace = self.coordinator.command_trace if self.coordinator else []
 
         return DiagnosticReport(
             metadata={
-                "version": "1.1",
+                "version": "2.0",
                 "timestamp": start_time.isoformat(),
                 "end_timestamp": end_time.isoformat(),
                 "capture_duration_seconds": self.capture_duration,
                 "integration_domain": DOMAIN,
             },
-            device=device_info,
-            advertisement=advertisement_info,
-            gatt_services=[self._service_to_dict(s) for s in services_info],
+            device=self._build_device_section(best_snapshot[0] if best_snapshot else None),
+            advertisement=self._build_best_advertisement(best_snapshot),
+            advertisements_by_source=self._build_advertisements_by_source(),
+            detection=detection,
+            gatt_services=[service.to_dict() for service in services_info],
             gatt_summary=self._build_gatt_summary(services_info),
             device_information=device_information,
             notifications=[
                 {
-                    "characteristic": n.characteristic,
-                    "timestamp": n.timestamp,
-                    "data_hex": n.data_hex,
+                    "characteristic": notification.characteristic,
+                    "timestamp": notification.timestamp,
+                    "data_hex": notification.data_hex,
                 }
-                for n in self._notifications
+                for notification in self._notifications
             ],
+            notification_summary=self._build_notification_summary(),
             adapter_details=adapter_details,
             connection_history=connection_history,
+            connection_attempt_details=connection_attempt_details,
+            command_trace=command_trace,
             errors=self._errors,
         )
 
     async def _connect(self) -> None:
         """Connect to the BLE device."""
-        # If we have a coordinator with an active connection, use it
         if self.coordinator and self.coordinator.client and self.coordinator.is_connected:
             _LOGGER.info("Using existing connection from coordinator")
             self._client = self.coordinator.client
             self._using_coordinator_connection = True
-            # Pause the disconnect timer while capturing - capture may exceed idle timeout
+            self._selected_source = self.coordinator.connection_source
+            self._actual_source = self.coordinator.connection_source
+            self._selected_rssi = self.coordinator.connection_rssi
+            self._selected_connectable = True
             self.coordinator.pause_disconnect_timer()
             return
 
-        # Otherwise, establish a new connection
         _LOGGER.info("Establishing new BLE connection to %s", self.address)
         self._using_coordinator_connection = False
 
-        device, connectable = get_ble_device_with_fallback(
-            self.hass,
-            self.address,
-            allow_non_connectable=True,
-        )
-        if device is None:
-            error = f"Device {self.address} not found in Bluetooth scanner"
-            self._errors.append(error)
-            raise BleakError(error)
-        if connectable is False:
-            warning = (
-                f"Using non-connectable scanner record for {self.address}; "
-                "the Bluetooth proxy may be misclassifying the advertisement"
+        preferred_adapter = ADAPTER_AUTO
+        if self.coordinator is not None:
+            preferred_adapter = self.coordinator.entry.data.get(
+                CONF_PREFERRED_ADAPTER,
+                ADAPTER_AUTO,
             )
-            _LOGGER.warning(warning)
-            self._errors.append(warning)
 
-        try:
-            self._client = await establish_connection(
-                BleakClient,
-                device,
-                f"diagnostic_{self.address}",
-                max_attempts=2,
-                timeout=CONNECTION_TIMEOUT,
+        for attempt in range(2):
+            attempt_start = time.monotonic()
+            attempt_details: dict[str, Any] = {
+                "attempt": attempt + 1,
+                "started_at": datetime.now(UTC).isoformat(),
+                "preferred_adapter": preferred_adapter,
+                "selected_source": None,
+                "actual_source": None,
+                "selected_rssi": None,
+                "selected_connectable": None,
+                "non_connectable_fallback_used": False,
+                "visible_sources": [],
+                "lookup_elapsed_seconds": None,
+                "connect_elapsed_seconds": None,
+                "total_elapsed_seconds": None,
+                "error": None,
+                "error_type": None,
+                "error_category": None,
+                "service_discovery": {
+                    "attempted": False,
+                    "success": None,
+                    "service_count": None,
+                },
+                "result": "started",
+            }
+
+            adapter_result = await select_adapter(
+                self.hass,
+                self.address,
+                preferred_adapter,
             )
-            _LOGGER.info("Connected to %s", self.address)
-            # Explicitly discover services - not all backends auto-discover on connect
-            # In recent Bleak versions, service discovery is automatic.
-            if hasattr(self._client, "get_services"):
-                await self._client.get_services()
-            _LOGGER.debug("Service discovery completed for %s", self.address)
-        except Exception as err:
-            error = f"Failed to connect: {err}"
-            self._errors.append(error)
-            raise
+            attempt_details["selected_source"] = adapter_result.source
+            attempt_details["selected_rssi"] = adapter_result.rssi
+            attempt_details["selected_connectable"] = adapter_result.connectable
+            attempt_details["non_connectable_fallback_used"] = adapter_result.connectable is False
+            attempt_details["visible_sources"] = list(adapter_result.available_sources)
+            attempt_details["lookup_elapsed_seconds"] = round(
+                time.monotonic() - attempt_start, 3
+            )
+
+            device = adapter_result.device
+            if device is None:
+                error = f"Device {self.address} not found in Bluetooth scanner"
+                attempt_details["total_elapsed_seconds"] = attempt_details["lookup_elapsed_seconds"]
+                attempt_details["error"] = error
+                attempt_details["error_type"] = "BleakError"
+                attempt_details["error_category"] = "DEVICE NOT FOUND"
+                attempt_details["result"] = "device_not_found"
+                self._connection_attempt_details.append(attempt_details)
+                self._errors.append(error)
+                raise BleakError(error)
+
+            self._selected_ble_device = device
+            self._selected_source = adapter_result.source
+            self._selected_rssi = adapter_result.rssi
+            self._selected_connectable = adapter_result.connectable
+            self._using_non_connectable_fallback = adapter_result.connectable is False
+
+            if adapter_result.connectable is False:
+                warning = (
+                    f"Using non-connectable scanner record for {self.address}; "
+                    "the Bluetooth proxy may be misclassifying the advertisement"
+                )
+                _LOGGER.warning(warning)
+                self._errors.append(warning)
+
+            try:
+                connect_start = time.monotonic()
+                self._client = await establish_connection(
+                    BleakClient,
+                    device,
+                    f"diagnostic_{self.address}",
+                    max_attempts=1,
+                    timeout=CONNECTION_TIMEOUT,
+                )
+                attempt_details["connect_elapsed_seconds"] = round(
+                    time.monotonic() - connect_start, 3
+                )
+                attempt_details["service_discovery"]["attempted"] = True
+                if hasattr(self._client, "get_services"):
+                    await self._client.get_services()
+                attempt_details["service_discovery"]["success"] = True
+                attempt_details["service_discovery"]["service_count"] = (
+                    len(list(self._client.services)) if self._client.services else 0
+                )
+                attempt_details["total_elapsed_seconds"] = round(
+                    time.monotonic() - attempt_start, 3
+                )
+                attempt_details["result"] = "connected"
+                self._actual_source = self._extract_client_source(self._client) or self._selected_source
+                attempt_details["actual_source"] = self._actual_source
+                self._connection_attempt_details.append(attempt_details)
+                _LOGGER.info("Connected to %s", self.address)
+                return
+            except Exception as err:
+                attempt_details["connect_elapsed_seconds"] = round(
+                    time.monotonic() - attempt_start, 3
+                )
+                attempt_details["total_elapsed_seconds"] = round(
+                    time.monotonic() - attempt_start, 3
+                )
+                attempt_details["error"] = str(err)
+                attempt_details["error_type"] = type(err).__name__
+                attempt_details["error_category"] = "BLE ERROR"
+                attempt_details["result"] = "failed"
+                if attempt_details["service_discovery"]["attempted"]:
+                    attempt_details["service_discovery"]["success"] = False
+                self._connection_attempt_details.append(attempt_details)
+
+                if self._client is not None:
+                    with contextlib.suppress(Exception):
+                        await self._client.disconnect()
+                    self._client = None
+
+                if attempt == 1:
+                    error = f"Failed to connect: {err}"
+                    self._errors.append(error)
+                    raise
+
+                await asyncio.sleep(1)
 
     async def _disconnect(self) -> None:
         """Disconnect from the BLE device."""
-        # Don't disconnect if we're using the coordinator's connection
         if self._using_coordinator_connection:
             _LOGGER.debug("Leaving coordinator connection intact")
-            # Resume the disconnect timer now that capture is complete
             if self.coordinator:
                 self.coordinator.resume_disconnect_timer()
             self._client = None
@@ -301,19 +453,35 @@ class BLEDiagnosticRunner:
         services: list[ServiceInfo] = []
 
         for service in self._client.services:
-            service_info = ServiceInfo(uuid=service.uuid)
+            service_info = ServiceInfo(
+                uuid=service.uuid,
+                handle=getattr(service, "handle", None),
+            )
 
             for char in service.characteristics:
                 char_info = CharacteristicInfo(
                     uuid=char.uuid,
+                    handle=getattr(char, "handle", None),
                     properties=list(char.properties),
+                    notify_subscription={
+                        "attempted": False,
+                        "success": None,
+                        "method": None,
+                        "error": None,
+                    },
+                    descriptors=[
+                        DescriptorInfo(
+                            uuid=descriptor.uuid,
+                            handle=getattr(descriptor, "handle", None),
+                        )
+                        for descriptor in getattr(char, "descriptors", [])
+                    ],
                 )
 
-                # Try to read the characteristic value if readable
                 if "read" in char.properties:
                     try:
-                        value = await self._client.read_gatt_char(char.uuid)
-                        char_info.value_hex = value.hex()
+                        value = await self._client.read_gatt_char(char)
+                        char_info.read_result = format_payload(value)
                     except Exception as err:
                         char_info.read_error = str(err)
                         _LOGGER.debug(
@@ -336,13 +504,9 @@ class BLEDiagnosticRunner:
 
         info: dict[str, str | None] = {}
 
-        # Check if Device Information Service exists
-        has_device_info = False
-        for service in self._client.services:
-            if service.uuid.lower() == DEVICE_INFO_SERVICE_UUID:
-                has_device_info = True
-                break
-
+        has_device_info = any(
+            service.uuid.lower() == DEVICE_INFO_SERVICE_UUID for service in self._client.services
+        )
         if not has_device_info:
             _LOGGER.debug("Device Information Service not found")
             return info
@@ -350,12 +514,10 @@ class BLEDiagnosticRunner:
         for name, uuid in DEVICE_INFO_CHARS.items():
             try:
                 value = await self._client.read_gatt_char(uuid)
-                # Device info chars are typically strings
                 try:
                     info[name] = value.decode("utf-8").rstrip("\x00")
                 except UnicodeDecodeError:
                     info[name] = value.hex()
-                _LOGGER.debug("Device info %s: %s", name, info[name])
             except Exception as err:
                 _LOGGER.debug("Could not read %s: %s", name, err)
                 info[name] = None
@@ -363,11 +525,7 @@ class BLEDiagnosticRunner:
         return info
 
     def _raw_notify_callback(self, characteristic_uuid: str, data: bytes) -> None:
-        """Handle raw notification from coordinator's controller.
-
-        This is called synchronously from the controller's notification handler.
-        We schedule the async handler to run in the event loop.
-        """
+        """Handle raw notification from coordinator's controller."""
         asyncio.create_task(self._handle_notification(characteristic_uuid, data))
 
     async def _subscribe_to_notifications(self, services: list[ServiceInfo]) -> None:
@@ -375,35 +533,61 @@ class BLEDiagnosticRunner:
         if not self._client:
             return
 
-        # When using coordinator's connection, register a raw callback instead
-        # of subscribing directly (which would replace coordinator callbacks)
         if self._using_coordinator_connection:
             if self.coordinator is not None:
                 _LOGGER.debug("Registering raw notification callback with coordinator")
                 self.coordinator.set_raw_notify_callback(self._raw_notify_callback)
-
-                # If angle sensing is disabled, notifications aren't started by default.
-                # Start them now for diagnostic capture purposes.
                 if self.coordinator.disable_angle_sensing:
                     _LOGGER.info(
                         "Angle sensing disabled - starting notifications for diagnostic capture"
                     )
                     await self.coordinator.async_start_notify_for_diagnostics()
                     self._diagnostic_notifications_started = True
+
+            for service in services:
+                for char in service.characteristics:
+                    if "notify" in char.properties or "indicate" in char.properties:
+                        char.notify_subscription.update(
+                            {
+                                "attempted": False,
+                                "success": None,
+                                "method": "shared_connection",
+                                "error": (
+                                    "Direct per-characteristic subscription skipped while "
+                                    "reusing the coordinator connection"
+                                ),
+                            }
+                        )
             return
 
         for service in services:
+            bleak_service = self._client.services.get_service(service.uuid)
             for char in service.characteristics:
-                if "notify" in char.properties or "indicate" in char.properties:
-                    try:
-                        # Use functools.partial to properly capture uuid per-characteristic
-                        handler = functools.partial(self._notification_handler_sync, char.uuid)
-                        await self._client.start_notify(char.uuid, handler)
-                        _LOGGER.debug("Subscribed to notifications on %s", char.uuid)
-                    except Exception as err:
-                        error = f"Failed to subscribe to {char.uuid}: {err}"
-                        _LOGGER.debug(error)
-                        self._errors.append(error)
+                if "notify" not in char.properties and "indicate" not in char.properties:
+                    continue
+
+                char.notify_subscription["attempted"] = True
+                char.notify_subscription["method"] = "direct_subscription"
+
+                bleak_characteristic = None
+                if bleak_service is not None:
+                    for candidate in bleak_service.characteristics:
+                        if getattr(candidate, "handle", None) == char.handle:
+                            bleak_characteristic = candidate
+                            break
+                if bleak_characteristic is None:
+                    bleak_characteristic = char.uuid
+
+                try:
+                    handler = functools.partial(self._notification_handler_sync, char.uuid)
+                    await self._client.start_notify(bleak_characteristic, handler)
+                    char.notify_subscription["success"] = True
+                except Exception as err:
+                    error = f"Failed to subscribe to {char.uuid}: {err}"
+                    char.notify_subscription["success"] = False
+                    char.notify_subscription["error"] = str(err)
+                    _LOGGER.debug(error)
+                    self._errors.append(error)
 
     def _notification_handler_sync(self, uuid: str, sender: object, data: bytearray) -> None:
         """Synchronous notification handler that schedules async processing."""
@@ -411,13 +595,10 @@ class BLEDiagnosticRunner:
 
     async def _unsubscribe_from_notifications(self, services: list[ServiceInfo]) -> None:
         """Unsubscribe from all notifiable characteristics."""
-        # When using coordinator's connection, always clear the raw callback
-        # (even if disconnected, to avoid stale callbacks)
         if self._using_coordinator_connection:
             if self.coordinator is not None:
                 _LOGGER.debug("Clearing raw notification callback from coordinator")
                 self.coordinator.set_raw_notify_callback(None)
-                # Stop notifications if we started them for diagnostics (only if still connected)
                 if (
                     self._diagnostic_notifications_started
                     and self.coordinator.controller is not None
@@ -433,75 +614,363 @@ class BLEDiagnosticRunner:
             return
 
         for service in services:
+            bleak_service = self._client.services.get_service(service.uuid)
             for char in service.characteristics:
-                if "notify" in char.properties or "indicate" in char.properties:
-                    try:
-                        await self._client.stop_notify(char.uuid)
-                    except Exception as err:
-                        _LOGGER.debug(
-                            "Error unsubscribing from %s: %s",
-                            char.uuid,
-                            err,
-                        )
+                if "notify" not in char.properties and "indicate" not in char.properties:
+                    continue
+                try:
+                    bleak_characteristic = None
+                    if bleak_service is not None:
+                        for candidate in bleak_service.characteristics:
+                            if getattr(candidate, "handle", None) == char.handle:
+                                bleak_characteristic = candidate
+                                break
+                    await self._client.stop_notify(bleak_characteristic or char.uuid)
+                except Exception as err:
+                    _LOGGER.debug(
+                        "Error unsubscribing from %s: %s",
+                        char.uuid,
+                        err,
+                    )
 
     async def _handle_notification(self, characteristic_uuid: str, data: bytes | bytearray) -> None:
         """Handle an incoming notification."""
         timestamp = datetime.now(UTC).isoformat()
+        payload = bytes(data)
 
         async with self._notification_lock:
             notification = CapturedNotification(
                 characteristic=characteristic_uuid,
                 timestamp=timestamp,
-                data_hex=data.hex(),
+                data_hex=payload.hex(),
             )
             self._notifications.append(notification)
+            self._notification_payloads.setdefault(characteristic_uuid, []).append(payload)
 
         _LOGGER.debug(
             "Notification on %s: %s",
             characteristic_uuid,
-            data.hex(),
+            payload.hex(),
         )
 
     def _build_gatt_summary(self, services: list[ServiceInfo]) -> dict[str, Any]:
         """Build GATT summary from enumerated services."""
         if not services:
-            return {"available": False}
+            return {
+                "available": False,
+                "service_count": 0,
+                "characteristic_count": 0,
+                "descriptor_count": 0,
+                "notifiable_characteristics": [],
+                "writable_characteristics": [],
+                "readable_characteristics": [],
+            }
 
         char_count = 0
+        descriptor_count = 0
         notifiable_chars: list[str] = []
         writable_chars: list[str] = []
+        readable_chars: list[str] = []
 
         for service in services:
             for char in service.characteristics:
                 char_count += 1
+                descriptor_count += len(char.descriptors)
                 if "notify" in char.properties or "indicate" in char.properties:
                     notifiable_chars.append(char.uuid)
                 if "write" in char.properties or "write-without-response" in char.properties:
                     writable_chars.append(char.uuid)
+                if "read" in char.properties:
+                    readable_chars.append(char.uuid)
 
         return {
             "available": True,
             "service_count": len(services),
             "characteristic_count": char_count,
-            "notifiable_characteristics": notifiable_chars,
-            "writable_characteristics": writable_chars,
+            "descriptor_count": descriptor_count,
+            "notifiable_characteristics": sorted(notifiable_chars),
+            "writable_characteristics": sorted(writable_chars),
+            "readable_characteristics": sorted(readable_chars),
         }
 
-    @staticmethod
-    def _service_to_dict(service: ServiceInfo) -> dict[str, Any]:
-        """Convert ServiceInfo to dictionary."""
+    def _build_detection_section(self, service_info: Any | None) -> dict[str, Any]:
+        """Build a detection reasoning section."""
+        if service_info is None:
+            return {
+                "bed_type": None,
+                "confidence": 0.0,
+                "signals": [],
+                "ambiguous_types": [],
+                "requires_characteristic_check": False,
+                "detected_remote": None,
+                "supported_match": False,
+            }
+
+        detection = detect_bed_type_detailed(service_info)
         return {
-            "uuid": service.uuid,
-            "characteristics": [
-                {
-                    "uuid": char.uuid,
-                    "properties": char.properties,
-                    "value_hex": char.value_hex,
-                    "read_error": char.read_error,
-                }
-                for char in service.characteristics
-            ],
+            "bed_type": detection.bed_type,
+            "confidence": detection.confidence,
+            "signals": list(detection.signals),
+            "ambiguous_types": list(detection.ambiguous_types or []),
+            "requires_characteristic_check": detection.requires_characteristic_check,
+            "detected_remote": detection.detected_remote,
+            "supported_match": detection.bed_type in SUPPORTED_BED_TYPES
+            if detection.bed_type is not None
+            else False,
+            "manufacturer_id": detection.manufacturer_id,
         }
+
+    def _build_best_advertisement(
+        self,
+        best_snapshot: tuple[Any, bool] | None,
+    ) -> dict[str, Any]:
+        """Build the best current advertisement snapshot."""
+        if best_snapshot is None:
+            return {
+                "captured_at": datetime.now(UTC).isoformat(),
+                "address": self.address,
+                "name": None,
+                "rssi": None,
+                "source": self._selected_source,
+                "connectable": self._selected_connectable,
+                "service_uuids": [],
+                "manufacturer_data": {},
+                "service_data": {},
+                "selected_for_connection": False,
+                "non_connectable_fallback_used": self._using_non_connectable_fallback,
+            }
+
+        service_info, connectable = best_snapshot
+        return self._service_info_snapshot_to_dict(
+            service_info,
+            connectable,
+            selected_for_connection=True,
+        )
+
+    def _build_advertisements_by_source(self) -> list[dict[str, Any]]:
+        """Build one advertisement row per current scanner source."""
+        if not self._advertisement_snapshots:
+            return []
+
+        rows = [
+            self._service_info_snapshot_to_dict(
+                service_info,
+                connectable,
+                selected_for_connection=(
+                    getattr(service_info, "source", None) == self._actual_source
+                    or getattr(service_info, "source", None) == self._selected_source
+                ),
+            )
+            for service_info, connectable in self._advertisement_snapshots
+        ]
+
+        rows.sort(
+            key=lambda row: (
+                row["selected_for_connection"],
+                row["connectable"],
+                row["rssi"] if isinstance(row["rssi"], int) else -999,
+            ),
+            reverse=True,
+        )
+        return rows
+
+    def _service_info_snapshot_to_dict(
+        self,
+        service_info: Any,
+        connectable: bool,
+        *,
+        selected_for_connection: bool,
+    ) -> dict[str, Any]:
+        """Convert a Bluetooth service snapshot to a dictionary."""
+        return {
+            "captured_at": datetime.now(UTC).isoformat(),
+            "address": service_info.address.upper(),
+            "name": service_info.name,
+            "source": getattr(service_info, "source", None),
+            "rssi": getattr(service_info, "rssi", None),
+            "connectable": connectable,
+            "service_uuids": [str(uuid) for uuid in (service_info.service_uuids or [])],
+            "manufacturer_data": format_mapping_payloads(service_info.manufacturer_data),
+            "service_data": format_mapping_payloads(service_info.service_data),
+            "scanner_time": self._serialize_scanner_time(getattr(service_info, "time", None)),
+            "selected_for_connection": selected_for_connection,
+            "non_connectable_fallback_used": (
+                selected_for_connection and self._using_non_connectable_fallback
+            ),
+        }
+
+    def _build_device_section(self, service_info: Any | None) -> dict[str, Any]:
+        """Build enriched device and backend info."""
+        backend_device = self._extract_backend_device()
+        details = self._extract_backend_details(
+            backend_device.details if backend_device is not None else None
+        )
+        if self._selected_ble_device is not None:
+            details.setdefault(
+                "ble_device_details",
+                self._extract_backend_details(self._selected_ble_device.details),
+            )
+
+        pairing = self._extract_pairing_info(details)
+        visible_sources = [
+            getattr(snapshot, "source", None)
+            for snapshot, _ in self._advertisement_snapshots
+            if getattr(snapshot, "source", None) is not None
+        ]
+
+        return {
+            "address": self.address,
+            "name": service_info.name if service_info is not None else None,
+            "rssi": getattr(service_info, "rssi", None) if service_info is not None else None,
+            "selected_source": self._selected_source,
+            "actual_source": self._actual_source,
+            "connectable": self._selected_connectable,
+            "non_connectable_fallback_used": self._using_non_connectable_fallback,
+            "backend_details": details,
+            "pairing": pairing,
+            "scanner_count": self._get_scanner_count(),
+            "visible_sources": visible_sources,
+        }
+
+    def _build_notification_summary(self) -> dict[str, Any]:
+        """Build an aggregated notification summary."""
+        summary: dict[str, Any] = {
+            "total_notifications": len(self._notifications),
+            "by_characteristic": {},
+        }
+
+        if not self._notifications:
+            return summary
+
+        notifications_by_characteristic: dict[str, list[CapturedNotification]] = {}
+        for notification in self._notifications:
+            notifications_by_characteristic.setdefault(notification.characteristic, []).append(
+                notification
+            )
+
+        for characteristic, notifications in notifications_by_characteristic.items():
+            payloads = self._notification_payloads.get(characteristic, [])
+            summary["by_characteristic"][characteristic] = {
+                "count": len(notifications),
+                "first_timestamp": notifications[0].timestamp,
+                "last_timestamp": notifications[-1].timestamp,
+                "observed_payload_lengths": sorted({len(payload) for payload in payloads}),
+                "ascii_previews": sorted(
+                    {
+                        preview
+                        for preview in (
+                            payload_ascii_preview(payload) for payload in payloads
+                        )
+                        if preview is not None
+                    }
+                )[:5],
+                "top_repeated_payloads": summarize_repeated_payloads(payloads),
+            }
+
+        return summary
+
+    def _best_snapshot(self) -> tuple[Any, bool] | None:
+        """Return the best current advertisement snapshot."""
+        if not self._advertisement_snapshots:
+            service_info, connectable = find_service_info_by_address(
+                self.hass,
+                self.address,
+                allow_non_connectable=True,
+            )
+            if service_info is None:
+                self._errors.append("No advertisement data available")
+                return None
+            return service_info, connectable
+
+        for snapshot in self._advertisement_snapshots:
+            source = getattr(snapshot[0], "source", None)
+            if source is not None and source in {self._actual_source, self._selected_source}:
+                return snapshot
+
+        return self._advertisement_snapshots[0]
+
+    def _extract_backend_device(self) -> BLEDevice | None:
+        """Return the backend BLEDevice when available."""
+        if self._client is None:
+            return self._selected_ble_device
+
+        backend = getattr(self._client, "_backend", None)
+        backend_device = getattr(backend, "_device", None)
+        if isinstance(backend_device, BLEDevice):
+            return backend_device
+        return self._selected_ble_device
+
+    def _extract_client_source(self, client: BleakClient | None) -> str | None:
+        """Return the connected client source when available."""
+        backend = getattr(client, "_backend", None)
+        backend_device = getattr(backend, "_device", None)
+        if hasattr(backend_device, "details") and isinstance(backend_device.details, dict):
+            source = backend_device.details.get("source")
+            if isinstance(source, str):
+                return source
+        return None
+
+    def _extract_backend_details(self, details: Any) -> dict[str, Any]:
+        """Serialize backend details into a JSON-friendly structure."""
+        if not isinstance(details, dict):
+            return {}
+        return {str(key): self._serialize_value(value) for key, value in details.items()}
+
+    def _extract_pairing_info(self, details: dict[str, Any]) -> dict[str, Any]:
+        """Extract pairing-related flags from backend details."""
+        props = details.get("props", {})
+        if not isinstance(props, dict):
+            props = {}
+
+        def _get_field(name: str, fallback_name: str | None = None) -> Any:
+            if name in props:
+                return props[name]
+            if name in details:
+                return details[name]
+            if fallback_name and fallback_name in details:
+                return details[fallback_name]
+            return None
+
+        return {
+            "paired": _get_field("Paired", "paired"),
+            "bonded": _get_field("Bonded", "bonded"),
+            "trusted": _get_field("Trusted", "trusted"),
+            "address_type": _get_field("AddressType", "address_type"),
+        }
+
+    def _get_scanner_count(self) -> int | None:
+        """Return current connectable scanner count."""
+        try:
+            return bluetooth.async_scanner_count(self.hass, connectable=True)
+        except Exception as err:
+            self._errors.append(f"Could not read scanner count: {err}")
+            return None
+
+    def _serialize_scanner_time(self, raw_time: Any) -> str | float | int | None:
+        """Serialize scanner timestamps when available."""
+        if raw_time is None:
+            return None
+        if isinstance(raw_time, datetime):
+            return raw_time.isoformat()
+        if isinstance(raw_time, (int, float)):
+            if raw_time > 1_000_000_000:
+                return datetime.fromtimestamp(raw_time, tz=UTC).isoformat()
+            return raw_time
+        return str(raw_time)
+
+    def _serialize_value(self, value: Any) -> Any:
+        """Serialize nested backend values into JSON-safe structures."""
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return value
+        if isinstance(value, bytes):
+            return format_payload(value)
+        if isinstance(value, datetime):
+            return value.isoformat()
+        if isinstance(value, dict):
+            return {str(key): self._serialize_value(val) for key, val in value.items()}
+        if isinstance(value, (list, tuple, set)):
+            return [self._serialize_value(item) for item in value]
+        return str(value)
 
 
 def save_diagnostic_report(
@@ -518,7 +987,7 @@ def save_diagnostic_report(
     filepath = config_dir / filename
 
     with open(filepath, "w", encoding="utf-8") as f:
-        json.dump(report.to_dict(), f, indent=2)
+        json.dump(report.to_dict(), f, indent=2, default=str)
 
     _LOGGER.info("Diagnostic report saved to %s", filepath)
     return filepath

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.selector import (
 )
 from homeassistant.helpers.translation import async_get_translations
 
-from .adapter import get_discovered_service_info
+from .adapter import find_service_info_by_address, get_discovered_service_info
 from .actuator_groups import (
     ACTUATOR_GROUPS,
     SINGLE_TYPE_GROUPS,
@@ -36,7 +36,6 @@ from .const import (
     ADAPTER_AUTO,
     ALL_PROTOCOL_VARIANTS,
     BED_MOTOR_PULSE_DEFAULTS,
-    BED_TYPE_DIAGNOSTIC,
     BED_TYPE_JENSEN,
     BED_TYPE_KAIDI,
     BED_TYPE_KEESON,
@@ -163,6 +162,32 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             manufacturer_data=manufacturer_data,
         )
         return add_kaidi_entry_metadata(entry_data, advertisement)
+
+    def _async_abort_diagnostic_browser(
+        self,
+        *,
+        address: str,
+        name: str | None,
+        source: str | None,
+        connectable: bool | None,
+    ) -> ConfigFlowResult:
+        """Finish the BLE browser flow without creating a config entry."""
+        if connectable is True:
+            connectable_text = "Yes"
+        elif connectable is False:
+            connectable_text = "No (scanner says non-connectable)"
+        else:
+            connectable_text = "Unknown"
+
+        return self.async_abort(
+            reason="diagnostic_browser_ready",
+            description_placeholders={
+                "name": name or "Unknown",
+                "address": address,
+                "source": source or "unknown",
+                "connectable": connectable_text,
+            },
+        )
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
@@ -677,7 +702,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         devices.update(
             {address: f"{info.name or 'Unknown'} ({address})" for address, info in sorted_beds}
         )
-        devices["diagnostic"] = "Diagnostic mode (unsupported device)"
+        devices["diagnostic"] = "Browse unsupported BLE devices"
 
         return self.async_show_form(
             step_id="user",
@@ -1525,34 +1550,30 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_diagnostic(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle diagnostic mode device selection.
-
-        Lists ALL visible BLE devices (not just recognized beds) so users can
-        add unsupported devices for diagnostic capture.
-        """
+        """Handle unsupported BLE device browsing."""
         if user_input is not None:
             address = user_input[CONF_ADDRESS]
             if address == "manual":
-                _LOGGER.debug("User selected manual entry for diagnostic mode")
+                _LOGGER.debug("User selected manual entry for BLE browser")
                 return await self.async_step_diagnostic_manual()
 
-            _LOGGER.info("User selected device for diagnostic mode: %s", address)
-            # Normalize address to uppercase to match Bluetooth discovery
-            await self.async_set_unique_id(address.upper())
-            self._abort_if_unique_id_configured()
+            _LOGGER.info("User selected device from BLE browser: %s", address)
+            discovery_info = self._all_ble_devices[address]
+            return self._async_abort_diagnostic_browser(
+                address=discovery_info.address.upper(),
+                name=discovery_info.name,
+                source=getattr(discovery_info, "source", None),
+                connectable=getattr(discovery_info, "connectable", None),
+            )
 
-            self._discovery_info = self._all_ble_devices[address]
-            return await self.async_step_diagnostic_confirm()
-
-        # Get ALL BLE devices (not just beds)
-        _LOGGER.debug("Scanning for ALL BLE devices for diagnostic mode...")
+        _LOGGER.debug("Scanning for all BLE devices for browser mode...")
 
         all_discovered = get_discovered_service_info(
             self.hass,
             include_non_connectable=True,
         )
         _LOGGER.debug(
-            "Total BLE devices visible for diagnostic mode: %d",
+            "Total BLE devices visible for browser mode: %d",
             len(all_discovered),
         )
 
@@ -1565,7 +1586,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 self._all_ble_devices[discovery_info.address] = discovery_info
 
         _LOGGER.info(
-            "Diagnostic mode: found %d unconfigured BLE devices",
+            "BLE browser: found %d unconfigured BLE devices",
             len(self._all_ble_devices),
         )
 
@@ -1594,106 +1615,45 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_diagnostic_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Confirm diagnostic device setup."""
+        """Backward-compatible handler for old flow links."""
         assert self._discovery_info is not None
-
-        # Get discovery source for default adapter selection
-        discovery_source = getattr(self._discovery_info, "source", None) or ADAPTER_AUTO
-
-        if user_input is not None:
-            preferred_adapter = user_input.get(CONF_PREFERRED_ADAPTER, discovery_source)
-            device_name = user_input.get(
-                CONF_NAME, self._discovery_info.name or "Diagnostic Device"
-            )
-            _LOGGER.info(
-                "Creating diagnostic device entry: name=%s, address=%s, adapter=%s",
-                device_name,
-                self._discovery_info.address,
-                preferred_adapter,
-            )
-
-            return self.async_create_entry(
-                title=device_name,
-                data={
-                    CONF_ADDRESS: self._discovery_info.address.upper(),
-                    CONF_BED_TYPE: BED_TYPE_DIAGNOSTIC,
-                    CONF_NAME: device_name,
-                    CONF_MOTOR_COUNT: 0,  # No motors for diagnostic
-                    CONF_HAS_MASSAGE: False,
-                    CONF_DISABLE_ANGLE_SENSING: True,
-                    CONF_PREFERRED_ADAPTER: preferred_adapter,
-                },
-            )
-
-        # Get available Bluetooth adapters
-        adapters = get_available_adapters(self.hass)
-
-        return self.async_show_form(
-            step_id="diagnostic_confirm",
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_NAME, default=self._discovery_info.name or "Diagnostic Device"
-                    ): str,
-                    vol.Optional(CONF_PREFERRED_ADAPTER, default=discovery_source): vol.In(
-                        adapters
-                    ),
-                }
-            ),
-            description_placeholders={
-                "name": self._discovery_info.name or self._discovery_info.address,
-                "address": self._discovery_info.address,
-            },
+        return self._async_abort_diagnostic_browser(
+            address=self._discovery_info.address.upper(),
+            name=self._discovery_info.name,
+            source=getattr(self._discovery_info, "source", None),
+            connectable=getattr(self._discovery_info, "connectable", None),
         )
 
     async def async_step_diagnostic_manual(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle manual MAC address entry for diagnostic mode."""
+        """Handle manual MAC address entry for BLE browser mode."""
         errors: dict[str, str] = {}
 
         if user_input is not None:
             address = user_input[CONF_ADDRESS].upper().replace("-", ":")
 
-            # Validate MAC address format
             if not is_valid_mac_address(address):
                 errors["base"] = "invalid_mac_address"
             else:
-                await self.async_set_unique_id(address)
-                self._abort_if_unique_id_configured()
-
-                preferred_adapter = user_input.get(CONF_PREFERRED_ADAPTER, ADAPTER_AUTO)
-                device_name = user_input.get(CONF_NAME, "Diagnostic Device")
-                _LOGGER.info(
-                    "Creating diagnostic device entry (manual): name=%s, address=%s, adapter=%s",
-                    device_name,
+                service_info, connectable = find_service_info_by_address(
+                    self.hass,
                     address,
-                    preferred_adapter,
+                    allow_non_connectable=True,
                 )
-
-                return self.async_create_entry(
-                    title=device_name,
-                    data={
-                        CONF_ADDRESS: address,
-                        CONF_BED_TYPE: BED_TYPE_DIAGNOSTIC,
-                        CONF_NAME: device_name,
-                        CONF_MOTOR_COUNT: 0,  # No motors for diagnostic
-                        CONF_HAS_MASSAGE: False,
-                        CONF_DISABLE_ANGLE_SENSING: True,
-                        CONF_PREFERRED_ADAPTER: preferred_adapter,
-                    },
+                return self._async_abort_diagnostic_browser(
+                    address=address,
+                    name=user_input.get(CONF_NAME) or getattr(service_info, "name", None),
+                    source=getattr(service_info, "source", None),
+                    connectable=connectable if service_info is not None else None,
                 )
-
-        # Get available Bluetooth adapters
-        adapters = get_available_adapters(self.hass)
 
         return self.async_show_form(
             step_id="diagnostic_manual",
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_ADDRESS): str,
-                    vol.Optional(CONF_NAME, default="Diagnostic Device"): str,
-                    vol.Optional(CONF_PREFERRED_ADAPTER, default=ADAPTER_AUTO): vol.In(adapters),
+                    vol.Optional(CONF_NAME, default="Unknown BLE Device"): str,
                 }
             ),
             errors=errors,

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -8,7 +8,6 @@ from typing import Any
 import voluptuous as vol
 from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,
-    async_discovered_service_info,
 )
 from homeassistant.config_entries import (
     ConfigEntry,
@@ -28,6 +27,7 @@ from homeassistant.helpers.selector import (
 )
 from homeassistant.helpers.translation import async_get_translations
 
+from .adapter import get_discovered_service_info
 from .actuator_groups import (
     ACTUATOR_GROUPS,
     SINGLE_TYPE_GROUPS,
@@ -626,8 +626,12 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         except Exception as err:
             _LOGGER.debug("Could not get scanner count: %s", err)
 
-        # Get all discovered devices
-        all_discovered = list(async_discovered_service_info(self.hass))
+        # Include non-connectable records as a fallback because some Bluetooth
+        # proxies have been observed to misclassify connectable beds.
+        all_discovered = get_discovered_service_info(
+            self.hass,
+            include_non_connectable=True,
+        )
         _LOGGER.debug(
             "Total BLE devices visible: %d",
             len(all_discovered),
@@ -786,9 +790,12 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         # Get ALL BLE devices (not just beds)
         _LOGGER.debug("Scanning for ALL BLE devices for manual selection...")
 
-        all_discovered = list(async_discovered_service_info(self.hass, connectable=True))
+        all_discovered = get_discovered_service_info(
+            self.hass,
+            include_non_connectable=True,
+        )
         _LOGGER.debug(
-            "Total connectable BLE devices visible: %d",
+            "Total BLE devices visible for manual selection: %d",
             len(all_discovered),
         )
 
@@ -806,7 +813,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
         if not self._all_ble_devices:
-            _LOGGER.info("No BLE devices found, showing manual entry form")
+            _LOGGER.info("No BLE devices found in either scanner view, showing manual entry form")
             return await self.async_step_manual_entry()
 
         # Sort devices: named devices first (alphabetically), then MAC-only/unnamed
@@ -814,9 +821,12 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             self._all_ble_devices.items(),
             key=lambda x: (is_mac_like_name(x[1].name), (x[1].name or "").lower()),
         )
-        devices = {
-            address: f"{info.name or 'Unknown'} ({address})" for address, info in sorted_devices
-        }
+        devices = {}
+        for address, info in sorted_devices:
+            label = f"{info.name or 'Unknown'} ({address})"
+            if getattr(info, "connectable", True) is False:
+                label += " [scanner says non-connectable]"
+            devices[address] = label
         devices["manual_entry"] = "Enter address manually"
 
         return self.async_show_form(
@@ -1462,7 +1472,10 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         address_upper = address.upper()
         matching_service_info = None
 
-        for service_info in async_discovered_service_info(self.hass, connectable=True):
+        for service_info in get_discovered_service_info(
+            self.hass,
+            include_non_connectable=True,
+        ):
             if service_info.address.upper() != address_upper:
                 continue
             # Check adapter preference
@@ -1486,9 +1499,10 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
 
         device = matching_service_info.device
         _LOGGER.debug(
-            "Found device %s via adapter %s",
+            "Found device %s via adapter %s (connectable=%s)",
             address,
             getattr(matching_service_info, "source", "unknown"),
+            getattr(matching_service_info, "connectable", None),
         )
 
         # Connect with pairing enabled - this handles both built-in HA Bluetooth
@@ -1533,9 +1547,12 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         # Get ALL BLE devices (not just beds)
         _LOGGER.debug("Scanning for ALL BLE devices for diagnostic mode...")
 
-        all_discovered = list(async_discovered_service_info(self.hass, connectable=True))
+        all_discovered = get_discovered_service_info(
+            self.hass,
+            include_non_connectable=True,
+        )
         _LOGGER.debug(
-            "Total connectable BLE devices visible: %d",
+            "Total BLE devices visible for diagnostic mode: %d",
             len(all_discovered),
         )
 
@@ -1553,7 +1570,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
         if not self._all_ble_devices:
-            _LOGGER.info("No BLE devices found, showing manual entry form")
+            _LOGGER.info("No BLE devices found in either scanner view, showing manual entry form")
             return await self.async_step_diagnostic_manual()
 
         # Sort devices: named devices first (alphabetically), then MAC-only/unnamed
@@ -1561,9 +1578,12 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             self._all_ble_devices.items(),
             key=lambda x: (is_mac_like_name(x[1].name), (x[1].name or "").lower()),
         )
-        devices = {
-            address: f"{info.name or 'Unknown'} ({address})" for address, info in sorted_devices
-        }
+        devices = {}
+        for address, info in sorted_devices:
+            label = f"{info.name or 'Unknown'} ({address})"
+            if getattr(info, "connectable", True) is False:
+                label += " [scanner says non-connectable]"
+            devices[address] = label
         devices["manual"] = "Enter address manually"
 
         return self.async_show_form(

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -119,6 +119,7 @@ from .const import (
 )
 from .controller_factory import create_controller
 from .detection import detect_richmat_remote_from_name
+from .diagnostic_payloads import new_connection_attempt_details
 
 if TYPE_CHECKING:
     from .beds.base import BedController
@@ -632,30 +633,7 @@ class AdjustableBedCoordinator:
 
         for attempt in range(self._max_retries):
             attempt_start = time.monotonic()
-            attempt_started_at = datetime.now(UTC)
-            attempt_details: dict[str, Any] = {
-                "attempt": attempt + 1,
-                "started_at": attempt_started_at.isoformat(),
-                "preferred_adapter": self._preferred_adapter,
-                "selected_source": None,
-                "actual_source": None,
-                "selected_rssi": None,
-                "selected_connectable": None,
-                "non_connectable_fallback_used": False,
-                "visible_sources": [],
-                "lookup_elapsed_seconds": None,
-                "connect_elapsed_seconds": None,
-                "total_elapsed_seconds": None,
-                "error": None,
-                "error_type": None,
-                "error_category": None,
-                "service_discovery": {
-                    "attempted": False,
-                    "success": None,
-                    "service_count": None,
-                },
-                "result": "started",
-            }
+            attempt_details = new_connection_attempt_details(attempt + 1, self._preferred_adapter)
             # Track connection attempt for diagnostics (issue #168)
             self._connection_attempt_count += 1
             self._last_connection_attempt = datetime.now(UTC)

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -10,6 +10,7 @@ import random
 import time
 import traceback
 from collections.abc import Callable, Coroutine
+from collections import deque
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
@@ -123,6 +124,9 @@ if TYPE_CHECKING:
     from .beds.base import BedController
 
 _LOGGER = logging.getLogger(__name__)
+
+MAX_COMMAND_TRACE_ENTRIES = 100
+MAX_CONNECTION_ATTEMPT_DETAILS = 25
 
 
 class NotConnectedError(Exception):
@@ -253,6 +257,10 @@ class AdjustableBedCoordinator:
         # Adapter selection details for diagnostics (issue #168)
         self._actual_adapter: str | None = None
         self._available_adapters: list[str] = []
+        self._command_trace: deque[dict[str, Any]] = deque(maxlen=MAX_COMMAND_TRACE_ENTRIES)
+        self._connection_attempt_details: deque[dict[str, Any]] = deque(
+            maxlen=MAX_CONNECTION_ATTEMPT_DETAILS
+        )
 
         _LOGGER.debug(
             "Coordinator initialized for %s at %s (type: %s, motors: %d, massage: %s, disable_angle_sensing: %s, adapter: %s, connection_profile: %s)",
@@ -446,6 +454,16 @@ class AdjustableBedCoordinator:
         }
 
     @property
+    def command_trace(self) -> list[dict[str, Any]]:
+        """Return recent integration-issued BLE writes."""
+        return list(self._command_trace)
+
+    @property
+    def connection_attempt_details(self) -> list[dict[str, Any]]:
+        """Return detailed recent connection attempts."""
+        return list(self._connection_attempt_details)
+
+    @property
     def device_info(self) -> DeviceInfo:
         """Return device info for this bed."""
         return DeviceInfo(
@@ -556,6 +574,33 @@ class AdjustableBedCoordinator:
             self._address,
         )
 
+    def record_command_trace(
+        self,
+        *,
+        payload: dict[str, Any],
+        characteristic_uuid: str,
+        characteristic_handle: int | None,
+        response: bool,
+        repeat_count: int,
+        repeat_delay_ms: int,
+        command_origin: str | None,
+        controller_class: str,
+    ) -> None:
+        """Record an integration-issued write for support bundles."""
+        self._command_trace.append(
+            {
+                "timestamp": datetime.now(UTC).isoformat(),
+                "controller_class": controller_class,
+                "characteristic_uuid": characteristic_uuid,
+                "characteristic_handle": characteristic_handle,
+                "payload": payload,
+                "write_mode": "with_response" if response else "without_response",
+                "repeat_count": repeat_count,
+                "repeat_delay_ms": repeat_delay_ms,
+                "command_origin": command_origin,
+            }
+        )
+
     async def async_connect(self) -> bool:
         """Connect to the bed."""
         _LOGGER.debug("async_connect called for %s", self._address)
@@ -587,6 +632,30 @@ class AdjustableBedCoordinator:
 
         for attempt in range(self._max_retries):
             attempt_start = time.monotonic()
+            attempt_started_at = datetime.now(UTC)
+            attempt_details: dict[str, Any] = {
+                "attempt": attempt + 1,
+                "started_at": attempt_started_at.isoformat(),
+                "preferred_adapter": self._preferred_adapter,
+                "selected_source": None,
+                "actual_source": None,
+                "selected_rssi": None,
+                "selected_connectable": None,
+                "non_connectable_fallback_used": False,
+                "visible_sources": [],
+                "lookup_elapsed_seconds": None,
+                "connect_elapsed_seconds": None,
+                "total_elapsed_seconds": None,
+                "error": None,
+                "error_type": None,
+                "error_category": None,
+                "service_discovery": {
+                    "attempted": False,
+                    "success": None,
+                    "service_count": None,
+                },
+                "result": "started",
+            }
             # Track connection attempt for diagnostics (issue #168)
             self._connection_attempt_count += 1
             self._last_connection_attempt = datetime.now(UTC)
@@ -644,10 +713,20 @@ class AdjustableBedCoordinator:
                     self._preferred_adapter,
                     exclude_adapters=exhausted_adapters or None,
                 )
+                attempt_details["selected_source"] = adapter_result.source
+                attempt_details["selected_rssi"] = adapter_result.rssi
+                attempt_details["selected_connectable"] = adapter_result.connectable
+                attempt_details["non_connectable_fallback_used"] = (
+                    adapter_result.connectable is False
+                )
+                attempt_details["visible_sources"] = list(adapter_result.available_sources)
                 device = adapter_result.device
 
                 if device is None:
                     lookup_elapsed = time.monotonic() - attempt_start
+                    attempt_details["lookup_elapsed_seconds"] = round(lookup_elapsed, 3)
+                    attempt_details["total_elapsed_seconds"] = round(lookup_elapsed, 3)
+                    attempt_details["result"] = "device_not_found"
                     _LOGGER.warning(
                         "Device %s NOT FOUND in Bluetooth scanner after %.1fs (attempt %d/%d). "
                         "Bed may be powered off, out of range, or connected to another device.",
@@ -682,6 +761,7 @@ class AdjustableBedCoordinator:
                             _LOGGER.debug("No BLE devices currently visible")
                     except Exception as err:
                         _LOGGER.debug("Could not enumerate visible devices: %s", err)
+                    self._connection_attempt_details.append(attempt_details)
                     # Don't sleep here - the retry backoff at loop start handles delays
                     continue
 
@@ -691,6 +771,7 @@ class AdjustableBedCoordinator:
                     device_source = device.details.get("source")
 
                 lookup_elapsed = time.monotonic() - attempt_start
+                attempt_details["lookup_elapsed_seconds"] = round(lookup_elapsed, 3)
                 _LOGGER.info(
                     "✓ Device %s FOUND in %.1fs (name: %s) via adapter: %s",
                     self._address,
@@ -906,9 +987,13 @@ class AdjustableBedCoordinator:
                 self._actual_adapter = actual_adapter
                 self._last_connection_error = None
                 self._last_connection_error_type = None
+                attempt_details["actual_source"] = actual_adapter
 
                 connect_elapsed = time.monotonic() - connect_start
                 total_elapsed = time.monotonic() - attempt_start
+                attempt_details["connect_elapsed_seconds"] = round(connect_elapsed, 3)
+                attempt_details["total_elapsed_seconds"] = round(total_elapsed, 3)
+                attempt_details["result"] = "connected"
                 _LOGGER.info(
                     "✓ CONNECTED to %s in %.1fs (GATT: %.1fs) via adapter: %s",
                     self._address,
@@ -941,7 +1026,12 @@ class AdjustableBedCoordinator:
                 )
 
                 # Discover services and log hierarchy
-                await discover_services(self._client, self._address)
+                attempt_details["service_discovery"]["attempted"] = True
+                service_discovery_success = await discover_services(self._client, self._address)
+                attempt_details["service_discovery"]["success"] = service_discovery_success
+                attempt_details["service_discovery"]["service_count"] = (
+                    len(list(self._client.services)) if self._client.services else 0
+                )
 
                 # Validate expected services are present (for beds requiring pairing)
                 if bed_requires_pairing and self._client.services:
@@ -1066,11 +1156,16 @@ class AdjustableBedCoordinator:
                 self._connection_source = actual_adapter
                 self._connection_rssi = adapter_result.rssi
                 self._notify_connection_state_change(True)
+                self._connection_attempt_details.append(attempt_details)
 
                 return True
 
             except (BleakError, TimeoutError, OSError) as err:
                 attempt_elapsed = time.monotonic() - attempt_start
+                attempt_details["total_elapsed_seconds"] = round(attempt_elapsed, 3)
+                attempt_details["result"] = "failed"
+                attempt_details["error"] = str(err)
+                attempt_details["error_type"] = type(err).__name__
                 err_str = str(err).lower()
                 # Categorize the error for clearer diagnostics
                 if isinstance(err, TimeoutError) or "timeout" in err_str:
@@ -1079,6 +1174,7 @@ class AdjustableBedCoordinator:
                     error_category = "CONNECTION REFUSED (another device may be connected)"
                 else:
                     error_category = "BLE ERROR"
+                attempt_details["error_category"] = error_category
 
                 # Detect connection slot exhaustion and exclude the adapter
                 # on subsequent retries so we try an alternative (issue #152).
@@ -1123,11 +1219,19 @@ class AdjustableBedCoordinator:
                             type(disconnect_err).__name__,
                         )
                     self._client = None
+                self._connection_attempt_details.append(attempt_details)
                 # Delay is handled at the start of the next iteration with progressive backoff
             except Exception as err:
                 # Track connection error for diagnostics (issue #168)
                 self._last_connection_error = str(err)
                 self._last_connection_error_type = type(err).__name__
+                attempt_details["total_elapsed_seconds"] = round(
+                    time.monotonic() - attempt_start, 3
+                )
+                attempt_details["result"] = "failed"
+                attempt_details["error"] = str(err)
+                attempt_details["error_type"] = type(err).__name__
+                attempt_details["error_category"] = "UNEXPECTED ERROR"
 
                 _LOGGER.warning(
                     "Unexpected error connecting to %s (attempt %d/%d): %s",
@@ -1155,6 +1259,7 @@ class AdjustableBedCoordinator:
                             type(disconnect_err).__name__,
                         )
                     self._client = None
+                self._connection_attempt_details.append(attempt_details)
                 # Delay is handled at the start of the next iteration with progressive backoff
 
         total_elapsed = time.monotonic() - overall_start

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -33,6 +33,8 @@ from .adapter import (
     AdapterSelectionResult,
     detect_esphome_proxy,
     discover_services,
+    get_ble_device_with_fallback,
+    get_discovered_service_info,
     read_ble_device_info,
     select_adapter,
 )
@@ -656,8 +658,9 @@ class AdjustableBedCoordinator:
                     )
                     # Log what devices ARE visible
                     try:
-                        discovered = list(
-                            bluetooth.async_discovered_service_info(self.hass, connectable=True)
+                        discovered = get_discovered_service_info(
+                            self.hass,
+                            include_non_connectable=True,
                         )
                         if discovered:
                             _LOGGER.debug(
@@ -666,11 +669,12 @@ class AdjustableBedCoordinator:
                             )
                             for svc_info in discovered[:10]:  # Limit to first 10
                                 _LOGGER.debug(
-                                    "  - %s (name: %s, rssi: %s, source: %s)",
+                                    "  - %s (name: %s, rssi: %s, source: %s, connectable: %s)",
                                     svc_info.address,
                                     svc_info.name or "Unknown",
                                     getattr(svc_info, "rssi", "N/A"),
                                     getattr(svc_info, "source", "N/A"),
+                                    getattr(svc_info, "connectable", None),
                                 )
                             if len(discovered) > 10:
                                 _LOGGER.debug("  ... and %d more devices", len(discovered) - 10)
@@ -694,6 +698,13 @@ class AdjustableBedCoordinator:
                     device.name or "Unknown",
                     device_source or "unknown",
                 )
+                if adapter_result.connectable is False:
+                    _LOGGER.warning(
+                        "Device %s was recovered from a non-connectable scanner record. "
+                        "This usually means the Bluetooth proxy or scanner classified the "
+                        "advertisement incorrectly.",
+                        self._address,
+                    )
                 _LOGGER.debug(
                     "Device details: address=%s, name=%s, details=%s",
                     device.address,
@@ -761,8 +772,9 @@ class AdjustableBedCoordinator:
                     selected_source: str | None = target_source,
                 ) -> BLEDevice:
                     """Return a fresh BLEDevice from the current scanner data."""
-                    discovered = bluetooth.async_discovered_service_info(
-                        self.hass, connectable=True
+                    discovered = get_discovered_service_info(
+                        self.hass,
+                        include_non_connectable=True,
                     )
                     for svc_info in discovered:
                         if svc_info.address.upper() != self._address:
@@ -770,9 +782,10 @@ class AdjustableBedCoordinator:
                         svc_source = getattr(svc_info, "source", None)
                         if selected_source is None or svc_source == selected_source:
                             _LOGGER.debug(
-                                "ble_device_callback returning device from %s (RSSI: %s)",
+                                "ble_device_callback returning device from %s (RSSI: %s, connectable=%s)",
                                 svc_source or "unknown",
                                 getattr(svc_info, "rssi", "N/A"),
+                                getattr(svc_info, "connectable", None),
                             )
                             return svc_info.device
 
@@ -783,11 +796,18 @@ class AdjustableBedCoordinator:
                             self._address,
                         )
 
-                    fallback = bluetooth.async_ble_device_from_address(
-                        self.hass, self._address, connectable=True
+                    fallback, connectable = get_ble_device_with_fallback(
+                        self.hass,
+                        self._address,
+                        allow_non_connectable=True,
                     )
                     if fallback is None:
                         raise BleakError(f"Device {self._address} not found")
+                    if connectable is False:
+                        _LOGGER.debug(
+                            "ble_device_callback falling back to non-connectable record for %s",
+                            self._address,
+                        )
                     return fallback
 
                 ble_device_callback: Callable[[], BLEDevice] | None = (

--- a/custom_components/adjustable_bed/diagnostic_payloads.py
+++ b/custom_components/adjustable_bed/diagnostic_payloads.py
@@ -1,0 +1,96 @@
+"""Shared payload formatting helpers for diagnostics and support bundles."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+MAX_ASCII_PREVIEW_LENGTH = 64
+MAX_REPEATED_PAYLOADS = 5
+
+
+def payload_hex(data: bytes | bytearray | memoryview | None) -> str | None:
+    """Return payload as hex string."""
+    if data is None:
+        return None
+    return bytes(data).hex()
+
+
+def payload_length(data: bytes | bytearray | memoryview | None) -> int | None:
+    """Return payload length in bytes."""
+    if data is None:
+        return None
+    return len(bytes(data))
+
+
+def payload_ascii_preview(
+    data: bytes | bytearray | memoryview | None,
+    *,
+    max_length: int = MAX_ASCII_PREVIEW_LENGTH,
+) -> str | None:
+    """Return a safe ASCII preview when the payload is printable."""
+    if data is None:
+        return None
+
+    payload = bytes(data)
+    if not payload:
+        return ""
+
+    if not all(32 <= byte <= 126 or byte in (9, 10, 13) for byte in payload):
+        return None
+
+    preview = payload.decode("ascii", errors="ignore")
+    if len(preview) > max_length:
+        return preview[:max_length] + "..."
+    return preview
+
+
+def format_payload(
+    data: bytes | bytearray | memoryview | None,
+    *,
+    include_raw_hex_key: bool = False,
+) -> dict[str, Any] | None:
+    """Return a consistent payload representation."""
+    if data is None:
+        return None
+
+    payload = bytes(data)
+    formatted: dict[str, Any] = {
+        "hex": payload.hex(),
+        "length": len(payload),
+        "ascii_preview": payload_ascii_preview(payload),
+    }
+    if include_raw_hex_key:
+        formatted["data_hex"] = formatted["hex"]
+    return formatted
+
+
+def format_mapping_payloads(mapping: dict[Any, bytes] | None) -> dict[str, dict[str, Any]]:
+    """Return a consistent payload mapping representation."""
+    if not mapping:
+        return {}
+    return {
+        str(key): format_payload(value) or {"hex": "", "length": 0, "ascii_preview": ""}
+        for key, value in mapping.items()
+    }
+
+
+def summarize_repeated_payloads(
+    payloads: list[bytes | bytearray | memoryview],
+    *,
+    limit: int = MAX_REPEATED_PAYLOADS,
+) -> list[dict[str, Any]]:
+    """Return the most common payloads with counts."""
+    counter = Counter(bytes(payload).hex() for payload in payloads)
+    repeated: list[dict[str, Any]] = []
+
+    for payload_hex_value, count in counter.most_common(limit):
+        payload = bytes.fromhex(payload_hex_value)
+        repeated.append(
+            {
+                "count": count,
+                "payload": format_payload(payload),
+            }
+        )
+
+    return repeated

--- a/custom_components/adjustable_bed/diagnostic_payloads.py
+++ b/custom_components/adjustable_bed/diagnostic_payloads.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import Counter
+from datetime import UTC, datetime
 from typing import Any
 
 MAX_ASCII_PREVIEW_LENGTH = 64
@@ -94,3 +95,34 @@ def summarize_repeated_payloads(
         )
 
     return repeated
+
+
+def new_connection_attempt_details(attempt: int, preferred_adapter: str) -> dict[str, Any]:
+    """Return a fresh connection-attempt details dict.
+
+    Used by both ``coordinator.py`` and ``ble_diagnostics.py`` so the
+    schema stays in sync.
+    """
+    return {
+        "attempt": attempt,
+        "started_at": datetime.now(UTC).isoformat(),
+        "preferred_adapter": preferred_adapter,
+        "selected_source": None,
+        "actual_source": None,
+        "selected_rssi": None,
+        "selected_connectable": None,
+        "non_connectable_fallback_used": False,
+        "visible_sources": [],
+        "lookup_elapsed_seconds": None,
+        "connect_elapsed_seconds": None,
+        "total_elapsed_seconds": None,
+        "error": None,
+        "error_type": None,
+        "error_category": None,
+        "service_discovery": {
+            "attempted": False,
+            "success": None,
+            "service_count": None,
+        },
+        "result": "started",
+    }

--- a/custom_components/adjustable_bed/diagnostics.py
+++ b/custom_components/adjustable_bed/diagnostics.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import sys
 from typing import Any
 
-from homeassistant.components import bluetooth
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant
 from homeassistant.loader import async_get_integration
 
+from .adapter import find_service_info_by_address
 from .const import (
     CONF_BED_TYPE,
     CONF_DISABLE_ANGLE_SENSING,
@@ -78,7 +78,11 @@ async def async_get_config_entry_diagnostics(
 
     # Get advertisement data
     advertisement_info: dict[str, Any] = {}
-    service_info = bluetooth.async_last_service_info(hass, coordinator.address, connectable=True)
+    service_info, service_info_connectable = find_service_info_by_address(
+        hass,
+        coordinator.address,
+        allow_non_connectable=True,
+    )
     if service_info:
         advertisement_info = {
             # Use "device_name" to avoid redaction (name is useful for debugging)
@@ -94,7 +98,7 @@ async def async_get_config_entry_diagnostics(
                 if service_info.manufacturer_data
                 else []
             ),
-            "connectable": service_info.connectable,
+            "connectable": service_info_connectable,
         }
         if hasattr(service_info, "source"):
             advertisement_info["source"] = service_info.source

--- a/custom_components/adjustable_bed/redaction.py
+++ b/custom_components/adjustable_bed/redaction.py
@@ -114,7 +114,6 @@ def redact_pins_only(data: Any, depth: int = 0) -> Any:
             else:
                 result[key] = redact_pins_only(value, depth + 1)
         return result
-    elif isinstance(data, list):
+    if isinstance(data, list):
         return [redact_pins_only(item, depth + 1) for item in data]
-    else:
-        return data
+    return data

--- a/custom_components/adjustable_bed/redaction.py
+++ b/custom_components/adjustable_bed/redaction.py
@@ -90,3 +90,31 @@ def redact_data(data: Any, depth: int = 0) -> Any:
         return redact_string(data)
     else:
         return data
+
+
+# Keys that contain actual secrets (PINs)
+_PIN_KEYS = {CONF_JENSEN_PIN, CONF_OCTO_PIN}
+
+
+def redact_pins_only(data: Any, depth: int = 0) -> Any:
+    """Recursively redact only PIN fields, leaving names/addresses/MACs intact.
+
+    Used for support bundles where BLE device names and MAC addresses are
+    essential debugging information and should not be stripped.
+    """
+    if depth > 20:
+        return data
+
+    if isinstance(data, dict):
+        result = {}
+        for key, value in data.items():
+            key_lower = key.lower() if isinstance(key, str) else key
+            if key in _PIN_KEYS or key_lower in _PIN_KEYS:
+                result[key] = "**REDACTED**"
+            else:
+                result[key] = redact_pins_only(value, depth + 1)
+        return result
+    elif isinstance(data, list):
+        return [redact_pins_only(item, depth + 1) for item in data]
+    else:
+        return data

--- a/custom_components/adjustable_bed/services.yaml
+++ b/custom_components/adjustable_bed/services.yaml
@@ -143,27 +143,27 @@ timed_move:
           unit_of_measurement: ms
           mode: box
 
-run_diagnostics:
-  name: Run BLE Diagnostics
-  description: Capture BLE protocol data from a device for troubleshooting and adding support for new bed models. Either provide a configured device or a target MAC address.
+generate_support_bundle:
+  name: Generate Support Bundle
+  description: Capture the full adjustable-bed support bundle. This combines BLE diagnostics, detection reasoning, GATT details, scanner state, and recent integration logs into one JSON file.
   fields:
     device_id:
       name: Device
-      description: A configured adjustable bed device to diagnose.
+      description: A configured adjustable bed device to capture.
       required: false
       selector:
         device:
           integration: adjustable_bed
     target_address:
       name: Target Address
-      description: Bluetooth MAC address of an unconfigured device (e.g., AA:BB:CC:DD:EE:FF). Use this to diagnose devices that haven't been set up yet.
+      description: Bluetooth MAC address of an unconfigured device (for example `AA:BB:CC:DD:EE:FF`).
       required: false
       example: "AA:BB:CC:DD:EE:FF"
       selector:
         text:
     capture_duration:
       name: Capture Duration
-      description: How long to capture notifications in seconds. Operate the physical remote during this time to generate data.
+      description: How long to capture notifications in seconds. Operate the physical remote during this time to generate useful traffic.
       required: false
       default: 120
       selector:
@@ -172,21 +172,9 @@ run_diagnostics:
           max: 300
           unit_of_measurement: seconds
           mode: box
-
-generate_support_report:
-  name: Generate Support Report
-  description: Generate a comprehensive debug report for submitting bug reports. Collects diagnostics, logs, and system information into a single file.
-  fields:
-    device_id:
-      name: Device
-      description: The adjustable bed device to generate the report for.
-      required: true
-      selector:
-        device:
-          integration: adjustable_bed
     include_logs:
       name: Include Recent Logs
-      description: Include recent log entries related to the integration.
+      description: Include recent Home Assistant log entries related to Bluetooth and this integration.
       required: false
       default: true
       selector:

--- a/custom_components/adjustable_bed/services.yaml
+++ b/custom_components/adjustable_bed/services.yaml
@@ -149,14 +149,14 @@ generate_support_bundle:
   fields:
     device_id:
       name: Device
-      description: A configured adjustable bed device to capture.
+      description: A configured adjustable bed device to capture. Provide exactly one of `device_id` or `target_address`.
       required: false
       selector:
         device:
           integration: adjustable_bed
     target_address:
       name: Target Address
-      description: Bluetooth MAC address of an unconfigured device (for example `AA:BB:CC:DD:EE:FF`).
+      description: Bluetooth MAC address of an unconfigured device (for example `AA:BB:CC:DD:EE:FF`). Provide exactly one of `device_id` or `target_address`.
       required: false
       example: "AA:BB:CC:DD:EE:FF"
       selector:

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -189,22 +189,22 @@
         }
       },
       "diagnostic": {
-        "title": "Diagnostic Mode - Select Device",
-        "description": "Select any BLE device to add for diagnostic capture. This allows you to run BLE diagnostics on unsupported devices to help add support for new bed models.",
+        "title": "Browse Unsupported BLE Devices",
+        "description": "Select any visible BLE device to inspect its MAC address and scanner details. Then run the `adjustable_bed.generate_support_bundle` action with that address.",
         "data": {
           "address": "Device"
         }
       },
       "diagnostic_confirm": {
-        "title": "Confirm Diagnostic Device",
-        "description": "Add {name} ({address}) as a diagnostic device?\n\nNo motor controls will be available - this device is only for running BLE diagnostics.",
+        "title": "Unsupported BLE Device Details",
+        "description": "Device: {name} ({address})",
         "data": {
           "name": "Device name"
         }
       },
       "diagnostic_manual": {
-        "title": "Diagnostic Mode - Manual Entry",
-        "description": "Enter the Bluetooth MAC address of the device you want to diagnose.",
+        "title": "Unsupported BLE Device - Manual Entry",
+        "description": "Enter the Bluetooth MAC address of the device you want to inspect, then use that address with `adjustable_bed.generate_support_bundle`.",
         "data": {
           "address": "Bluetooth address",
           "name": "Device name"
@@ -216,7 +216,8 @@
     },
     "abort": {
       "already_configured": "Device is already configured",
-      "not_supported": "Device is not supported. The required Bluetooth service was not found."
+      "not_supported": "Device is not supported. The required Bluetooth service was not found.",
+      "diagnostic_browser_ready": "**{name}**\n\nAddress: `{address}`\nSource: `{source}`\nScanner connectable: `{connectable}`\n\nRun `adjustable_bed.generate_support_bundle` with `target_address: {address}` to capture the full support bundle."
     },
     "error": {
       "cannot_connect": "Failed to connect to bed. Check that the bed is powered on and in range.",
@@ -534,31 +535,21 @@
       "name": "Stop All Motors",
       "description": "Immediately stop all bed motors."
     },
-    "run_diagnostics": {
-      "name": "Run BLE Diagnostics",
-      "description": "Capture BLE protocol data from a device for troubleshooting and adding support for new bed models.",
+    "generate_support_bundle": {
+      "name": "Generate Support Bundle",
+      "description": "Capture the full adjustable-bed support bundle for troubleshooting unsupported or broken beds.",
       "fields": {
         "device_id": {
           "name": "Device",
-          "description": "A configured adjustable bed device to diagnose."
+          "description": "A configured adjustable bed device to capture."
         },
         "target_address": {
           "name": "Target Address",
-          "description": "Bluetooth MAC address of an unconfigured device (e.g., AA:BB:CC:DD:EE:FF)."
+          "description": "Bluetooth MAC address of an unconfigured device (for example AA:BB:CC:DD:EE:FF)."
         },
         "capture_duration": {
           "name": "Capture Duration",
           "description": "How long to capture notifications in seconds (10-300). Operate the physical remote during this time."
-        }
-      }
-    },
-    "generate_support_report": {
-      "name": "Generate Support Report",
-      "description": "Generate a comprehensive debug report for submitting bug reports.",
-      "fields": {
-        "device_id": {
-          "name": "Device",
-          "description": "The adjustable bed device to generate the report for."
         },
         "include_logs": {
           "name": "Include Recent Logs",

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -630,7 +630,7 @@
   "issues": {
     "unsupported_device": {
       "title": "Unsupported BLE device: {name}",
-      "description": "A Bluetooth device was detected that could not be identified as a supported adjustable bed.\n\n**Device:** {name}\n**Address:** `{address}`\n**Reason:** {reason}\n\nIf this is an adjustable bed that you'd like to see supported, please [report it on GitHub]({github_url}) with as much information as possible about your bed model.\n\nYou can also run the **Run BLE Diagnostics** service with this device's address to capture protocol data that can help us add support."
+      "description": "A Bluetooth device was detected that could not be identified as a supported adjustable bed.\n\n**Device:** {name}\n**Address:** `{address}`\n**Reason:** {reason}\n\nIf this is an adjustable bed that you'd like to see supported, please [report it on GitHub]({github_url}) with as much information as possible about your bed model.\n\nYou can also run **Generate Support Bundle** (`adjustable_bed.generate_support_bundle`) with this device's address to capture protocol data that can help us add support."
     },
     "pairing_required": {
       "title": "Bluetooth pairing required for {name}",

--- a/custom_components/adjustable_bed/support_bundle.py
+++ b/custom_components/adjustable_bed/support_bundle.py
@@ -10,13 +10,12 @@ from typing import Any
 
 from homeassistant.components import bluetooth
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.loader import async_get_integration
 
 from .ble_diagnostics import BLEDiagnosticRunner
 from .const import DOMAIN, SUPPORTED_BED_TYPES
-from .redaction import redact_data
+from .redaction import redact_pins_only
 from .support_report import (
     _get_bluetooth_info,
     _get_connection_info,
@@ -107,7 +106,7 @@ async def generate_support_bundle(
         "errors": list(diagnostics_report.errors),
     }
 
-    return redact_data(report)  # type: ignore[no-any-return]
+    return redact_pins_only(report)  # type: ignore[no-any-return]
 
 
 async def _build_bluetooth_section(
@@ -159,7 +158,7 @@ def _build_connection_info_from_diagnostics(diagnostics_report: dict[str, Any]) 
         "is_connecting": False,
         "mtu_size": None,
         "services_discovered": len(gatt_services),
-        "service_uuids": [service.get("uuid") for service in gatt_services],
+        "service_uuids": [uuid for service in gatt_services if (uuid := service.get("uuid")) is not None],
     }
 
 

--- a/custom_components/adjustable_bed/support_bundle.py
+++ b/custom_components/adjustable_bed/support_bundle.py
@@ -1,0 +1,206 @@
+"""Combined support bundle generation for Adjustable Bed."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from homeassistant.components import bluetooth
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant
+from homeassistant.loader import async_get_integration
+
+from .ble_diagnostics import BLEDiagnosticRunner
+from .const import DOMAIN, SUPPORTED_BED_TYPES
+from .redaction import redact_data
+from .support_report import (
+    _get_bluetooth_info,
+    _get_connection_info,
+    _get_controller_info,
+    _get_integration_info,
+    _get_recent_logs,
+    _get_system_info,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def generate_support_bundle(
+    hass: HomeAssistant,
+    *,
+    address: str,
+    capture_duration: int,
+    include_logs: bool,
+    coordinator: Any | None = None,
+    entry: ConfigEntry | None = None,
+    device_id: str | None = None,
+) -> dict[str, Any]:
+    """Generate a single combined support bundle."""
+    timestamp = datetime.now(UTC)
+    integration = await async_get_integration(hass, DOMAIN)
+    integration_version = str(integration.version) if integration.version is not None else "unknown"
+
+    diagnostics_report = await BLEDiagnosticRunner(
+        hass,
+        address,
+        capture_duration=capture_duration,
+        coordinator=coordinator,
+    ).run_diagnostics()
+
+    bluetooth_info = await _build_bluetooth_section(
+        hass,
+        address,
+        diagnostics_report.to_dict(),
+        coordinator,
+    )
+
+    if coordinator is not None:
+        connection = _get_connection_info(coordinator)
+        connection_history = coordinator.connection_history
+        adapter = coordinator.adapter_details
+        controller = _get_controller_info(coordinator)
+        position_data = dict(coordinator.position_data)
+    else:
+        connection = _build_connection_info_from_diagnostics(diagnostics_report.to_dict())
+        connection_history = {}
+        adapter = _build_raw_adapter_info(diagnostics_report.to_dict())
+        controller = {"initialized": False, "class": None, "characteristic_uuid": None}
+        position_data = {}
+
+    report: dict[str, Any] = {
+        "metadata": {
+            "report_version": "2.0",
+            "generated_at": timestamp.isoformat(),
+            "capture_duration_seconds": capture_duration,
+            "integration_domain": DOMAIN,
+        },
+        "target": {
+            "mode": "configured_device" if coordinator is not None and entry is not None else "target_address",
+            "address": address,
+            "device_id": device_id,
+            "entry_id": entry.entry_id if entry is not None else None,
+            "title": entry.title if entry is not None else None,
+        },
+        "system": _get_system_info(hass, integration_version),
+        "integration": _get_integration_info(entry) if entry is not None else _empty_integration_info(address),
+        "device": diagnostics_report.device,
+        "detection": diagnostics_report.detection,
+        "connection": connection,
+        "connection_history": connection_history,
+        "connection_attempt_details": diagnostics_report.connection_attempt_details,
+        "adapter": adapter,
+        "bluetooth": bluetooth_info,
+        "gatt_services": diagnostics_report.gatt_services,
+        "gatt_summary": diagnostics_report.gatt_summary,
+        "device_information": diagnostics_report.device_information,
+        "controller": controller,
+        "position_data": position_data,
+        "notifications": diagnostics_report.notifications,
+        "notification_summary": diagnostics_report.notification_summary,
+        "command_trace": diagnostics_report.command_trace if coordinator is not None else [],
+        "recent_logs": _get_recent_logs() if include_logs else [],
+        "supported_bed_types": list(SUPPORTED_BED_TYPES),
+        "errors": list(diagnostics_report.errors),
+    }
+
+    return redact_data(report)  # type: ignore[no-any-return]
+
+
+async def _build_bluetooth_section(
+    hass: HomeAssistant,
+    address: str,
+    diagnostics_report: dict[str, Any],
+    coordinator: Any | None,
+) -> dict[str, Any]:
+    """Build the support bundle Bluetooth section."""
+    info: dict[str, Any]
+    if coordinator is not None:
+        info = await _get_bluetooth_info(hass, coordinator)
+    else:
+        info = {"last_advertisement": None, "scanners": []}
+
+    info["last_advertisement"] = diagnostics_report.get("advertisement")
+    info["advertisements_by_source"] = diagnostics_report.get("advertisements_by_source", [])
+    info["scanner_count"] = diagnostics_report.get("device", {}).get("scanner_count")
+    info["visible_sources"] = diagnostics_report.get("device", {}).get("visible_sources", [])
+    info["selected_source"] = diagnostics_report.get("device", {}).get("selected_source")
+    info["actual_source"] = diagnostics_report.get("device", {}).get("actual_source")
+    info["non_connectable_fallback_used"] = diagnostics_report.get("device", {}).get(
+        "non_connectable_fallback_used"
+    )
+    info["target_address"] = address
+
+    if "scanners" not in info or not info["scanners"]:
+        try:
+            scanners = bluetooth.async_current_scanners(hass)
+            info["scanners"] = [
+                {
+                    "source": getattr(scanner, "source", "unknown"),
+                    "name": getattr(scanner, "name", "unknown"),
+                    "scanning": getattr(scanner, "scanning", None),
+                }
+                for scanner in scanners
+            ]
+        except Exception as err:
+            info["scanners_error"] = str(err)
+
+    return info
+
+
+def _build_connection_info_from_diagnostics(diagnostics_report: dict[str, Any]) -> dict[str, Any]:
+    """Build connection info for a raw-address run."""
+    gatt_services = diagnostics_report.get("gatt_services", [])
+    return {
+        "is_connected": False,
+        "is_connecting": False,
+        "mtu_size": None,
+        "services_discovered": len(gatt_services),
+        "service_uuids": [service.get("uuid") for service in gatt_services],
+    }
+
+
+def _build_raw_adapter_info(diagnostics_report: dict[str, Any]) -> dict[str, Any]:
+    """Build adapter details for raw-address runs."""
+    device = diagnostics_report.get("device", {})
+    return {
+        "preferred": "auto",
+        "actual": device.get("actual_source"),
+        "available": device.get("visible_sources", []),
+    }
+
+
+def _empty_integration_info(address: str) -> dict[str, Any]:
+    """Return a standardized integration section for raw-address runs."""
+    return {
+        "entry_id": None,
+        "version": None,
+        "title": None,
+        "bed_type": None,
+        "protocol_variant": None,
+        "motor_count": None,
+        "has_massage": None,
+        "disable_angle_sensing": None,
+        "preferred_adapter": None,
+        "address": address,
+        "configured_device": False,
+    }
+
+
+def save_support_bundle(hass: HomeAssistant, report: dict[str, Any], address: str) -> Path:
+    """Save the support bundle to a JSON file in the config directory."""
+    timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+    address_safe = address.replace(":", "").lower()
+    filename = f"adjustable_bed_support_bundle_{address_safe}_{timestamp}.json"
+
+    config_dir = Path(hass.config.config_dir)
+    filepath = config_dir / filename
+
+    with open(filepath, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2, default=str)
+
+    _LOGGER.info("Support bundle saved to %s", filepath)
+    return filepath

--- a/custom_components/adjustable_bed/support_report.py
+++ b/custom_components/adjustable_bed/support_report.py
@@ -28,7 +28,7 @@ from .const import (
     SUPPORTED_BED_TYPES,
 )
 from .diagnostics_utils import get_gatt_summary
-from .redaction import redact_data
+from .redaction import redact_data, redact_pins_only
 
 if TYPE_CHECKING:
     from .coordinator import AdjustableBedCoordinator
@@ -223,8 +223,8 @@ def _get_recent_logs() -> list[dict[str, str]]:
                         or "bluetooth" in record.name.lower()
                         or "bleak" in record.name.lower()
                     ):
-                        # Apply redaction to log messages to protect sensitive data
-                        redacted_message = redact_data({"msg": record.getMessage()})["msg"]
+                        # Only redact PINs in log messages — MACs/names are needed for debugging
+                        redacted_message = redact_pins_only({"msg": record.getMessage()})["msg"]
                         logs.append(
                             {
                                 "timestamp": datetime.fromtimestamp(

--- a/custom_components/adjustable_bed/support_report.py
+++ b/custom_components/adjustable_bed/support_report.py
@@ -16,6 +16,7 @@ from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant
 from homeassistant.loader import async_get_integration
 
+from .adapter import find_service_info_by_address
 from .const import (
     CONF_BED_TYPE,
     CONF_DISABLE_ANGLE_SENSING,
@@ -158,7 +159,11 @@ async def _get_bluetooth_info(
     info: dict[str, Any] = {}
 
     # Get last known advertisement data
-    service_info = bluetooth.async_last_service_info(hass, coordinator.address, connectable=True)
+    service_info, service_info_connectable = find_service_info_by_address(
+        hass,
+        coordinator.address,
+        allow_non_connectable=True,
+    )
     if service_info:
         # Guard against None values for optional BLE advertisement fields
         service_uuids = service_info.service_uuids or []
@@ -172,7 +177,7 @@ async def _get_bluetooth_info(
             "service_uuids": [str(uuid) for uuid in service_uuids],
             "manufacturer_data": {str(k): bytes(v).hex() for k, v in manufacturer_data.items()},
             "service_data": {str(k): bytes(v).hex() for k, v in service_data.items()},
-            "connectable": service_info.connectable,
+            "connectable": service_info_connectable,
         }
         # Include source info (adapter/proxy)
         if hasattr(service_info, "source"):

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -548,7 +548,7 @@
   "issues": {
     "unsupported_device": {
       "title": "Unsupported BLE device: {name}",
-      "description": "A Bluetooth device was detected that could not be identified as a supported adjustable bed.\n\n**Device:** {name}\n**Address:** `{address}`\n**Reason:** {reason}\n\nIf this is an adjustable bed that you'd like to see supported, please [report it on GitHub]({github_url}) with as much information as possible about your bed model.\n\nYou can also run the **Run BLE Diagnostics** service with this device's address to capture protocol data that can help us add support."
+      "description": "A Bluetooth device was detected that could not be identified as a supported adjustable bed.\n\n**Device:** {name}\n**Address:** `{address}`\n**Reason:** {reason}\n\nIf this is an adjustable bed that you'd like to see supported, please [report it on GitHub]({github_url}) with as much information as possible about your bed model.\n\nYou can also run **Generate Support Bundle** (`adjustable_bed.generate_support_bundle`) with this device's address to capture protocol data that can help us add support."
     },
     "pairing_required": {
       "title": "Bluetooth pairing required for {name}",

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -189,22 +189,22 @@
         }
       },
       "diagnostic": {
-        "title": "Diagnostic Mode - Select Device",
-        "description": "Select any BLE device to add for diagnostic capture. This allows you to run BLE diagnostics on unsupported devices to help add support for new bed models.",
+        "title": "Browse Unsupported BLE Devices",
+        "description": "Select any visible BLE device to inspect its MAC address and scanner details. Then run the `adjustable_bed.generate_support_bundle` action with that address.",
         "data": {
           "address": "Device"
         }
       },
       "diagnostic_confirm": {
-        "title": "Confirm Diagnostic Device",
-        "description": "Add {name} ({address}) as a diagnostic device?\n\nNo motor controls will be available - this device is only for running BLE diagnostics.",
+        "title": "Unsupported BLE Device Details",
+        "description": "Device: {name} ({address})",
         "data": {
           "name": "Device name"
         }
       },
       "diagnostic_manual": {
-        "title": "Diagnostic Mode - Manual Entry",
-        "description": "Enter the Bluetooth MAC address of the device you want to diagnose.",
+        "title": "Unsupported BLE Device - Manual Entry",
+        "description": "Enter the Bluetooth MAC address of the device you want to inspect, then use that address with `adjustable_bed.generate_support_bundle`.",
         "data": {
           "address": "Bluetooth address",
           "name": "Device name"
@@ -216,7 +216,8 @@
     },
     "abort": {
       "already_configured": "Device is already configured",
-      "not_supported": "Device is not supported. The required Bluetooth service was not found."
+      "not_supported": "Device is not supported. The required Bluetooth service was not found.",
+      "diagnostic_browser_ready": "**{name}**\n\nAddress: `{address}`\nSource: `{source}`\nScanner connectable: `{connectable}`\n\nRun `adjustable_bed.generate_support_bundle` with `target_address: {address}` to capture the full support bundle."
     },
     "error": {
       "cannot_connect": "Failed to connect to bed. Check that the bed is powered on and in range.",
@@ -507,31 +508,21 @@
       "name": "Stop All Motors",
       "description": "Immediately stop all bed motors."
     },
-    "run_diagnostics": {
-      "name": "Run BLE Diagnostics",
-      "description": "Capture BLE protocol data from a device for troubleshooting and adding support for new bed models.",
+    "generate_support_bundle": {
+      "name": "Generate Support Bundle",
+      "description": "Capture the full adjustable-bed support bundle for troubleshooting unsupported or broken beds.",
       "fields": {
         "device_id": {
           "name": "Device",
-          "description": "A configured adjustable bed device to diagnose."
+          "description": "A configured adjustable bed device to capture."
         },
         "target_address": {
           "name": "Target Address",
-          "description": "Bluetooth MAC address of an unconfigured device (e.g., AA:BB:CC:DD:EE:FF)."
+          "description": "Bluetooth MAC address of an unconfigured device (for example AA:BB:CC:DD:EE:FF)."
         },
         "capture_duration": {
           "name": "Capture Duration",
           "description": "How long to capture notifications in seconds (10-300). Operate the physical remote during this time."
-        }
-      }
-    },
-    "generate_support_report": {
-      "name": "Generate Support Report",
-      "description": "Generate a comprehensive debug report for submitting bug reports.",
-      "fields": {
-        "device_id": {
-          "name": "Device",
-          "description": "The adjustable bed device to generate the report for."
         },
         "include_logs": {
           "name": "Include Recent Logs",

--- a/docs/CONNECTION_GUIDE.md
+++ b/docs/CONNECTION_GUIDE.md
@@ -163,7 +163,7 @@ If your bed isn't auto-discovered:
 
 If your bed doesn't appear in Home Assistant at all (not visible to any adapter or proxy), use [nRF Connect](https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-mobile) on your phone to verify the device exists and check its range. If nRF Connect sees it but Home Assistant doesn't, the bed may be out of range of your HA Bluetooth adapter - consider adding an ESPHome proxy closer to the bed.
 
-**Tip:** If your bed type isn't recognized, you can add it in Diagnostic mode to capture BLE data. See [Getting Help](GETTING_HELP.md) for details.
+**Tip:** If your bed type isn't recognized, use **Browse unsupported BLE devices** to find the MAC address, then run `adjustable_bed.generate_support_bundle` with `target_address`. See [Getting Help](GETTING_HELP.md) for details.
 
 ---
 

--- a/docs/GETTING_HELP.md
+++ b/docs/GETTING_HELP.md
@@ -60,17 +60,19 @@ The support bundle includes everything we need in one file:
 1. Go to **Developer Tools** → **Actions**
 2. Search for `adjustable_bed.generate_support_bundle`
 3. Select your bed device, or enter `target_address` for an unconfigured device, then click **Perform action**
-4. A notification will show the file location (in your `/config/` folder)
-5. Attach the JSON file to your GitHub issue
+4. (Optional) Adjust `capture_duration` to change how long notifications are captured (default: 120 seconds). Operate the physical remote during capture to generate useful traffic.
+5. A notification will show the file location (in your `/config/` folder)
+6. Attach the JSON file to your GitHub issue
 
 The support bundle includes:
 - System info (HA version, Python version, platform)
 - Integration configuration and detected bed type
-- Connection status and BLE adapter info
-- BLE advertisements by source, detection reasoning, and GATT details
+- Connection status, BLE adapter info, and connection attempt details
+- BLE advertisements by source, detection reasoning, and GATT/descriptor details
+- Captured notifications and buffered command trace
 - Recent error logs
 
-**Privacy note:** MAC addresses are partially redacted (manufacturer prefix kept), PINs and names are masked.
+**Privacy note:** PINs are redacted. MAC addresses, device names, and other BLE identifiers are preserved since they are essential for debugging.
 
 ### Alternative: Download Diagnostics
 
@@ -151,7 +153,7 @@ The `generate_support_bundle` action captures GATT structure, device info, scann
 
 1. Go to **Developer Tools** → **Actions**
 2. Search for `adjustable_bed.generate_support_bundle`
-3. Select your bed device (or enter a MAC address for unconfigured devices)
+3. Select your bed device (or enter `target_address` for unconfigured devices)
 4. Click **Perform action**
 5. Optionally operate your physical remote during capture to record notifications
 6. Find the JSON report in your `/config/` folder

--- a/docs/GETTING_HELP.md
+++ b/docs/GETTING_HELP.md
@@ -53,20 +53,21 @@ If you've found a bug, please file a [Bug Report](https://github.com/kristofferR
 - **Connection method** (built-in Bluetooth, USB adapter, or ESPHome proxy)
 - **Diagnostics file** (see below)
 
-### Generating a Support Report (Recommended)
+### Generating a Support Bundle (Recommended)
 
-The support report includes everything we need in one file:
+The support bundle includes everything we need in one file:
 
 1. Go to **Developer Tools** → **Actions**
-2. Search for `adjustable_bed.generate_support_report`
-3. Select your bed device and click **Perform action**
+2. Search for `adjustable_bed.generate_support_bundle`
+3. Select your bed device, or enter `target_address` for an unconfigured device, then click **Perform action**
 4. A notification will show the file location (in your `/config/` folder)
 5. Attach the JSON file to your GitHub issue
 
-The support report includes:
+The support bundle includes:
 - System info (HA version, Python version, platform)
 - Integration configuration and detected bed type
 - Connection status and BLE adapter info
+- BLE advertisements by source, detection reasoning, and GATT details
 - Recent error logs
 
 **Privacy note:** MAC addresses are partially redacted (manufacturer prefix kept), PINs and names are masked.
@@ -105,9 +106,10 @@ If your bed isn't supported yet, file a [New Bed Support Request](https://github
 
 The easiest way is to use the integration's built-in tools:
 
-1. **Add the device in Diagnostic mode**: Settings → Integrations → Add Integration → Adjustable Bed → Manual entry → Select "Diagnostic/Unknown" as bed type
-2. **Run diagnostics**: Developer Tools → Actions → `adjustable_bed.run_diagnostics` → Select your device
-3. **Check the output file** in your `/config/` folder for service UUIDs and device info
+1. **Find the MAC address if needed**: Settings → Integrations → Add Integration → Adjustable Bed → **Browse unsupported BLE devices**
+2. **Run the support bundle action**: Developer Tools → Actions → `adjustable_bed.generate_support_bundle`
+3. Select your configured bed, or enter `target_address` for an unsupported device
+4. **Check the output file** in your `/config/` folder for service UUIDs, detection details, and device info
 
 If your bed doesn't appear in Home Assistant at all (not visible to any Bluetooth adapter), use [nRF Connect](https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-mobile) on your phone to verify the device exists and is advertising.
 
@@ -131,9 +133,9 @@ Let us know if you can:
 
 | Scenario | Recommended Tool |
 |----------|------------------|
-| Troubleshooting a configured bed | Support report or diagnostics download |
+| Troubleshooting a configured bed | Support bundle or diagnostics download |
 | Finding your bed's MAC address | Integration shows discovered MACs when manually adding |
-| Identifying bed type/service UUIDs | `run_diagnostics` in Diagnostic mode |
+| Identifying bed type/service UUIDs | `generate_support_bundle` with `target_address` |
 | New bed support - capture what app sends | nRF Connect logging (see below) |
 | Device not visible to HA at all | nRF Connect to verify it exists |
 
@@ -143,12 +145,12 @@ Let us know if you can:
 
 For most troubleshooting, the **built-in diagnostics** provide everything needed:
 
-### Using run_diagnostics Action
+### Using generate_support_bundle Action
 
-The `run_diagnostics` action captures GATT structure, device info, and notifications from your bed:
+The `generate_support_bundle` action captures GATT structure, device info, scanner state, and notifications from your bed:
 
 1. Go to **Developer Tools** → **Actions**
-2. Search for `adjustable_bed.run_diagnostics`
+2. Search for `adjustable_bed.generate_support_bundle`
 3. Select your bed device (or enter a MAC address for unconfigured devices)
 4. Click **Perform action**
 5. Optionally operate your physical remote during capture to record notifications

--- a/docs/SUPPORTED_ACTUATORS.md
+++ b/docs/SUPPORTED_ACTUATORS.md
@@ -126,7 +126,7 @@ These beds have their own dedicated integrations:
    - `Rize*` → Often [DewertOkin](beds/dewertokin.md), but `Mouselet*` devices are [Kaidi](beds/kaidi.md)
    - `Simmons*`, `Glory*`, `Symphony*` → See [DewertOkin](beds/dewertokin.md)
 
-4. **Use Diagnostic mode to find service UUIDs**: If unsure, add the device as "Diagnostic/Unknown" and run the `run_diagnostics` action. The output includes service UUIDs:
+4. **Use the support bundle to find service UUIDs**: If unsure, use **Browse unsupported BLE devices** to find the MAC address, then run `adjustable_bed.generate_support_bundle` with `target_address`. The output includes service UUIDs:
    - Service `62741523-...` → Okin family (see [Okin Protocol Family](#okin-protocol-family))
    - Service `45e25100-...` → Leggett & Platt Gen2
    - Service `0000aa5c-...` → Octo Star2 variant

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -304,7 +304,7 @@ There are two ways to gather diagnostic information:
 |---------|---------------|----------------|
 | **How to access** | Settings → Devices → ⋮ menu → Enable debug logging | Perform the `adjustable_bed.generate_support_bundle` action |
 | **What it captures** | Real-time stream of all integration activity | Snapshot of device state at one moment |
-| **Content** | Actual BLE commands sent (e.g., `e5fe16...`), connection events, errors with stack traces | Configuration, advertisements, detection reasoning, GATT services, notifications |
+| **Content** | Actual BLE commands sent (e.g., `e5fe16...`), connection events, errors with stack traces | Configuration, advertisements (per source), detection reasoning, GATT/descriptor details, notifications, buffered command trace, connection-attempt details |
 | **Size** | Large, includes unrelated entries from other integrations | Focused JSON file for one device |
 | **Best for** | "Why didn't this command work?" - seeing exact bytes sent | "What device do I have?" - sharing device info in bug reports |
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -296,15 +296,15 @@ Use these to identify your bed type in a BLE scanner:
 
 ## Debugging Tools
 
-### Debug Logging vs Support Report
+### Debug Logging vs Support Bundle
 
 There are two ways to gather diagnostic information:
 
-| Feature | Debug Logging | Support Report |
+| Feature | Debug Logging | Support Bundle |
 |---------|---------------|----------------|
-| **How to access** | Settings → Devices → ⋮ menu → Enable debug logging | Perform the `adjustable_bed.generate_support_report` action |
+| **How to access** | Settings → Devices → ⋮ menu → Enable debug logging | Perform the `adjustable_bed.generate_support_bundle` action |
 | **What it captures** | Real-time stream of all integration activity | Snapshot of device state at one moment |
-| **Content** | Actual BLE commands sent (e.g., `e5fe16...`), connection events, errors with stack traces | Configuration, device info, GATT services |
+| **Content** | Actual BLE commands sent (e.g., `e5fe16...`), connection events, errors with stack traces | Configuration, advertisements, detection reasoning, GATT services, notifications |
 | **Size** | Large, includes unrelated entries from other integrations | Focused JSON file for one device |
 | **Best for** | "Why didn't this command work?" - seeing exact bytes sent | "What device do I have?" - sharing device info in bug reports |
 
@@ -313,7 +313,7 @@ There are two ways to gather diagnostic information:
 - Investigating connection failures or timeouts
 - Comparing expected vs actual command bytes
 
-**When to use Support Report:**
+**When to use Support Bundle:**
 - Opening a new GitHub issue
 - Sharing device information with developers
 - Documenting your bed's GATT services for protocol analysis
@@ -324,7 +324,7 @@ There are two ways to gather diagnostic information:
 
 If you've tried the troubleshooting steps above and still have issues, see the **[Getting Help Guide](GETTING_HELP.md)** for:
 
-- How to generate a support report with all the info we need
+- How to generate a support bundle with all the info we need
 - Filing a bug report on GitHub
 - Requesting support for a new bed
 - Capturing BLE protocol data for debugging

--- a/docs/beds/kaidi.md
+++ b/docs/beds/kaidi.md
@@ -48,4 +48,4 @@ Home Assistant reproduces the app's startup flow:
 
 1. The bed must already be provisioned in the official app. Home Assistant does not currently implement the add-device/reset workflow.
 2. The current controller targets the single-bed command set used by standard head/foot bases.
-3. If your bed exposes different Kaidi behavior, open an issue and attach a support report plus any nRF Connect logs you can capture.
+3. If your bed exposes different Kaidi behavior, open an issue and attach a support bundle plus any nRF Connect logs you can capture.

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,0 +1,73 @@
+"""Tests for Bluetooth adapter helper fallbacks."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.adjustable_bed.adapter import (
+    get_ble_device_with_fallback,
+    get_discovered_service_info,
+)
+
+
+class TestAdapterFallbacks:
+    """Test discovery helpers that fall back to non-connectable records."""
+
+    def test_get_discovered_service_info_includes_non_connectable(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Merged discovery should include non-connectable entries when requested."""
+        connectable_info = MagicMock()
+        connectable_info.address = "AA:BB:CC:DD:EE:FF"
+        connectable_info.source = "proxy_1"
+        connectable_info.connectable = True
+
+        non_connectable_info = MagicMock()
+        non_connectable_info.address = "11:22:33:44:55:66"
+        non_connectable_info.source = "proxy_1"
+        non_connectable_info.connectable = False
+
+        with patch(
+            "custom_components.adjustable_bed.adapter.bluetooth.async_discovered_service_info",
+            side_effect=([connectable_info], [non_connectable_info]),
+        ):
+            discovered = get_discovered_service_info(
+                hass,
+                include_non_connectable=True,
+            )
+
+        assert discovered == [connectable_info, non_connectable_info]
+
+    def test_get_ble_device_with_fallback_uses_non_connectable_service_info(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """A non-connectable scanner snapshot should still provide the BLEDevice."""
+        fallback_device = MagicMock()
+        fallback_device.address = "AA:BB:CC:DD:EE:FF"
+
+        non_connectable_info = MagicMock()
+        non_connectable_info.address = "AA:BB:CC:DD:EE:FF"
+        non_connectable_info.device = fallback_device
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.adapter.bluetooth.async_ble_device_from_address",
+                return_value=None,
+            ),
+            patch(
+                "custom_components.adjustable_bed.adapter.bluetooth.async_last_service_info",
+                side_effect=(None, non_connectable_info),
+            ),
+        ):
+            device, connectable = get_ble_device_with_fallback(
+                hass,
+                "AA:BB:CC:DD:EE:FF",
+                allow_non_connectable=True,
+            )
+
+        assert device is fallback_device
+        assert connectable is False

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -881,6 +881,115 @@ class TestManualFlow:
 class TestUserFlow:
     """Test user-initiated flow with device selection."""
 
+    async def test_user_flow_select_diagnostic_browser(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,
+    ):
+        """Selecting the unsupported-device browser should show all BLE devices."""
+        unknown_info = MagicMock()
+        unknown_info.address = "11:22:33:44:55:66"
+        unknown_info.name = "Unknown Device"
+        unknown_info.connectable = False
+        unknown_info.service_uuids = []
+        unknown_info.manufacturer_data = {}
+        unknown_info.source = "proxy_1"
+        unknown_info.device = MagicMock()
+
+        with patch(
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
+            side_effect=[[], [unknown_info]],
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_USER},
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADDRESS: "diagnostic"},
+            )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "diagnostic"
+
+    async def test_diagnostic_browser_returns_mac_details_instead_of_creating_entry(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,
+    ):
+        """Selecting an unsupported device should abort with support-bundle instructions."""
+        unknown_info = MagicMock()
+        unknown_info.address = "11:22:33:44:55:66"
+        unknown_info.name = "Unknown Device"
+        unknown_info.connectable = False
+        unknown_info.service_uuids = []
+        unknown_info.manufacturer_data = {}
+        unknown_info.source = "proxy_1"
+        unknown_info.device = MagicMock()
+
+        with patch(
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
+            side_effect=[[], [unknown_info]],
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_USER},
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADDRESS: "diagnostic"},
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADDRESS: unknown_info.address},
+            )
+
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "diagnostic_browser_ready"
+        assert result["description_placeholders"]["address"] == unknown_info.address
+        assert result["description_placeholders"]["source"] == "proxy_1"
+
+    async def test_diagnostic_manual_returns_bundle_instructions(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,
+    ):
+        """Manual unsupported-device lookup should finish without creating an entry."""
+        with (
+            patch(
+                "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
+                side_effect=[[], []],
+            ),
+            patch(
+                "custom_components.adjustable_bed.config_flow.find_service_info_by_address",
+                return_value=(None, False),
+            ),
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_USER},
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADDRESS: "diagnostic"},
+            )
+
+            assert result["type"] == FlowResultType.FORM
+            assert result["step_id"] == "diagnostic_manual"
+
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={
+                    CONF_ADDRESS: "11:22:33:44:55:66",
+                    CONF_NAME: "Mystery Bed",
+                },
+            )
+
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "diagnostic_browser_ready"
+        assert result["description_placeholders"]["address"] == "11:22:33:44:55:66"
+        assert result["description_placeholders"]["name"] == "Mystery Bed"
+
     async def test_user_flow_shows_discovered_devices(
         self,
         hass: HomeAssistant,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -654,7 +654,7 @@ class TestManualFlow:
         """Test manual select step shows all BLE devices."""
         # First go to user step and select manual
         with patch(
-            "custom_components.adjustable_bed.config_flow.async_discovered_service_info",
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
             return_value=[mock_bluetooth_service_info],
         ):
             result = await hass.config_entries.flow.async_init(
@@ -677,7 +677,7 @@ class TestManualFlow:
         """Test manual step goes to manual_entry when no devices are found."""
         # First go to user step (no beds discovered, but form still shown)
         with patch(
-            "custom_components.adjustable_bed.config_flow.async_discovered_service_info",
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
             return_value=[],
         ):
             result = await hass.config_entries.flow.async_init(
@@ -695,13 +695,44 @@ class TestManualFlow:
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "manual_entry"
 
+    async def test_manual_non_connectable_device_still_shows_selection(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,
+    ):
+        """Manual flow should include non-connectable fallback records."""
+        non_connectable_info = MagicMock()
+        non_connectable_info.address = "11:22:33:44:55:66"
+        non_connectable_info.name = "Mouselet Test"
+        non_connectable_info.connectable = False
+        non_connectable_info.service_uuids = []
+        non_connectable_info.manufacturer_data = {}
+        non_connectable_info.source = "proxy_1"
+        non_connectable_info.device = MagicMock()
+
+        with patch(
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
+            side_effect=([], [non_connectable_info]),
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_USER},
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADDRESS: "manual"},
+            )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "manual"
+
     async def test_manual_entry_creates_entry(
         self, hass: HomeAssistant, enable_custom_integrations
     ):
         """Test manual entry creates a config entry."""
         # First go to user step
         with patch(
-            "custom_components.adjustable_bed.config_flow.async_discovered_service_info",
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
             return_value=[],
         ):
             result = await hass.config_entries.flow.async_init(
@@ -740,7 +771,7 @@ class TestManualFlow:
     ):
         """Manual Kaidi setup should cache room/VADDR metadata when available."""
         with patch(
-            "custom_components.adjustable_bed.config_flow.async_discovered_service_info",
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
             return_value=[],
         ):
             result = await hass.config_entries.flow.async_init(
@@ -780,7 +811,7 @@ class TestManualFlow:
     async def test_manual_entry_invalid_mac(self, hass: HomeAssistant, enable_custom_integrations):
         """Test manual entry with invalid MAC address shows error."""
         with patch(
-            "custom_components.adjustable_bed.config_flow.async_discovered_service_info",
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
             return_value=[],
         ):
             result = await hass.config_entries.flow.async_init(
@@ -816,7 +847,7 @@ class TestManualFlow:
     ):
         """Test manual entry normalizes MAC address format."""
         with patch(
-            "custom_components.adjustable_bed.config_flow.async_discovered_service_info",
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
             return_value=[],
         ):
             result = await hass.config_entries.flow.async_init(
@@ -858,7 +889,7 @@ class TestUserFlow:
     ):
         """Test user flow shows discovered devices."""
         with patch(
-            "custom_components.adjustable_bed.config_flow.async_discovered_service_info",
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
             return_value=[mock_bluetooth_service_info],
         ):
             result = await hass.config_entries.flow.async_init(
@@ -877,7 +908,7 @@ class TestUserFlow:
     ):
         """Test user can select manual entry from device list."""
         with patch(
-            "custom_components.adjustable_bed.config_flow.async_discovered_service_info",
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
             return_value=[mock_bluetooth_service_info],
         ):
             result = await hass.config_entries.flow.async_init(
@@ -911,7 +942,7 @@ class TestOptionsFlow:
         await hass.async_block_till_done()
 
         with patch(
-            "custom_components.adjustable_bed.config_flow.async_discovered_service_info",
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
             return_value=[],
         ):
             result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
@@ -198,6 +198,39 @@ class TestDiagnosticsOutput:
         assert "class" in controller_info
         assert controller_info["class"] == "LinakController"
         assert "characteristic_uuid" in controller_info
+
+    async def test_diagnostics_uses_non_connectable_advertisement_fallback(
+        self,
+        hass: HomeAssistant,
+        mock_diagnostics_config_entry,
+        mock_coordinator_connected,  # noqa: ARG002
+        enable_custom_integrations,  # noqa: ARG002
+    ):
+        """Diagnostics should surface non-connectable fallback advertisement data."""
+        from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
+
+        coordinator = AdjustableBedCoordinator(hass, mock_diagnostics_config_entry)
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][mock_diagnostics_config_entry.entry_id] = coordinator
+
+        service_info = MagicMock()
+        service_info.name = "Mouselet"
+        service_info.rssi = -67
+        service_info.service_uuids = ["0000ffc0-0000-1000-8000-00805f9b34fb"]
+        service_info.manufacturer_data = {65535: b"\xc0\xff"}
+        service_info.source = "proxy_1"
+
+        with patch(
+            "custom_components.adjustable_bed.diagnostics.find_service_info_by_address",
+            return_value=(service_info, False),
+        ):
+            result = await async_get_config_entry_diagnostics(
+                hass,
+                mock_diagnostics_config_entry,
+            )
+
+        assert result["advertisement"]["device_name"] == "Mouselet"
+        assert result["advertisement"]["connectable"] is False
 
     async def test_diagnostics_supported_bed_types(
         self,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.config_entries import ConfigEntryState
@@ -11,9 +12,8 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 # Import enable_custom_integrations fixture
 from custom_components.adjustable_bed import (
-    SERVICE_GENERATE_SUPPORT_REPORT,
+    SERVICE_GENERATE_SUPPORT_BUNDLE,
     SERVICE_GOTO_PRESET,
-    SERVICE_RUN_DIAGNOSTICS,
     SERVICE_SAVE_PRESET,
     SERVICE_SET_POSITION,
     SERVICE_STOP_ALL,
@@ -71,6 +71,7 @@ class TestIntegrationSetup:
         assert hass.services.has_service(DOMAIN, SERVICE_GOTO_PRESET)
         assert hass.services.has_service(DOMAIN, SERVICE_SAVE_PRESET)
         assert hass.services.has_service(DOMAIN, SERVICE_STOP_ALL)
+        assert hass.services.has_service(DOMAIN, SERVICE_GENERATE_SUPPORT_BUNDLE)
 
     async def test_setup_entry_connection_timeout(
         self,
@@ -91,8 +92,7 @@ class TestIntegrationSetup:
 
         assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
         assert hass.services.has_service(DOMAIN, SERVICE_GOTO_PRESET)
-        assert hass.services.has_service(DOMAIN, SERVICE_RUN_DIAGNOSTICS)
-        assert hass.services.has_service(DOMAIN, SERVICE_GENERATE_SUPPORT_REPORT)
+        assert hass.services.has_service(DOMAIN, SERVICE_GENERATE_SUPPORT_BUNDLE)
 
     async def test_setup_entry_connection_failed(
         self,
@@ -111,8 +111,7 @@ class TestIntegrationSetup:
 
         assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
         assert hass.services.has_service(DOMAIN, SERVICE_GOTO_PRESET)
-        assert hass.services.has_service(DOMAIN, SERVICE_RUN_DIAGNOSTICS)
-        assert hass.services.has_service(DOMAIN, SERVICE_GENERATE_SUPPORT_REPORT)
+        assert hass.services.has_service(DOMAIN, SERVICE_GENERATE_SUPPORT_BUNDLE)
 
     async def test_setup_entry_loads_diagnostic_device_without_connection(
         self,
@@ -253,8 +252,7 @@ class TestIntegrationUnload:
         assert hass.services.has_service(DOMAIN, SERVICE_GOTO_PRESET)
         assert hass.services.has_service(DOMAIN, SERVICE_SAVE_PRESET)
         assert hass.services.has_service(DOMAIN, SERVICE_STOP_ALL)
-        assert hass.services.has_service(DOMAIN, SERVICE_RUN_DIAGNOSTICS)
-        assert hass.services.has_service(DOMAIN, SERVICE_GENERATE_SUPPORT_REPORT)
+        assert hass.services.has_service(DOMAIN, SERVICE_GENERATE_SUPPORT_BUNDLE)
 
     async def test_unload_keeps_services_with_remaining_entries(
         self,
@@ -299,7 +297,7 @@ class TestIntegrationUnload:
 
         # Services remain available after the final entry unload
         assert hass.services.has_service(DOMAIN, SERVICE_GOTO_PRESET)
-        assert hass.services.has_service(DOMAIN, SERVICE_RUN_DIAGNOSTICS)
+        assert hass.services.has_service(DOMAIN, SERVICE_GENERATE_SUPPORT_BUNDLE)
 
 
 class TestMigration:
@@ -436,6 +434,72 @@ class TestMigration:
 
 class TestServices:
     """Test integration services."""
+
+    async def test_generate_support_bundle_service(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """Test generate_support_bundle service delegates to the bundle generator."""
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        from homeassistant.helpers import device_registry as dr
+
+        device_registry = dr.async_get(hass)
+        devices = dr.async_entries_for_config_entry(device_registry, mock_config_entry.entry_id)
+        assert len(devices) == 1
+        device_id = devices[0].id
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+                new=AsyncMock(return_value={"notifications": [], "errors": []}),
+            ) as mock_generate_support_bundle,
+            patch(
+                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
+                return_value=Path("/tmp/support_bundle.json"),
+            ) as mock_save_support_bundle,
+        ):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_GENERATE_SUPPORT_BUNDLE,
+                {"device_id": [device_id]},
+                blocking=True,
+            )
+
+        mock_generate_support_bundle.assert_awaited_once()
+        kwargs = mock_generate_support_bundle.await_args.kwargs
+        assert kwargs["device_id"] == device_id
+        assert kwargs["entry"] == mock_config_entry
+        assert kwargs["coordinator"] == hass.data[DOMAIN][mock_config_entry.entry_id]
+        mock_save_support_bundle.assert_called_once()
+
+    async def test_generate_support_bundle_service_rejects_invalid_target_address(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """Test generate_support_bundle validates raw MAC addresses."""
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        with patch(
+            "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+            new=AsyncMock(),
+        ) as mock_generate_support_bundle:
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_GENERATE_SUPPORT_BUNDLE,
+                {"target_address": "not-a-mac"},
+                blocking=True,
+            )
+
+        mock_generate_support_bundle.assert_not_called()
 
     async def test_goto_preset_service(
         self,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -485,21 +485,19 @@ class TestServices:
         enable_custom_integrations,
     ):
         """Test generate_support_bundle validates raw MAC addresses."""
+        import pytest
+        from homeassistant.exceptions import ServiceValidationError
+
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-        with patch(
-            "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
-            new=AsyncMock(),
-        ) as mock_generate_support_bundle:
+        with pytest.raises(ServiceValidationError, match="Invalid MAC address format"):
             await hass.services.async_call(
                 DOMAIN,
                 SERVICE_GENERATE_SUPPORT_BUNDLE,
                 {"target_address": "not-a-mac"},
                 blocking=True,
             )
-
-        mock_generate_support_bundle.assert_not_called()
 
     async def test_goto_preset_service(
         self,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -22,6 +22,7 @@ from custom_components.adjustable_bed import (
 )
 from custom_components.adjustable_bed.const import (
     BED_TYPE_BEDTECH,
+    BED_TYPE_DIAGNOSTIC,
     BED_TYPE_LINAK,
     BED_TYPE_MALOUF_LEGACY_OKIN,
     BED_TYPE_RICHMAT,
@@ -112,6 +113,48 @@ class TestIntegrationSetup:
         assert hass.services.has_service(DOMAIN, SERVICE_GOTO_PRESET)
         assert hass.services.has_service(DOMAIN, SERVICE_RUN_DIAGNOSTICS)
         assert hass.services.has_service(DOMAIN, SERVICE_GENERATE_SUPPORT_REPORT)
+
+    async def test_setup_entry_loads_diagnostic_device_without_connection(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_adapters,
+        enable_custom_integrations,
+    ):
+        """Diagnostic entries should still load so they can be targeted by actions."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Diagnostic Device",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:10",
+                CONF_NAME: "Diagnostic Device",
+                CONF_BED_TYPE: BED_TYPE_DIAGNOSTIC,
+                CONF_MOTOR_COUNT: 0,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:10",
+            entry_id="diagnostic_entry_id",
+        )
+        entry.add_to_hass(hass)
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator.bluetooth.async_ble_device_from_address",
+            return_value=None,
+        ):
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert entry.state == ConfigEntryState.LOADED
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        assert coordinator.controller is not None
+        assert coordinator.controller.__class__.__name__ == "DiagnosticBedController"
+
+        from homeassistant.helpers import device_registry as dr
+
+        device_registry = dr.async_get(hass)
+        devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+        assert len(devices) == 1
 
     async def test_setup_entry_reclassifies_legacy_bedtech_qrrm_entry(
         self,

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -1,0 +1,256 @@
+"""Tests for support bundle generation and enriched diagnostics."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.adjustable_bed.adapter import AdapterSelectionResult
+from custom_components.adjustable_bed.ble_diagnostics import (
+    BLEDiagnosticRunner,
+    DiagnosticReport,
+)
+from custom_components.adjustable_bed.const import (
+    DEVICE_INFO_CHARS,
+    LINAK_CONTROL_SERVICE_UUID,
+    SOLACE_SERVICE_UUID,
+)
+from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
+from custom_components.adjustable_bed.support_bundle import generate_support_bundle
+
+
+class _FakeServices:
+    """Simple BLE service collection for tests."""
+
+    def __init__(self, services: list[MagicMock]) -> None:
+        self._services = services
+
+    def __iter__(self):
+        return iter(self._services)
+
+    def __len__(self) -> int:
+        return len(self._services)
+
+    def get_service(self, uuid: str) -> MagicMock | None:
+        for service in self._services:
+            if service.uuid == uuid:
+                return service
+        return None
+
+
+def _build_unknown_service_info(*, source: str, connectable: bool, rssi: int) -> MagicMock:
+    """Create a mock BLE advertisement snapshot."""
+    service_info = MagicMock()
+    service_info.name = "HHC3611243CDEF"
+    service_info.address = "AA:BB:CC:DD:EE:FF"
+    service_info.rssi = rssi
+    service_info.manufacturer_data = {65535: b"AT"}
+    service_info.service_data = {"test": b"OK"}
+    service_info.service_uuids = [SOLACE_SERVICE_UUID]
+    service_info.source = source
+    service_info.device = MagicMock(
+        address="AA:BB:CC:DD:EE:FF",
+        name="HHC3611243CDEF",
+        details={"source": source, "props": {"Paired": True, "Trusted": False}},
+    )
+    service_info.connectable = connectable
+    service_info.time = 1_700_000_000
+    return service_info
+
+
+class TestBleDiagnosticsRunner:
+    """Test enriched BLE diagnostics output."""
+
+    async def test_run_diagnostics_enriches_detection_gatt_and_notifications(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,
+    ):
+        """Diagnostics should include detection, per-source advertisements, and summaries."""
+        connectable_info = _build_unknown_service_info(
+            source="proxy_1",
+            connectable=True,
+            rssi=-55,
+        )
+        fallback_info = _build_unknown_service_info(
+            source="proxy_2",
+            connectable=False,
+            rssi=-70,
+        )
+
+        descriptor = MagicMock(uuid="00002902-0000-1000-8000-00805f9b34fb", handle=34)
+        characteristic = MagicMock(
+            uuid="0000ffe1-0000-1000-8000-00805f9b34fb",
+            handle=33,
+            properties=["read", "notify"],
+            descriptors=[descriptor],
+        )
+        service = MagicMock(
+            uuid="0000ffe0-0000-1000-8000-00805f9b34fb",
+            handle=32,
+            characteristics=[characteristic],
+        )
+        services = _FakeServices([service])
+
+        client = MagicMock()
+        client.is_connected = True
+        client.services = services
+        client._backend = MagicMock(
+            _device=MagicMock(
+                details={
+                    "source": "proxy_1",
+                    "props": {"Paired": True, "Trusted": False, "AddressType": "random"},
+                }
+            )
+        )
+        client.get_services = AsyncMock()
+
+        async def _read_gatt_char(target):
+            target_uuid = getattr(target, "uuid", target)
+            if target_uuid == characteristic.uuid:
+                return b"AT+INFO"
+            if target_uuid == DEVICE_INFO_CHARS["manufacturer_name"]:
+                return b"Acme\x00"
+            if target_uuid == DEVICE_INFO_CHARS["model_number"]:
+                return b"Base-1\x00"
+            raise ValueError(f"unexpected read target {target_uuid}")
+
+        async def _start_notify(target, handler):
+            handler(MagicMock(), bytearray(b"OK"))
+
+        client.read_gatt_char = AsyncMock(side_effect=_read_gatt_char)
+        client.start_notify = AsyncMock(side_effect=_start_notify)
+        client.stop_notify = AsyncMock()
+        client.disconnect = AsyncMock()
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.get_service_info_snapshots_by_address",
+                return_value=[(connectable_info, True), (fallback_info, False)],
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.select_adapter",
+                new=AsyncMock(
+                    return_value=AdapterSelectionResult(
+                        device=connectable_info.device,
+                        source="proxy_1",
+                        rssi=-55,
+                        connectable=True,
+                        available_sources=["proxy_1 (RSSI: -55)", "proxy_2 (RSSI: -70)"],
+                    )
+                ),
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.establish_connection",
+                new=AsyncMock(return_value=client),
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.bluetooth.async_scanner_count",
+                return_value=2,
+            ),
+        ):
+            report = await BLEDiagnosticRunner(
+                hass,
+                "AA:BB:CC:DD:EE:FF",
+                capture_duration=0,
+            ).run_diagnostics()
+
+        assert report.detection["bed_type"] == "motosleep"
+        assert report.detection["supported_match"] is True
+        assert len(report.advertisements_by_source) == 2
+        assert report.advertisement["selected_for_connection"] is True
+        assert report.device["pairing"]["paired"] is True
+        assert report.device["scanner_count"] == 2
+        assert report.gatt_services[0]["handle"] == 32
+        assert report.gatt_services[0]["characteristics"][0]["handle"] == 33
+        assert report.gatt_services[0]["characteristics"][0]["descriptors"][0]["handle"] == 34
+        assert report.gatt_services[0]["characteristics"][0]["read_result"]["ascii_preview"] == "AT+INFO"
+        assert report.gatt_services[0]["characteristics"][0]["notify_subscription"]["success"] is True
+        assert report.notifications[0]["data_hex"] == "4f4b"
+        assert report.notification_summary["by_characteristic"][characteristic.uuid]["count"] == 1
+        assert report.notification_summary["by_characteristic"][characteristic.uuid][
+            "observed_payload_lengths"
+        ] == [2]
+
+
+class TestSupportBundle:
+    """Test support bundle orchestration."""
+
+    async def test_generate_support_bundle_raw_address_has_standard_sections(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,
+    ):
+        """Raw-address bundles should keep configured-device sections empty but present."""
+        diagnostic_report = DiagnosticReport(
+            metadata={"version": "2.0"},
+            device={
+                "address": "AA:BB:CC:DD:EE:FF",
+                "selected_source": "proxy_1",
+                "actual_source": "proxy_1",
+                "scanner_count": 2,
+                "visible_sources": ["proxy_1", "proxy_2"],
+                "non_connectable_fallback_used": False,
+            },
+            advertisement={"address": "AA:BB:CC:DD:EE:FF", "selected_for_connection": True},
+            advertisements_by_source=[{"source": "proxy_1"}],
+            detection={"bed_type": "linak", "supported_match": True},
+            gatt_services=[{"uuid": LINAK_CONTROL_SERVICE_UUID}],
+            gatt_summary={"available": True, "service_count": 1},
+            device_information={"manufacturer_name": "Linak"},
+            notifications=[],
+            notification_summary={"total_notifications": 0, "by_characteristic": {}},
+            adapter_details={},
+            connection_history={},
+            connection_attempt_details=[{"attempt": 1, "result": "connected"}],
+            command_trace=[],
+            errors=[],
+        )
+
+        with (
+            patch.object(
+                BLEDiagnosticRunner,
+                "run_diagnostics",
+                new=AsyncMock(return_value=diagnostic_report),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.bluetooth.async_current_scanners",
+                return_value=[MagicMock(source="proxy_1", name="Proxy 1", scanning=True)],
+            ),
+        ):
+            report = await generate_support_bundle(
+                hass,
+                address="AA:BB:CC:DD:EE:FF",
+                capture_duration=0,
+                include_logs=False,
+            )
+
+        assert report["target"]["mode"] == "target_address"
+        assert report["integration"]["configured_device"] is False
+        assert report["controller"]["initialized"] is False
+        assert report["command_trace"] == []
+        assert report["bluetooth"]["advertisements_by_source"] == [{"source": "proxy_1"}]
+        assert report["connection_attempt_details"][0]["result"] == "connected"
+
+    async def test_coordinator_records_command_trace(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """Integration-issued writes should be buffered for support bundles."""
+        coordinator = AdjustableBedCoordinator(hass, mock_config_entry)
+        await coordinator.async_connect()
+
+        controller = coordinator.controller
+        assert controller is not None
+
+        await controller.write_command(b"\x01\x02", repeat_count=2, repeat_delay_ms=25)
+
+        trace = coordinator.command_trace
+        assert trace
+        assert trace[-1]["payload"]["hex"] == "0102"
+        assert trace[-1]["repeat_count"] == 2
+        assert trace[-1]["repeat_delay_ms"] == 25


### PR DESCRIPTION
## Summary
- replace the split `run_diagnostics` and `generate_support_report` actions with a single `generate_support_bundle` action
- enrich BLE capture with detection reasoning, per-source advertisements, detailed GATT/descriptor output, notification summaries, command trace buffering, and connection-attempt details
- repurpose the diagnostic config-flow branch into a BLE browser that points users at the new support-bundle flow instead of creating diagnostic entries

## Testing
- `uv run pytest tests/test_support_bundle.py tests/test_init.py tests/test_config_flow.py tests/test_diagnostics.py tests/test_adapter.py tests/test_coordinator.py -q`
- `uv run python -m compileall custom_components/adjustable_bed`

## Notes
- this removes the public `adjustable_bed.run_diagnostics` and `adjustable_bed.generate_support_report` action names
- existing legacy diagnostic config entries still load, but new troubleshooting flow no longer depends on creating one


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generate Support Bundle service (optional logs) for comprehensive troubleshooting.
  * Browse Unsupported BLE Devices UI to inspect unconfigured devices and obtain MACs.
  * Offline diagnostic mode for unsupported beds when initial BLE connection fails.

* **Improvements**
  * Improved handling of non-connectable Bluetooth advertisements and adapter fallbacks.
  * Richer support bundles: connection history, command traces, GATT/details, per-source diagnostics.

* **Documentation**
  * Guides and UI strings updated to reflect the support bundle workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->