### PR TITLE
Add full Kaidi OEM family support

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -34,8 +34,13 @@ from .const import (
     CONF_BED_TYPE,
     CONF_DISABLE_ANGLE_SENSING,
     CONF_HAS_MASSAGE,
+    CONF_KAIDI_ADV_TYPE,
+    CONF_KAIDI_PRODUCT_ID,
+    CONF_KAIDI_RESOLVED_VARIANT,
     CONF_KAIDI_ROOM_ID,
+    CONF_KAIDI_SOFA_ACU_NO,
     CONF_KAIDI_TARGET_VADDR,
+    CONF_KAIDI_VARIANT_SOURCE,
     CONF_MOTOR_COUNT,
     CONF_PROTOCOL_VARIANT,
     CONF_RICHMAT_REMOTE,
@@ -169,18 +174,20 @@ def _maybe_cache_kaidi_metadata(hass: HomeAssistant, entry: ConfigEntry) -> None
         return
 
     new_data = add_kaidi_entry_metadata(entry.data, advertisement)
-    if (
-        new_data.get(CONF_KAIDI_ROOM_ID) == entry.data.get(CONF_KAIDI_ROOM_ID)
-        and new_data.get(CONF_KAIDI_TARGET_VADDR) == entry.data.get(CONF_KAIDI_TARGET_VADDR)
-    ):
+    if new_data == dict(entry.data):
         return
 
     hass.config_entries.async_update_entry(entry, data=new_data)
     _LOGGER.info(
-        "Cached Kaidi session metadata for %s (room_id=%s, target_vaddr=%s)",
+        "Cached Kaidi metadata for %s (room_id=%s, target_vaddr=%s, product_id=%s, sofa_acu_no=%s, adv_type=%s, resolved_variant=%s, variant_source=%s)",
         entry.data[CONF_ADDRESS],
         new_data.get(CONF_KAIDI_ROOM_ID),
         new_data.get(CONF_KAIDI_TARGET_VADDR),
+        new_data.get(CONF_KAIDI_PRODUCT_ID),
+        new_data.get(CONF_KAIDI_SOFA_ACU_NO),
+        new_data.get(CONF_KAIDI_ADV_TYPE),
+        new_data.get(CONF_KAIDI_RESOLVED_VARIANT),
+        new_data.get(CONF_KAIDI_VARIANT_SOURCE),
     )
 
 

--- a/custom_components/adjustable_bed/beds/kaidi.py
+++ b/custom_components/adjustable_bed/beds/kaidi.py
@@ -373,7 +373,13 @@ class KaidiController(BedController):
         self._manufacturer_data = dict(manufacturer_data or {})
         self._variant = variant
         self._variant_source = variant_source
-        self._command_profile = KAIDI_COMMAND_PROFILES[variant]
+        profile = KAIDI_COMMAND_PROFILES.get(variant)
+        if profile is None:
+            raise ValueError(
+                f"Unsupported Kaidi variant '{variant}'. "
+                f"Expected one of: {', '.join(sorted(KAIDI_COMMAND_PROFILES))}"
+            )
+        self._command_profile = profile
 
         # For dual beds (seat_1_2), build a map from seat_1 → seat_2 commands
         if variant == KAIDI_VARIANT_SEAT_1_2:

--- a/custom_components/adjustable_bed/beds/kaidi.py
+++ b/custom_components/adjustable_bed/beds/kaidi.py
@@ -179,7 +179,7 @@ KAIDI_PRODUCT_FAMILIES: dict[int, KaidiProductFamily] = {
     139: KaidiProductFamily(bed_ui=2),
     142: KaidiProductFamily(
         bed_ui=5, has_back=True, has_waist=True, has_all=True,
-        has_lights=True, has_massage=True,
+        has_lights=True, has_massage=True, has_book=True, has_leisure=True,
     ),
     143: KaidiProductFamily(bed_ui=2),
 }

--- a/custom_components/adjustable_bed/beds/kaidi.py
+++ b/custom_components/adjustable_bed/beds/kaidi.py
@@ -17,16 +17,25 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from bleak.backends.characteristic import BleakGATTCharacteristic
 
 from ..const import (
+    CONF_KAIDI_PRODUCT_ID,
     CONF_KAIDI_ROOM_ID,
+    CONF_KAIDI_SOFA_ACU_NO,
     CONF_KAIDI_TARGET_VADDR,
     KAIDI_BROADCAST_VADDR,
     KAIDI_JOIN_PASSWORD,
     KAIDI_NOTIFY_CHAR_UUID,
+    KAIDI_VARIANT_BED_1,
+    KAIDI_VARIANT_BED_12,
+    KAIDI_VARIANT_BED_2,
+    KAIDI_VARIANT_SEAT_1,
+    KAIDI_VARIANT_SEAT_2,
+    KAIDI_VARIANT_SEAT_3,
     KAIDI_WRITE_CHAR_UUID,
 )
 from ..kaidi_protocol import extract_kaidi_advertisement, format_kaidi_node_address
@@ -42,7 +51,7 @@ KAIDI_PING_CHANNEL = 0xFF
 
 
 class KaidiCommands:
-    """Kaidi command bytes for single-bed control."""
+    """Legacy aliases for the Kaidi Seat 1 command bytes."""
 
     HEAD_UP = 0x01
     HEAD_DOWN = 0x02
@@ -51,20 +60,108 @@ class KaidiCommands:
     FOOT_DOWN = 0x05
     FOOT_STOP = 0x06
     STOP_ALL = 0x1C
-
     MEMORY_SAVE_1 = 0x25
     MEMORY_SAVE_2 = 0x26
     MEMORY_SAVE_3 = 0x27
     MEMORY_SAVE_4 = 0x28
-
     MEMORY_RECALL_1 = 0x29
     MEMORY_RECALL_2 = 0x2A
     MEMORY_RECALL_3 = 0x2B
     MEMORY_RECALL_4 = 0x2C
-
     PRESET_ZERO_G = 0x62
     PRESET_ANTI_SNORE = 0x65
     PRESET_FLAT = 0x68
+
+
+@dataclass(frozen=True, slots=True)
+class KaidiCommandProfile:
+    """Command mapping for one Kaidi variant family."""
+
+    variant: str
+    head_up: int
+    head_down: int
+    head_stop: int
+    foot_up: int
+    foot_down: int
+    foot_stop: int
+    stop_all: int | None = None
+    memory_save: dict[int, int] | None = None
+    memory_recall: dict[int, int] | None = None
+    preset_flat: int | None = None
+    preset_zero_g: int | None = None
+    preset_anti_snore: int | None = None
+
+
+KAIDI_COMMAND_PROFILES: dict[str, KaidiCommandProfile] = {
+    KAIDI_VARIANT_SEAT_1: KaidiCommandProfile(
+        variant=KAIDI_VARIANT_SEAT_1,
+        head_up=0x01,
+        head_down=0x02,
+        head_stop=0x03,
+        foot_up=0x04,
+        foot_down=0x05,
+        foot_stop=0x06,
+        stop_all=0x1C,
+        memory_save={1: 0x25, 2: 0x26, 3: 0x27, 4: 0x28},
+        memory_recall={1: 0x29, 2: 0x2A, 3: 0x2B, 4: 0x2C},
+        preset_zero_g=0x62,
+        preset_anti_snore=0x65,
+        preset_flat=0x68,
+    ),
+    KAIDI_VARIANT_SEAT_2: KaidiCommandProfile(
+        variant=KAIDI_VARIANT_SEAT_2,
+        head_up=0x0A,
+        head_down=0x0B,
+        head_stop=0x0C,
+        foot_up=0x0D,
+        foot_down=0x0E,
+        foot_stop=0x0F,
+        stop_all=0x1D,
+        memory_save={1: 0x2D, 2: 0x2E, 3: 0x2F, 4: 0x30},
+        memory_recall={1: 0x31, 2: 0x32, 3: 0x33, 4: 0x34},
+        preset_zero_g=0x63,
+        preset_anti_snore=0x66,
+        preset_flat=0x69,
+    ),
+    KAIDI_VARIANT_SEAT_3: KaidiCommandProfile(
+        variant=KAIDI_VARIANT_SEAT_3,
+        head_up=0x13,
+        head_down=0x14,
+        head_stop=0x15,
+        foot_up=0x16,
+        foot_down=0x17,
+        foot_stop=0x18,
+        memory_save={1: 0x35, 2: 0x36, 3: 0x37, 4: 0x38},
+        memory_recall={1: 0x39, 2: 0x3A, 3: 0x3B, 4: 0x3C},
+    ),
+    KAIDI_VARIANT_BED_1: KaidiCommandProfile(
+        variant=KAIDI_VARIANT_BED_1,
+        head_up=0x47,
+        head_down=0x48,
+        head_stop=0x49,
+        foot_up=0x4D,
+        foot_down=0x4E,
+        foot_stop=0x4F,
+    ),
+    KAIDI_VARIANT_BED_2: KaidiCommandProfile(
+        variant=KAIDI_VARIANT_BED_2,
+        head_up=0x4A,
+        head_down=0x4B,
+        head_stop=0x4C,
+        foot_up=0x50,
+        foot_down=0x51,
+        foot_stop=0x52,
+    ),
+    KAIDI_VARIANT_BED_12: KaidiCommandProfile(
+        variant=KAIDI_VARIANT_BED_12,
+        head_up=0x53,
+        head_down=0x54,
+        head_stop=0x55,
+        foot_up=0x56,
+        foot_down=0x57,
+        foot_stop=0x58,
+    ),
+}
 
 
 class KaidiController(BedController):
@@ -76,11 +173,16 @@ class KaidiController(BedController):
         *,
         device_name: str | None = None,
         manufacturer_data: dict[int, bytes] | None = None,
+        variant: str = KAIDI_VARIANT_SEAT_1,
+        variant_source: str = "legacy_fallback",
     ) -> None:
         """Initialize the Kaidi controller."""
         super().__init__(coordinator)
         self._device_name = device_name
         self._manufacturer_data = dict(manufacturer_data or {})
+        self._variant = variant
+        self._variant_source = variant_source
+        self._command_profile = KAIDI_COMMAND_PROFILES[variant]
 
         self._notify_started = False
         self._session_ready = False
@@ -95,16 +197,24 @@ class KaidiController(BedController):
         self._own_vaddr: int | None = None
         self._target_vaddr: int | None = None
         self._write_with_response = True
+        self._product_id: int | None = None
+        self._sofa_acu_no: int | None = None
 
         entry_data = getattr(getattr(self._coordinator, "entry", None), "data", {})
         cached_room_id = entry_data.get(CONF_KAIDI_ROOM_ID)
         cached_target_vaddr = entry_data.get(CONF_KAIDI_TARGET_VADDR)
+        cached_product_id = entry_data.get(CONF_KAIDI_PRODUCT_ID)
+        cached_sofa_acu_no = entry_data.get(CONF_KAIDI_SOFA_ACU_NO)
         if isinstance(cached_room_id, int):
             self._room_id = cached_room_id
             _LOGGER.debug("Loaded cached room_id=%s from entry data", cached_room_id)
         if isinstance(cached_target_vaddr, int):
             self._target_vaddr = cached_target_vaddr
             _LOGGER.debug("Loaded cached target_vaddr=%s from entry data", cached_target_vaddr)
