### PR TITLE
Add Richmat RGB light control for Casper beds

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -102,6 +102,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.COVER,
+    Platform.LIGHT,
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,

--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -635,6 +635,19 @@ class BedController(ABC):
         return False
 
     @property
+    def supports_light_color_control(self) -> bool:
+        """Return True if bed supports setting light RGB color directly."""
+        return False
+
+    @property
+    def default_light_rgb_color(self) -> tuple[int, int, int] | None:
+        """Return the default RGB color used when turning lights on.
+
+        Beds without direct light color support should return None.
+        """
+        return None
+
+    @property
     def has_lumbar_support(self) -> bool:
         """Return True if bed has lumbar motor control."""
         return False
@@ -1360,6 +1373,17 @@ class BedController(ABC):
             NotImplementedError: If the bed doesn't support light level control
         """
         raise NotImplementedError("Light level control not supported on this bed")
+
+    async def set_light_color(self, rgb_color: tuple[int, int, int]) -> None:
+        """Set light RGB color.
+
+        Args:
+            rgb_color: RGB tuple with values from 0-255
+
+        Raises:
+            NotImplementedError: If the bed doesn't support direct RGB color control
+        """
+        raise NotImplementedError("Light color control not supported on this bed")
 
     # Light timer control (optional - for beds with auto-off timer)
 

--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -635,6 +635,16 @@ class BedController(ABC):
         return False
 
     @property
+    def supports_explicit_light_on_control(self) -> bool:
+        """Return True if bed has a dedicated light-on command.
+
+        Beds with discrete on/off inherently support explicit power-on.
+        Toggle-only controllers can override this when they still expose
+        an idempotent or otherwise dedicated light-on packet.
+        """
+        return self.supports_discrete_light_control
+
+    @property
     def supports_light_color_control(self) -> bool:
         """Return True if bed supports setting light RGB color directly."""
         return False

--- a/custom_components/adjustable_bed/beds/richmat.py
+++ b/custom_components/adjustable_bed/beds/richmat.py
@@ -39,6 +39,15 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+RICHMAT_RGB_LIGHT_REMOTE_CODES = frozenset({"bt6500", "i7rm", "qrrm"})
+RICHMAT_RGB_LIGHT_DEFAULT_COLOR = (1, 221, 255)
+RICHMAT_RGB_LIGHT_TIMER_ALWAYS_ON = "Always On"
+RICHMAT_RGB_LIGHT_TIMER_MAX_MINUTES = 30
+RICHMAT_RGB_LIGHT_TIMER_OPTIONS = [
+    RICHMAT_RGB_LIGHT_TIMER_ALWAYS_ON,
+    *(f"{minute} min" for minute in range(1, RICHMAT_RGB_LIGHT_TIMER_MAX_MINUTES + 1)),
+]
+
 
 class RichmatCommands:
     """Richmat command constants (command byte values).
@@ -304,8 +313,35 @@ class RichmatController(BedController):
 
     @property
     def supports_discrete_light_control(self) -> bool:
-        """Return False - Richmat only supports toggle, not discrete on/off."""
-        return False
+        """Return True for Richmat RGB-strip remotes with explicit power packets."""
+        return self.supports_light_color_control
+
+    @property
+    def supports_light_color_control(self) -> bool:
+        """Return True for WiLinke Richmat remotes with dedicated RGB light packets."""
+        return (
+            self._command_protocol == RICHMAT_PROTOCOL_WILINKE
+            and self._remote_code.lower() in RICHMAT_RGB_LIGHT_REMOTE_CODES
+        )
+
+    @property
+    def default_light_rgb_color(self) -> tuple[int, int, int] | None:
+        """Return the default Richmat RGB light color used by the OEM apps."""
+        if self.supports_light_color_control:
+            return RICHMAT_RGB_LIGHT_DEFAULT_COLOR
+        return None
+
+    @property
+    def supports_light_timer(self) -> bool:
+        """Return True for Richmat remotes with the dedicated under-bed light timer UI."""
+        return self.supports_light_color_control
+
+    @property
+    def light_timer_options(self) -> list[str]:
+        """Return supported Richmat under-bed light timer options."""
+        if not self.supports_light_timer:
+            return []
+        return list(RICHMAT_RGB_LIGHT_TIMER_OPTIONS)
 
     @property
     def supports_memory_presets(self) -> bool:
@@ -360,6 +396,50 @@ class RichmatController(BedController):
         else:
             # Single/Nordic: just the command byte
             return bytes([command_byte])
