### PR TITLE
Add Remacro/Cheers RGB light control

### DIFF
--- a/custom_components/adjustable_bed/beds/remacro.py
+++ b/custom_components/adjustable_bed/beds/remacro.py
@@ -188,7 +188,7 @@ class RemacroController(BedController):
 
     @property
     def supports_explicit_light_on_control(self) -> bool:
-        return True  # Sending LED_RGBV turns on the LED
+        return False  # set_light_color (LED_RGBV) inherently turns on the LED
 
     @property
     def supports_discrete_light_control(self) -> bool:
@@ -463,8 +463,8 @@ class RemacroController(BedController):
         await self._send_command(RemacroCommands.LED_W)
 
     async def lights_on(self) -> None:
-        """Turn on under-bed light (white via LED_RGBV)."""
-        await self.set_light_color((255, 255, 255))
+        """Turn on under-bed light (white preset)."""
+        await self._send_command(RemacroCommands.LED_W)
 
     async def lights_off(self) -> None:
         """Turn off under-bed light."""

--- a/tests/test_remacro.py
+++ b/tests/test_remacro.py
@@ -544,13 +544,13 @@ class TestRemacroPresets:
 class TestRemacroLights:
     """Test Remacro light commands."""
 
-    async def test_lights_on_sends_led_rgbv_white(
+    async def test_lights_on_sends_led_w_preset(
         self,
         hass: HomeAssistant,
         mock_remacro_config_entry,
         mock_coordinator_connected,
     ):
-        """lights_on should send LED_RGBV with white color (255, 255, 255)."""
+        """lights_on should send LED_W white preset command."""
         coordinator = AdjustableBedCoordinator(hass, mock_remacro_config_entry)
         await coordinator.async_connect()
         mock_client = coordinator._client
@@ -559,16 +559,9 @@ class TestRemacroLights:
 
         calls = mock_client.write_gatt_char.call_args_list
         call_data = calls[0][0][1]
-        # LED_RGBV = 1281 = 0x0501 in little-endian: [0x01, 0x05]
-        assert call_data[2] == 0x01
+        # LED_W = 1282 = 0x0502 in little-endian: [0x02, 0x05]
+        assert call_data[2] == 0x02
         assert call_data[3] == 0x05
-        # White (255,255,255) at brightness 255:
-        # dp = (255 << 24) | (255 << 16) | (255 << 8) | 255 = 0xFFFFFFFF
-        # LE bytes: [0xFF, 0xFF, 0xFF, 0xFF]
-        assert call_data[4] == 0xFF
-        assert call_data[5] == 0xFF
-        assert call_data[6] == 0xFF
-        assert call_data[7] == 0xFF
 
     async def test_lights_off_sends_led_off(
         self,
@@ -638,10 +631,10 @@ class TestRemacroRGBLight:
         controller = RemacroController(MagicMock())
         assert controller.supports_light_color_control is True
 
-    def test_supports_explicit_light_on_control(self):
-        """RemacroController should report explicit light-on support."""
+    def test_supports_explicit_light_on_control_is_false(self):
+        """set_light_color inherently turns LED on, no separate on command needed."""
         controller = RemacroController(MagicMock())
-        assert controller.supports_explicit_light_on_control is True
+        assert controller.supports_explicit_light_on_control is False
 
     def test_supports_discrete_light_control(self):
         """RemacroController should report discrete on/off support."""
@@ -891,7 +884,7 @@ class TestRemacroLightEntity:
         mock_bleak_client: MagicMock,
         enable_custom_integrations,
     ):
-        """Light turn_on should send lights_on + set_light_color via BLE."""
+        """Light turn_on should send set_light_color only (no redundant lights_on)."""
         entry = MockConfigEntry(
             domain=DOMAIN,
             title="Jeromes Remacro Bed",
@@ -928,15 +921,12 @@ class TestRemacroLightEntity:
             blocking=True,
         )
 
-        # lights_on() sends set_light_color(white), then set_light_color(requested)
-        # But the light entity calls lights_on() then set_light_color(target_rgb),
-        # and lights_on() itself calls set_light_color((255,255,255)).
-        # So we get 2 writes: white from lights_on + requested color from entity.
+        # supports_explicit_light_on_control is False, so only set_light_color is sent
         calls = mock_bleak_client.write_gatt_char.call_args_list
-        assert len(calls) >= 2
+        assert len(calls) == 1
 
-        # The final (second) write should be the requested color
-        final_data = calls[-1][0][1]
+        # The single write should be the requested color
+        final_data = calls[0][0][1]
         assert len(final_data) == 8
         # LED_RGBV command: [0x01, 0x05]
         assert final_data[2] == 0x01


### PR DESCRIPTION
## Summary
- Add full RGB light color control to Remacro beds (Jeromes, The Brick, Slumberland)
- Add missing LED command constants (M4-M6, RGBV_Save)
- Replace toggle-only light with discrete on/off + RGB color picker
- RGB encoding: `dp = (R << 24) | (G << 16) | (B << 8) | brightness`, sent little-endian in 8-byte SynData packet

## Details
The Remacro SynData protocol supports 16 LED commands (0x0500-0x050F) including custom RGB, preset colors (white/red/green/blue/combinations), 6 animation modes, and save-to-device. All Remacro beds have LED support.

The `LED_RGBV` (0x0501) command sets an arbitrary RGB color with brightness. The 32-bit parameter encodes as `[brightness, B, G, R]` in little-endian order across packet bytes 4-7.

## Test plan
- [x] `set_light_color((255, 0, 128))` produces correct 8-byte packet with RGB encoding
- [x] Pure R, G, B color encoding verified
- [x] `lights_off()` sends LED_OFF (0x0500)
- [x] Light entity created, stale switch/button removed
- [x] turn_on/turn_off service calls send correct BLE commands
- [x] All 1578 tests pass

Ref #300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RGB light color control to adjustable beds, allowing custom color selection.
  * Introduced additional LED mode options for more lighting presets.
  * Enabled saving custom RGB colors to the device.
  * Improved light capability detection for better compatibility and behavior (including a white preset for the default on state).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->