+        if isinstance(cached_product_id, int):
+            self._product_id = cached_product_id
+        if isinstance(cached_sofa_acu_no, int):
+            self._sofa_acu_no = cached_sofa_acu_no
 
         if self._manufacturer_data:
             _LOGGER.debug(
@@ -123,13 +233,23 @@ class KaidiController(BedController):
         advertisement = extract_kaidi_advertisement(self._manufacturer_data)
         if advertisement is not None:
             _LOGGER.debug(
-                "Parsed Kaidi advertisement: type=%s room_id=%s vaddr=%s",
-                advertisement.adv_type, advertisement.room_id, advertisement.vaddr,
+                "Parsed Kaidi advertisement: type=%s room_id=%s vaddr=%s product_id=%s sofa_acu_no=%s variant=%s (%s)",
+                advertisement.adv_type,
+                advertisement.room_id,
+                advertisement.vaddr,
+                advertisement.product_id,
+                advertisement.sofa_acu_no,
+                self._variant,
+                self._variant_source,
             )
             if advertisement.room_id is not None:
                 self._room_id = advertisement.room_id
             if advertisement.vaddr is not None:
                 self._target_vaddr = advertisement.vaddr
+            if advertisement.product_id is not None:
+                self._product_id = advertisement.product_id
+            if advertisement.sofa_acu_no is not None:
+                self._sofa_acu_no = advertisement.sofa_acu_no
         elif self._manufacturer_data:
             _LOGGER.warning(
                 "Manufacturer data present but not recognized as Kaidi advertisement "
@@ -143,24 +263,28 @@ class KaidiController(BedController):
         return KAIDI_WRITE_CHAR_UUID
 
     @property
+    def supports_preset_flat(self) -> bool:
+        return self._command_profile.preset_flat is not None
+
+    @property
     def supports_preset_zero_g(self) -> bool:
-        return True
+        return self._command_profile.preset_zero_g is not None
 
     @property
     def supports_preset_anti_snore(self) -> bool:
-        return True
+        return self._command_profile.preset_anti_snore is not None
 
     @property
     def supports_memory_presets(self) -> bool:
-        return True
+        return self._command_profile.memory_recall is not None
 
     @property
     def memory_slot_count(self) -> int:
-        return 4
+        return len(self._command_profile.memory_recall or {})
 
     @property
     def supports_memory_programming(self) -> bool:
-        return True
+        return self._command_profile.memory_save is not None
 
     def _refresh_write_mode(self) -> None:
         """Refresh write mode from discovered GATT characteristics when available."""
@@ -300,6 +424,10 @@ class KaidiController(BedController):
                         self._target_vaddr,
                         self._coordinator.address,
                     )
+                if advertisement.product_id is not None:
+                    self._product_id = advertisement.product_id
+                if advertisement.sofa_acu_no is not None:
+                    self._sofa_acu_no = advertisement.sofa_acu_no
         except Exception:
             _LOGGER.debug(
                 "Could not resolve Kaidi metadata from HA scanner for %s",
@@ -477,15 +605,40 @@ class KaidiController(BedController):
             except ConnectionError:
                 _LOGGER.debug("Kaidi cleanup stop skipped because device disconnected")
 
+    def _require_memory_command(self, command_map: dict[int, int] | None, memory_num: int) -> int:
+        """Resolve a Kaidi memory command or raise a helpful error."""
+        if command_map is None:
+            raise NotImplementedError(
+                f"Kaidi variant {self._variant} does not expose memory presets"
+            )
+        try:
+            return command_map[memory_num]
+        except KeyError as err:
+            raise ValueError(f"Invalid Kaidi memory slot {memory_num}") from err
+
+    async def _write_optional_control_command(self, command_id: int | None, label: str) -> None:
+        """Send a variant-specific command that may not exist on all profiles."""
+        if command_id is None:
+            raise NotImplementedError(
+                f"Kaidi variant {self._variant} does not support {label}"
+            )
+        await self._write_control_command(command_id)
+
     async def move_head_up(self) -> None:
-        await self._move_with_stop_command(KaidiCommands.HEAD_UP, KaidiCommands.HEAD_STOP)
+        await self._move_with_stop_command(
+            self._command_profile.head_up,
+            self._command_profile.head_stop,
+        )
 
     async def move_head_down(self) -> None:
-        await self._move_with_stop_command(KaidiCommands.HEAD_DOWN, KaidiCommands.HEAD_STOP)
+        await self._move_with_stop_command(
+            self._command_profile.head_down,
+            self._command_profile.head_stop,
+        )
 
     async def move_head_stop(self) -> None:
         await self._write_control_command(
-            KaidiCommands.HEAD_STOP,
+            self._command_profile.head_stop,
             cancel_event=asyncio.Event(),
         )
 
@@ -499,14 +652,20 @@ class KaidiController(BedController):
         await self.move_head_stop()
 
     async def move_legs_up(self) -> None:
-        await self._move_with_stop_command(KaidiCommands.FOOT_UP, KaidiCommands.FOOT_STOP)
+        await self._move_with_stop_command(
+            self._command_profile.foot_up,
+            self._command_profile.foot_stop,
+        )
 
     async def move_legs_down(self) -> None:
-        await self._move_with_stop_command(KaidiCommands.FOOT_DOWN, KaidiCommands.FOOT_STOP)
+        await self._move_with_stop_command(
+            self._command_profile.foot_down,
+            self._command_profile.foot_stop,
+        )
 
     async def move_legs_stop(self) -> None:
         await self._write_control_command(
-            KaidiCommands.FOOT_STOP,
+            self._command_profile.foot_stop,
             cancel_event=asyncio.Event(),
         )
 
@@ -520,42 +679,44 @@ class KaidiController(BedController):
         await self.move_legs_stop()
 
     async def stop_all(self) -> None:
-        await self._write_control_command(
-            KaidiCommands.STOP_ALL,
-            cancel_event=asyncio.Event(),
-        )
+        if self._command_profile.stop_all is not None:
+            await self._write_control_command(
+                self._command_profile.stop_all,
+                cancel_event=asyncio.Event(),
+            )
+            return
+
+        await self.move_head_stop()
+        await self.move_legs_stop()
 
     async def preset_flat(self) -> None:
-        await self._write_control_command(KaidiCommands.PRESET_FLAT)
+        await self._write_optional_control_command(
+            self._command_profile.preset_flat,
+            "the flat preset",
+        )
 
     async def preset_zero_g(self) -> None:
-        await self._write_control_command(KaidiCommands.PRESET_ZERO_G)
+        await self._write_optional_control_command(
+            self._command_profile.preset_zero_g,
+            "the Zero-G preset",
+        )
 
     async def preset_anti_snore(self) -> None:
-        await self._write_control_command(KaidiCommands.PRESET_ANTI_SNORE)
+        await self._write_optional_control_command(
+            self._command_profile.preset_anti_snore,
+            "the anti-snore preset",
+        )
 
     async def preset_memory(self, memory_num: int) -> None:
-        command_map = {
-            1: KaidiCommands.MEMORY_RECALL_1,
-            2: KaidiCommands.MEMORY_RECALL_2,
-            3: KaidiCommands.MEMORY_RECALL_3,
-            4: KaidiCommands.MEMORY_RECALL_4,
-        }
-        try:
-            command_id = command_map[memory_num]
-        except KeyError as err:
-            raise ValueError(f"Invalid Kaidi memory preset {memory_num}") from err
+        command_id = self._require_memory_command(
+            self._command_profile.memory_recall,
+            memory_num,
+        )
         await self._write_control_command(command_id)
 
     async def program_memory(self, memory_num: int) -> None:
-        command_map = {
-            1: KaidiCommands.MEMORY_SAVE_1,
-            2: KaidiCommands.MEMORY_SAVE_2,
-            3: KaidiCommands.MEMORY_SAVE_3,
-            4: KaidiCommands.MEMORY_SAVE_4,
-        }
-        try:
-            command_id = command_map[memory_num]
-        except KeyError as err:
-            raise ValueError(f"Invalid Kaidi memory slot {memory_num}") from err
+        command_id = self._require_memory_command(
+            self._command_profile.memory_save,
+            memory_num,
+        )
         await self._write_control_command(command_id)

--- a/custom_components/adjustable_bed/beds/kaidi.py
+++ b/custom_components/adjustable_bed/beds/kaidi.py
@@ -10,6 +10,11 @@ The transport is a custom packet format over BLE GATT:
 The mobile app performs a lightweight "join" against a room/home ID carried in
 the advertisement payload, then sends motor/preset commands as 4-byte control
 payloads wrapped in a mesh-style frame.
+
+All three OEM apps (Rize 1.3.0, ISleep 1.6.3, Floyd 1.0.7) use exclusively
+SEAT_* command values (1-167).  The BED_* constants (71-115) found in
+PLDataTrans.java are legacy/enterprise firmware values and are NOT used by any
+consumer mobile app.
 """
 
 from __future__ import annotations
@@ -17,7 +22,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from bleak.backends.characteristic import BleakGATTCharacteristic
@@ -30,10 +35,8 @@ from ..const import (
     KAIDI_BROADCAST_VADDR,
     KAIDI_JOIN_PASSWORD,
     KAIDI_NOTIFY_CHAR_UUID,
-    KAIDI_VARIANT_BED_1,
-    KAIDI_VARIANT_BED_12,
-    KAIDI_VARIANT_BED_2,
     KAIDI_VARIANT_SEAT_1,
+    KAIDI_VARIANT_SEAT_1_2,
     KAIDI_VARIANT_SEAT_2,
     KAIDI_VARIANT_SEAT_3,
     KAIDI_WRITE_CHAR_UUID,
@@ -75,9 +78,14 @@ class KaidiCommands:
 
 @dataclass(frozen=True, slots=True)
 class KaidiCommandProfile:
-    """Command mapping for one Kaidi variant family."""
+    """Command mapping for one Kaidi variant family.
+
+    All values come from the SEAT_* instruction tables found in the de-minified
+    JS bundles of the Rize, ISleep, and Floyd Android apps.
+    """
 
     variant: str
+    # Core motors (all beds)
     head_up: int
     head_down: int
     head_stop: int
@@ -85,12 +93,104 @@ class KaidiCommandProfile:
     foot_down: int
     foot_stop: int
     stop_all: int | None = None
-    memory_save: dict[int, int] | None = None
-    memory_recall: dict[int, int] | None = None
+    # Memory presets
+    memory_save: dict[int, int] = field(default_factory=dict)
+    memory_recall: dict[int, int] = field(default_factory=dict)
+    # Standard presets
     preset_flat: int | None = None
     preset_zero_g: int | None = None
     preset_anti_snore: int | None = None
+    # Extended motors (3+ motor beds)
+    back_up: int | None = None
+    back_down: int | None = None
+    back_stop: int | None = None
+    waist_up: int | None = None
+    waist_down: int | None = None
+    waist_stop: int | None = None
+    neck_up: int | None = None
+    neck_down: int | None = None
+    neck_stop: int | None = None
+    all_up: int | None = None
+    all_down: int | None = None
+    all_stop: int | None = None
+    new_all_up: int | None = None
+    new_all_down: int | None = None
+    new_all_stop: int | None = None
+    # Lights
+    light_on: int | None = None
+    light_off: int | None = None
+    # Extended presets
+    preset_book: int | None = None
+    preset_leisure: int | None = None
+    # Massage
+    massage_mode_1: int | None = None
+    massage_mode_2: int | None = None
+    massage_mode_3: int | None = None
 
+
+# ---------------------------------------------------------------------------
+# Product family metadata
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class KaidiProductFamily:
+    """Capabilities for a product ID, derived from the OEM app's bedUI mapping."""
+
+    bed_ui: int
+    has_back: bool = False
+    has_waist: bool = False
+    has_neck: bool = False
+    has_all: bool = False
+    has_lights: bool = False
+    has_massage: bool = False
+    has_book: bool = False
+    has_leisure: bool = False
+
+
+# Product ID → capability set.  Derived from the Rize/Floyd/ISleep JS bundles.
+# bedUI 2: head + foot only
+# bedUI 3: back + foot + all
+# bedUI 4: back + foot + waist + all
+# bedUI 5-6: back + foot + waist + all + book + leisure presets
+# bedUI 7-8: back + foot + waist + all + leisure preset (+ neck for bedUI 8)
+KAIDI_PRODUCT_FAMILIES: dict[int, KaidiProductFamily] = {
+    129: KaidiProductFamily(bed_ui=2),
+    130: KaidiProductFamily(bed_ui=2),
+    131: KaidiProductFamily(bed_ui=3, has_back=True, has_all=True),
+    132: KaidiProductFamily(bed_ui=4, has_back=True, has_waist=True, has_all=True),
+    133: KaidiProductFamily(bed_ui=3, has_back=True, has_all=True),
+    134: KaidiProductFamily(bed_ui=4, has_back=True, has_waist=True, has_all=True),
+    135: KaidiProductFamily(
+        bed_ui=5, has_back=True, has_waist=True, has_all=True,
+        has_lights=True, has_massage=True, has_book=True, has_leisure=True,
+    ),
+    136: KaidiProductFamily(
+        bed_ui=6, has_back=True, has_waist=True, has_all=True,
+        has_lights=True, has_massage=True, has_book=True, has_leisure=True,
+    ),
+    137: KaidiProductFamily(
+        bed_ui=7, has_back=True, has_waist=True, has_all=True,
+        has_lights=True, has_massage=True, has_leisure=True,
+    ),
+    138: KaidiProductFamily(
+        bed_ui=8, has_back=True, has_waist=True, has_neck=True, has_all=True,
+        has_lights=True, has_massage=True, has_leisure=True,
+    ),
+    139: KaidiProductFamily(bed_ui=2),
+    142: KaidiProductFamily(
+        bed_ui=5, has_back=True, has_waist=True, has_all=True,
+        has_lights=True, has_massage=True,
+    ),
+    143: KaidiProductFamily(bed_ui=2),
+}
+
+# Default for beds without a known product ID.
+_DEFAULT_PRODUCT_FAMILY = KaidiProductFamily(bed_ui=2)
+
+
+# ---------------------------------------------------------------------------
+# Command profiles
+# ---------------------------------------------------------------------------
 
 KAIDI_COMMAND_PROFILES: dict[str, KaidiCommandProfile] = {
     KAIDI_VARIANT_SEAT_1: KaidiCommandProfile(
@@ -107,6 +207,32 @@ KAIDI_COMMAND_PROFILES: dict[str, KaidiCommandProfile] = {
         preset_zero_g=0x62,
         preset_anti_snore=0x65,
         preset_flat=0x68,
+        # Extended motors
+        back_up=0x7A,     # SEAT_1_BACK_UP = 122
+        back_down=0x7B,   # SEAT_1_BACK_DOWN = 123
+        back_stop=0x7C,   # SEAT_1_BACK_STOP = 124
+        waist_up=0x83,    # SEAT_1_WAIST_UP = 131
+        waist_down=0x84,  # SEAT_1_WAIST_DOWN = 132
+        waist_stop=0x85,  # SEAT_1_WAIST_STOP = 133
+        neck_up=0x8C,     # SEAT_1_NECK_UP = 140
+        neck_down=0x8D,   # SEAT_1_NECK_DOWN = 141
+        neck_stop=0x8E,   # SEAT_1_NECK_STOP = 142
+        all_up=0x07,      # SEAT_1_ALL_UP = 7
+        all_down=0x08,    # SEAT_1_ALL_DOWN = 8
+        all_stop=0x09,    # SEAT_1_ALL_STOP = 9
+        new_all_up=0x95,  # SEAT_1_NEW_ALL_UP = 149
+        new_all_down=0x96,  # SEAT_1_NEW_ALL_DOWN = 150
+        new_all_stop=0x97,  # SEAT_1_NEW_ALL_STOP = 151
+        # Lights
+        light_on=0x5C,    # SEAT_1_BED_LIGHT_ON = 92
+        light_off=0x5D,   # SEAT_1_BED_LIGHT_OFF = 93
+        # Extended presets
+        preset_book=0x9E,    # SEAT_1_BOOK = 158
+        preset_leisure=0xA1,  # SEAT_1_LEISURE = 161
+        # Massage
+        massage_mode_1=0x6B,  # SEAT_1_MASSAGE_MODE1 = 107
+        massage_mode_2=0x6E,  # SEAT_1_MASSAGE_MODE2 = 110
+        massage_mode_3=0x71,  # SEAT_1_MASSAGE_MODE3 = 113
     ),
     KAIDI_VARIANT_SEAT_2: KaidiCommandProfile(
         variant=KAIDI_VARIANT_SEAT_2,
@@ -122,6 +248,29 @@ KAIDI_COMMAND_PROFILES: dict[str, KaidiCommandProfile] = {
         preset_zero_g=0x63,
         preset_anti_snore=0x66,
         preset_flat=0x69,
+        # Extended motors
+        back_up=0x7D,     # SEAT_2_BACK_UP = 125
+        back_down=0x7E,   # SEAT_2_BACK_DOWN = 126
+        back_stop=0x7F,   # SEAT_2_BACK_STOP = 127
+        waist_up=0x86,    # SEAT_2_WAIST_UP = 134
+        waist_down=0x87,  # SEAT_2_WAIST_DOWN = 135
+        waist_stop=0x88,  # SEAT_2_WAIST_STOP = 136
+        neck_up=0x8F,     # SEAT_2_NECK_UP = 143
+        neck_down=0x90,   # SEAT_2_NECK_DOWN = 144
+        neck_stop=0x91,   # SEAT_2_NECK_STOP = 145
+        new_all_up=0x98,  # SEAT_2_NEW_ALL_UP = 152
+        new_all_down=0x99,  # SEAT_2_NEW_ALL_DOWN = 153
+        new_all_stop=0x9A,  # SEAT_2_NEW_ALL_STOP = 154
+        # Lights
+        light_on=0x5E,    # SEAT_2_BED_LIGHT_ON = 94
+        light_off=0x5F,   # SEAT_2_BED_LIGHT_OFF = 95
+        # Extended presets
+        preset_book=0x9F,    # SEAT_2_BOOK = 159
+        preset_leisure=0xA2,  # SEAT_2_LEISURE = 162
+        # Massage
+        massage_mode_1=0x6C,  # SEAT_2_MASSAGE_MODE1 = 108
+        massage_mode_2=0x6F,  # SEAT_2_MASSAGE_MODE2 = 111
+        massage_mode_3=0x72,  # SEAT_2_MASSAGE_MODE3 = 114
     ),
     KAIDI_VARIANT_SEAT_3: KaidiCommandProfile(
         variant=KAIDI_VARIANT_SEAT_3,
@@ -133,35 +282,77 @@ KAIDI_COMMAND_PROFILES: dict[str, KaidiCommandProfile] = {
         foot_stop=0x18,
         memory_save={1: 0x35, 2: 0x36, 3: 0x37, 4: 0x38},
         memory_recall={1: 0x39, 2: 0x3A, 3: 0x3B, 4: 0x3C},
-    ),
-    KAIDI_VARIANT_BED_1: KaidiCommandProfile(
-        variant=KAIDI_VARIANT_BED_1,
-        head_up=0x47,
-        head_down=0x48,
-        head_stop=0x49,
-        foot_up=0x4D,
-        foot_down=0x4E,
-        foot_stop=0x4F,
-    ),
-    KAIDI_VARIANT_BED_2: KaidiCommandProfile(
-        variant=KAIDI_VARIANT_BED_2,
-        head_up=0x4A,
-        head_down=0x4B,
-        head_stop=0x4C,
-        foot_up=0x50,
-        foot_down=0x51,
-        foot_stop=0x52,
-    ),
-    KAIDI_VARIANT_BED_12: KaidiCommandProfile(
-        variant=KAIDI_VARIANT_BED_12,
-        head_up=0x53,
-        head_down=0x54,
-        head_stop=0x55,
-        foot_up=0x56,
-        foot_down=0x57,
-        foot_stop=0x58,
+        # Seat 3 has limited extended commands
+        neck_up=0x92,     # SEAT_3_NECK_UP = 146
+        neck_down=0x93,   # SEAT_3_NECK_DOWN = 147
+        neck_stop=0x94,   # SEAT_3_NECK_STOP = 148
+        new_all_up=0x9B,  # SEAT_3_NEW_ALL_UP = 155
+        new_all_down=0x9C,  # SEAT_3_NEW_ALL_DOWN = 156
+        new_all_stop=0x9D,  # SEAT_3_NEW_ALL_STOP = 157
+        # Lights
+        light_on=0x60,    # SEAT_3_BED_LIGHT_ON = 96
+        light_off=0x61,   # SEAT_3_BED_LIGHT_OFF = 97
+        # Extended presets
+        preset_book=0xA0,    # SEAT_3_BOOK = 160
+        preset_leisure=0xA3,  # SEAT_3_LEISURE = 163
+        # Massage
+        massage_mode_1=0x6D,  # SEAT_3_MASSAGE_MODE1 = 109
+        massage_mode_2=0x70,  # SEAT_3_MASSAGE_MODE2 = 112
+        massage_mode_3=0x73,  # SEAT_3_MASSAGE_MODE3 = 115
     ),
 }
+
+# seat_1_2 uses seat_1 as primary — dual-bed sending is handled by the controller
+KAIDI_COMMAND_PROFILES[KAIDI_VARIANT_SEAT_1_2] = KaidiCommandProfile(
+    variant=KAIDI_VARIANT_SEAT_1_2,
+    **{
+        f.name: getattr(KAIDI_COMMAND_PROFILES[KAIDI_VARIANT_SEAT_1], f.name)
+        for f in KaidiCommandProfile.__dataclass_fields__.values()
+        if f.name != "variant"
+    },
+)
+
+# Scalar command fields used to build the dual-bed command map.
+_PROFILE_SCALAR_FIELDS: tuple[str, ...] = (
+    "head_up", "head_down", "head_stop",
+    "foot_up", "foot_down", "foot_stop",
+    "stop_all",
+    "preset_flat", "preset_zero_g", "preset_anti_snore",
+    "back_up", "back_down", "back_stop",
+    "waist_up", "waist_down", "waist_stop",
+    "neck_up", "neck_down", "neck_stop",
+    "all_up", "all_down", "all_stop",
+    "new_all_up", "new_all_down", "new_all_stop",
+    "light_on", "light_off",
+    "preset_book", "preset_leisure",
+    "massage_mode_1", "massage_mode_2", "massage_mode_3",
+)
+
+
+def _build_dual_command_map(
+    primary: KaidiCommandProfile,
+    secondary: KaidiCommandProfile,
+) -> dict[int, int]:
+    """Build a mapping from primary command IDs to secondary command IDs.
+
+    Used by seat_1_2 to also send the seat_2 equivalent of every seat_1 command
+    so that both sides of a split/dual bed move together.
+    """
+    mapping: dict[int, int] = {}
+    for field_name in _PROFILE_SCALAR_FIELDS:
+        p = getattr(primary, field_name, None)
+        s = getattr(secondary, field_name, None)
+        if p is not None and s is not None:
+            mapping[p] = s
+    for slot, p_cmd in primary.memory_save.items():
+        s_cmd = secondary.memory_save.get(slot)
+        if s_cmd is not None:
+            mapping[p_cmd] = s_cmd
+    for slot, p_cmd in primary.memory_recall.items():
+        s_cmd = secondary.memory_recall.get(slot)
+        if s_cmd is not None:
+            mapping[p_cmd] = s_cmd
+    return mapping
 
 
 class KaidiController(BedController):
@@ -183,6 +374,15 @@ class KaidiController(BedController):
         self._variant = variant
         self._variant_source = variant_source
         self._command_profile = KAIDI_COMMAND_PROFILES[variant]
+
+        # For dual beds (seat_1_2), build a map from seat_1 → seat_2 commands
+        if variant == KAIDI_VARIANT_SEAT_1_2:
+            self._dual_map = _build_dual_command_map(
+                KAIDI_COMMAND_PROFILES[KAIDI_VARIANT_SEAT_1],
+                KAIDI_COMMAND_PROFILES[KAIDI_VARIANT_SEAT_2],
+            )
+        else:
+            self._dual_map: dict[int, int] = {}
 
         self._notify_started = False
         self._session_ready = False
@@ -257,6 +457,21 @@ class KaidiController(BedController):
                 self._coordinator.address,
             )
 
+    # ------------------------------------------------------------------
+    # Product family helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def _product_family(self) -> KaidiProductFamily:
+        """Return the capability set for this bed's product ID."""
+        if self._product_id is not None:
+            return KAIDI_PRODUCT_FAMILIES.get(self._product_id, _DEFAULT_PRODUCT_FAMILY)
+        return _DEFAULT_PRODUCT_FAMILY
+
+    # ------------------------------------------------------------------
+    # Capability properties
+    # ------------------------------------------------------------------
+
     @property
     def control_characteristic_uuid(self) -> str:
         """Return the UUID of the control characteristic."""
@@ -276,15 +491,26 @@ class KaidiController(BedController):
 
     @property
     def supports_memory_presets(self) -> bool:
-        return self._command_profile.memory_recall is not None
+        return bool(self._command_profile.memory_recall)
 
     @property
     def memory_slot_count(self) -> int:
-        return len(self._command_profile.memory_recall or {})
+        return len(self._command_profile.memory_recall)
 
     @property
     def supports_memory_programming(self) -> bool:
-        return self._command_profile.memory_save is not None
+        return bool(self._command_profile.memory_save)
+
+    @property
+    def supports_lights(self) -> bool:
+        return (
+            self._command_profile.light_on is not None
+            and self._product_family.has_lights
+        )
+
+    # ------------------------------------------------------------------
+    # BLE transport
+    # ------------------------------------------------------------------
 
     def _refresh_write_mode(self) -> None:
         """Refresh write mode from discovered GATT characteristics when available."""
@@ -529,6 +755,10 @@ class KaidiController(BedController):
                 self._target_vaddr,
             )
 
+    # ------------------------------------------------------------------
+    # Command helpers
+    # ------------------------------------------------------------------
+
     async def write_command(
         self,
         command: bytes,
@@ -556,7 +786,11 @@ class KaidiController(BedController):
         repeat_delay_ms: int = 100,
         cancel_event: asyncio.Event | None = None,
     ) -> None:
-        """Build and send a Kaidi control command."""
+        """Build and send a Kaidi control command.
+
+        For dual-bed variants (seat_1_2), also sends the seat_2 equivalent so
+        both sides of a split bed move together.
+        """
         await self._ensure_session_ready()
         await self._write_gatt_with_retry(
             KAIDI_WRITE_CHAR_UUID,
@@ -566,6 +800,16 @@ class KaidiController(BedController):
             cancel_event=cancel_event,
             response=self._write_with_response,
         )
+        secondary_id = self._dual_map.get(command_id)
+        if secondary_id is not None:
+            await self._write_gatt_with_retry(
+                KAIDI_WRITE_CHAR_UUID,
+                self._build_control_packet(secondary_id, param=param),
+                repeat_count=repeat_count,
+                repeat_delay_ms=repeat_delay_ms,
+                cancel_event=cancel_event,
+                response=self._write_with_response,
+            )
 
     async def start_notify(
         self,
@@ -588,6 +832,10 @@ class KaidiController(BedController):
         await self.client.stop_notify(KAIDI_NOTIFY_CHAR_UUID)
         self._notify_started = False
 
+    # ------------------------------------------------------------------
+    # Movement helpers
+    # ------------------------------------------------------------------
+
     async def _move_with_stop_command(self, move_command: int, stop_command: int) -> None:
         """Send a movement command, then stop that motor."""
         try:
@@ -605,9 +853,9 @@ class KaidiController(BedController):
             except ConnectionError:
                 _LOGGER.debug("Kaidi cleanup stop skipped because device disconnected")
 
-    def _require_memory_command(self, command_map: dict[int, int] | None, memory_num: int) -> int:
+    def _require_memory_command(self, command_map: dict[int, int], memory_num: int) -> int:
         """Resolve a Kaidi memory command or raise a helpful error."""
-        if command_map is None:
+        if not command_map:
             raise NotImplementedError(
                 f"Kaidi variant {self._variant} does not expose memory presets"
             )
@@ -623,6 +871,10 @@ class KaidiController(BedController):
                 f"Kaidi variant {self._variant} does not support {label}"
             )
         await self._write_control_command(command_id)
+
+    # ------------------------------------------------------------------
+    # Core motor methods (all beds)
+    # ------------------------------------------------------------------
 
     async def move_head_up(self) -> None:
         await self._move_with_stop_command(
@@ -643,13 +895,25 @@ class KaidiController(BedController):
         )
 
     async def move_back_up(self) -> None:
-        await self.move_head_up()
+        p = self._command_profile
+        if p.back_up is not None and self._product_family.has_back:
+            await self._move_with_stop_command(p.back_up, p.back_stop)
+        else:
+            await self.move_head_up()
 
     async def move_back_down(self) -> None:
-        await self.move_head_down()
+        p = self._command_profile
+        if p.back_down is not None and self._product_family.has_back:
+            await self._move_with_stop_command(p.back_down, p.back_stop)
+        else:
+            await self.move_head_down()
 
     async def move_back_stop(self) -> None:
-        await self.move_head_stop()
+        p = self._command_profile
+        if p.back_stop is not None and self._product_family.has_back:
+            await self._write_control_command(p.back_stop, cancel_event=asyncio.Event())
+        else:
+            await self.move_head_stop()
 
     async def move_legs_up(self) -> None:
         await self._move_with_stop_command(
@@ -689,6 +953,10 @@ class KaidiController(BedController):
         await self.move_head_stop()
         await self.move_legs_stop()
 
+    # ------------------------------------------------------------------
+    # Presets
+    # ------------------------------------------------------------------
+
     async def preset_flat(self) -> None:
         await self._write_optional_control_command(
             self._command_profile.preset_flat,
@@ -720,3 +988,28 @@ class KaidiController(BedController):
             memory_num,
         )
         await self._write_control_command(command_id)
+
+    # ------------------------------------------------------------------
+    # Lights
+    # ------------------------------------------------------------------
+
+    async def lights_on(self) -> None:
+        await self._write_optional_control_command(
+            self._command_profile.light_on,
+            "lights",
+        )
+
+    async def lights_off(self) -> None:
+        await self._write_optional_control_command(
+            self._command_profile.light_off,
+            "lights",
+        )
+
+    # ------------------------------------------------------------------
+    # Massage
+    # ------------------------------------------------------------------
+
+    async def massage_toggle(self) -> None:
+        """Cycle through massage modes (mode 1 → 2 → 3 → off)."""
+        if self._command_profile.massage_mode_1 is not None:
+            await self._write_control_command(self._command_profile.massage_mode_1)

--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -40,6 +40,7 @@ from .diagnostic_payloads import (
     payload_ascii_preview,
     summarize_repeated_payloads,
 )
+from .kaidi_protocol import extract_kaidi_advertisement, kaidi_advertisement_to_dict
 
 if TYPE_CHECKING:
     from .coordinator import AdjustableBedCoordinator
@@ -769,7 +770,7 @@ class BLEDiagnosticRunner:
         selected_for_connection: bool,
     ) -> dict[str, Any]:
         """Convert a Bluetooth service snapshot to a dictionary."""
-        return {
+        snapshot = {
             "captured_at": datetime.now(UTC).isoformat(),
             "address": service_info.address.upper(),
             "name": service_info.name,
@@ -785,6 +786,10 @@ class BLEDiagnosticRunner:
                 selected_for_connection and self._using_non_connectable_fallback
             ),
         }
+        kaidi_advertisement = extract_kaidi_advertisement(service_info.manufacturer_data)
+        if kaidi_advertisement is not None:
+            snapshot["kaidi"] = kaidi_advertisement_to_dict(kaidi_advertisement)
+        return snapshot
 
     def _build_device_section(self, service_info: Any | None) -> dict[str, Any]:
         """Build enriched device and backend info."""
@@ -958,5 +963,4 @@ class BLEDiagnosticRunner:
         if isinstance(value, (list, tuple, set)):
             return [self._serialize_value(item) for item in value]
         return str(value)
-
 

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -67,6 +67,11 @@ CONF_BACK_MAX_ANGLE: Final = "back_max_angle"
 CONF_LEGS_MAX_ANGLE: Final = "legs_max_angle"
 CONF_KAIDI_ROOM_ID: Final = "kaidi_room_id"
 CONF_KAIDI_TARGET_VADDR: Final = "kaidi_target_vaddr"
+CONF_KAIDI_PRODUCT_ID: Final = "kaidi_product_id"
+CONF_KAIDI_SOFA_ACU_NO: Final = "kaidi_sofa_acu_no"
+CONF_KAIDI_ADV_TYPE: Final = "kaidi_adv_type"
+CONF_KAIDI_RESOLVED_VARIANT: Final = "kaidi_resolved_variant"
+CONF_KAIDI_VARIANT_SOURCE: Final = "kaidi_variant_source"
 
 # Default angle limits (from Linak beds)
 DEFAULT_BACK_MAX_ANGLE: Final = 68.0
@@ -360,10 +365,10 @@ TIMOTION_AHF_WRITE_CHAR_UUID: Final = NORDIC_UART_WRITE_CHAR_UUID
 TIMOTION_AHF_NOTIFY_CHAR_UUID: Final = NORDIC_UART_READ_CHAR_UUID
 
 # Kaidi custom mesh-over-GATT protocol (Rize/Floyd/ISleep)
-# The bed advertises FFC0 service UUID, name "Mouselet", and manufacturer data
-# with BLE Company ID 0xFFFF and marker 0xC0FF. The OEM app discovers purely by
-# manufacturer data, but the other signals are present and useful for HA discovery.
-# The actual command transport is on the 9e5d1e47-... service/characteristics.
+# Discovery is driven primarily by manufacturer data with BLE Company ID 0xFFFF
+# and marker 0xC0FF. Some devices also surface the "Mouselet" name and/or the
+# FFC0 discovery UUID, but those are supporting signals rather than the source
+# of truth. The actual command transport is on the 9e5d1e47-... service.
 KAIDI_MANUFACTURER_COMPANY_ID: Final = 0xFFFF
 KAIDI_DISCOVERY_SERVICE_UUID: Final = "0000ffc0-0000-1000-8000-00805f9b34fb"
 KAIDI_MESH_SERVICE_UUID: Final = "9e5d1e47-5c13-43a0-8635-82adffc0386f"
@@ -779,6 +784,23 @@ REMACRO_READ_CHAR_UUID: Final = "6e403589-b5a3-f393-e0a9-e50e24dcca9e"
 
 # Protocol variants
 VARIANT_AUTO: Final = "auto"
+
+# Kaidi variants
+KAIDI_VARIANT_SEAT_1: Final = "seat_1"
+KAIDI_VARIANT_SEAT_2: Final = "seat_2"
+KAIDI_VARIANT_SEAT_3: Final = "seat_3"
+KAIDI_VARIANT_BED_1: Final = "bed_1"
+KAIDI_VARIANT_BED_2: Final = "bed_2"
+KAIDI_VARIANT_BED_12: Final = "bed_12"
+KAIDI_VARIANTS: Final = {
+    VARIANT_AUTO: "Auto-detect (recommended)",
+    KAIDI_VARIANT_SEAT_1: "Seat 1 (single base / legacy)",
+    KAIDI_VARIANT_SEAT_2: "Seat 2",
+    KAIDI_VARIANT_SEAT_3: "Seat 3",
+    KAIDI_VARIANT_BED_1: "Bed 1",
+    KAIDI_VARIANT_BED_2: "Bed 2",
+    KAIDI_VARIANT_BED_12: "Bed 1+2",
+}
 
 # OKIN CB24 profile variants (SmartBed app device profiles)
 # Source: com.okin.bedding.smartbedwifi model/device/*
@@ -1249,6 +1271,12 @@ OKIN_64BIT_VARIANTS: Final = {
 # All protocol variants (for validation)
 ALL_PROTOCOL_VARIANTS: Final = [
     VARIANT_AUTO,
+    KAIDI_VARIANT_SEAT_1,
+    KAIDI_VARIANT_SEAT_2,
+    KAIDI_VARIANT_SEAT_3,
+    KAIDI_VARIANT_BED_1,
+    KAIDI_VARIANT_BED_2,
+    KAIDI_VARIANT_BED_12,
     OKIN_CB24_VARIANT_OLD,
     OKIN_CB24_VARIANT_NEW,
     OKIN_CB24_VARIANT_CB24,

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -785,21 +785,19 @@ REMACRO_READ_CHAR_UUID: Final = "6e403589-b5a3-f393-e0a9-e50e24dcca9e"
 # Protocol variants
 VARIANT_AUTO: Final = "auto"
 
-# Kaidi variants
+# Kaidi variants — all OEM apps use SEAT_* commands exclusively.
+# BED_* constants from PLDataTrans.java are legacy/enterprise firmware and are
+# NOT used by any consumer mobile app (Rize, Floyd, ISleep).
 KAIDI_VARIANT_SEAT_1: Final = "seat_1"
 KAIDI_VARIANT_SEAT_2: Final = "seat_2"
 KAIDI_VARIANT_SEAT_3: Final = "seat_3"
-KAIDI_VARIANT_BED_1: Final = "bed_1"
-KAIDI_VARIANT_BED_2: Final = "bed_2"
-KAIDI_VARIANT_BED_12: Final = "bed_12"
+KAIDI_VARIANT_SEAT_1_2: Final = "seat_1_2"
 KAIDI_VARIANTS: Final = {
     VARIANT_AUTO: "Auto-detect (recommended)",
-    KAIDI_VARIANT_SEAT_1: "Seat 1 (single base / legacy)",
+    KAIDI_VARIANT_SEAT_1: "Seat 1 (single base)",
     KAIDI_VARIANT_SEAT_2: "Seat 2",
     KAIDI_VARIANT_SEAT_3: "Seat 3",
-    KAIDI_VARIANT_BED_1: "Bed 1",
-    KAIDI_VARIANT_BED_2: "Bed 2",
-    KAIDI_VARIANT_BED_12: "Bed 1+2",
+    KAIDI_VARIANT_SEAT_1_2: "Seat 1+2 (split/dual base)",
 }
 
 # OKIN CB24 profile variants (SmartBed app device profiles)
@@ -1274,9 +1272,7 @@ ALL_PROTOCOL_VARIANTS: Final = [
     KAIDI_VARIANT_SEAT_1,
     KAIDI_VARIANT_SEAT_2,
     KAIDI_VARIANT_SEAT_3,
-    KAIDI_VARIANT_BED_1,
-    KAIDI_VARIANT_BED_2,
-    KAIDI_VARIANT_BED_12,
+    KAIDI_VARIANT_SEAT_1_2,
     OKIN_CB24_VARIANT_OLD,
     OKIN_CB24_VARIANT_NEW,
     OKIN_CB24_VARIANT_CB24,

--- a/custom_components/adjustable_bed/controller_factory.py
+++ b/custom_components/adjustable_bed/controller_factory.py
@@ -57,6 +57,8 @@ from .const import (
     BED_TYPE_TIMOTION_AHF,
     BED_TYPE_VIBRADORM,
     CB1322_MANUFACTURER_MARKERS,
+    CONF_KAIDI_PRODUCT_ID,
+    CONF_KAIDI_SOFA_ACU_NO,
     KEESON_BETTERLIVING_SERVICE_UUIDS,
     KEESON_FALLBACK_GATT_PAIRS,
     KEESON_SINO_NAME_PATTERNS,
@@ -89,6 +91,8 @@ from .const import (
     SBI_VARIANT_BOTH,
     VARIANT_AUTO,
 )
+from .kaidi_protocol import extract_kaidi_advertisement
+from .kaidi_variants import resolve_kaidi_variant
 
 if TYPE_CHECKING:
     from bleak import BleakClient
@@ -224,10 +228,33 @@ async def create_controller(
     if bed_type == BED_TYPE_KAIDI:
         from .beds.kaidi import KaidiController
 
+        advertisement = extract_kaidi_advertisement(manufacturer_data)
+        entry_data = getattr(getattr(coordinator, "entry", None), "data", {})
+        resolution = resolve_kaidi_variant(
+            protocol_variant or VARIANT_AUTO,
+            product_id=(
+                advertisement.product_id
+                if advertisement is not None and advertisement.product_id is not None
+                else entry_data.get(CONF_KAIDI_PRODUCT_ID)
+            ),
+            sofa_acu_no=(
+                advertisement.sofa_acu_no
+                if advertisement is not None and advertisement.sofa_acu_no is not None
+                else entry_data.get(CONF_KAIDI_SOFA_ACU_NO)
+            ),
+        )
+        if resolution.variant is None:
+            raise ValueError(
+                "Kaidi product metadata could not be mapped to a command family. "
+                "Select a Kaidi protocol variant manually in options."
+            )
+
         return KaidiController(
             coordinator,
             device_name=device_name,
             manufacturer_data=manufacturer_data,
+            variant=resolution.variant,
+            variant_source=resolution.source,
         )
 
     if bed_type == BED_TYPE_OKIN_CB24:
@@ -269,7 +296,8 @@ async def create_controller(
             }
         )
         initial_continuous_presets = (
-            adaptive_preset_fallback and coordinator.cb24_continuous_presets_learned
+            adaptive_preset_fallback
+            and getattr(coordinator, "cb24_continuous_presets_learned", False)
         )
 
         if initial_continuous_presets:

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -419,11 +419,15 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
     _LOGGER.debug("  Service UUIDs: %s", service_uuids)
     _LOGGER.debug("  Manufacturer data: %s", service_info.manufacturer_data)
 
+    # Parse Kaidi metadata up front so validated Kaidi advertisements are not
+    # discarded by the generic "mouse" exclusion before protocol detection.
+    kaidi_adv = extract_kaidi_advertisement(service_info.manufacturer_data)
+
     # Exclude devices that are clearly not beds based on name, but only when
     # they have generic/shared UUIDs. This preserves UUID-based detection for
     # beds with unique service UUIDs (e.g., a hypothetical "Linak Band" bed
     # with Linak's unique UUID would not be excluded by the "band" pattern).
-    if _has_only_generic_uuids(service_uuids):
+    if _has_only_generic_uuids(service_uuids) and kaidi_adv is None:
         for pattern in EXCLUDED_DEVICE_PATTERNS:
             if pattern in device_name:
                 _LOGGER.debug(
@@ -458,7 +462,6 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
     # Company ID 0xFFFF / marker 0xC0FF. Manufacturer data alone is sufficient
     # for detection (matches the OEM app's discovery), but the other signals
     # boost confidence when present.
-    kaidi_adv = extract_kaidi_advertisement(service_info.manufacturer_data)
     has_kaidi_uuid = (
         KAIDI_DISCOVERY_SERVICE_UUID.lower() in service_uuids
         or KAIDI_MESH_SERVICE_UUID.lower() in service_uuids

--- a/custom_components/adjustable_bed/diagnostics.py
+++ b/custom_components/adjustable_bed/diagnostics.py
@@ -15,6 +15,13 @@ from .const import (
     CONF_BED_TYPE,
     CONF_DISABLE_ANGLE_SENSING,
     CONF_HAS_MASSAGE,
+    CONF_KAIDI_ADV_TYPE,
+    CONF_KAIDI_PRODUCT_ID,
+    CONF_KAIDI_RESOLVED_VARIANT,
+    CONF_KAIDI_ROOM_ID,
+    CONF_KAIDI_SOFA_ACU_NO,
+    CONF_KAIDI_TARGET_VADDR,
+    CONF_KAIDI_VARIANT_SOURCE,
     CONF_MOTOR_COUNT,
     CONF_PREFERRED_ADAPTER,
     CONF_PROTOCOL_VARIANT,
@@ -23,6 +30,7 @@ from .const import (
 )
 from .coordinator import AdjustableBedCoordinator
 from .diagnostics_utils import get_gatt_summary
+from .kaidi_protocol import extract_kaidi_advertisement, kaidi_advertisement_to_dict
 from .redaction import redact_data
 
 
@@ -70,6 +78,8 @@ async def async_get_config_entry_diagnostics(
             controller_info["richmat_is_wilinke"] = controller._is_wilinke
         if hasattr(controller, "_variant"):
             controller_info["variant"] = controller._variant
+        if hasattr(controller, "_variant_source"):
+            controller_info["variant_source"] = controller._variant_source
         if hasattr(controller, "_char_uuid"):
             controller_info["char_uuid"] = controller._char_uuid
 
@@ -100,6 +110,9 @@ async def async_get_config_entry_diagnostics(
             ),
             "connectable": service_info_connectable,
         }
+        kaidi_advertisement = extract_kaidi_advertisement(service_info.manufacturer_data)
+        if kaidi_advertisement is not None:
+            advertisement_info["kaidi"] = kaidi_advertisement_to_dict(kaidi_advertisement)
         if hasattr(service_info, "source"):
             advertisement_info["source"] = service_info.source
 
@@ -123,6 +136,13 @@ async def async_get_config_entry_diagnostics(
             "has_massage": entry.data.get(CONF_HAS_MASSAGE),
             "disable_angle_sensing": entry.data.get(CONF_DISABLE_ANGLE_SENSING),
             "preferred_adapter": entry.data.get(CONF_PREFERRED_ADAPTER),
+            "kaidi_room_id": entry.data.get(CONF_KAIDI_ROOM_ID),
+            "kaidi_target_vaddr": entry.data.get(CONF_KAIDI_TARGET_VADDR),
+            "kaidi_product_id": entry.data.get(CONF_KAIDI_PRODUCT_ID),
+            "kaidi_sofa_acu_no": entry.data.get(CONF_KAIDI_SOFA_ACU_NO),
+            "kaidi_adv_type": entry.data.get(CONF_KAIDI_ADV_TYPE),
+            "kaidi_resolved_variant": entry.data.get(CONF_KAIDI_RESOLVED_VARIANT),
+            "kaidi_variant_source": entry.data.get(CONF_KAIDI_VARIANT_SOURCE),
         },
         "coordinator": {
             "is_connected": is_connected,

--- a/custom_components/adjustable_bed/kaidi_metadata.py
+++ b/custom_components/adjustable_bed/kaidi_metadata.py
@@ -8,8 +8,17 @@ from typing import Any
 from homeassistant.components import bluetooth
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_KAIDI_ROOM_ID, CONF_KAIDI_TARGET_VADDR
+from .const import (
+    CONF_KAIDI_ADV_TYPE,
+    CONF_KAIDI_PRODUCT_ID,
+    CONF_KAIDI_RESOLVED_VARIANT,
+    CONF_KAIDI_ROOM_ID,
+    CONF_KAIDI_SOFA_ACU_NO,
+    CONF_KAIDI_TARGET_VADDR,
+    CONF_KAIDI_VARIANT_SOURCE,
+)
 from .kaidi_protocol import KaidiAdvertisement, extract_best_kaidi_advertisement
+from .kaidi_variants import resolve_kaidi_variant_from_entry_data
 
 
 def resolve_kaidi_advertisement(
@@ -53,11 +62,23 @@ def add_kaidi_entry_metadata(
     updated = dict(entry_data)
 
     if advertisement is None:
-        return updated
+        resolution = resolve_kaidi_variant_from_entry_data(updated)
+    else:
+        updated[CONF_KAIDI_ADV_TYPE] = advertisement.adv_type
+        if advertisement.room_id is not None:
+            updated[CONF_KAIDI_ROOM_ID] = advertisement.room_id
+        if advertisement.vaddr is not None:
+            updated[CONF_KAIDI_TARGET_VADDR] = advertisement.vaddr
+        if advertisement.product_id is not None:
+            updated[CONF_KAIDI_PRODUCT_ID] = advertisement.product_id
+        if advertisement.sofa_acu_no is not None:
+            updated[CONF_KAIDI_SOFA_ACU_NO] = advertisement.sofa_acu_no
+        resolution = resolve_kaidi_variant_from_entry_data(updated)
 
-    if advertisement.room_id is not None:
-        updated[CONF_KAIDI_ROOM_ID] = advertisement.room_id
-    if advertisement.vaddr is not None:
-        updated[CONF_KAIDI_TARGET_VADDR] = advertisement.vaddr
+    updated[CONF_KAIDI_VARIANT_SOURCE] = resolution.source
+    if resolution.variant is not None:
+        updated[CONF_KAIDI_RESOLVED_VARIANT] = resolution.variant
+    else:
+        updated.pop(CONF_KAIDI_RESOLVED_VARIANT, None)
 
     return updated

--- a/custom_components/adjustable_bed/kaidi_protocol.py
+++ b/custom_components/adjustable_bed/kaidi_protocol.py
@@ -31,7 +31,31 @@ class KaidiAdvertisement:
     room_id: int | None = None
     vaddr: int | None = None
     sofa_type: int | None = None
+    sofa_acu_no: int | None = None
+    product_id: int | None = None
     company_id: int | None = None
+
+
+@dataclass(frozen=True)
+class KaidiSeatBars:
+    """Decoded seat-bar counts from Kaidi's sofaAcuNo field."""
+
+    seat_1: int
+    seat_2: int
+    seat_3: int
+    is_store: bool
+
+    @property
+    def populated_seats(self) -> tuple[int, ...]:
+        """Return seat indexes that advertise at least one actuator bar."""
+        populated: list[int] = []
+        if self.seat_1 > 0:
+            populated.append(1)
+        if self.seat_2 > 0:
+            populated.append(2)
+        if self.seat_3 > 0:
+            populated.append(3)
+        return tuple(populated)
 
 
 def _le_u16(data: bytes) -> int:
@@ -42,6 +66,42 @@ def _le_u16(data: bytes) -> int:
 def _le_u32(data: bytes) -> int:
     """Parse a little-endian 32-bit integer."""
     return int.from_bytes(data[:4], "little")
+
+
+def _be_u16(data: bytes) -> int:
+    """Parse a big-endian 16-bit integer."""
+    return int.from_bytes(data[:2], "big")
+
+
+def decode_kaidi_sofa_acu_no(sofa_acu_no: int | None) -> KaidiSeatBars | None:
+    """Decode Kaidi's sofaAcuNo bitfield into per-seat actuator bars."""
+    if sofa_acu_no is None:
+        return None
+
+    return KaidiSeatBars(
+        seat_1=sofa_acu_no & 0x0F,
+        seat_2=(sofa_acu_no & 0x00F0) >> 4,
+        seat_3=(sofa_acu_no & 0x0F00) >> 8,
+        is_store=((sofa_acu_no & 0xF000) >> 12) != 0,
+    )
+
+
+def kaidi_advertisement_to_dict(advertisement: KaidiAdvertisement) -> dict[str, int | bool | None]:
+    """Serialize parsed Kaidi advertisement data for diagnostics output."""
+    seat_bars = decode_kaidi_sofa_acu_no(advertisement.sofa_acu_no)
+    return {
+        "adv_type": advertisement.adv_type,
+        "room_id": advertisement.room_id,
+        "vaddr": advertisement.vaddr,
+        "sofa_type": advertisement.sofa_type,
+        "sofa_acu_no": advertisement.sofa_acu_no,
+        "product_id": advertisement.product_id,
+        "company_id": advertisement.company_id,
+        "seat_1_bars": seat_bars.seat_1 if seat_bars else None,
+        "seat_2_bars": seat_bars.seat_2 if seat_bars else None,
+        "seat_3_bars": seat_bars.seat_3 if seat_bars else None,
+        "is_store": seat_bars.is_store if seat_bars else None,
+    }
 
 
 def normalize_kaidi_manufacturer_payload(payload: bytes) -> bytes | None:
@@ -76,10 +136,14 @@ def parse_kaidi_manufacturer_payload(payload: bytes) -> KaidiAdvertisement | Non
     if adv_type == KAIDI_ADV_TYPE_SINGLE:
         if len(normalized) < 18:
             return None
+        sofa_type = normalized[9]
+        sofa_acu_no = _be_u16(normalized[10:12])
         return KaidiAdvertisement(
             adv_type=adv_type,
             room_id=_le_u32(normalized[5:9]),
-            sofa_type=normalized[9],
+            sofa_type=sofa_type,
+            sofa_acu_no=sofa_acu_no,
+            product_id=sofa_type,
         )
 
     if adv_type == KAIDI_ADV_TYPE_BROADCAST:
@@ -87,25 +151,34 @@ def parse_kaidi_manufacturer_payload(payload: bytes) -> KaidiAdvertisement | Non
             return None
 
         sofa_type: int | None = None
+        sofa_acu_no: int | None = None
         if len(normalized) >= 21 and normalized[20] in (0xA0, 0xA1):
             sofa_type = normalized[17]
+            sofa_acu_no = _be_u16(normalized[18:20])
         elif len(normalized) >= 28:
             sofa_type = normalized[25]
+            sofa_acu_no = _be_u16(normalized[26:28])
 
         return KaidiAdvertisement(
             adv_type=adv_type,
             room_id=_le_u32(normalized[5:9]),
             vaddr=_le_u32(normalized[21:25]),
             sofa_type=sofa_type,
+            sofa_acu_no=sofa_acu_no,
+            product_id=sofa_type,
         )
 
     if adv_type == KAIDI_ADV_TYPE_DISCOVERABLE:
         if len(normalized) < 18:
             return None
+        sofa_type = normalized[15]
+        sofa_acu_no = _be_u16(normalized[16:18])
         return KaidiAdvertisement(
             adv_type=adv_type,
             company_id=_le_u16(normalized[11:13]),
-            sofa_type=normalized[15],
+            sofa_type=sofa_type,
+            sofa_acu_no=sofa_acu_no,
+            product_id=sofa_type,
         )
 
     return KaidiAdvertisement(adv_type=adv_type)
@@ -159,6 +232,16 @@ def merge_kaidi_advertisements(
             room_id=merged.room_id if merged.room_id is not None else advertisement.room_id,
             vaddr=merged.vaddr if merged.vaddr is not None else advertisement.vaddr,
             sofa_type=merged.sofa_type if merged.sofa_type is not None else advertisement.sofa_type,
+            sofa_acu_no=(
+                merged.sofa_acu_no
+                if merged.sofa_acu_no is not None
+                else advertisement.sofa_acu_no
+            ),
+            product_id=(
+                merged.product_id
+                if merged.product_id is not None
+                else advertisement.product_id
+            ),
             company_id=(
                 merged.company_id
                 if merged.company_id is not None

--- a/custom_components/adjustable_bed/kaidi_variants.py
+++ b/custom_components/adjustable_bed/kaidi_variants.py
@@ -1,0 +1,137 @@
+"""Kaidi variant selection helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .const import (
+    CONF_KAIDI_PRODUCT_ID,
+    CONF_KAIDI_SOFA_ACU_NO,
+    CONF_PROTOCOL_VARIANT,
+    KAIDI_VARIANT_BED_1,
+    KAIDI_VARIANT_BED_12,
+    KAIDI_VARIANT_BED_2,
+    KAIDI_VARIANT_SEAT_1,
+    KAIDI_VARIANT_SEAT_2,
+    KAIDI_VARIANT_SEAT_3,
+    VARIANT_AUTO,
+)
+from .kaidi_protocol import KaidiSeatBars, decode_kaidi_sofa_acu_no
+
+KAIDI_MANUAL_VARIANTS: frozenset[str] = frozenset(
+    {
+        KAIDI_VARIANT_SEAT_1,
+        KAIDI_VARIANT_SEAT_2,
+        KAIDI_VARIANT_SEAT_3,
+        KAIDI_VARIANT_BED_1,
+        KAIDI_VARIANT_BED_2,
+        KAIDI_VARIANT_BED_12,
+    }
+)
+
+# Product IDs exposed by the OEM APKs as explicit bed types.
+# `MainActivity.getProductId()` only returns these IDs directly for the Kaidi
+# bed family; everything else is either a sofa-style type (100-102) or `0`.
+KAIDI_SINGLE_PRODUCT_IDS: frozenset[int] = frozenset({129, 131, 132, 142})
+KAIDI_DOUBLE_PRODUCT_IDS: frozenset[int] = frozenset({130, 133, 134, 143})
+
+
+@dataclass(frozen=True, slots=True)
+class KaidiVariantResolution:
+    """Result of resolving a Kaidi profile variant."""
+
+    variant: str | None
+    source: str
+    product_id: int | None
+    sofa_acu_no: int | None
+    seat_bars: KaidiSeatBars | None
+
+
+def _coerce_int(value: Any) -> int | None:
+    """Return an integer value when the input is already int-like."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def resolve_kaidi_variant(
+    protocol_variant: str | None,
+    *,
+    product_id: int | None = None,
+    sofa_acu_no: int | None = None,
+) -> KaidiVariantResolution:
+    """Resolve the effective Kaidi command family."""
+    seat_bars = decode_kaidi_sofa_acu_no(sofa_acu_no)
+
+    if protocol_variant in KAIDI_MANUAL_VARIANTS:
+        return KaidiVariantResolution(
+            variant=protocol_variant,
+            source="manual_override",
+            product_id=product_id,
+            sofa_acu_no=sofa_acu_no,
+            seat_bars=seat_bars,
+        )
+
+    if product_id in KAIDI_SINGLE_PRODUCT_IDS:
+        return KaidiVariantResolution(
+            variant=KAIDI_VARIANT_SEAT_1,
+            source="product_id",
+            product_id=product_id,
+            sofa_acu_no=sofa_acu_no,
+            seat_bars=seat_bars,
+        )
+
+    if product_id in KAIDI_DOUBLE_PRODUCT_IDS:
+        return KaidiVariantResolution(
+            variant=KAIDI_VARIANT_BED_12,
+            source="product_id",
+            product_id=product_id,
+            sofa_acu_no=sofa_acu_no,
+            seat_bars=seat_bars,
+        )
+
+    if seat_bars is not None and len(seat_bars.populated_seats) == 1:
+        seat_variant = {
+            1: KAIDI_VARIANT_SEAT_1,
+            2: KAIDI_VARIANT_SEAT_2,
+            3: KAIDI_VARIANT_SEAT_3,
+        }[seat_bars.populated_seats[0]]
+        return KaidiVariantResolution(
+            variant=seat_variant,
+            source="sofa_acu_no",
+            product_id=product_id,
+            sofa_acu_no=sofa_acu_no,
+            seat_bars=seat_bars,
+        )
+
+    if product_id is not None or sofa_acu_no is not None:
+        return KaidiVariantResolution(
+            variant=None,
+            source="unresolved_metadata",
+            product_id=product_id,
+            sofa_acu_no=sofa_acu_no,
+            seat_bars=seat_bars,
+        )
+
+    return KaidiVariantResolution(
+        variant=KAIDI_VARIANT_SEAT_1,
+        source="legacy_fallback",
+        product_id=None,
+        sofa_acu_no=None,
+        seat_bars=None,
+    )
+
+
+def resolve_kaidi_variant_from_entry_data(
+    entry_data: Mapping[str, Any],
+    protocol_variant: str | None = None,
+) -> KaidiVariantResolution:
+    """Resolve a Kaidi variant from config-entry metadata."""
+    return resolve_kaidi_variant(
+        protocol_variant or entry_data.get(CONF_PROTOCOL_VARIANT, VARIANT_AUTO),
+        product_id=_coerce_int(entry_data.get(CONF_KAIDI_PRODUCT_ID)),
+        sofa_acu_no=_coerce_int(entry_data.get(CONF_KAIDI_SOFA_ACU_NO)),
+    )

--- a/custom_components/adjustable_bed/kaidi_variants.py
+++ b/custom_components/adjustable_bed/kaidi_variants.py
@@ -30,6 +30,10 @@ KAIDI_MANUAL_VARIANTS: frozenset[str] = frozenset(
 # All three apps use ONLY SEAT_* commands.  Single-base products use seat_1,
 # dual-base products use seat_1 + seat_2 (seat_1_2).
 #
+# IDs 140-141 do not appear in any of the three APK versions and are
+# intentionally omitted.  Devices with unmapped IDs fall through to the
+# sofa_acu_no seat-bar heuristic or resolve to "unresolved_metadata".
+#
 # ID  | Name              | App         | bedUI | Classification
 # ----|-------------------|-------------|-------|---------------
 # 129 | BED_TYPE_SINGLE   | All         | 2     | seat_1

--- a/custom_components/adjustable_bed/kaidi_variants.py
+++ b/custom_components/adjustable_bed/kaidi_variants.py
@@ -9,10 +9,8 @@ from .const import (
     CONF_KAIDI_PRODUCT_ID,
     CONF_KAIDI_SOFA_ACU_NO,
     CONF_PROTOCOL_VARIANT,
-    KAIDI_VARIANT_BED_1,
-    KAIDI_VARIANT_BED_12,
-    KAIDI_VARIANT_BED_2,
     KAIDI_VARIANT_SEAT_1,
+    KAIDI_VARIANT_SEAT_1_2,
     KAIDI_VARIANT_SEAT_2,
     KAIDI_VARIANT_SEAT_3,
     VARIANT_AUTO,
@@ -24,16 +22,32 @@ KAIDI_MANUAL_VARIANTS: frozenset[str] = frozenset(
         KAIDI_VARIANT_SEAT_1,
         KAIDI_VARIANT_SEAT_2,
         KAIDI_VARIANT_SEAT_3,
-        KAIDI_VARIANT_BED_1,
-        KAIDI_VARIANT_BED_2,
-        KAIDI_VARIANT_BED_12,
+        KAIDI_VARIANT_SEAT_1_2,
     }
 )
 
-# Product IDs exposed by the OEM APKs as explicit bed types.
-# `MainActivity.getProductId()` only returns these IDs directly for the Kaidi
-# bed family; everything else is either a sofa-style type (100-102) or `0`.
-KAIDI_SINGLE_PRODUCT_IDS: frozenset[int] = frozenset({129, 131, 132, 142})
+# Product IDs from the OEM APKs (Rize 1.3.0, ISleep 1.6.3, Floyd 1.0.7).
+# All three apps use ONLY SEAT_* commands.  Single-base products use seat_1,
+# dual-base products use seat_1 + seat_2 (seat_1_2).
+#
+# ID  | Name              | App         | bedUI | Classification
+# ----|-------------------|-------------|-------|---------------
+# 129 | BED_TYPE_SINGLE   | All         | 2     | seat_1
+# 130 | BED_TYPE_DOUBLE2_4| All         | 2     | seat_1_2
+# 131 | BED_TYPE_SINGLE3  | All         | 3     | seat_1
+# 132 | BED_TYPE_SINGLE4  | All         | 4     | seat_1
+# 133 | BED_TYPE_DOUBLE3  | All         | 3     | seat_1_2
+# 134 | BED_TYPE_DOUBLE4  | All         | 4     | seat_1_2
+# 135 | REMEDY_3          | Rize/Floyd  | 5     | seat_1
+# 136 | REMEDY_4          | Rize/Floyd  | 6     | seat_1
+# 137 | CONTEMPORARY_4    | Rize/Floyd  | 7     | seat_1
+# 138 | CONTEMPORARY_5    | Rize/Floyd  | 8     | seat_1
+# 139 | TRANQUILITY_II    | Floyd       | —     | seat_1
+# 142 | BED_TYPE_SINGLE5  | ISleep      | 5     | seat_1
+# 143 | BED_TYPE_DOUBLE_NEW | ISleep    | —     | seat_1_2
+KAIDI_SINGLE_PRODUCT_IDS: frozenset[int] = frozenset(
+    {129, 131, 132, 135, 136, 137, 138, 139, 142}
+)
 KAIDI_DOUBLE_PRODUCT_IDS: frozenset[int] = frozenset({130, 133, 134, 143})
 
 
@@ -86,7 +100,7 @@ def resolve_kaidi_variant(
 
     if product_id in KAIDI_DOUBLE_PRODUCT_IDS:
         return KaidiVariantResolution(
-            variant=KAIDI_VARIANT_BED_12,
+            variant=KAIDI_VARIANT_SEAT_1_2,
             source="product_id",
             product_id=product_id,
             sofa_acu_no=sofa_acu_no,

--- a/custom_components/adjustable_bed/support_bundle.py
+++ b/custom_components/adjustable_bed/support_bundle.py
@@ -185,6 +185,13 @@ def _empty_integration_info(address: str) -> dict[str, Any]:
         "disable_angle_sensing": None,
         "preferred_adapter": None,
         "address": address,
+        "kaidi_room_id": None,
+        "kaidi_target_vaddr": None,
+        "kaidi_product_id": None,
+        "kaidi_sofa_acu_no": None,
+        "kaidi_adv_type": None,
+        "kaidi_resolved_variant": None,
+        "kaidi_variant_source": None,
         "configured_device": False,
     }
 

--- a/custom_components/adjustable_bed/support_report.py
+++ b/custom_components/adjustable_bed/support_report.py
@@ -21,13 +21,21 @@ from .const import (
     CONF_BED_TYPE,
     CONF_DISABLE_ANGLE_SENSING,
     CONF_HAS_MASSAGE,
+    CONF_KAIDI_ADV_TYPE,
+    CONF_KAIDI_PRODUCT_ID,
+    CONF_KAIDI_RESOLVED_VARIANT,
+    CONF_KAIDI_SOFA_ACU_NO,
+    CONF_KAIDI_TARGET_VADDR,
+    CONF_KAIDI_VARIANT_SOURCE,
     CONF_MOTOR_COUNT,
     CONF_PREFERRED_ADAPTER,
     CONF_PROTOCOL_VARIANT,
+    CONF_KAIDI_ROOM_ID,
     DOMAIN,
     SUPPORTED_BED_TYPES,
 )
 from .diagnostics_utils import get_gatt_summary
+from .kaidi_protocol import extract_kaidi_advertisement, kaidi_advertisement_to_dict
 from .redaction import redact_data, redact_pins_only
 
 if TYPE_CHECKING:
@@ -100,6 +108,13 @@ def _get_integration_info(entry: ConfigEntry) -> dict[str, Any]:
         "disable_angle_sensing": entry.data.get(CONF_DISABLE_ANGLE_SENSING),
         "preferred_adapter": entry.data.get(CONF_PREFERRED_ADAPTER),
         "address": entry.data.get(CONF_ADDRESS),
+        "kaidi_room_id": entry.data.get(CONF_KAIDI_ROOM_ID),
+        "kaidi_target_vaddr": entry.data.get(CONF_KAIDI_TARGET_VADDR),
+        "kaidi_product_id": entry.data.get(CONF_KAIDI_PRODUCT_ID),
+        "kaidi_sofa_acu_no": entry.data.get(CONF_KAIDI_SOFA_ACU_NO),
+        "kaidi_adv_type": entry.data.get(CONF_KAIDI_ADV_TYPE),
+        "kaidi_resolved_variant": entry.data.get(CONF_KAIDI_RESOLVED_VARIANT),
+        "kaidi_variant_source": entry.data.get(CONF_KAIDI_VARIANT_SOURCE),
     }
 
 
@@ -146,6 +161,8 @@ def _get_controller_info(coordinator: AdjustableBedCoordinator) -> dict[str, Any
             info["richmat_is_wilinke"] = controller._is_wilinke
         if hasattr(controller, "_variant"):
             info["variant"] = controller._variant
+        if hasattr(controller, "_variant_source"):
+            info["variant_source"] = controller._variant_source
         if hasattr(controller, "_char_uuid"):
             info["char_uuid"] = controller._char_uuid
 
@@ -179,6 +196,11 @@ async def _get_bluetooth_info(
             "service_data": {str(k): bytes(v).hex() for k, v in service_data.items()},
             "connectable": service_info_connectable,
         }
+        kaidi_advertisement = extract_kaidi_advertisement(manufacturer_data)
+        if kaidi_advertisement is not None:
+            info["last_advertisement"]["kaidi"] = kaidi_advertisement_to_dict(
+                kaidi_advertisement
+            )
         # Include source info (adapter/proxy)
         if hasattr(service_info, "source"):
             info["last_advertisement"]["source"] = service_info.source

--- a/custom_components/adjustable_bed/validators.py
+++ b/custom_components/adjustable_bed/validators.py
@@ -10,6 +10,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import (
     ADAPTER_AUTO,
+    BED_TYPE_KAIDI,
     BED_TYPE_KEESON,
     BED_TYPE_LEGGETT_PLATT,
     BED_TYPE_OCTO,
@@ -19,6 +20,7 @@ from .const import (
     BED_TYPE_OKIN_UUID,
     BED_TYPE_RICHMAT,
     KEESON_VARIANTS,
+    KAIDI_VARIANTS,
     LEGGETT_VARIANTS,
     OCTO_VARIANTS,
     OKIMAT_VARIANTS,
@@ -56,6 +58,7 @@ def is_valid_octo_pin(pin: str) -> bool:
 
 # Single source of truth for bed types with variants
 VARIANTS_BY_BED_TYPE: dict[str, dict[str, str]] = {
+    BED_TYPE_KAIDI: KAIDI_VARIANTS,
     BED_TYPE_OKIN_CB24: OKIN_CB24_VARIANTS,
     BED_TYPE_KEESON: KEESON_VARIANTS,
     BED_TYPE_LEGGETT_PLATT: LEGGETT_VARIANTS,

--- a/docs/beds/kaidi.md
+++ b/docs/beds/kaidi.md
@@ -6,46 +6,105 @@
 
 ## Known Brands / Apps
 
-- Rize Beds
-- Floyd Home
-- ISleep
+- Rize Beds (`com.kaidi_test4.rize`)
+- Floyd Home (`com.kaidi_test4.floyd`)
+- ISleep (`com.kaidi_test4.isleep`)
 
-These apps share the same Kaidi OEM protocol family.
+These apps share the same Kaidi OEM transport and command family.
 
-## Features
+## Discovery And Transport
 
-| Feature | Supported |
-|---------|-----------|
-| Motor Control | ✅ (head/back + legs/feet) |
-| Position Feedback | ❌ |
-| Memory Presets | ✅ (4 slots) |
-| Factory Presets | ✅ (Flat, Zero-G, Anti-Snore) |
-| Massage | ❌ Not wired yet |
+Kaidi beds are identified primarily by manufacturer data, not by advertised
+service UUIDs.
 
-## Protocol Details
+| Signal | Value |
+|--------|-------|
+| Manufacturer data company ID | `0xFFFF` in Home Assistant advertisements |
+| Manufacturer data marker | `0xC0FF` |
+| Common device name | `Mouselet` |
+| Known MAC OUIs in OEM app | `00:95:69`, `F0:AC:D7` |
+| Connected GATT service | `9e5d1e47-5c13-43a0-8635-82adffc0386f` |
+| Write characteristic | `9e5d1e47-5c13-43a0-8635-82adffc1386f` |
+| Notify characteristic | `9e5d1e47-5c13-43a0-8635-82adffc2386f` |
 
-**Advertised Service UUID:** `0000ffc0-0000-1000-8000-00805f9b34fb`
-**Advertised Name:** `Mouselet`
-**Manufacturer Data:** Company ID `0xFFFF` with marker bytes `0xC0FF`
-**Known MAC prefixes:** `00:95:69`, `F0:AC:D7`
-**GATT Service:** `9e5d1e47-5c13-43a0-8635-82adffc0386f`
-**Write Characteristic:** `9e5d1e47-5c13-43a0-8635-82adffc1386f`
-**Notify Characteristic:** `9e5d1e47-5c13-43a0-8635-82adffc2386f`
+Supported advertisement layouts:
 
-## How It Works
+- `0x01`: single-bed payload with `room_id`
+- `0x02`: broadcast payload with `room_id` and `vAddr`
+- `0x09`: discoverable/add-device payload
 
-Kaidi beds use normal BLE GATT, but the app wraps commands in a custom
-"mesh-style" packet format.
+The integration caches the following Kaidi metadata in the config entry when it
+can see a valid advertisement:
 
-Home Assistant reproduces the app's startup flow:
+- `room_id`
+- `vaddr`
+- `product_id` (from advertised `sofaType`)
+- `sofa_acu_no`
+- advertisement type
+- resolved Kaidi variant and the source used to resolve it
 
-1. Parse the manufacturer data payload to recover the room/home ID
-2. Send the join packet with the Kaidi password (`"1122"`)
-3. Resolve the bed's target virtual address (`vAddr`) from advertisement data or ping
-4. Send control packets on channel `0x20`
+## Session Setup
+
+Home Assistant follows the same bootstrap flow as the OEM apps:
+
+1. Parse manufacturer data to recover the room/home ID and any advertised `vAddr`
+2. Send the Kaidi join packet with ASCII password `"1122"`
+3. Use the advertised `vAddr`, or ping to discover it if only a single-bed advertisement is visible
+4. Send 4-byte control payloads wrapped in Kaidi's mesh-style GATT frame
+
+## Command Families
+
+The OEM APKs expose six control families that are now supported by one shared
+`kaidi` bed type.
+
+| Variant | Use |
+|--------|-----|
+| `seat_1` | Single-seat / lane 1 commands |
+| `seat_2` | Single-seat / lane 2 commands |
+| `seat_3` | Single-seat / lane 3 commands |
+| `bed_1` | Split-bed lane 1 commands |
+| `bed_2` | Split-bed lane 2 commands |
+| `bed_12` | Split-bed combined commands |
+
+### APK-backed product IDs
+
+The OEM `MainActivity.getProductId()` logic only treats the following IDs as
+explicit Kaidi bed products:
+
+| Product IDs | Auto family |
+|------------|-------------|
+| `129`, `131`, `132`, `142` | `seat_1` |
+| `130`, `133`, `134`, `143` | `bed_12` |
+
+For other advertised `sofaType` values, the integration does not guess from the
+number alone.
+
+### `sofa_acu_no` heuristic
+
+When the product ID is not one of the OEM `BED_TYPE` values, the integration
+uses `sofa_acu_no` only for the narrow case the APK data supports cleanly:
+
+- exactly one populated seat bar resolves to `seat_1`, `seat_2`, or `seat_3`
+
+This is how issue `#247` style beds advertising `sofaType=136` are handled:
+`136` is not in the OEM `BED_TYPE` list, but `sofa_acu_no=0x2004` resolves to a
+single populated seat-1 profile, so the integration auto-selects `seat_1`.
+
+If Kaidi metadata is present but does not map cleanly, `auto` refuses to guess
+and a manual Kaidi variant override is required.
+
+## Features By Family
+
+| Feature | `seat_1` | `seat_2` | `seat_3` | `bed_1` | `bed_2` | `bed_12` |
+|--------|----------|----------|----------|---------|---------|----------|
+| Head/back + leg/foot movement | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Dedicated stop-all command | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Memory recall/programming | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Flat / Zero-G / Anti-Snore presets | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Massage / lights | Not exposed yet | Not exposed yet | Not exposed yet | Not exposed yet | Not exposed yet | Not exposed yet |
 
 ## Notes
 
-1. The bed must already be provisioned in the official app. Home Assistant does not currently implement the add-device/reset workflow.
-2. The current controller targets the single-bed command set used by standard head/foot bases.
-3. If your bed exposes different Kaidi behavior, open an issue and attach a support bundle plus any nRF Connect logs you can capture.
+1. The bed must already be provisioned in the official app. Home Assistant does not implement the add-device/reset workflow.
+2. Kaidi devices named `Mouselet` are valid beds when the manufacturer payload matches Kaidi; the generic `"mouse"` exclusion no longer applies in that case.
+3. If `auto` reports unresolved Kaidi metadata, switch the integration option to one of `seat_1`, `seat_2`, `seat_3`, `bed_1`, `bed_2`, or `bed_12`.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -34,11 +34,17 @@ from custom_components.adjustable_bed.const import (
     CONF_BED_TYPE,
     CONF_DISABLE_ANGLE_SENSING,
     CONF_HAS_MASSAGE,
+    CONF_KAIDI_ADV_TYPE,
+    CONF_KAIDI_PRODUCT_ID,
+    CONF_KAIDI_RESOLVED_VARIANT,
     CONF_KAIDI_ROOM_ID,
+    CONF_KAIDI_SOFA_ACU_NO,
     CONF_KAIDI_TARGET_VADDR,
+    CONF_KAIDI_VARIANT_SOURCE,
     CONF_MOTOR_COUNT,
     CONF_PREFERRED_ADAPTER,
     DOMAIN,
+    KAIDI_VARIANT_SEAT_1,
     RICHMAT_WILINKE_SERVICE_UUIDS,
     SUTA_SERVICE_UUID,
     TIMOTION_AHF_SERVICE_UUID,
@@ -769,7 +775,7 @@ class TestManualFlow:
     async def test_manual_entry_caches_kaidi_metadata(
         self, hass: HomeAssistant, enable_custom_integrations
     ):
-        """Manual Kaidi setup should cache room/VADDR metadata when available."""
+        """Manual Kaidi setup should cache Kaidi metadata when available."""
         with patch(
             "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
             return_value=[],
@@ -789,6 +795,8 @@ class TestManualFlow:
                 adv_type=KAIDI_ADV_TYPE_BROADCAST,
                 room_id=0x12345678,
                 vaddr=0x01020304,
+                product_id=136,
+                sofa_acu_no=0x2004,
             ),
         ):
             result = await hass.config_entries.flow.async_configure(
@@ -807,6 +815,11 @@ class TestManualFlow:
         assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_KAIDI_ROOM_ID] == 0x12345678
         assert result["data"][CONF_KAIDI_TARGET_VADDR] == 0x01020304
+        assert result["data"][CONF_KAIDI_PRODUCT_ID] == 136
+        assert result["data"][CONF_KAIDI_SOFA_ACU_NO] == 0x2004
+        assert result["data"][CONF_KAIDI_ADV_TYPE] == KAIDI_ADV_TYPE_BROADCAST
+        assert result["data"][CONF_KAIDI_RESOLVED_VARIANT] == KAIDI_VARIANT_SEAT_1
+        assert result["data"][CONF_KAIDI_VARIANT_SOURCE] == "sofa_acu_no"
 
     async def test_manual_entry_invalid_mac(self, hass: HomeAssistant, enable_custom_integrations):
         """Test manual entry with invalid MAC address shows error."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -819,7 +819,7 @@ class TestManualFlow:
         assert result["data"][CONF_KAIDI_SOFA_ACU_NO] == 0x2004
         assert result["data"][CONF_KAIDI_ADV_TYPE] == KAIDI_ADV_TYPE_BROADCAST
         assert result["data"][CONF_KAIDI_RESOLVED_VARIANT] == KAIDI_VARIANT_SEAT_1
-        assert result["data"][CONF_KAIDI_VARIANT_SOURCE] == "sofa_acu_no"
+        assert result["data"][CONF_KAIDI_VARIANT_SOURCE] == "product_id"
 
     async def test_manual_entry_invalid_mac(self, hass: HomeAssistant, enable_custom_integrations):
         """Test manual entry with invalid MAC address shows error."""

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -156,6 +156,19 @@ class TestDetectBedTypeByServiceUUID:
         assert result.confidence == 0.95
         assert "uuid:kaidi" in result.signals
 
+    def test_detect_kaidi_mouselet_not_excluded_by_generic_mouse_filter(self):
+        """Valid Kaidi manufacturer data should bypass the generic mouse exclusion."""
+        service_info = _make_service_info(
+            name="Mouselet",
+            service_uuids=[],
+            manufacturer_data={
+                0xFFFF: bytes.fromhex("c0ff025e270000e55d547fc5ec0200882004a101000000")
+            },
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type == BED_TYPE_KAIDI
+        assert not any(signal == "excluded:mouse" for signal in result.signals)
+
     def test_detect_vibradorm_by_uuid(self):
         """Test Vibradorm detection by unique service UUID."""
         service_info = _make_service_info(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -10,10 +10,18 @@ from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adjustable_bed.const import (
+    BED_TYPE_KAIDI,
     BED_TYPE_LINAK,
     CONF_BED_TYPE,
     CONF_DISABLE_ANGLE_SENSING,
     CONF_HAS_MASSAGE,
+    CONF_KAIDI_ADV_TYPE,
+    CONF_KAIDI_PRODUCT_ID,
+    CONF_KAIDI_RESOLVED_VARIANT,
+    CONF_KAIDI_ROOM_ID,
+    CONF_KAIDI_SOFA_ACU_NO,
+    CONF_KAIDI_TARGET_VADDR,
+    CONF_KAIDI_VARIANT_SOURCE,
     CONF_MOTOR_COUNT,
     CONF_PREFERRED_ADAPTER,
     DOMAIN,
@@ -250,3 +258,61 @@ class TestDiagnosticsOutput:
 
         assert len(result["supported_bed_types"]) > 0
         assert "linak" in result["supported_bed_types"]
+
+    async def test_diagnostics_include_kaidi_metadata_and_parsed_advertisement(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,  # noqa: ARG002
+    ):
+        """Diagnostics should include Kaidi config metadata and parsed manufacturer data."""
+        from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Kaidi Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:FF",
+                CONF_NAME: "Mouselet",
+                CONF_BED_TYPE: BED_TYPE_KAIDI,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+                CONF_KAIDI_ROOM_ID: 0x275E,
+                CONF_KAIDI_TARGET_VADDR: 0x00000001,
+                CONF_KAIDI_PRODUCT_ID: 136,
+                CONF_KAIDI_SOFA_ACU_NO: 0x2004,
+                CONF_KAIDI_ADV_TYPE: 0x02,
+                CONF_KAIDI_RESOLVED_VARIANT: "seat_1",
+                CONF_KAIDI_VARIANT_SOURCE: "sofa_acu_no",
+            },
+            unique_id="AA:BB:CC:DD:EE:FF",
+            entry_id="diagnostics_kaidi_entry",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][entry.entry_id] = coordinator
+
+        service_info = MagicMock()
+        service_info.name = "Mouselet"
+        service_info.rssi = -60
+        service_info.service_uuids = []
+        service_info.manufacturer_data = {
+            0xFFFF: bytes.fromhex("c0ff025e270000e55d547fc5ec0200882004a101000000")
+        }
+        service_info.source = "proxy_kaidi"
+
+        with patch(
+            "custom_components.adjustable_bed.diagnostics.find_service_info_by_address",
+            return_value=(service_info, True),
+        ):
+            result = await async_get_config_entry_diagnostics(hass, entry)
+
+        assert result["config"]["kaidi_product_id"] == 136
+        assert result["config"]["kaidi_sofa_acu_no"] == 0x2004
+        assert result["config"]["kaidi_resolved_variant"] == "seat_1"
+        assert result["advertisement"]["kaidi"]["product_id"] == 136
+        assert result["advertisement"]["kaidi"]["seat_1_bars"] == 4
+        assert result["advertisement"]["source"] == "proxy_kaidi"

--- a/tests/test_kaidi.py
+++ b/tests/test_kaidi.py
@@ -12,6 +12,13 @@ from custom_components.adjustable_bed.beds.kaidi import KaidiCommands, KaidiCont
 from custom_components.adjustable_bed.const import (
     CONF_KAIDI_ROOM_ID,
     KAIDI_BROADCAST_VADDR,
+    KAIDI_VARIANT_BED_1,
+    KAIDI_VARIANT_BED_12,
+    KAIDI_VARIANT_BED_2,
+    KAIDI_VARIANT_SEAT_1,
+    KAIDI_VARIANT_SEAT_2,
+    KAIDI_VARIANT_SEAT_3,
+    VARIANT_AUTO,
 )
 from custom_components.adjustable_bed.kaidi_protocol import (
     KAIDI_ADV_TYPE_BROADCAST,
@@ -19,7 +26,19 @@ from custom_components.adjustable_bed.kaidi_protocol import (
     extract_best_kaidi_advertisement,
     extract_kaidi_advertisement,
     format_kaidi_node_address,
+    kaidi_advertisement_to_dict,
     parse_kaidi_manufacturer_payload,
+)
+from custom_components.adjustable_bed.kaidi_variants import resolve_kaidi_variant
+
+BROADCAST_MANUFACTURER_DATA = {
+    0xFFFF: bytes.fromhex("c0ff0278563412ffeeddccbbaa0000810100a004030201")
+}
+SINGLE_MANUFACTURER_DATA = {
+    0xFFFF: bytes.fromhex("c0ff017856341281010000000000000000")
+}
+ISSUE247_BROADCAST_PAYLOAD = bytes.fromhex(
+    "c0ff025e270000e55d547fc5ec0200882004a101000000"
 )
 
 
@@ -35,7 +54,47 @@ class _KaidiCoordinator(SimpleNamespace):
             address=address,
             name="Kaidi Test Bed",
             entry=SimpleNamespace(data={}),
+            record_command_trace=MagicMock(),
         )
+
+
+async def _prepare_controller(
+    mock_bleak_client: MagicMock,
+    *,
+    variant: str = KAIDI_VARIANT_SEAT_1,
+    manufacturer_data: dict[int, bytes] | None = None,
+    entry_data: dict[str, int] | None = None,
+) -> KaidiController:
+    """Create a Kaidi controller with a primed session."""
+    coordinator = _KaidiCoordinator(mock_bleak_client)
+    if entry_data:
+        coordinator.entry.data.update(entry_data)
+
+    controller = KaidiController(
+        coordinator,
+        device_name="Mouselet",
+        manufacturer_data=manufacturer_data or BROADCAST_MANUFACTURER_DATA,
+        variant=variant,
+    )
+
+    notify_callback: object | None = None
+
+    async def start_notify(_uuid: str, callback: object) -> None:
+        nonlocal notify_callback
+        notify_callback = callback
+
+    async def write_side_effect(_uuid: str, data: bytes, response: bool = True) -> None:
+        del response
+        assert notify_callback is not None
+        if data == controller._build_join_packet(0x12345678):
+            notify_callback(MagicMock(), bytearray([0x02, 0x16, 0x00]))
+
+    mock_bleak_client.start_notify = AsyncMock(side_effect=start_notify)
+    mock_bleak_client.write_gatt_char = AsyncMock(side_effect=write_side_effect)
+
+    await controller._ensure_session_ready()
+    mock_bleak_client.write_gatt_char = AsyncMock()
+    return controller
 
 
 def test_parse_broadcast_advertisement_payload() -> None:
@@ -49,28 +108,46 @@ def test_parse_broadcast_advertisement_payload() -> None:
     assert parsed.room_id == 0x12345678
     assert parsed.vaddr == 0x01020304
     assert parsed.sofa_type == 0x81
+    assert parsed.product_id == 0x81
+    assert parsed.sofa_acu_no == 0x0100
+
+
+def test_parse_issue247_broadcast_payload() -> None:
+    """The issue-247 payload should decode Kaidi metadata from manufacturer data."""
+    parsed = parse_kaidi_manufacturer_payload(ISSUE247_BROADCAST_PAYLOAD)
+
+    assert parsed is not None
+    assert parsed.adv_type == KAIDI_ADV_TYPE_BROADCAST
+    assert parsed.room_id == 0x275E
+    assert parsed.vaddr == 0x00000001
+    assert parsed.product_id == 136
+    assert parsed.sofa_acu_no == 0x2004
+
+    serialized = kaidi_advertisement_to_dict(parsed)
+    assert serialized["seat_1_bars"] == 4
+    assert serialized["seat_2_bars"] == 0
+    assert serialized["seat_3_bars"] == 0
+    assert serialized["is_store"] is True
 
 
 def test_extract_single_advertisement_payload() -> None:
     """Single-bed advertisements should still expose the room/home ID."""
-    parsed = extract_kaidi_advertisement(
-        {
-            0xFFFF: bytes.fromhex("c0ff017856341281010000000000000000"),
-        }
-    )
+    parsed = extract_kaidi_advertisement(SINGLE_MANUFACTURER_DATA)
 
     assert parsed is not None
     assert parsed.adv_type == KAIDI_ADV_TYPE_SINGLE
     assert parsed.room_id == 0x12345678
     assert parsed.vaddr is None
+    assert parsed.product_id == 0x81
+    assert parsed.sofa_acu_no == 0x0100
 
 
 def test_merge_kaidi_advertisement_snapshots() -> None:
     """Mixed advertisement snapshots should combine room ID and VADDR state."""
     parsed = extract_best_kaidi_advertisement(
         [
-            {0xFFFF: bytes.fromhex("c0ff017856341281010000000000000000")},
-            {0xFFFF: bytes.fromhex("c0ff0278563412ffeeddccbbaa0000810100a004030201")},
+            SINGLE_MANUFACTURER_DATA,
+            BROADCAST_MANUFACTURER_DATA,
         ]
     )
 
@@ -78,11 +155,71 @@ def test_merge_kaidi_advertisement_snapshots() -> None:
     assert parsed.adv_type == KAIDI_ADV_TYPE_BROADCAST
     assert parsed.room_id == 0x12345678
     assert parsed.vaddr == 0x01020304
+    assert parsed.product_id == 0x81
+    assert parsed.sofa_acu_no == 0x0100
 
 
 def test_format_kaidi_node_address() -> None:
     """Ping response node addresses should format to standard MAC notation."""
     assert format_kaidi_node_address(bytes.fromhex("ffeeddccbbaa")) == "AA:BB:CC:DD:EE:FF"
+
+
+def test_resolve_kaidi_variant_manual_override() -> None:
+    """Manual variant overrides must win over advertised metadata."""
+    resolution = resolve_kaidi_variant(
+        KAIDI_VARIANT_BED_2,
+        product_id=129,
+        sofa_acu_no=0x2004,
+    )
+
+    assert resolution.variant == KAIDI_VARIANT_BED_2
+    assert resolution.source == "manual_override"
+
+
+def test_resolve_kaidi_variant_prefers_exact_product_mapping() -> None:
+    """Exact OEM BED_TYPE mappings should take precedence over seat-bar heuristics."""
+    resolution = resolve_kaidi_variant(
+        VARIANT_AUTO,
+        product_id=130,
+        sofa_acu_no=0x2004,
+    )
+
+    assert resolution.variant == KAIDI_VARIANT_BED_12
+    assert resolution.source == "product_id"
+
+
+def test_resolve_kaidi_variant_issue247_uses_sofa_acu_no() -> None:
+    """The issue-247 sofa metadata should resolve to the seat-1 profile."""
+    resolution = resolve_kaidi_variant(
+        VARIANT_AUTO,
+        product_id=136,
+        sofa_acu_no=0x2004,
+    )
+
+    assert resolution.variant == KAIDI_VARIANT_SEAT_1
+    assert resolution.source == "sofa_acu_no"
+    assert resolution.seat_bars is not None
+    assert resolution.seat_bars.populated_seats == (1,)
+
+
+def test_resolve_kaidi_variant_without_metadata_falls_back_to_legacy() -> None:
+    """Legacy Kaidi entries without metadata should keep the old seat-1 behavior."""
+    resolution = resolve_kaidi_variant(VARIANT_AUTO)
+
+    assert resolution.variant == KAIDI_VARIANT_SEAT_1
+    assert resolution.source == "legacy_fallback"
+
+
+def test_resolve_kaidi_variant_with_unknown_metadata_requires_override() -> None:
+    """Unknown Kaidi metadata should refuse to guess a profile automatically."""
+    resolution = resolve_kaidi_variant(
+        VARIANT_AUTO,
+        product_id=136,
+        sofa_acu_no=0x0000,
+    )
+
+    assert resolution.variant is None
+    assert resolution.source == "unresolved_metadata"
 
 
 @pytest.mark.asyncio
@@ -92,9 +229,7 @@ async def test_session_uses_advertised_vaddr_without_ping(mock_bleak_client: Mag
     controller = KaidiController(
         coordinator,
         device_name="Mouselet",
-        manufacturer_data={
-            0xFFFF: bytes.fromhex("c0ff0278563412ffeeddccbbaa0000810100a004030201")
-        },
+        manufacturer_data=BROADCAST_MANUFACTURER_DATA,
     )
 
     notify_callback: object | None = None
@@ -127,9 +262,7 @@ async def test_session_pings_when_advertisement_lacks_vaddr(mock_bleak_client: M
     controller = KaidiController(
         coordinator,
         device_name="Mouselet",
-        manufacturer_data={
-            0xFFFF: bytes.fromhex("c0ff017856341281010000000000000000")
-        },
+        manufacturer_data=SINGLE_MANUFACTURER_DATA,
     )
 
     notify_callback: object | None = None
@@ -198,38 +331,180 @@ async def test_session_uses_cached_room_id_when_manufacturer_data_is_missing(
 
 
 @pytest.mark.asyncio
-async def test_move_head_up_sends_move_then_stop(mock_bleak_client: MagicMock) -> None:
-    """Head movement should emit the motor command followed by a stop command."""
-    coordinator = _KaidiCoordinator(mock_bleak_client)
-    controller = KaidiController(
-        coordinator,
-        device_name="Mouselet",
-        manufacturer_data={
-            0xFFFF: bytes.fromhex("c0ff0278563412ffeeddccbbaa0000810100a004030201")
-        },
-    )
-
-    notify_callback: object | None = None
-
-    async def start_notify(_uuid: str, callback: object) -> None:
-        nonlocal notify_callback
-        notify_callback = callback
-
-    async def write_side_effect(_uuid: str, data: bytes, response: bool = True) -> None:
-        del response
-        if data == controller._build_join_packet(0x12345678):
-            assert notify_callback is not None
-            notify_callback(MagicMock(), bytearray([0x02, 0x16, 0x00]))
-
-    mock_bleak_client.start_notify = AsyncMock(side_effect=start_notify)
-    mock_bleak_client.write_gatt_char = AsyncMock(side_effect=write_side_effect)
-
-    await controller._ensure_session_ready()
-    mock_bleak_client.write_gatt_char.reset_mock(side_effect=False)
+@pytest.mark.parametrize(
+    ("variant", "move_command", "stop_command"),
+    [
+        (KAIDI_VARIANT_SEAT_1, 0x01, 0x03),
+        (KAIDI_VARIANT_SEAT_2, 0x0A, 0x0C),
+        (KAIDI_VARIANT_SEAT_3, 0x13, 0x15),
+        (KAIDI_VARIANT_BED_1, 0x47, 0x49),
+        (KAIDI_VARIANT_BED_2, 0x4A, 0x4C),
+        (KAIDI_VARIANT_BED_12, 0x53, 0x55),
+    ],
+)
+async def test_move_head_up_uses_variant_specific_command_profile(
+    mock_bleak_client: MagicMock,
+    variant: str,
+    move_command: int,
+    stop_command: int,
+) -> None:
+    """Head movement should follow the selected Kaidi profile."""
+    controller = await _prepare_controller(mock_bleak_client, variant=variant)
 
     await controller.move_head_up()
 
     calls = mock_bleak_client.write_gatt_char.await_args_list
     assert len(calls) == 2
-    assert calls[0].args[1] == controller._build_control_packet(KaidiCommands.HEAD_UP)
-    assert calls[1].args[1] == controller._build_control_packet(KaidiCommands.HEAD_STOP)
+    assert calls[0].args[1] == controller._build_control_packet(move_command)
+    assert calls[1].args[1] == controller._build_control_packet(stop_command)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("variant", "move_command", "stop_command"),
+    [
+        (KAIDI_VARIANT_SEAT_1, 0x05, 0x06),
+        (KAIDI_VARIANT_SEAT_2, 0x0E, 0x0F),
+        (KAIDI_VARIANT_SEAT_3, 0x17, 0x18),
+        (KAIDI_VARIANT_BED_1, 0x4E, 0x4F),
+        (KAIDI_VARIANT_BED_2, 0x51, 0x52),
+        (KAIDI_VARIANT_BED_12, 0x57, 0x58),
+    ],
+)
+async def test_move_legs_down_uses_variant_specific_command_profile(
+    mock_bleak_client: MagicMock,
+    variant: str,
+    move_command: int,
+    stop_command: int,
+) -> None:
+    """Leg movement should follow the selected Kaidi profile."""
+    controller = await _prepare_controller(mock_bleak_client, variant=variant)
+
+    await controller.move_legs_down()
+
+    calls = mock_bleak_client.write_gatt_char.await_args_list
+    assert len(calls) == 2
+    assert calls[0].args[1] == controller._build_control_packet(move_command)
+    assert calls[1].args[1] == controller._build_control_packet(stop_command)
+
+
+@pytest.mark.asyncio
+async def test_stop_all_uses_dedicated_command_when_available(mock_bleak_client: MagicMock) -> None:
+    """Seat-1 should use its dedicated stop-all opcode."""
+    controller = await _prepare_controller(mock_bleak_client, variant=KAIDI_VARIANT_SEAT_1)
+
+    await controller.stop_all()
+
+    calls = mock_bleak_client.write_gatt_char.await_args_list
+    assert len(calls) == 1
+    assert calls[0].args[1] == controller._build_control_packet(KaidiCommands.STOP_ALL)
+
+
+@pytest.mark.asyncio
+async def test_stop_all_falls_back_to_per_motor_stops(mock_bleak_client: MagicMock) -> None:
+    """Profiles without stop-all should stop head and foot motors explicitly."""
+    controller = await _prepare_controller(mock_bleak_client, variant=KAIDI_VARIANT_BED_12)
+
+    await controller.stop_all()
+
+    calls = mock_bleak_client.write_gatt_char.await_args_list
+    assert len(calls) == 2
+    assert calls[0].args[1] == controller._build_control_packet(0x55)
+    assert calls[1].args[1] == controller._build_control_packet(0x58)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("variant", "method_name", "expected_command"),
+    [
+        (KAIDI_VARIANT_SEAT_1, "preset_flat", 0x68),
+        (KAIDI_VARIANT_SEAT_2, "preset_zero_g", 0x63),
+        (KAIDI_VARIANT_SEAT_2, "preset_anti_snore", 0x66),
+    ],
+)
+async def test_preset_commands_use_variant_specific_profile(
+    mock_bleak_client: MagicMock,
+    variant: str,
+    method_name: str,
+    expected_command: int,
+) -> None:
+    """Seat-profile preset buttons should emit the APK-backed opcodes."""
+    controller = await _prepare_controller(mock_bleak_client, variant=variant)
+
+    await getattr(controller, method_name)()
+
+    calls = mock_bleak_client.write_gatt_char.await_args_list
+    assert len(calls) == 1
+    assert calls[0].args[1] == controller._build_control_packet(expected_command)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("variant", "memory_slot", "expected_command"),
+    [
+        (KAIDI_VARIANT_SEAT_1, 4, 0x2C),
+        (KAIDI_VARIANT_SEAT_2, 4, 0x34),
+        (KAIDI_VARIANT_SEAT_3, 3, 0x3B),
+    ],
+)
+async def test_memory_recall_commands_use_variant_specific_profile(
+    mock_bleak_client: MagicMock,
+    variant: str,
+    memory_slot: int,
+    expected_command: int,
+) -> None:
+    """Memory recall should follow the selected seat profile."""
+    controller = await _prepare_controller(mock_bleak_client, variant=variant)
+
+    await controller.preset_memory(memory_slot)
+
+    calls = mock_bleak_client.write_gatt_char.await_args_list
+    assert len(calls) == 1
+    assert calls[0].args[1] == controller._build_control_packet(expected_command)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("variant", "memory_slot", "expected_command"),
+    [
+        (KAIDI_VARIANT_SEAT_1, 1, 0x25),
+        (KAIDI_VARIANT_SEAT_2, 2, 0x2E),
+        (KAIDI_VARIANT_SEAT_3, 4, 0x38),
+    ],
+)
+async def test_memory_programming_commands_use_variant_specific_profile(
+    mock_bleak_client: MagicMock,
+    variant: str,
+    memory_slot: int,
+    expected_command: int,
+) -> None:
+    """Memory programming should follow the selected seat profile."""
+    controller = await _prepare_controller(mock_bleak_client, variant=variant)
+
+    await controller.program_memory(memory_slot)
+
+    calls = mock_bleak_client.write_gatt_char.await_args_list
+    assert len(calls) == 1
+    assert calls[0].args[1] == controller._build_control_packet(expected_command)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("variant", "method_name", "args"),
+    [
+        (KAIDI_VARIANT_BED_1, "preset_flat", ()),
+        (KAIDI_VARIANT_BED_2, "preset_memory", (1,)),
+        (KAIDI_VARIANT_BED_12, "program_memory", (1,)),
+    ],
+)
+async def test_bed_profiles_reject_unsupported_preset_and_memory_commands(
+    mock_bleak_client: MagicMock,
+    variant: str,
+    method_name: str,
+    args: tuple[int, ...],
+) -> None:
+    """Split-bed profiles should not expose unsupported seat preset helpers."""
+    controller = await _prepare_controller(mock_bleak_client, variant=variant)
+
+    with pytest.raises(NotImplementedError):
+        await getattr(controller, method_name)(*args)

--- a/tests/test_kaidi.py
+++ b/tests/test_kaidi.py
@@ -8,14 +8,16 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.adjustable_bed.beds.kaidi import KaidiCommands, KaidiController
+from custom_components.adjustable_bed.beds.kaidi import (
+    KAIDI_COMMAND_PROFILES,
+    KaidiCommands,
+    KaidiController,
+)
 from custom_components.adjustable_bed.const import (
     CONF_KAIDI_ROOM_ID,
     KAIDI_BROADCAST_VADDR,
-    KAIDI_VARIANT_BED_1,
-    KAIDI_VARIANT_BED_12,
-    KAIDI_VARIANT_BED_2,
     KAIDI_VARIANT_SEAT_1,
+    KAIDI_VARIANT_SEAT_1_2,
     KAIDI_VARIANT_SEAT_2,
     KAIDI_VARIANT_SEAT_3,
     VARIANT_AUTO,
@@ -97,6 +99,11 @@ async def _prepare_controller(
     return controller
 
 
+# ---------------------------------------------------------------------------
+# Protocol parsing tests
+# ---------------------------------------------------------------------------
+
+
 def test_parse_broadcast_advertisement_payload() -> None:
     """Broadcast advertisements should expose room ID and virtual address."""
     parsed = parse_kaidi_manufacturer_payload(
@@ -164,35 +171,67 @@ def test_format_kaidi_node_address() -> None:
     assert format_kaidi_node_address(bytes.fromhex("ffeeddccbbaa")) == "AA:BB:CC:DD:EE:FF"
 
 
+# ---------------------------------------------------------------------------
+# Variant resolution tests
+# ---------------------------------------------------------------------------
+
+
 def test_resolve_kaidi_variant_manual_override() -> None:
     """Manual variant overrides must win over advertised metadata."""
     resolution = resolve_kaidi_variant(
-        KAIDI_VARIANT_BED_2,
+        KAIDI_VARIANT_SEAT_2,
         product_id=129,
         sofa_acu_no=0x2004,
     )
 
-    assert resolution.variant == KAIDI_VARIANT_BED_2
+    assert resolution.variant == KAIDI_VARIANT_SEAT_2
     assert resolution.source == "manual_override"
 
 
-def test_resolve_kaidi_variant_prefers_exact_product_mapping() -> None:
-    """Exact OEM BED_TYPE mappings should take precedence over seat-bar heuristics."""
+def test_resolve_kaidi_variant_manual_override_seat_1_2() -> None:
+    """Manual seat_1_2 override should be accepted."""
     resolution = resolve_kaidi_variant(
-        VARIANT_AUTO,
-        product_id=130,
-        sofa_acu_no=0x2004,
+        KAIDI_VARIANT_SEAT_1_2,
+        product_id=129,
     )
 
-    assert resolution.variant == KAIDI_VARIANT_BED_12
-    assert resolution.source == "product_id"
+    assert resolution.variant == KAIDI_VARIANT_SEAT_1_2
+    assert resolution.source == "manual_override"
 
 
-def test_resolve_kaidi_variant_issue247_uses_sofa_acu_no() -> None:
-    """The issue-247 sofa metadata should resolve to the seat-1 profile."""
+def test_resolve_kaidi_variant_single_product_id() -> None:
+    """Single-base product IDs should resolve to seat_1."""
+    for pid in (129, 131, 132, 135, 136, 137, 138, 139, 142):
+        resolution = resolve_kaidi_variant(VARIANT_AUTO, product_id=pid)
+        assert resolution.variant == KAIDI_VARIANT_SEAT_1, f"product_id={pid}"
+        assert resolution.source == "product_id"
+
+
+def test_resolve_kaidi_variant_double_product_id() -> None:
+    """Double-base product IDs should resolve to seat_1_2."""
+    for pid in (130, 133, 134, 143):
+        resolution = resolve_kaidi_variant(VARIANT_AUTO, product_id=pid)
+        assert resolution.variant == KAIDI_VARIANT_SEAT_1_2, f"product_id={pid}"
+        assert resolution.source == "product_id"
+
+
+def test_resolve_kaidi_variant_issue247_uses_product_id() -> None:
+    """Product 136 (Rize Remedy 4) should resolve to seat_1 via product_id."""
     resolution = resolve_kaidi_variant(
         VARIANT_AUTO,
         product_id=136,
+        sofa_acu_no=0x2004,
+    )
+
+    assert resolution.variant == KAIDI_VARIANT_SEAT_1
+    assert resolution.source == "product_id"
+
+
+def test_resolve_kaidi_variant_sofa_acu_no_fallback() -> None:
+    """When product_id is unknown, seat-bar heuristic should be used."""
+    resolution = resolve_kaidi_variant(
+        VARIANT_AUTO,
+        product_id=999,
         sofa_acu_no=0x2004,
     )
 
@@ -214,12 +253,17 @@ def test_resolve_kaidi_variant_with_unknown_metadata_requires_override() -> None
     """Unknown Kaidi metadata should refuse to guess a profile automatically."""
     resolution = resolve_kaidi_variant(
         VARIANT_AUTO,
-        product_id=136,
+        product_id=999,
         sofa_acu_no=0x0000,
     )
 
     assert resolution.variant is None
     assert resolution.source == "unresolved_metadata"
+
+
+# ---------------------------------------------------------------------------
+# Session management tests
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -330,6 +374,11 @@ async def test_session_uses_cached_room_id_when_manufacturer_data_is_missing(
     assert controller._target_vaddr == 0x01020304
 
 
+# ---------------------------------------------------------------------------
+# Motor command tests
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("variant", "move_command", "stop_command"),
@@ -337,9 +386,6 @@ async def test_session_uses_cached_room_id_when_manufacturer_data_is_missing(
         (KAIDI_VARIANT_SEAT_1, 0x01, 0x03),
         (KAIDI_VARIANT_SEAT_2, 0x0A, 0x0C),
         (KAIDI_VARIANT_SEAT_3, 0x13, 0x15),
-        (KAIDI_VARIANT_BED_1, 0x47, 0x49),
-        (KAIDI_VARIANT_BED_2, 0x4A, 0x4C),
-        (KAIDI_VARIANT_BED_12, 0x53, 0x55),
     ],
 )
 async def test_move_head_up_uses_variant_specific_command_profile(
@@ -366,9 +412,6 @@ async def test_move_head_up_uses_variant_specific_command_profile(
         (KAIDI_VARIANT_SEAT_1, 0x05, 0x06),
         (KAIDI_VARIANT_SEAT_2, 0x0E, 0x0F),
         (KAIDI_VARIANT_SEAT_3, 0x17, 0x18),
-        (KAIDI_VARIANT_BED_1, 0x4E, 0x4F),
-        (KAIDI_VARIANT_BED_2, 0x51, 0x52),
-        (KAIDI_VARIANT_BED_12, 0x57, 0x58),
     ],
 )
 async def test_move_legs_down_uses_variant_specific_command_profile(
@@ -402,15 +445,15 @@ async def test_stop_all_uses_dedicated_command_when_available(mock_bleak_client:
 
 @pytest.mark.asyncio
 async def test_stop_all_falls_back_to_per_motor_stops(mock_bleak_client: MagicMock) -> None:
-    """Profiles without stop-all should stop head and foot motors explicitly."""
-    controller = await _prepare_controller(mock_bleak_client, variant=KAIDI_VARIANT_BED_12)
+    """Seat-3 (no stop_all) should stop head and foot motors explicitly."""
+    controller = await _prepare_controller(mock_bleak_client, variant=KAIDI_VARIANT_SEAT_3)
 
     await controller.stop_all()
 
     calls = mock_bleak_client.write_gatt_char.await_args_list
     assert len(calls) == 2
-    assert calls[0].args[1] == controller._build_control_packet(0x55)
-    assert calls[1].args[1] == controller._build_control_packet(0x58)
+    assert calls[0].args[1] == controller._build_control_packet(0x15)  # seat_3 head_stop
+    assert calls[1].args[1] == controller._build_control_packet(0x18)  # seat_3 foot_stop
 
 
 @pytest.mark.asyncio
@@ -488,23 +531,83 @@ async def test_memory_programming_commands_use_variant_specific_profile(
     assert calls[0].args[1] == controller._build_control_packet(expected_command)
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("variant", "method_name", "args"),
-    [
-        (KAIDI_VARIANT_BED_1, "preset_flat", ()),
-        (KAIDI_VARIANT_BED_2, "preset_memory", (1,)),
-        (KAIDI_VARIANT_BED_12, "program_memory", (1,)),
-    ],
-)
-async def test_bed_profiles_reject_unsupported_preset_and_memory_commands(
-    mock_bleak_client: MagicMock,
-    variant: str,
-    method_name: str,
-    args: tuple[int, ...],
-) -> None:
-    """Split-bed profiles should not expose unsupported seat preset helpers."""
-    controller = await _prepare_controller(mock_bleak_client, variant=variant)
+# ---------------------------------------------------------------------------
+# Dual-bed (seat_1_2) tests
+# ---------------------------------------------------------------------------
 
-    with pytest.raises(NotImplementedError):
-        await getattr(controller, method_name)(*args)
+
+@pytest.mark.asyncio
+async def test_seat_1_2_sends_both_sides_for_head_up(mock_bleak_client: MagicMock) -> None:
+    """seat_1_2 should send seat_1 HEAD_UP then seat_2 HEAD_UP."""
+    controller = await _prepare_controller(mock_bleak_client, variant=KAIDI_VARIANT_SEAT_1_2)
+
+    await controller.move_head_up()
+
+    calls = mock_bleak_client.write_gatt_char.await_args_list
+    # move: seat_1 head_up + seat_2 head_up, then stop: seat_1 head_stop + seat_2 head_stop
+    assert len(calls) == 4
+    assert calls[0].args[1] == controller._build_control_packet(0x01)  # SEAT_1_HEAD_UP
+    assert calls[1].args[1] == controller._build_control_packet(0x0A)  # SEAT_2_HEAD_UP
+    assert calls[2].args[1] == controller._build_control_packet(0x03)  # SEAT_1_HEAD_STOP
+    assert calls[3].args[1] == controller._build_control_packet(0x0C)  # SEAT_2_HEAD_STOP
+
+
+@pytest.mark.asyncio
+async def test_seat_1_2_stop_all_sends_both_sides(mock_bleak_client: MagicMock) -> None:
+    """seat_1_2 stop_all should send seat_1 STOP_ALL then seat_2 STOP_ALL."""
+    controller = await _prepare_controller(mock_bleak_client, variant=KAIDI_VARIANT_SEAT_1_2)
+
+    await controller.stop_all()
+
+    calls = mock_bleak_client.write_gatt_char.await_args_list
+    assert len(calls) == 2
+    assert calls[0].args[1] == controller._build_control_packet(0x1C)  # SEAT_1_STOP_ALL
+    assert calls[1].args[1] == controller._build_control_packet(0x1D)  # SEAT_2_STOP_ALL
+
+
+@pytest.mark.asyncio
+async def test_seat_1_2_preset_sends_both_sides(mock_bleak_client: MagicMock) -> None:
+    """seat_1_2 presets should send for both seats."""
+    controller = await _prepare_controller(mock_bleak_client, variant=KAIDI_VARIANT_SEAT_1_2)
+
+    await controller.preset_flat()
+
+    calls = mock_bleak_client.write_gatt_char.await_args_list
+    assert len(calls) == 2
+    assert calls[0].args[1] == controller._build_control_packet(0x68)  # SEAT_1_FLAT
+    assert calls[1].args[1] == controller._build_control_packet(0x69)  # SEAT_2_FLAT
+
+
+# ---------------------------------------------------------------------------
+# Extended command tests
+# ---------------------------------------------------------------------------
+
+
+def test_all_seat_profiles_have_extended_commands() -> None:
+    """Seat_1 and seat_2 profiles should include back/waist/neck/light commands."""
+    for variant_key in (KAIDI_VARIANT_SEAT_1, KAIDI_VARIANT_SEAT_2):
+        profile = KAIDI_COMMAND_PROFILES[variant_key]
+        assert profile.back_up is not None, f"{variant_key} missing back_up"
+        assert profile.waist_up is not None, f"{variant_key} missing waist_up"
+        assert profile.neck_up is not None, f"{variant_key} missing neck_up"
+        assert profile.light_on is not None, f"{variant_key} missing light_on"
+        assert profile.massage_mode_1 is not None, f"{variant_key} missing massage_mode_1"
+        assert profile.preset_book is not None, f"{variant_key} missing preset_book"
+        assert profile.preset_leisure is not None, f"{variant_key} missing preset_leisure"
+
+
+def test_seat_1_2_profile_uses_seat_1_values() -> None:
+    """seat_1_2 profile should have the same command values as seat_1."""
+    seat_1 = KAIDI_COMMAND_PROFILES[KAIDI_VARIANT_SEAT_1]
+    seat_1_2 = KAIDI_COMMAND_PROFILES[KAIDI_VARIANT_SEAT_1_2]
+
+    assert seat_1_2.head_up == seat_1.head_up
+    assert seat_1_2.foot_down == seat_1.foot_down
+    assert seat_1_2.back_up == seat_1.back_up
+    assert seat_1_2.light_on == seat_1.light_on
+
+
+def test_no_bed_variant_profiles_exist() -> None:
+    """BED_* variant profiles must not exist — they used wrong command values."""
+    for key in KAIDI_COMMAND_PROFILES:
+        assert not key.startswith("bed_"), f"Found legacy BED profile: {key}"

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -228,6 +228,11 @@ class TestSupportBundle:
 
         assert report["target"]["mode"] == "target_address"
         assert report["integration"]["configured_device"] is False
+        assert report["integration"]["kaidi_product_id"] is None
+        assert report["integration"]["kaidi_sofa_acu_no"] is None
+        assert report["integration"]["kaidi_adv_type"] is None
+        assert report["integration"]["kaidi_resolved_variant"] is None
+        assert report["integration"]["kaidi_variant_source"] is None
         assert report["controller"]["initialized"] is False
         assert report["command_trace"] == []
         assert report["bluetooth"]["advertisements_by_source"] == [{"source": "proxy_1"}]


### PR DESCRIPTION
## Summary
- expand the existing `kaidi` integration to cover the confirmed Rize, Floyd, and ISleep OEM family under one bed type
- stop excluding valid Kaidi `Mouselet` devices via the generic mouse-name filter
- resolve Kaidi command families automatically from advertisement metadata, with manual overrides for `seat_1`, `seat_2`, `seat_3`, `bed_1`, `bed_2`, and `bed_12`

## Why
Issue [#247](https://github.com/kristofferR/ha-adjustable-bed/issues/247) ended up exposing two separate root causes:

- valid Kaidi beds named `Mouselet` could be filtered out before detection because the generic `mouse` exclusion ran too early
- once connected, the controller still assumed the legacy `seat_1` byte set, so beds on other Kaidi families could join successfully but never respond to actions

This PR fixes both paths and keeps the implementation conservative where the OEM APK evidence is incomplete.

## What Changed
- added Kaidi profile resolution and metadata helpers in `custom_components/adjustable_bed/kaidi_variants.py`
- extended Kaidi advertisement parsing to expose and merge `product_id`, `sofa_acu_no`, `adv_type`, `room_id`, and `vaddr`
- cached resolved Kaidi metadata in config entries and surfaced it in diagnostics/support bundles
- moved Kaidi manufacturer-payload detection ahead of the generic non-bed exclusion so valid `Mouselet` devices are treated as beds
- replaced the flat Kaidi command table with profile-specific command mappings for:
  - `seat_1`
  - `seat_2`
  - `seat_3`
  - `bed_1`
  - `bed_2`
  - `bed_12`
- updated controller capability flags so preset and memory entities only appear on families with confirmed support
- documented the OEM family matrix and the new auto-resolution behavior in `docs/beds/kaidi.md`

## Auto-Resolution Rules
The new Kaidi resolver follows this order:

1. manual override from `protocol_variant`
2. exact OEM `BED_TYPE` mappings proven by the APKs
3. `sofa_acu_no` single-seat heuristic when exactly one seat bar is populated
4. legacy `seat_1` fallback only when Kaidi metadata is absent
5. metadata-present-but-ambiguous cases refuse to guess and require a manual override

That means issue-247 style payloads now resolve cleanly: `sofaType=136` with `sofa_acu_no=0x2004` maps to `seat_1` from the seat-bar heuristic, while OEM `BED_TYPE` values like `130/133/134/143` resolve to `bed_12` directly.

## Scope Notes
- massage and light commands for the `bed_*` families are intentionally not surfaced yet; the APK command space overlaps with other seat-family commands and I did not want to guess entity behavior
- the implementation stays under the existing `kaidi` bed type rather than introducing separate Home Assistant bed types for each OEM brand
- I also hardened the CB24 controller factory path to avoid assuming every coordinator stub exposes `cb24_continuous_presets_learned`

## Testing
```bash
uv run pytest tests/test_kaidi.py tests/test_detection.py tests/test_config_flow.py tests/test_diagnostics.py tests/test_support_bundle.py tests/test_controller_contract.py -q
```

Ref #247


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Support for multiple Kaidi bed/sofa variants (including dual-bed wiring), with variant-specific controls, lights, massage, presets and memory slots where supported; improved automatic variant selection.

* **Bug Fixes**
  - Kaidi metadata caching refined to reduce unnecessary updates; BLE detection updated so Kaidi adverts aren’t misclassified.

* **Documentation**
  - Expanded Kaidi docs with discovery, setup workflow, variant capabilities and provisioning guidance.

* **Diagnostics**
  - Richer Kaidi diagnostics and support report data for troubleshooting.

* **Tests**
  - Extensive Kaidi unit tests added and updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->