+
+    @staticmethod
+    def _richmat_checksum(payload: bytes) -> int:
+        """Return the Richmat additive checksum for a single command segment."""
+        return sum(payload) & 0xFF
+
+    def _build_rgb_light_frame(self, command_id: int, payload: bytes) -> bytes:
+        """Build a Richmat RGB-strip frame with additive checksum."""
+        frame = bytearray((0x04, 0x00, command_id, 0x01, 0x00))
+        frame.extend(payload)
+        frame.extend((0x00, 0x00))
+        frame[1] = len(frame) + 1
+        frame.append(self._richmat_checksum(bytes(frame)))
+        return bytes(frame)
+
+    def _build_light_color_command(self, rgb_color: tuple[int, int, int]) -> bytes:
+        """Build the Richmat QRRM-family RGB-strip color packet."""
+        if not self.supports_light_color_control:
+            raise NotImplementedError("RGB light control not supported for this Richmat remote")
+
+        red, green, blue = rgb_color
+        if not all(0 <= value <= 255 for value in (red, green, blue)):
+            raise ValueError(f"RGB values must be between 0 and 255: {rgb_color}")
+
+        return self._build_rgb_light_frame(0x01, bytes((red, green, blue)))
+
+    def _build_light_power_command(self, *, is_on: bool) -> bytes:
+        """Build the Richmat QRRM-family RGB-strip power packet."""
+        if not self.supports_discrete_light_control:
+            raise NotImplementedError("Discrete light power control not supported")
+
+        return self._build_rgb_light_frame(0x04, bytes((0x02 if is_on else 0x00,)))
+
+    def _build_light_timer_command(self, minutes: int) -> bytes:
+        """Build the Richmat QRRM-family RGB-strip timer packet."""
+        if not self.supports_light_timer:
+            raise NotImplementedError("Light timer not supported for this Richmat remote")
+        if minutes < 0:
+            raise ValueError(f"Timer minutes must be >= 0: {minutes}")
+
+        return self._build_rgb_light_frame(
+            0x02,
+            bytes(((minutes >> 8) & 0xFF, minutes & 0xFF)),
+        )
 
     async def write_command(
         self,
@@ -578,12 +658,35 @@ class RichmatController(BedController):
         await self.write_command(self._build_command(RichmatCommands.LIGHTS_TOGGLE))
 
     async def lights_on(self) -> None:
-        """Turn on under-bed lights (toggle-only, state unknown)."""
+        """Turn on under-bed lights."""
+        if self.supports_discrete_light_control:
+            await self.write_command(self._build_light_power_command(is_on=True))
+            return
         await self.lights_toggle()
 
     async def lights_off(self) -> None:
-        """Turn off under-bed lights (toggle-only, state unknown)."""
+        """Turn off under-bed lights."""
+        if self.supports_discrete_light_control:
+            await self.write_command(self._build_light_power_command(is_on=False))
+            return
         await self.lights_toggle()
+
+    async def set_light_color(self, rgb_color: tuple[int, int, int]) -> None:
+        """Set the Richmat under-bed light RGB color."""
+        await self.write_command(self._build_light_color_command(rgb_color))
+
+    async def set_light_timer(self, timer_option: str) -> None:
+        """Set the Richmat under-bed light auto-off timer."""
+        if timer_option == RICHMAT_RGB_LIGHT_TIMER_ALWAYS_ON:
+            minutes = 0
+        elif timer_option.endswith(" min") and timer_option.split()[0].isdigit():
+            minutes = int(timer_option.split()[0])
+        else:
+            minutes = -1
+
+        if not 0 <= minutes <= RICHMAT_RGB_LIGHT_TIMER_MAX_MINUTES:
+            raise ValueError(f"Unsupported Richmat light timer option: {timer_option}")
+        await self.write_command(self._build_light_timer_command(minutes))
 
     # Massage methods
     async def massage_toggle(self) -> None:

--- a/custom_components/adjustable_bed/beds/richmat.py
+++ b/custom_components/adjustable_bed/beds/richmat.py
@@ -271,7 +271,9 @@ class RichmatController(BedController):
         if remote_code == "i7rm" and "sleep function" in haystack:
             return RICHMAT_LIGHT_PROTOCOL_RGB_STRIP
 
-        if any(hint in haystack for hint in RICHMAT_RGB_STRIP_LIGHT_NAME_HINTS):
+        if remote_code == "i7rm" and any(
+            hint in haystack for hint in RICHMAT_RGB_STRIP_LIGHT_NAME_HINTS
+        ):
             return RICHMAT_LIGHT_PROTOCOL_RGB_STRIP
 
         if not bool(self._features & RichmatFeatures.UNDER_BED_LIGHTS):

--- a/custom_components/adjustable_bed/beds/richmat.py
+++ b/custom_components/adjustable_bed/beds/richmat.py
@@ -39,13 +39,25 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-RICHMAT_RGB_LIGHT_REMOTE_CODES = frozenset({"bt6500", "i7rm", "qrrm"})
-RICHMAT_RGB_LIGHT_DEFAULT_COLOR = (1, 221, 255)
-RICHMAT_RGB_LIGHT_TIMER_ALWAYS_ON = "Always On"
-RICHMAT_RGB_LIGHT_TIMER_MAX_MINUTES = 30
-RICHMAT_RGB_LIGHT_TIMER_OPTIONS = [
-    RICHMAT_RGB_LIGHT_TIMER_ALWAYS_ON,
-    *(f"{minute} min" for minute in range(1, RICHMAT_RGB_LIGHT_TIMER_MAX_MINUTES + 1)),
+RICHMAT_LIGHT_PROTOCOL_LEGACY_RGB = "legacy_rgb"
+RICHMAT_LIGHT_PROTOCOL_RGB_STRIP = "rgb_strip"
+
+RICHMAT_RGB_STRIP_LIGHT_REMOTE_CODES = frozenset({"bt6500", "qrrm"})
+RICHMAT_RGB_STRIP_LIGHT_NAME_HINTS = ("casper",)
+RICHMAT_LIGHT_TIMER_ALWAYS_ON = "Always On"
+
+RICHMAT_RGB_STRIP_LIGHT_DEFAULT_COLOR = (1, 221, 255)
+RICHMAT_RGB_STRIP_LIGHT_TIMER_MAX_MINUTES = 30
+RICHMAT_RGB_STRIP_LIGHT_TIMER_OPTIONS = [
+    RICHMAT_LIGHT_TIMER_ALWAYS_ON,
+    *(f"{minute} min" for minute in range(1, RICHMAT_RGB_STRIP_LIGHT_TIMER_MAX_MINUTES + 1)),
+]
+
+RICHMAT_LEGACY_RGB_LIGHT_DEFAULT_COLOR = (0, 255, 0)
+RICHMAT_LEGACY_RGB_LIGHT_TIMER_MAX_SECONDS = 300
+RICHMAT_LEGACY_RGB_LIGHT_TIMER_OPTIONS = [
+    RICHMAT_LIGHT_TIMER_ALWAYS_ON,
+    *(f"{minute} min" for minute in range(1, 6)),
 ]
 
 
@@ -163,6 +175,9 @@ class RichmatController(BedController):
         remote_code: str | None = None,
         command_protocol: str | None = None,
         write_with_response: bool = True,
+        entry_title: str | None = None,
+        configured_name: str | None = None,
+        device_name: str | None = None,
     ) -> None:
         """Initialize the Richmat controller.
 
@@ -173,6 +188,9 @@ class RichmatController(BedController):
             remote_code: The remote code for feature detection (e.g., "VIRM", "I7RM")
             command_protocol: Override the command protocol (single, wilinke, prefix55, prefixaa)
             write_with_response: Whether to use write-with-response for GATT writes
+            entry_title: Config entry title for Richmat model-specific hints
+            configured_name: User-configured name for Richmat model-specific hints
+            device_name: BLE device name for Richmat model-specific hints
         """
         super().__init__(coordinator)
         self._is_wilinke = is_wilinke
@@ -191,13 +209,19 @@ class RichmatController(BedController):
         else:
             self._command_protocol = RICHMAT_PROTOCOL_SINGLE
         self._stop_command_byte = self._resolve_stop_command_byte()
+        self._light_protocol_family = self._resolve_light_protocol_family(
+            entry_title=entry_title,
+            configured_name=configured_name,
+            device_name=device_name,
+        )
 
         _LOGGER.debug(
-            "RichmatController initialized (char: %s, protocol: %s, remote: %s, stop: 0x%02X, response: %s)",
+            "RichmatController initialized (char: %s, protocol: %s, remote: %s, stop: 0x%02X, light_protocol: %s, response: %s)",
             self._char_uuid,
             self._command_protocol,
             self._remote_code,
             self._stop_command_byte,
+            self._light_protocol_family,
             self._write_with_response,
         )
 
@@ -219,6 +243,41 @@ class RichmatController(BedController):
     def _build_stop_command(self) -> bytes:
         """Build stop command bytes using resolved stop compatibility byte."""
         return self._build_command(self._stop_command_byte)
+
+    def _resolve_light_protocol_family(
+        self,
+        *,
+        entry_title: str | None,
+        configured_name: str | None,
+        device_name: str | None,
+    ) -> str | None:
+        """Resolve the Richmat light packet family for this controller."""
+        if self._command_protocol != RICHMAT_PROTOCOL_WILINKE:
+            return None
+
+        remote_code = (self._remote_code or "").lower()
+        if remote_code in {"", RICHMAT_REMOTE_AUTO}:
+            return None
+
+        haystack = " ".join(
+            part.lower()
+            for part in (entry_title, configured_name, device_name)
+            if part
+        )
+
+        if remote_code in RICHMAT_RGB_STRIP_LIGHT_REMOTE_CODES:
+            return RICHMAT_LIGHT_PROTOCOL_RGB_STRIP
+
+        if remote_code == "i7rm" and "sleep function" in haystack:
+            return RICHMAT_LIGHT_PROTOCOL_RGB_STRIP
+
+        if any(hint in haystack for hint in RICHMAT_RGB_STRIP_LIGHT_NAME_HINTS):
+            return RICHMAT_LIGHT_PROTOCOL_RGB_STRIP
+
+        if not bool(self._features & RichmatFeatures.UNDER_BED_LIGHTS):
+            return None
+
+        return RICHMAT_LIGHT_PROTOCOL_LEGACY_RGB
 
     @property
     def control_characteristic_uuid(self) -> str:
@@ -309,26 +368,43 @@ class RichmatController(BedController):
     @property
     def supports_lights(self) -> bool:
         """Return True if this bed supports under-bed lights."""
-        return bool(self._features & RichmatFeatures.UNDER_BED_LIGHTS)
+        return bool(self._features & RichmatFeatures.UNDER_BED_LIGHTS) or (
+            self._light_protocol_family is not None
+        )
+
+    @property
+    def light_protocol_family(self) -> str | None:
+        """Return the selected Richmat light packet family for this bed."""
+        return self._light_protocol_family
 
     @property
     def supports_discrete_light_control(self) -> bool:
-        """Return True for Richmat RGB-strip remotes with explicit power packets."""
-        return self.supports_light_color_control
+        """Return True when the selected light family has separate on/off packets."""
+        return self._light_protocol_family == RICHMAT_LIGHT_PROTOCOL_RGB_STRIP
+
+    @property
+    def supports_explicit_light_on_control(self) -> bool:
+        """Return True when the selected Richmat light family has an explicit ON packet."""
+        return self._light_protocol_family in {
+            RICHMAT_LIGHT_PROTOCOL_LEGACY_RGB,
+            RICHMAT_LIGHT_PROTOCOL_RGB_STRIP,
+        }
 
     @property
     def supports_light_color_control(self) -> bool:
-        """Return True for WiLinke Richmat remotes with dedicated RGB light packets."""
-        return (
-            self._command_protocol == RICHMAT_PROTOCOL_WILINKE
-            and self._remote_code.lower() in RICHMAT_RGB_LIGHT_REMOTE_CODES
-        )
+        """Return True for Richmat remotes with verified RGB light packets."""
+        return self._light_protocol_family in {
+            RICHMAT_LIGHT_PROTOCOL_LEGACY_RGB,
+            RICHMAT_LIGHT_PROTOCOL_RGB_STRIP,
+        }
 
     @property
     def default_light_rgb_color(self) -> tuple[int, int, int] | None:
         """Return the default Richmat RGB light color used by the OEM apps."""
-        if self.supports_light_color_control:
-            return RICHMAT_RGB_LIGHT_DEFAULT_COLOR
+        if self._light_protocol_family == RICHMAT_LIGHT_PROTOCOL_RGB_STRIP:
+            return RICHMAT_RGB_STRIP_LIGHT_DEFAULT_COLOR
+        if self._light_protocol_family == RICHMAT_LIGHT_PROTOCOL_LEGACY_RGB:
+            return RICHMAT_LEGACY_RGB_LIGHT_DEFAULT_COLOR
         return None
 
     @property
@@ -339,9 +415,11 @@ class RichmatController(BedController):
     @property
     def light_timer_options(self) -> list[str]:
         """Return supported Richmat under-bed light timer options."""
-        if not self.supports_light_timer:
-            return []
-        return list(RICHMAT_RGB_LIGHT_TIMER_OPTIONS)
+        if self._light_protocol_family == RICHMAT_LIGHT_PROTOCOL_RGB_STRIP:
+            return list(RICHMAT_RGB_STRIP_LIGHT_TIMER_OPTIONS)
+        if self._light_protocol_family == RICHMAT_LIGHT_PROTOCOL_LEGACY_RGB:
+            return list(RICHMAT_LEGACY_RGB_LIGHT_TIMER_OPTIONS)
+        return []
 
     @property
     def supports_memory_presets(self) -> bool:
@@ -411,9 +489,46 @@ class RichmatController(BedController):
         frame.append(self._richmat_checksum(bytes(frame)))
         return bytes(frame)
 
+    def _build_legacy_rgb_light_segment(self, command_id: int, payload: bytes) -> bytes:
+        """Build a legacy Richmat RGB-light command segment with checksum."""
+        if len(payload) != 2:
+            raise ValueError(f"Legacy Richmat light payload must be 2 bytes, got {payload!r}")
+
+        segment = bytes((0x6E, command_id, payload[0], payload[1]))
+        return segment + bytes((self._richmat_checksum(segment),))
+
+    def _build_legacy_light_power_on_command(self) -> bytes:
+        """Build the legacy Richmat light power-on packet from the Java OEM apps."""
+        if self._light_protocol_family != RICHMAT_LIGHT_PROTOCOL_LEGACY_RGB:
+            raise NotImplementedError("Legacy Richmat light power command not supported")
+
+        return self._build_legacy_rgb_light_segment(0x0A, bytes((0x00, 0x01)))
+
+    def _build_legacy_light_color_command(self, rgb_color: tuple[int, int, int]) -> bytes:
+        """Build the legacy Richmat RGB color packet."""
+        red, green, blue = rgb_color
+        if not all(0 <= value <= 255 for value in (red, green, blue)):
+            raise ValueError(f"RGB values must be between 0 and 255: {rgb_color}")
+
+        return self._build_legacy_rgb_light_segment(0x0C, bytes((0xFF, red))) + (
+            self._build_legacy_rgb_light_segment(0x0D, bytes((green, blue)))
+        )
+
+    def _build_legacy_light_timer_command(self, seconds: int) -> bytes:
+        """Build the legacy Richmat light timer packet."""
+        if not 0 <= seconds <= RICHMAT_LEGACY_RGB_LIGHT_TIMER_MAX_SECONDS:
+            raise ValueError(f"Legacy Richmat light timer must be 0-300 seconds: {seconds}")
+
+        return self._build_legacy_rgb_light_segment(
+            0x0B,
+            bytes(((seconds >> 8) & 0xFF, seconds & 0xFF)),
+        )
+
     def _build_light_color_command(self, rgb_color: tuple[int, int, int]) -> bytes:
-        """Build the Richmat QRRM-family RGB-strip color packet."""
-        if not self.supports_light_color_control:
+        """Build the Richmat RGB color packet for the selected light family."""
+        if self._light_protocol_family == RICHMAT_LIGHT_PROTOCOL_LEGACY_RGB:
+            return self._build_legacy_light_color_command(rgb_color)
+        if self._light_protocol_family != RICHMAT_LIGHT_PROTOCOL_RGB_STRIP:
             raise NotImplementedError("RGB light control not supported for this Richmat remote")
 
         red, green, blue = rgb_color
@@ -424,22 +539,25 @@ class RichmatController(BedController):
 
     def _build_light_power_command(self, *, is_on: bool) -> bytes:
         """Build the Richmat QRRM-family RGB-strip power packet."""
-        if not self.supports_discrete_light_control:
+        if self._light_protocol_family != RICHMAT_LIGHT_PROTOCOL_RGB_STRIP:
             raise NotImplementedError("Discrete light power control not supported")
 
         return self._build_rgb_light_frame(0x04, bytes((0x02 if is_on else 0x00,)))
 
-    def _build_light_timer_command(self, minutes: int) -> bytes:
+    def _build_rgb_strip_light_timer_command(self, minutes: int) -> bytes:
         """Build the Richmat QRRM-family RGB-strip timer packet."""
-        if not self.supports_light_timer:
-            raise NotImplementedError("Light timer not supported for this Richmat remote")
         if minutes < 0:
             raise ValueError(f"Timer minutes must be >= 0: {minutes}")
 
-        return self._build_rgb_light_frame(
-            0x02,
-            bytes(((minutes >> 8) & 0xFF, minutes & 0xFF)),
-        )
+        return self._build_rgb_light_frame(0x02, bytes(((minutes >> 8) & 0xFF, minutes & 0xFF)))
+
+    def _build_light_timer_command(self, value: int) -> bytes:
+        """Build the Richmat light timer packet for the selected light family."""
+        if self._light_protocol_family == RICHMAT_LIGHT_PROTOCOL_RGB_STRIP:
+            return self._build_rgb_strip_light_timer_command(value)
+        if self._light_protocol_family == RICHMAT_LIGHT_PROTOCOL_LEGACY_RGB:
+            return self._build_legacy_light_timer_command(value)
+        raise NotImplementedError("Light timer not supported for this Richmat remote")
 
     async def write_command(
         self,
@@ -659,14 +777,17 @@ class RichmatController(BedController):
 
     async def lights_on(self) -> None:
         """Turn on under-bed lights."""
-        if self.supports_discrete_light_control:
+        if self._light_protocol_family == RICHMAT_LIGHT_PROTOCOL_RGB_STRIP:
             await self.write_command(self._build_light_power_command(is_on=True))
+            return
+        if self._light_protocol_family == RICHMAT_LIGHT_PROTOCOL_LEGACY_RGB:
+            await self.write_command(self._build_legacy_light_power_on_command())
             return
         await self.lights_toggle()
 
     async def lights_off(self) -> None:
         """Turn off under-bed lights."""
-        if self.supports_discrete_light_control:
+        if self._light_protocol_family == RICHMAT_LIGHT_PROTOCOL_RGB_STRIP:
             await self.write_command(self._build_light_power_command(is_on=False))
             return
         await self.lights_toggle()
@@ -677,16 +798,33 @@ class RichmatController(BedController):
 
     async def set_light_timer(self, timer_option: str) -> None:
         """Set the Richmat under-bed light auto-off timer."""
-        if timer_option == RICHMAT_RGB_LIGHT_TIMER_ALWAYS_ON:
-            minutes = 0
-        elif timer_option.endswith(" min") and timer_option.split()[0].isdigit():
-            minutes = int(timer_option.split()[0])
-        else:
-            minutes = -1
+        if self._light_protocol_family == RICHMAT_LIGHT_PROTOCOL_RGB_STRIP:
+            if timer_option == RICHMAT_LIGHT_TIMER_ALWAYS_ON:
+                minutes = 0
+            elif timer_option.endswith(" min") and timer_option.split()[0].isdigit():
+                minutes = int(timer_option.split()[0])
+            else:
+                minutes = -1
 
-        if not 0 <= minutes <= RICHMAT_RGB_LIGHT_TIMER_MAX_MINUTES:
-            raise ValueError(f"Unsupported Richmat light timer option: {timer_option}")
-        await self.write_command(self._build_light_timer_command(minutes))
+            if not 0 <= minutes <= RICHMAT_RGB_STRIP_LIGHT_TIMER_MAX_MINUTES:
+                raise ValueError(f"Unsupported Richmat light timer option: {timer_option}")
+            await self.write_command(self._build_light_timer_command(minutes))
+            return
+
+        if self._light_protocol_family == RICHMAT_LIGHT_PROTOCOL_LEGACY_RGB:
+            if timer_option == RICHMAT_LIGHT_TIMER_ALWAYS_ON:
+                seconds = 0
+            elif timer_option.endswith(" min") and timer_option.split()[0].isdigit():
+                seconds = int(timer_option.split()[0]) * 60
+            else:
+                seconds = -1
+
+            if not 0 <= seconds <= RICHMAT_LEGACY_RGB_LIGHT_TIMER_MAX_SECONDS:
+                raise ValueError(f"Unsupported Richmat light timer option: {timer_option}")
+            await self.write_command(self._build_light_timer_command(seconds))
+            return
+
+        raise NotImplementedError("Light timer not supported for this Richmat remote")
 
     # Massage methods
     async def massage_toggle(self) -> None:

--- a/custom_components/adjustable_bed/button.py
+++ b/custom_components/adjustable_bed/button.py
@@ -472,7 +472,9 @@ def _should_add_button(
         return False
 
     if description.key == "toggle_light" and controller is not None:
-        if getattr(controller, "supports_discrete_light_control", False):
+        if getattr(controller, "supports_discrete_light_control", False) or getattr(
+            controller, "supports_light_color_control", False
+        ):
             return False
 
     if description.required_capability is not None:

--- a/custom_components/adjustable_bed/controller_factory.py
+++ b/custom_components/adjustable_bed/controller_factory.py
@@ -362,10 +362,22 @@ async def create_controller(
     if bed_type == BED_TYPE_RICHMAT:
         from .beds.richmat import RichmatController, detect_richmat_variant
 
+        entry = getattr(coordinator, "entry", None)
+        richmat_kwargs = {
+            "entry_title": getattr(entry, "title", None),
+            "configured_name": getattr(coordinator, "name", None),
+            "device_name": device_name,
+        }
+
         # Use configured variant or auto-detect
         if protocol_variant == RICHMAT_VARIANT_NORDIC:
             _LOGGER.debug("Using Nordic Richmat variant (configured)")
-            return RichmatController(coordinator, is_wilinke=False, remote_code=richmat_remote)
+            return RichmatController(
+                coordinator,
+                is_wilinke=False,
+                remote_code=richmat_remote,
+                **richmat_kwargs,
+            )
         elif protocol_variant == RICHMAT_VARIANT_WILINKE:
             _LOGGER.debug("Using WiLinke Richmat variant (configured)")
             # Still need to detect correct char_uuid - different WiLinke devices use different UUIDs
@@ -378,6 +390,7 @@ async def create_controller(
                 char_uuid=char_uuid,
                 remote_code=richmat_remote,
                 write_with_response=write_with_response,
+                **richmat_kwargs,
             )
         elif protocol_variant == RICHMAT_VARIANT_PREFIX55:
             _LOGGER.debug("Using Prefix55 Richmat variant (configured)")
@@ -391,6 +404,7 @@ async def create_controller(
                 command_protocol=RICHMAT_PROTOCOL_PREFIX55,
                 char_uuid=char_uuid,
                 write_with_response=write_with_response,
+                **richmat_kwargs,
             )
         elif protocol_variant == RICHMAT_VARIANT_PREFIXAA:
             _LOGGER.debug("Using PrefixAA Richmat variant (configured)")
@@ -404,6 +418,7 @@ async def create_controller(
                 command_protocol=RICHMAT_PROTOCOL_PREFIXAA,
                 char_uuid=char_uuid,
                 write_with_response=write_with_response,
+                **richmat_kwargs,
             )
         else:
             # Auto-detect variant based on available services
@@ -417,6 +432,7 @@ async def create_controller(
                 char_uuid=char_uuid,
                 remote_code=richmat_remote,
                 write_with_response=write_with_response,
+                **richmat_kwargs,
             )
 
     if bed_type == BED_TYPE_KEESON:

--- a/custom_components/adjustable_bed/light.py
+++ b/custom_components/adjustable_bed/light.py
@@ -123,7 +123,9 @@ class AdjustableBedLight(AdjustableBedEntity, RestoreEntity, LightEntity):
             raise ValueError("No RGB color available for this light")
 
         async def _turn_on(ctrl: BedController) -> None:
-            if not self._attr_is_on and getattr(ctrl, "supports_discrete_light_control", False):
+            if not self._attr_is_on and getattr(
+                ctrl, "supports_explicit_light_on_control", False
+            ):
                 await ctrl.lights_on()
             await ctrl.set_light_color(target_rgb)
 

--- a/custom_components/adjustable_bed/light.py
+++ b/custom_components/adjustable_bed/light.py
@@ -40,7 +40,11 @@ def _normalize_rgb_color(value: Any) -> tuple[int, int, int] | None:
     if not isinstance(value, (list, tuple)) or len(value) != 3:
         return None
 
-    rgb = tuple(int(channel) for channel in value)
+    try:
+        rgb = tuple(int(channel) for channel in value)
+    except (TypeError, ValueError):
+        return None
+
     if any(channel < 0 or channel > 255 for channel in rgb):
         return None
     return rgb

--- a/custom_components/adjustable_bed/light.py
+++ b/custom_components/adjustable_bed/light.py
@@ -127,9 +127,7 @@ class AdjustableBedLight(AdjustableBedEntity, RestoreEntity, LightEntity):
             raise ValueError("No RGB color available for this light")
 
         async def _turn_on(ctrl: BedController) -> None:
-            if not self._attr_is_on and getattr(
-                ctrl, "supports_explicit_light_on_control", False
-            ):
+            if getattr(ctrl, "supports_explicit_light_on_control", False):
                 await ctrl.lights_on()
             await ctrl.set_light_color(target_rgb)
 

--- a/custom_components/adjustable_bed/light.py
+++ b/custom_components/adjustable_bed/light.py
@@ -1,0 +1,161 @@
+"""Light entities for Adjustable Bed integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.light import (
+    ATTR_RGB_COLOR,
+    ColorMode,
+    LightEntity,
+    LightEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from .const import DOMAIN
+from .coordinator import AdjustableBedCoordinator
+from .entity import AdjustableBedEntity
+
+if TYPE_CHECKING:
+    from .beds.base import BedController
+
+_LOGGER = logging.getLogger(__name__)
+
+
+LIGHT_DESCRIPTION = LightEntityDescription(
+    key="under_bed_lights",
+    translation_key="under_bed_lights",
+    icon="mdi:led-strip-variant",
+)
+
+
+def _normalize_rgb_color(value: Any) -> tuple[int, int, int] | None:
+    """Normalize an RGB-like value to a strict 3-tuple."""
+    if not isinstance(value, (list, tuple)) or len(value) != 3:
+        return None
+
+    rgb = tuple(int(channel) for channel in value)
+    if any(channel < 0 or channel > 255 for channel in rgb):
+        return None
+    return rgb
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Adjustable Bed light entities."""
+    coordinator: AdjustableBedCoordinator = hass.data[DOMAIN][entry.entry_id]
+    controller = coordinator.controller
+
+    if controller is None or not getattr(controller, "supports_light_color_control", False):
+        _async_remove_stale_light_entity(hass, coordinator)
+        return
+
+    async_add_entities([AdjustableBedLight(coordinator, LIGHT_DESCRIPTION)])
+
+
+def _async_remove_stale_light_entity(
+    hass: HomeAssistant, coordinator: AdjustableBedCoordinator
+) -> None:
+    """Remove stale light entities when the controller no longer supports them."""
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "light",
+        DOMAIN,
+        f"{coordinator.address}_{LIGHT_DESCRIPTION.key}",
+    )
+    if entity_id is not None:
+        registry.async_remove(entity_id)
+
+
+class AdjustableBedLight(AdjustableBedEntity, RestoreEntity, LightEntity):
+    """RGB light entity for adjustable beds."""
+
+    entity_description: LightEntityDescription
+
+    _attr_assumed_state = True
+    _attr_color_mode = ColorMode.RGB
+    _attr_supported_color_modes = {ColorMode.RGB}
+
+    def __init__(
+        self,
+        coordinator: AdjustableBedCoordinator,
+        description: LightEntityDescription,
+    ) -> None:
+        """Initialize the light."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.address}_{description.key}"
+
+        controller = coordinator.controller
+        default_rgb = (
+            getattr(controller, "default_light_rgb_color", None) if controller is not None else None
+        )
+        self._default_rgb_color = _normalize_rgb_color(default_rgb)
+        self._attr_is_on = False
+        self._attr_rgb_color = self._default_rgb_color
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last light state when available."""
+        await super().async_added_to_hass()
+
+        if (last_state := await self.async_get_last_state()) is None:
+            return
+
+        self._attr_is_on = last_state.state == STATE_ON
+        restored_rgb = _normalize_rgb_color(last_state.attributes.get(ATTR_RGB_COLOR))
+        if restored_rgb is not None:
+            self._attr_rgb_color = restored_rgb
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the light on and optionally set a specific RGB color."""
+        requested_rgb = _normalize_rgb_color(kwargs.get(ATTR_RGB_COLOR))
+        target_rgb = requested_rgb or self._attr_rgb_color or self._default_rgb_color
+        if target_rgb is None:
+            raise ValueError("No RGB color available for this light")
+
+        async def _turn_on(ctrl: BedController) -> None:
+            if not self._attr_is_on and getattr(ctrl, "supports_discrete_light_control", False):
+                await ctrl.lights_on()
+            await ctrl.set_light_color(target_rgb)
+
+        await self._coordinator.async_execute_controller_command(_turn_on, cancel_running=False)
+        self._attr_is_on = True
+        self._attr_rgb_color = target_rgb
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the light off using the controller's light-off semantics."""
+        del kwargs
+
+        controller = self._coordinator.controller
+        if controller is None:
+            return
+
+        if not self._attr_is_on and not getattr(controller, "supports_discrete_light_control", False):
+            _LOGGER.debug(
+                "Skipping toggle-based light off for %s because HA already believes it is off",
+                self._coordinator.name,
+            )
+            return
+
+        async def _turn_off(ctrl: BedController) -> None:
+            if getattr(ctrl, "supports_discrete_light_control", False):
+                await ctrl.lights_off()
+                return
+            if getattr(ctrl, "supports_light_toggle_control", False):
+                await ctrl.lights_toggle()
+                return
+            raise NotImplementedError("Light off control not supported on this bed")
+
+        await self._coordinator.async_execute_controller_command(_turn_off, cancel_running=False)
+        self._attr_is_on = False
+        self.async_write_ha_state()

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -465,6 +465,11 @@
         "name": "Massage: Timer Mode"
       }
     },
+    "light": {
+      "under_bed_lights": {
+        "name": "Under Bed Lights"
+      }
+    },
     "switch": {
       "under_bed_lights": {
         "name": "Under Bed Lights"

--- a/custom_components/adjustable_bed/switch.py
+++ b/custom_components/adjustable_bed/switch.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import BED_TYPE_OCTO, DOMAIN
@@ -68,6 +69,7 @@ async def async_setup_entry(
     """Set up Adjustable Bed switch entities."""
     coordinator: AdjustableBedCoordinator = hass.data[DOMAIN][entry.entry_id]
     controller = coordinator.controller
+    registry = er.async_get(hass)
 
     entities = []
     for description in SWITCH_DESCRIPTIONS:
@@ -76,6 +78,13 @@ async def async_setup_entry(
             and controller is not None
             and getattr(controller, "supports_light_color_control", False)
         ):
+            entity_id = registry.async_get_entity_id(
+                "switch",
+                DOMAIN,
+                f"{coordinator.address}_{description.key}",
+            )
+            if entity_id is not None:
+                registry.async_remove(entity_id)
             continue
         # Skip switches restricted to specific bed types
         if description.required_bed_types is not None:

--- a/custom_components/adjustable_bed/switch.py
+++ b/custom_components/adjustable_bed/switch.py
@@ -71,6 +71,12 @@ async def async_setup_entry(
 
     entities = []
     for description in SWITCH_DESCRIPTIONS:
+        if (
+            description.key == "under_bed_lights"
+            and controller is not None
+            and getattr(controller, "supports_light_color_control", False)
+        ):
+            continue
         # Skip switches restricted to specific bed types
         if description.required_bed_types is not None:
             if coordinator.bed_type not in description.required_bed_types:

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -458,6 +458,11 @@
         "name": "Feet Angle"
       }
     },
+    "light": {
+      "under_bed_lights": {
+        "name": "Under Bed Lights"
+      }
+    },
     "switch": {
       "under_bed_lights": {
         "name": "Under Bed Lights"

--- a/tests/test_controller_contract.py
+++ b/tests/test_controller_contract.py
@@ -34,6 +34,7 @@ SHARED_CAPABILITY_FLAGS: tuple[str, ...] = (
     "supports_light",
     "supports_under_bed_lights",
     "supports_discrete_light_control",
+    "supports_light_color_control",
     "supports_light_cycle",
     "supports_position_feedback",
     "supports_massage",
@@ -369,6 +370,9 @@ async def test_declared_capabilities_map_to_implemented_methods(bed_type: str) -
     if controller.supports_discrete_light_control:
         assert _is_overridden(controller, "lights_on")
         assert _is_overridden(controller, "lights_off")
+
+    if controller.supports_light_color_control:
+        assert _is_overridden(controller, "set_light_color")
 
     if controller.supports_memory_presets:
         assert controller.memory_slot_count > 0

--- a/tests/test_controller_contract.py
+++ b/tests/test_controller_contract.py
@@ -21,6 +21,7 @@ from custom_components.adjustable_bed.const import (
     LEGGETT_VARIANT_OKIN,
     OCTO_VARIANT_STANDARD,
     RICHMAT_VARIANT_NORDIC,
+    RICHMAT_VARIANT_WILINKE,
     SBI_VARIANT_BOTH,
     SUPPORTED_BED_TYPES,
     VARIANT_AUTO,
@@ -91,6 +92,17 @@ async def _create_controller_for_bed_type(bed_type: str) -> BedController:
     """Create a controller through the factory for the given bed type."""
     coordinator = _FactoryCoordinator()
     client = _make_connected_client()
+
+    if bed_type == BED_TYPE_RICHMAT:
+        return await create_controller(
+            coordinator,
+            bed_type,
+            RICHMAT_VARIANT_WILINKE,
+            client,
+            device_name="Casper QRRM Bed",
+            richmat_remote="qrrm",
+        )
+
     variant = _protocol_variant_for_bed_type(bed_type)
     return await create_controller(coordinator, bed_type, variant, client)
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -688,6 +688,34 @@ class TestLightEntities:
         mock_bleak_client.write_gatt_char.reset_mock()
         await hass.services.async_call(
             "light",
+            "turn_on",
+            {
+                "entity_id": entity_id,
+                "rgb_color": [255, 0, 0],
+            },
+            blocking=True,
+        )
+
+        assert mock_bleak_client.write_gatt_char.call_args_list == [
+            call(
+                coordinator.controller.control_characteristic_uuid,
+                coordinator.controller._build_light_power_command(is_on=True),
+                response=True,
+            ),
+            call(
+                coordinator.controller.control_characteristic_uuid,
+                coordinator.controller._build_light_color_command((255, 0, 0)),
+                response=True,
+            ),
+        ]
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == STATE_ON
+        assert state.attributes["rgb_color"] == (255, 0, 0)
+
+        mock_bleak_client.write_gatt_char.reset_mock()
+        await hass.services.async_call(
+            "light",
             "turn_off",
             {"entity_id": entity_id},
             blocking=True,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -586,6 +586,13 @@ class TestLightEntities:
 
         registry = er.async_get(hass)
         registry.async_get_or_create(
+            "switch",
+            DOMAIN,
+            "57:4C:62:C3:39:05_under_bed_lights",
+            config_entry=entry,
+            suggested_object_id="casper_qrrm_bed_under_bed_lights",
+        )
+        registry.async_get_or_create(
             "button",
             DOMAIN,
             "57:4C:62:C3:39:05_toggle_light",
@@ -686,11 +693,13 @@ class TestLightEntities:
             blocking=True,
         )
 
-        mock_bleak_client.write_gatt_char.assert_called_with(
-            coordinator.controller.control_characteristic_uuid,
-            coordinator.controller._build_light_power_command(is_on=False),
-            response=True,
-        )
+        assert mock_bleak_client.write_gatt_char.call_args_list == [
+            call(
+                coordinator.controller.control_characteristic_uuid,
+                coordinator.controller._build_light_power_command(is_on=False),
+                response=True,
+            )
+        ]
 
     async def test_richmat_qrrm_light_timer_select_supports_three_minutes(
         self,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
-from homeassistant.const import CONF_ADDRESS, CONF_NAME, STATE_UNAVAILABLE
+from homeassistant.const import CONF_ADDRESS, CONF_NAME, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-# Import enable_custom_integrations fixture
 from custom_components.adjustable_bed.button import BUTTON_DESCRIPTIONS
 from custom_components.adjustable_bed.const import (
     BED_TYPE_KAIDI,
     BED_TYPE_MALOUF_LEGACY_OKIN,
     BED_TYPE_MALOUF_NEW_OKIN,
+    BED_TYPE_RICHMAT,
     BED_TYPE_SLEEPYS_BOX25,
     CONF_BED_TYPE,
     CONF_DISABLE_ANGLE_SENSING,
@@ -22,6 +22,7 @@ from custom_components.adjustable_bed.const import (
     CONF_MOTOR_COUNT,
     CONF_PREFERRED_ADAPTER,
     CONF_PROTOCOL_VARIANT,
+    CONF_RICHMAT_REMOTE,
     DOMAIN,
     KAIDI_VARIANT_SEAT_1,
 )
@@ -549,6 +550,199 @@ class TestSwitchEntities:
 
         # Should have under-bed lights switch
         assert len(switch_states) == 1
+
+
+class TestLightEntities:
+    """Test light entities."""
+
+    async def test_richmat_qrrm_light_entity_created_and_toggle_button_removed(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """QRRM beds should expose a light entity instead of the legacy toggle button."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Casper QRRM Bed",
+            data={
+                CONF_ADDRESS: "57:4C:62:C3:39:05",
+                CONF_NAME: "Casper QRRM Bed",
+                CONF_BED_TYPE: BED_TYPE_RICHMAT,
+                CONF_PROTOCOL_VARIANT: "wilinke",
+                CONF_RICHMAT_REMOTE: "qrrm",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="57:4C:62:C3:39:05",
+            entry_id="richmat_qrrm_light_entity_entry",
+        )
+        entry.add_to_hass(hass)
+
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            "57:4C:62:C3:39:05_toggle_light",
+            config_entry=entry,
+            suggested_object_id="casper_qrrm_bed_toggle_light",
+        )
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert registry.async_get_entity_id(
+            "light", DOMAIN, "57:4C:62:C3:39:05_under_bed_lights"
+        ) is not None
+        assert (
+            registry.async_get_entity_id("switch", DOMAIN, "57:4C:62:C3:39:05_under_bed_lights")
+            is None
+        )
+        assert (
+            registry.async_get_entity_id("button", DOMAIN, "57:4C:62:C3:39:05_toggle_light")
+            is None
+        )
+        assert registry.async_get_entity_id(
+            "select", DOMAIN, "57:4C:62:C3:39:05_light_timer"
+        ) is not None
+
+    async def test_richmat_qrrm_light_turn_on_and_off(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+        enable_custom_integrations,
+    ):
+        """QRRM light entity should power on, set color, and power off explicitly."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Casper QRRM Bed",
+            data={
+                CONF_ADDRESS: "57:4C:62:C3:39:05",
+                CONF_NAME: "Casper QRRM Bed",
+                CONF_BED_TYPE: BED_TYPE_RICHMAT,
+                CONF_PROTOCOL_VARIANT: "wilinke",
+                CONF_RICHMAT_REMOTE: "qrrm",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="57:4C:62:C3:39:05",
+            entry_id="richmat_qrrm_light_service_entry",
+        )
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        entity_id = registry.async_get_entity_id(
+            "light", DOMAIN, "57:4C:62:C3:39:05_under_bed_lights"
+        )
+        assert entity_id is not None
+
+        mock_bleak_client.write_gatt_char.reset_mock()
+        await hass.services.async_call(
+            "light",
+            "turn_on",
+            {
+                "entity_id": entity_id,
+                "rgb_color": [1, 221, 255],
+            },
+            blocking=True,
+        )
+
+        assert mock_bleak_client.write_gatt_char.call_args_list == [
+            call(
+                coordinator.controller.control_characteristic_uuid,
+                coordinator.controller._build_light_power_command(is_on=True),
+                response=True,
+            ),
+            call(
+                coordinator.controller.control_characteristic_uuid,
+                coordinator.controller._build_light_color_command((1, 221, 255)),
+                response=True,
+            ),
+        ]
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == STATE_ON
+        assert state.attributes["rgb_color"] == (1, 221, 255)
+
+        mock_bleak_client.write_gatt_char.reset_mock()
+        await hass.services.async_call(
+            "light",
+            "turn_off",
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            coordinator.controller.control_characteristic_uuid,
+            coordinator.controller._build_light_power_command(is_on=False),
+            response=True,
+        )
+
+    async def test_richmat_qrrm_light_timer_select_supports_three_minutes(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+        enable_custom_integrations,
+    ):
+        """QRRM timer select should expose minute-granular RGB-strip timers."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Casper QRRM Bed",
+            data={
+                CONF_ADDRESS: "57:4C:62:C3:39:05",
+                CONF_NAME: "Casper QRRM Bed",
+                CONF_BED_TYPE: BED_TYPE_RICHMAT,
+                CONF_PROTOCOL_VARIANT: "wilinke",
+                CONF_RICHMAT_REMOTE: "qrrm",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="57:4C:62:C3:39:05",
+            entry_id="richmat_qrrm_light_timer_service_entry",
+        )
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        entity_id = registry.async_get_entity_id(
+            "select", DOMAIN, "57:4C:62:C3:39:05_light_timer"
+        )
+        assert entity_id is not None
+
+        mock_bleak_client.write_gatt_char.reset_mock()
+        await hass.services.async_call(
+            "select",
+            "select_option",
+            {"entity_id": entity_id, "option": "3 min"},
+            blocking=True,
+        )
+
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            coordinator.controller.control_characteristic_uuid,
+            coordinator.controller._build_light_timer_command(3),
+            response=True,
+        )
 
     async def test_switch_turn_on_off(
         self,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -776,7 +776,7 @@ class TestLightEntities:
             blocking=True,
         )
 
-        mock_bleak_client.write_gatt_char.assert_called_with(
+        mock_bleak_client.write_gatt_char.assert_called_once_with(
             coordinator.controller.control_characteristic_uuid,
             coordinator.controller._build_light_timer_command(3),
             response=True,
@@ -912,7 +912,7 @@ class TestLightEntities:
             blocking=True,
         )
 
-        mock_bleak_client.write_gatt_char.assert_called_with(
+        mock_bleak_client.write_gatt_char.assert_called_once_with(
             coordinator.controller.control_characteristic_uuid,
             coordinator.controller._build_command(RichmatCommands.LIGHTS_TOGGLE),
             response=True,
@@ -965,7 +965,7 @@ class TestLightEntities:
             blocking=True,
         )
 
-        mock_bleak_client.write_gatt_char.assert_called_with(
+        mock_bleak_client.write_gatt_char.assert_called_once_with(
             coordinator.controller.control_characteristic_uuid,
             coordinator.controller._build_light_timer_command(180),
             response=True,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -8,6 +8,7 @@ from homeassistant.const import CONF_ADDRESS, CONF_NAME, STATE_ON, STATE_UNAVAIL
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.adjustable_bed.beds.richmat import RichmatCommands
 from custom_components.adjustable_bed.button import BUTTON_DESCRIPTIONS
 from custom_components.adjustable_bed.const import (
     BED_TYPE_KAIDI,
@@ -741,6 +742,195 @@ class TestLightEntities:
         mock_bleak_client.write_gatt_char.assert_called_with(
             coordinator.controller.control_characteristic_uuid,
             coordinator.controller._build_light_timer_command(3),
+            response=True,
+        )
+
+    async def test_richmat_legacy_rgb_light_entity_created_and_toggle_button_removed(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """Legacy Richmat RGB beds should expose a light entity and timer select."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Forty Winks VIRM Bed",
+            data={
+                CONF_ADDRESS: "57:4C:62:C3:39:06",
+                CONF_NAME: "Forty Winks VIRM Bed",
+                CONF_BED_TYPE: BED_TYPE_RICHMAT,
+                CONF_PROTOCOL_VARIANT: "wilinke",
+                CONF_RICHMAT_REMOTE: "virm",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="57:4C:62:C3:39:06",
+            entry_id="richmat_virm_light_entity_entry",
+        )
+        entry.add_to_hass(hass)
+
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            "57:4C:62:C3:39:06_toggle_light",
+            config_entry=entry,
+            suggested_object_id="forty_winks_virm_bed_toggle_light",
+        )
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert registry.async_get_entity_id(
+            "light", DOMAIN, "57:4C:62:C3:39:06_under_bed_lights"
+        ) is not None
+        assert (
+            registry.async_get_entity_id("switch", DOMAIN, "57:4C:62:C3:39:06_under_bed_lights")
+            is None
+        )
+        assert (
+            registry.async_get_entity_id("button", DOMAIN, "57:4C:62:C3:39:06_toggle_light")
+            is None
+        )
+        assert registry.async_get_entity_id(
+            "select", DOMAIN, "57:4C:62:C3:39:06_light_timer"
+        ) is not None
+
+    async def test_richmat_legacy_rgb_light_turn_on_and_off(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+        enable_custom_integrations,
+    ):
+        """Legacy Richmat RGB lights should use explicit ON and toggle-based OFF."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Forty Winks VIRM Bed",
+            data={
+                CONF_ADDRESS: "57:4C:62:C3:39:06",
+                CONF_NAME: "Forty Winks VIRM Bed",
+                CONF_BED_TYPE: BED_TYPE_RICHMAT,
+                CONF_PROTOCOL_VARIANT: "wilinke",
+                CONF_RICHMAT_REMOTE: "virm",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="57:4C:62:C3:39:06",
+            entry_id="richmat_virm_light_service_entry",
+        )
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        entity_id = registry.async_get_entity_id(
+            "light", DOMAIN, "57:4C:62:C3:39:06_under_bed_lights"
+        )
+        assert entity_id is not None
+
+        mock_bleak_client.write_gatt_char.reset_mock()
+        await hass.services.async_call(
+            "light",
+            "turn_on",
+            {
+                "entity_id": entity_id,
+                "rgb_color": [1, 221, 255],
+            },
+            blocking=True,
+        )
+
+        assert mock_bleak_client.write_gatt_char.call_args_list == [
+            call(
+                coordinator.controller.control_characteristic_uuid,
+                coordinator.controller._build_legacy_light_power_on_command(),
+                response=True,
+            ),
+            call(
+                coordinator.controller.control_characteristic_uuid,
+                coordinator.controller._build_light_color_command((1, 221, 255)),
+                response=True,
+            ),
+        ]
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == STATE_ON
+        assert state.attributes["rgb_color"] == (1, 221, 255)
+
+        mock_bleak_client.write_gatt_char.reset_mock()
+        await hass.services.async_call(
+            "light",
+            "turn_off",
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            coordinator.controller.control_characteristic_uuid,
+            coordinator.controller._build_command(RichmatCommands.LIGHTS_TOGGLE),
+            response=True,
+        )
+
+    async def test_richmat_legacy_rgb_light_timer_select_supports_three_minutes(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+        enable_custom_integrations,
+    ):
+        """Legacy Richmat RGB timers should expose minute labels and send seconds."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Forty Winks VIRM Bed",
+            data={
+                CONF_ADDRESS: "57:4C:62:C3:39:06",
+                CONF_NAME: "Forty Winks VIRM Bed",
+                CONF_BED_TYPE: BED_TYPE_RICHMAT,
+                CONF_PROTOCOL_VARIANT: "wilinke",
+                CONF_RICHMAT_REMOTE: "virm",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="57:4C:62:C3:39:06",
+            entry_id="richmat_virm_light_timer_service_entry",
+        )
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        entity_id = registry.async_get_entity_id(
+            "select", DOMAIN, "57:4C:62:C3:39:06_light_timer"
+        )
+        assert entity_id is not None
+
+        mock_bleak_client.write_gatt_char.reset_mock()
+        await hass.services.async_call(
+            "select",
+            "select_option",
+            {"entity_id": entity_id, "option": "3 min"},
+            blocking=True,
+        )
+
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            coordinator.controller.control_characteristic_uuid,
+            coordinator.controller._build_light_timer_command(180),
             response=True,
         )
 

--- a/tests/test_richmat.py
+++ b/tests/test_richmat.py
@@ -10,6 +10,7 @@ from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adjustable_bed.beds.richmat import (
+    RICHMAT_LEGACY_RGB_LIGHT_TIMER_OPTIONS,
     RichmatCommands,
     RichmatController,
 )
@@ -542,12 +543,36 @@ class TestRichmatFeatureDetection:
         coordinator = MagicMock()
         controller = RichmatController(coordinator, is_wilinke=True, remote_code="qrrm")
 
+        assert controller.light_protocol_family == "rgb_strip"
         assert controller.supports_light_color_control is True
         assert controller.supports_light_timer is True
         assert controller.supports_discrete_light_control is True
+        assert controller.supports_explicit_light_on_control is True
         assert controller.default_light_rgb_color == (1, 221, 255)
         assert controller.light_timer_options[:4] == ["Always On", "1 min", "2 min", "3 min"]
         assert controller.light_timer_options[-1] == "30 min"
+
+    def test_i7rm_sleep_function_prefers_rgb_strip_protocol(self):
+        """Sleep Function 2.0 aliases should stay on the newer RGB-strip family."""
+        coordinator = MagicMock()
+        controller = RichmatController(
+            coordinator,
+            is_wilinke=True,
+            remote_code="i7rm",
+            device_name="Sleep Function 2.0",
+        )
+
+        assert controller.light_protocol_family == "rgb_strip"
+        assert controller.supports_discrete_light_control is True
+        assert controller.supports_explicit_light_on_control is True
+
+    def test_i7rm_without_sleep_function_hint_uses_legacy_rgb_protocol(self):
+        """Generic I7RM remotes should default to the older Java RGB family."""
+        coordinator = MagicMock()
+        controller = RichmatController(coordinator, is_wilinke=True, remote_code="i7rm")
+
+        assert controller.light_protocol_family == "legacy_rgb"
+        assert controller.supports_discrete_light_control is False
 
     def test_qrrm_nordic_does_not_assume_rgb_light_packets(self):
         """The recovered RGB packets are WiLinke-specific and should not be used on Nordic."""
@@ -588,6 +613,43 @@ class TestRichmatFeatureDetection:
             "040a020100000a00001b"
         )
         assert controller._build_light_timer_command(0) == bytes.fromhex("040a0201000000000011")
+
+    def test_virm_wilinke_supports_legacy_rgb_light_and_timer(self):
+        """Legacy WiLinke remotes with lights should expose the older RGB family."""
+        coordinator = MagicMock()
+        controller = RichmatController(coordinator, is_wilinke=True, remote_code="virm")
+
+        assert controller.light_protocol_family == "legacy_rgb"
+        assert controller.supports_light_color_control is True
+        assert controller.supports_light_timer is True
+        assert controller.supports_discrete_light_control is False
+        assert controller.supports_explicit_light_on_control is True
+        assert controller.default_light_rgb_color == (0, 255, 0)
+        assert controller.light_timer_options == RICHMAT_LEGACY_RGB_LIGHT_TIMER_OPTIONS
+
+    def test_build_legacy_richmat_light_color_command(self):
+        """Legacy Richmat RGB packets should match the older Java OEM apps."""
+        coordinator = MagicMock()
+        controller = RichmatController(coordinator, is_wilinke=True, remote_code="virm")
+
+        command = controller._build_light_color_command((1, 221, 255))
+
+        assert command == bytes.fromhex("6e0cff017a6e0dddff57")
+
+    def test_build_legacy_richmat_light_power_on_command(self):
+        """Legacy Richmat light power-on should use the confirmed TX_LED packet."""
+        coordinator = MagicMock()
+        controller = RichmatController(coordinator, is_wilinke=True, remote_code="virm")
+
+        assert controller._build_legacy_light_power_on_command() == bytes.fromhex("6e0a000179")
+
+    def test_build_legacy_richmat_light_timer_command(self):
+        """Legacy Richmat timers should use seconds up to the 300-second app limit."""
+        coordinator = MagicMock()
+        controller = RichmatController(coordinator, is_wilinke=True, remote_code="virm")
+
+        assert controller._build_light_timer_command(180) == bytes.fromhex("6e0b00b42d")
+        assert controller._build_light_timer_command(0) == bytes.fromhex("6e0b000079")
 
 
 class TestRichmatPresets:
@@ -664,6 +726,72 @@ class TestRichmatPresets:
 
 class TestRichmatRgbLights:
     """Test Richmat RGB light controls."""
+
+    async def test_set_legacy_richmat_light_color(
+        self,
+        hass: HomeAssistant,
+        mock_richmat_config_entry_data: dict,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Legacy WiLinke Richmat beds should send the older RGB packet."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Richmat VIRM Bed",
+            data={
+                **mock_richmat_config_entry_data,
+                CONF_PROTOCOL_VARIANT: "wilinke",
+                CONF_RICHMAT_REMOTE: "virm",
+            },
+            unique_id="57:4C:62:AA:BB:CC",
+            entry_id="richmat_virm_light_entry",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        await coordinator.async_connect()
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.set_light_color((1, 221, 255))
+
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            coordinator.controller.control_characteristic_uuid,
+            bytes.fromhex("6e0cff017a6e0dddff57"),
+            response=True,
+        )
+
+    async def test_set_legacy_richmat_light_timer(
+        self,
+        hass: HomeAssistant,
+        mock_richmat_config_entry_data: dict,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Legacy WiLinke Richmat beds should use the older second-based timer packet."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Richmat VIRM Bed",
+            data={
+                **mock_richmat_config_entry_data,
+                CONF_PROTOCOL_VARIANT: "wilinke",
+                CONF_RICHMAT_REMOTE: "virm",
+            },
+            unique_id="57:4C:62:AA:BB:CC",
+            entry_id="richmat_virm_timer_entry",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        await coordinator.async_connect()
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.set_light_timer("3 min")
+
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            coordinator.controller.control_characteristic_uuid,
+            bytes.fromhex("6e0b00b42d"),
+            response=True,
+        )
 
     async def test_set_qrrm_light_color(
         self,

--- a/tests/test_richmat.py
+++ b/tests/test_richmat.py
@@ -537,6 +537,58 @@ class TestRichmatFeatureDetection:
         ]
         assert controller.stale_motor_entity_keys == {"back", "legs", "pillow", "lumbar"}
 
+    def test_qrrm_wilinke_supports_rgb_light_and_timer(self):
+        """QRRM WiLinke remotes should expose RGB light and timer controls."""
+        coordinator = MagicMock()
+        controller = RichmatController(coordinator, is_wilinke=True, remote_code="qrrm")
+
+        assert controller.supports_light_color_control is True
+        assert controller.supports_light_timer is True
+        assert controller.supports_discrete_light_control is True
+        assert controller.default_light_rgb_color == (1, 221, 255)
+        assert controller.light_timer_options[:4] == ["Always On", "1 min", "2 min", "3 min"]
+        assert controller.light_timer_options[-1] == "30 min"
+
+    def test_qrrm_nordic_does_not_assume_rgb_light_packets(self):
+        """The recovered RGB packets are WiLinke-specific and should not be used on Nordic."""
+        coordinator = MagicMock()
+        controller = RichmatController(coordinator, is_wilinke=False, remote_code="qrrm")
+
+        assert controller.supports_light_color_control is False
+        assert controller.supports_light_timer is False
+
+    def test_build_qrrm_light_color_command(self):
+        """QRRM RGB light packets should match the recovered Casper/Richmat app format."""
+        coordinator = MagicMock()
+        controller = RichmatController(coordinator, is_wilinke=True, remote_code="qrrm")
+
+        command = controller._build_light_color_command((1, 221, 255))
+
+        assert command == bytes.fromhex("040b01010001ddff0000ee")
+
+    def test_build_qrrm_light_power_command(self):
+        """QRRM RGB-strip power packets should use explicit on/off frames."""
+        coordinator = MagicMock()
+        controller = RichmatController(coordinator, is_wilinke=True, remote_code="qrrm")
+
+        assert controller._build_light_power_command(is_on=True) == bytes.fromhex(
+            "040904010002000014"
+        )
+        assert controller._build_light_power_command(is_on=False) == bytes.fromhex(
+            "040904010000000012"
+        )
+
+    def test_build_qrrm_light_timer_command(self):
+        """QRRM timer packets should use minute values in the RGB-strip frame."""
+        coordinator = MagicMock()
+        controller = RichmatController(coordinator, is_wilinke=True, remote_code="qrrm")
+
+        assert controller._build_light_timer_command(3) == bytes.fromhex("040a0201000003000014")
+        assert controller._build_light_timer_command(10) == bytes.fromhex(
+            "040a020100000a00001b"
+        )
+        assert controller._build_light_timer_command(0) == bytes.fromhex("040a0201000000000011")
+
 
 class TestRichmatPresets:
     """Test Richmat preset commands."""
@@ -608,6 +660,76 @@ class TestRichmatPresets:
         expected_cmd = coordinator.controller._build_command(RichmatCommands.PRESET_ANTI_SNORE)
         first_call = mock_bleak_client.write_gatt_char.call_args_list[0]
         assert first_call[0][1] == expected_cmd
+
+
+class TestRichmatRgbLights:
+    """Test Richmat RGB light controls."""
+
+    async def test_set_qrrm_light_color(
+        self,
+        hass: HomeAssistant,
+        mock_richmat_config_entry_data: dict,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """QRRM WiLinke beds should send the recovered RGB packet."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Casper QRRM Bed",
+            data={
+                **mock_richmat_config_entry_data,
+                CONF_PROTOCOL_VARIANT: "wilinke",
+                CONF_RICHMAT_REMOTE: "qrrm",
+            },
+            unique_id="57:4C:62:C3:39:05",
+            entry_id="richmat_qrrm_light_entry",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        await coordinator.async_connect()
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.set_light_color((1, 221, 255))
+
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            coordinator.controller.control_characteristic_uuid,
+            bytes.fromhex("040b01010001ddff0000ee"),
+            response=True,
+        )
+
+    async def test_set_qrrm_light_timer(
+        self,
+        hass: HomeAssistant,
+        mock_richmat_config_entry_data: dict,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """QRRM WiLinke beds should support minute-granular RGB-strip timers."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Casper QRRM Bed",
+            data={
+                **mock_richmat_config_entry_data,
+                CONF_PROTOCOL_VARIANT: "wilinke",
+                CONF_RICHMAT_REMOTE: "qrrm",
+            },
+            unique_id="57:4C:62:C3:39:05",
+            entry_id="richmat_qrrm_timer_entry",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        await coordinator.async_connect()
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.set_light_timer("3 min")
+
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            coordinator.controller.control_characteristic_uuid,
+            bytes.fromhex("040a0201000003000014"),
+            response=True,
+        )
 
     @pytest.mark.parametrize(
         "memory_num,expected_value",

--- a/tests/test_richmat.py
+++ b/tests/test_richmat.py
@@ -574,6 +574,19 @@ class TestRichmatFeatureDetection:
         assert controller.light_protocol_family == "legacy_rgb"
         assert controller.supports_discrete_light_control is False
 
+    def test_non_i7rm_casper_name_hint_stays_on_legacy_rgb_protocol(self):
+        """Casper-style names should not promote unrelated WiLinke remotes to RGB-strip."""
+        coordinator = MagicMock()
+        controller = RichmatController(
+            coordinator,
+            is_wilinke=True,
+            remote_code="virm",
+            entry_title="Casper Adjustable Bed",
+        )
+
+        assert controller.light_protocol_family == "legacy_rgb"
+        assert controller.supports_discrete_light_control is False
+
     def test_qrrm_nordic_does_not_assume_rgb_light_packets(self):
         """The recovered RGB packets are WiLinke-specific and should not be used on Nordic."""
         coordinator = MagicMock()

--- a/tests/test_richmat.py
+++ b/tests/test_richmat.py
@@ -549,8 +549,8 @@ class TestRichmatFeatureDetection:
         assert controller.supports_discrete_light_control is True
         assert controller.supports_explicit_light_on_control is True
         assert controller.default_light_rgb_color == (1, 221, 255)
-        assert controller.light_timer_options[:4] == ["Always On", "1 min", "2 min", "3 min"]
-        assert controller.light_timer_options[-1] == "30 min"
+        expected_options = ["Always On", *[f"{minute} min" for minute in range(1, 31)]]
+        assert controller.light_timer_options == expected_options
 
     def test_i7rm_sleep_function_prefers_rgb_strip_protocol(self):
         """Sleep Function 2.0 aliases should stay on the newer RGB-strip family."""


### PR DESCRIPTION
## Summary
- add a dedicated Home Assistant light platform for Richmat RGB under-bed lights and remove the legacy toggle entities for those models
- switch QRRM-family Richmat light control to the recovered Flutter RGB-strip packets for color, discrete power, and minute-granular timers
- add Richmat controller, entity, and contract tests for the new light behavior

## Notes
- timer options now expose `Always On` plus `1-30 min`, which covers the confirmed OEM `3 min` behavior without guessing at the ambiguous longer-duration encoding
- the recovered RGB-strip packet path is currently scoped to the confirmed WiLinke QRRM-family models already handled by the integration

## Testing
- `uv run pytest /Users/kristoffer/Code/Home Assistant/ha-adjustable-bed/.worktrees/codex-issue-300-richmat-lights/tests/test_richmat.py /Users/kristoffer/Code/Home Assistant/ha-adjustable-bed/.worktrees/codex-issue-300-richmat-lights/tests/test_entities.py /Users/kristoffer/Code/Home Assistant/ha-adjustable-bed/.worktrees/codex-issue-300-richmat-lights/tests/test_controller_contract.py -q`

Ref #300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RGB color control and a dedicated Under Bed Lights entity with restoreable color/state, explicit on behavior, and selectable light timers.

* **Improvements**
  * UI now surfaces the light entity and hides legacy switch/button when color control is available.
  * Localized label added for the under-bed light.

* **Tests**
  * Expanded test coverage for RGB commands, timer options, capability detection, and entity service behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->