### PR TITLE
feat: add Okin CB35 controller for Sealy Posturematic beds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a Home Assistant custom integration for controlling smart adjustable beds via Bluetooth Low Energy (BLE). It replaces the broken `smartbed-mqtt` addon with a native HA integration that uses Home Assistant's Bluetooth stack directly.
 
-**Current status:** 43 bed protocols implemented. Linak, Keeson, Richmat, MotoSleep, Jensen, Svane, Vibradorm, Octo, Okin UUID/Okimat, Okin CB24, SUTA, and BedTech tested. Other brands need community testing.
+**Current status:** 44 bed protocols implemented. Linak, Keeson, Richmat, MotoSleep, Jensen, Svane, Vibradorm, Octo, Okin UUID/Okimat, Okin CB24, SUTA, and BedTech tested. Other brands need community testing.
 
 ## GitHub Comment Approval
 
@@ -47,6 +47,7 @@ custom_components/adjustable_bed/
 │   ├── okin_7byte.py    # Okin 7-byte protocol
 │   ├── okin_nordic.py   # Okin 7-byte via Nordic UART
 │   ├── okin_cb24.py     # Okin CB24 protocol via Nordic UART
+│   ├── okin_cb35.py     # Okin CB35 Star protocol (Sealy Posturematic)
 │   ├── okin_ore.py      # Okin ORE protocol (A5 5A format)
 │   ├── okin_protocol.py # Shared Okin protocol utilities
 │   ├── okin_64bit.py    # OKIN 64-bit 10-byte protocol
@@ -134,6 +135,7 @@ custom_components/adjustable_bed/
 | Okin 7-byte | `Okin7ByteController` | 7-byte via Okin service UUID | Service UUID `62741523-...` + name | Needs testing |
 | Okin Nordic | `OkinNordicController` | 7-byte via Nordic UART | Service UUID `6e400001-...` | Needs testing |
 | Okin CB24 | `OkinCB24Controller` | CB24 protocol via Nordic UART | Name patterns (SmartBed, Amada) | ✅ Tested |
+| Okin CB35 | `OkinCB35Controller` | CB35 7-byte via Nordic UART (Sealy) | Name `Star35*` + Nordic UART + 2A29="STAR" | Needs testing |
 | Okin ORE | `OkinOreController` | A5 5A format protocol | Service UUID `00001000-...` | Needs testing |
 | Okin FFE | `KeesonController(variant="okin")` | 0xE6 prefix, Keeson protocol | Name patterns ("okin", "cb-") + FFE5 UUID | Needs testing |
 | Okin 64-bit | `Okin64BitController` | 10-byte commands | Service UUID `62741523-...` | Needs testing |

--- a/custom_components/adjustable_bed/beds/__init__.py
+++ b/custom_components/adjustable_bed/beds/__init__.py
@@ -8,6 +8,7 @@ Protocol-based controllers:
 - OkinUuidController: Okin 6-byte via UUID, requires pairing
 - Okin7ByteController: 7-byte via Okin service UUID
 - OkinNordicController: 7-byte via Nordic UART (Mattress Firm 900)
+- OkinCB35Controller: CB35 7-byte via Nordic UART (Sealy Posturematic)
 - LeggettGen2Controller: Leggett & Platt Gen2 ASCII protocol
 - LeggettOkinController: Leggett & Platt Okin binary protocol
 - LeggettWilinkeController: Leggett & Platt WiLinke 5-byte protocol
@@ -39,6 +40,7 @@ from .okin_7byte import Okin7ByteController
 
 # Protocol-based controllers
 from .okin_cb24 import OkinCB24Controller
+from .okin_cb35 import OkinCB35Controller
 from .okin_cst import OkinCstController
 from .okin_handle import OkinHandleController
 from .okin_nordic import OkinNordicController
@@ -63,6 +65,7 @@ __all__ = [
     "BedController",
     # Protocol-based controllers
     "OkinCB24Controller",
+    "OkinCB35Controller",
     "OkinCstController",
     "OkinHandleController",
     "OkinOreController",

--- a/custom_components/adjustable_bed/beds/okin_cb35.py
+++ b/custom_components/adjustable_bed/beds/okin_cb35.py
@@ -65,7 +65,7 @@ OKIN_CB35_CONFIG = Okin7ByteConfig(
     has_light_cycle=True,
     has_massage_intensity=True,
     massage_up_byte=0x60,
-    massage_down_byte=0x63,
+    massage_down_byte=0x61,
     extra_massage_modes=(0x52, 0x53, 0x54),
     massage_stop_byte=0x6F,
     lights_off_repeat=3,
@@ -88,7 +88,6 @@ class OkinCB35Controller(Okin7ByteController):
     def __init__(self, coordinator: AdjustableBedCoordinator) -> None:
         """Initialize the CB35 controller."""
         super().__init__(coordinator, config=OKIN_CB35_CONFIG)
-        self._massage_active = False
 
     # ─── Write override: CB35 requires write-without-response ─────────
 
@@ -164,6 +163,7 @@ class OkinCB35Controller(Okin7ByteController):
                 open_fn=lambda ctrl: ctrl.move_feet_up(),
                 close_fn=lambda ctrl: ctrl.move_feet_down(),
                 stop_fn=lambda ctrl: ctrl.move_feet_stop(),
+                max_angle=45,
             ),
             MotorControlSpec(
                 key="lumbar",
@@ -178,6 +178,7 @@ class OkinCB35Controller(Okin7ByteController):
                 open_fn=lambda ctrl: ctrl.move_neck_up(),
                 close_fn=lambda ctrl: ctrl.move_neck_down(),
                 stop_fn=lambda ctrl: ctrl.move_neck_stop(),
+                max_angle=30,
             ),
             MotorControlSpec(
                 key="tilt",
@@ -185,6 +186,7 @@ class OkinCB35Controller(Okin7ByteController):
                 open_fn=lambda ctrl: ctrl.move_tilt_up(),
                 close_fn=lambda ctrl: ctrl.move_tilt_down(),
                 stop_fn=lambda ctrl: ctrl.move_tilt_stop(),
+                max_angle=45,
             ),
         )
 
@@ -215,16 +217,6 @@ class OkinCB35Controller(Okin7ByteController):
     async def move_tilt_stop(self) -> None:
         await self._send_stop()
 
-    # ─── Additional presets ───────────────────────────────────────────
-
-    @property
-    def supports_preset_read(self) -> bool:
-        return True
-
-    async def preset_read(self) -> None:
-        """Go to read position."""
-        await self._preset_with_stop(_cmd(0x12))
-
     # ─── Light brightness / color ─────────────────────────────────────
 
     async def light_brightness_up(self) -> None:
@@ -238,6 +230,16 @@ class OkinCB35Controller(Okin7ByteController):
     async def light_color_change(self) -> None:
         """Cycle light color."""
         await self.write_command(_cmd(0x70))
+
+    # ─── Massage: override inherited intensity (parent uses 0x40 frame) ─
+
+    async def massage_intensity_up(self) -> None:
+        """Increase overall massage strength (CB35 uses 0x30 frame, not 0x40)."""
+        await self.write_command(_cmd(0x60))
+
+    async def massage_intensity_down(self) -> None:
+        """Decrease overall massage strength (CB35 uses 0x30 frame, not 0x40)."""
+        await self.write_command(_cmd(0x61))
 
     # ─── Massage: separate head/foot strength ─────────────────────────
 
@@ -267,18 +269,17 @@ class OkinCB35Controller(Okin7ByteController):
         self.forward_raw_notification(characteristic.uuid, raw)
 
         if len(raw) < 2:
+            _LOGGER.debug("CB35 notification too short (%d bytes): %s", len(raw), raw.hex())
             return
 
         # Massage status: header A5 0B
         if raw[0] == 0xA5 and raw[1] == 0x0B and len(raw) >= 8:
-            self._massage_active = True
             _LOGGER.debug("CB35 massage status: %s", raw.hex())
 
-    async def start_notify(self, callback=None) -> None:
+    async def start_notify(self, callback=None) -> None:  # noqa: ARG002
         """Start listening for notifications via Nordic UART RX."""
         from ..const import NORDIC_UART_READ_CHAR_UUID
 
-        self._notify_callback = callback
         client = self.client
         if client is None or not client.is_connected:
             return
@@ -293,7 +294,6 @@ class OkinCB35Controller(Okin7ByteController):
         """Stop listening for notifications."""
         from ..const import NORDIC_UART_READ_CHAR_UUID
 
-        self._notify_callback = None
         client = self.client
         if client is not None and client.is_connected:
             try:

--- a/custom_components/adjustable_bed/beds/okin_cb35.py
+++ b/custom_components/adjustable_bed/beds/okin_cb35.py
@@ -1,0 +1,302 @@
+"""DewertOkin CB35 Star protocol bed controller implementation.
+
+Reverse-engineered from the Sealy Posturematic app (com.okin.sealy v1.1.1).
+Protocol version: CB.35.22.01 ("star code new protocol")
+
+Known brands using this protocol:
+- Sealy Posturematic (Element, Ascent, Apex)
+
+BLE Name: Star*  (e.g., "Star352201011800")
+Service: Nordic UART (6e400001-b5a3-f393-e0a9-e50e24dcca9e)
+Write:   TX characteristic (6e400002), write-without-response
+Notify:  RX characteristic (6e400003)
+
+Uses the same 7-byte command frame as Okin Nordic:
+    5A 01 03 10 30 [CMD] A5
+
+Identical motor/preset/light/massage command bytes as Okin Nordic, but:
+- Init sequence is only the wake command (5A 0B 00 A5), no Mattress Firm handshake
+- Write-without-response required (Nordic uses write-with-response)
+- Additional motors: neck (0x0A/0x0B), hips (0x08/0x09), head+foot simultaneous (0x0C/0x0D)
+- Additional presets: TV/PC, Read, Inverse, Work, Incline, Extension
+- Light brightness and color control
+- Separate head/foot massage strength
+- Massage status feedback via notifications
+
+Protocol source: disassembly/output/com.okin.sealy/extracted/assets/flutter_assets/assets/protocol/35_22_01.json
+Ref: https://github.com/kristofferR/ha-adjustable-bed/issues/310
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from bleak.exc import BleakError
+
+from ..const import NORDIC_UART_WRITE_CHAR_UUID
+from .base import MotorControlSpec
+from .okin_7byte import Okin7ByteConfig, Okin7ByteController, _cmd
+
+if TYPE_CHECKING:
+    from bleak.backends.characteristic import BleakGATTCharacteristic
+
+    from ..coordinator import AdjustableBedCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# CB35 configuration: same command bytes as Okin Nordic but without the
+# Mattress Firm init handshake (09 05 0A 23 05 00 00).
+# Only the wake command (5A 0B 00 A5) is needed.
+OKIN_CB35_CONFIG = Okin7ByteConfig(
+    char_uuid=NORDIC_UART_WRITE_CHAR_UUID,
+    lumbar_up_byte=0x06,
+    lounge_byte=0x17,
+    tv_byte=0x11,
+    memory_1_byte=0x1A,
+    memory_2_byte=0x1B,
+    init_commands=(
+        bytes.fromhex("5A0B00A5"),  # Wake command only (no Mattress Firm handshake)
+    ),
+    has_incline=True,
+    incline_byte=0x18,
+    has_light_cycle=True,
+    has_massage_intensity=True,
+    massage_up_byte=0x60,
+    massage_down_byte=0x63,
+    extra_massage_modes=(0x52, 0x53, 0x54),
+    massage_stop_byte=0x6F,
+    lights_off_repeat=3,
+    supports_tv=True,
+)
+
+
+class OkinCB35Controller(Okin7ByteController):
+    """Controller for DewertOkin CB35 Star beds (Sealy Posturematic).
+
+    Extends the Okin 7-byte protocol with:
+    - Write-without-response (required by CB35 firmware)
+    - Neck and hips motor control
+    - Head+foot simultaneous movement
+    - Light brightness and color control
+    - Separate head/foot massage strength
+    - Massage status feedback via Nordic UART notifications
+    """
+
+    def __init__(self, coordinator: AdjustableBedCoordinator) -> None:
+        """Initialize the CB35 controller."""
+        super().__init__(coordinator, config=OKIN_CB35_CONFIG)
+        self._massage_active = False
+
+    # ─── Write override: CB35 requires write-without-response ─────────
+
+    async def write_command(
+        self,
+        command: bytes,
+        repeat_count: int = 1,
+        repeat_delay_ms: int = 100,
+        cancel_event: asyncio.Event | None = None,
+    ) -> None:
+        """Write a command using write-without-response."""
+        if self.client is None or not self.client.is_connected:
+            _LOGGER.error("Cannot write command: BLE client not connected")
+            raise ConnectionError("Not connected to bed")
+
+        effective_cancel = cancel_event or self._coordinator.cancel_command
+
+        # Send init/wake on first command
+        if not self._initialized:
+            if effective_cancel is not None and effective_cancel.is_set():
+                return
+            _LOGGER.debug("Sending CB35 wake command before first command")
+            try:
+                for init_cmd in self._config.init_commands:
+                    async with self._ble_lock:
+                        await self.client.write_gatt_char(
+                            self._config.char_uuid, init_cmd, response=False
+                        )
+                    await asyncio.sleep(0.1)
+                self._initialized = True
+            except BleakError:
+                _LOGGER.exception("Failed to send CB35 wake sequence")
+                raise
+
+        await self._write_gatt_with_retry(
+            self._config.char_uuid,
+            command,
+            repeat_count=repeat_count,
+            repeat_delay_ms=repeat_delay_ms,
+            cancel_event=cancel_event,
+            response=False,
+        )
+
+    # ─── Extra capability properties ──────────────────────────────────
+
+    @property
+    def has_neck_support(self) -> bool:
+        return True
+
+    @property
+    def has_tilt_support(self) -> bool:
+        """Hips motor exposed via the tilt surface."""
+        return True
+
+    @property
+    def supports_massage(self) -> bool:
+        return True
+
+    @property
+    def motor_control_specs(self) -> tuple[MotorControlSpec, ...]:
+        """Expose CB35 motors: head, feet, lumbar, neck, hips."""
+        return (
+            MotorControlSpec(
+                key="head",
+                translation_key="head",
+                open_fn=lambda ctrl: ctrl.move_head_up(),
+                close_fn=lambda ctrl: ctrl.move_head_down(),
+                stop_fn=lambda ctrl: ctrl.move_head_stop(),
+            ),
+            MotorControlSpec(
+                key="feet",
+                translation_key="feet",
+                open_fn=lambda ctrl: ctrl.move_feet_up(),
+                close_fn=lambda ctrl: ctrl.move_feet_down(),
+                stop_fn=lambda ctrl: ctrl.move_feet_stop(),
+            ),
+            MotorControlSpec(
+                key="lumbar",
+                translation_key="lumbar",
+                open_fn=lambda ctrl: ctrl.move_lumbar_up(),
+                close_fn=lambda ctrl: ctrl.move_lumbar_down(),
+                stop_fn=lambda ctrl: ctrl.move_lumbar_stop(),
+            ),
+            MotorControlSpec(
+                key="neck",
+                translation_key="neck",
+                open_fn=lambda ctrl: ctrl.move_neck_up(),
+                close_fn=lambda ctrl: ctrl.move_neck_down(),
+                stop_fn=lambda ctrl: ctrl.move_neck_stop(),
+            ),
+            MotorControlSpec(
+                key="tilt",
+                translation_key="head_end_tilt",
+                open_fn=lambda ctrl: ctrl.move_tilt_up(),
+                close_fn=lambda ctrl: ctrl.move_tilt_down(),
+                stop_fn=lambda ctrl: ctrl.move_tilt_stop(),
+            ),
+        )
+
+    @property
+    def stale_motor_entity_keys(self) -> frozenset[str]:
+        """Remove standard back/legs entities replaced by motor_control_specs."""
+        return frozenset({"back", "legs"})
+
+    # ─── Neck motor (0x0A/0x0B) ───────────────────────────────────────
+
+    async def move_neck_up(self) -> None:
+        await self._move_with_stop(_cmd(0x0A))
+
+    async def move_neck_down(self) -> None:
+        await self._move_with_stop(_cmd(0x0B))
+
+    async def move_neck_stop(self) -> None:
+        await self._send_stop()
+
+    # ─── Hips motor via tilt surface (0x08/0x09) ──────────────────────
+
+    async def move_tilt_up(self) -> None:
+        await self._move_with_stop(_cmd(0x08))
+
+    async def move_tilt_down(self) -> None:
+        await self._move_with_stop(_cmd(0x09))
+
+    async def move_tilt_stop(self) -> None:
+        await self._send_stop()
+
+    # ─── Additional presets ───────────────────────────────────────────
+
+    @property
+    def supports_preset_read(self) -> bool:
+        return True
+
+    async def preset_read(self) -> None:
+        """Go to read position."""
+        await self._preset_with_stop(_cmd(0x12))
+
+    # ─── Light brightness / color ─────────────────────────────────────
+
+    async def light_brightness_up(self) -> None:
+        """Increase light brightness."""
+        await self.write_command(_cmd(0x80))
+
+    async def light_brightness_down(self) -> None:
+        """Decrease light brightness."""
+        await self.write_command(_cmd(0x81))
+
+    async def light_color_change(self) -> None:
+        """Cycle light color."""
+        await self.write_command(_cmd(0x70))
+
+    # ─── Massage: separate head/foot strength ─────────────────────────
+
+    async def massage_head_up(self) -> None:
+        """Increase head massage strength."""
+        await self.write_command(_cmd(0x60))
+
+    async def massage_head_down(self) -> None:
+        """Decrease head massage strength."""
+        await self.write_command(_cmd(0x61))
+
+    async def massage_foot_up(self) -> None:
+        """Increase foot massage strength."""
+        await self.write_command(_cmd(0x62))
+
+    async def massage_foot_down(self) -> None:
+        """Decrease foot massage strength."""
+        await self.write_command(_cmd(0x63))
+
+    # ─── Notification handling ────────────────────────────────────────
+
+    def _on_notification(
+        self, characteristic: BleakGATTCharacteristic, data: bytearray
+    ) -> None:
+        """Handle BLE notification data from the bed."""
+        raw = bytes(data)
+        self.forward_raw_notification(characteristic.uuid, raw)
+
+        if len(raw) < 2:
+            return
+
+        # Massage status: header A5 0B
+        if raw[0] == 0xA5 and raw[1] == 0x0B and len(raw) >= 8:
+            self._massage_active = True
+            _LOGGER.debug("CB35 massage status: %s", raw.hex())
+
+    async def start_notify(self, callback=None) -> None:
+        """Start listening for notifications via Nordic UART RX."""
+        from ..const import NORDIC_UART_READ_CHAR_UUID
+
+        self._notify_callback = callback
+        client = self.client
+        if client is None or not client.is_connected:
+            return
+
+        try:
+            await client.start_notify(NORDIC_UART_READ_CHAR_UUID, self._on_notification)
+            _LOGGER.debug("Subscribed to CB35 notifications")
+        except BleakError:
+            _LOGGER.warning("Could not subscribe to CB35 notifications")
+
+    async def stop_notify(self) -> None:
+        """Stop listening for notifications."""
+        from ..const import NORDIC_UART_READ_CHAR_UUID
+
+        self._notify_callback = None
+        client = self.client
+        if client is not None and client.is_connected:
+            try:
+                await client.stop_notify(NORDIC_UART_READ_CHAR_UUID)
+            except BleakError:
+                pass

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -226,8 +226,11 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 # not for devices already identified as non-bed (speakers, etc.)
                 device_info = capture_device_info(discovery_info)
                 reason = determine_unsupported_reason(discovery_info)
-                log_unsupported_device(device_info, reason)
-                await create_unsupported_device_issue(self.hass, device_info, reason)
+                created = await create_unsupported_device_issue(
+                    self.hass, device_info, reason
+                )
+                if created:
+                    log_unsupported_device(device_info, reason)
 
             _LOGGER.debug(
                 "Device %s is not a supported bed type, aborting",

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -126,6 +126,7 @@ BED_TYPE_LIMOSS: Final = "limoss"  # Limoss / Stawett TEA-encrypted protocol
 BED_TYPE_SERTA: Final = "serta"  # Serta Motion Perfect (uses Keeson protocol with serta variant)
 BED_TYPE_BEDTECH: Final = "bedtech"  # BedTech 5-byte ASCII protocol
 BED_TYPE_JENSEN: Final = "jensen"  # Jensen JMC400/LinON Entry (6-byte commands)
+BED_TYPE_OKIN_CB35: Final = "okin_cb35"  # DewertOkin CB35 Star (Sealy Posturematic, NUS 7-byte)
 BED_TYPE_OKIN_64BIT: Final = "okin_64bit"  # OKIN 64-bit protocol (10-byte commands)
 BED_TYPE_SLEEPYS_BOX15: Final = "sleepys_box15"  # Sleepy's Elite BOX15 protocol (9-byte with checksum)
 BED_TYPE_SLEEPYS_BOX24: Final = "sleepys_box24"  # Sleepy's Elite BOX24 protocol (7-byte)
@@ -189,6 +190,8 @@ SUPPORTED_BED_TYPES: Final = [
     BED_TYPE_BEDTECH,
     # Jensen
     BED_TYPE_JENSEN,
+    # OKIN CB35 Star (Sealy Posturematic)
+    BED_TYPE_OKIN_CB35,
     # OKIN 64-bit
     BED_TYPE_OKIN_64BIT,
     # Sleepy's Elite
@@ -1569,6 +1572,9 @@ BED_MOTOR_PULSE_DEFAULTS: Final = {
     # OKIN CB24: 300ms delay → 3 repeats = 0.9s total
     # Source: com.okin.bedding.smartbedwifi ANALYSIS.md
     BED_TYPE_OKIN_CB24: (3, 300),
+    # OKIN CB35: 300ms delay → 3 repeats = 0.9s total
+    # Source: com.okin.sealy ANALYSIS.md (Timer.periodic 300ms, exTimes: 2 → 3 sends)
+    BED_TYPE_OKIN_CB35: (3, 300),
     # OKIN ORE: 300ms delay → 1 repeat = 0.3s per command (preset-based)
     # Source: com.ore.bedding.glideawaymontion ANALYSIS.md
     BED_TYPE_OKIN_ORE: (1, 300),

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -694,8 +694,10 @@ MALOUF_NAME_PATTERNS: Final = ("malouf",)
 # These beds use the Sleepy's Elite app (com.okin.bedding.sleepy)
 SLEEPYS_NAME_PATTERNS: Final = ("sleepy", "mfrm")
 
-# Sleepy's Elite BOX25 Star name pattern (DewertOkin BOX25 Star controller)
-# Devices advertise as "Star" + suffix (e.g., "Star1234")
+# DewertOkin Star controller name patterns (BOX25 Star / CB35 Star)
+# Devices advertise as "Star" + suffix (e.g., "Star352201011800")
+# Source: com.okin.bedding.sleepy (Sleepy's Elite) BOX25 Star analysis
+# Also used by Sealy Posturematic CB35 (com.okin.sealy)
 SLEEPYS_BOX25_NAME_PATTERNS: Final = ("star",)
 
 # Jensen name patterns (JMC400 / LinON Entry)

--- a/custom_components/adjustable_bed/controller_factory.py
+++ b/custom_components/adjustable_bed/controller_factory.py
@@ -35,6 +35,7 @@ from .const import (
     BED_TYPE_OKIN_7BYTE,
     BED_TYPE_OKIN_64BIT,
     BED_TYPE_OKIN_CB24,
+    BED_TYPE_OKIN_CB35,
     BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_FFE,
     # Protocol-based bed types (new)
@@ -228,6 +229,11 @@ async def create_controller(
         from .beds.okin_nordic import OkinNordicController
 
         return OkinNordicController(coordinator)
+
+    if bed_type == BED_TYPE_OKIN_CB35:
+        from .beds.okin_cb35 import OkinCB35Controller
+
+        return OkinCB35Controller(coordinator)
 
     if bed_type == BED_TYPE_KAIDI:
         from .beds.kaidi import KaidiController

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -65,8 +65,10 @@ from .const import (
     BED_TYPE_OKIN_7BYTE,
     BED_TYPE_OKIN_FFE,
     BED_TYPE_OKIN_HANDLE,
+    BED_TYPE_OKIN_CB35,
     BED_TYPE_OKIN_NORDIC,
     BED_TYPE_OKIN_UUID,
+    BED_TYPE_SLEEPYS_BOX25,
     BED_TYPE_REVERIE,
     BED_TYPE_REVERIE_NIGHTSTAND,
     BED_TYPE_RICHMAT,
@@ -1056,6 +1058,35 @@ class AdjustableBedCoordinator:
                 )
                 self._ble_manufacturer = ble_manufacturer
                 self._ble_model = ble_model
+
+                # Post-connection protocol verification for DewertOkin Star devices.
+                # The adjustbed app (com.okin.bedding.adjustbed) reads BLE characteristic
+                # 2A29 (Manufacturer Name) after connecting: exactly "STAR" = CB35 protocol
+                # (35_22_01), anything else = BOX25 protocol (25_42_02).
+                if self._bed_type in (BED_TYPE_OKIN_CB35, BED_TYPE_SLEEPYS_BOX25):
+                    is_star_manufacturer = (
+                        ble_manufacturer is not None
+                        and ble_manufacturer.strip().upper() == "STAR"
+                    )
+                    if is_star_manufacturer and self._bed_type == BED_TYPE_SLEEPYS_BOX25:
+                        _LOGGER.warning(
+                            "BLE Manufacturer Name is 'STAR' for %s - this indicates a "
+                            "CB35 protocol device, but configured as BOX25. Auto-correcting "
+                            "to CB35. Source: com.okin.bedding.adjustbed 2A29 detection",
+                            self._address,
+                        )
+                        self._bed_type = BED_TYPE_OKIN_CB35
+                    elif not is_star_manufacturer and self._bed_type == BED_TYPE_OKIN_CB35:
+                        if ble_manufacturer is not None:
+                            _LOGGER.warning(
+                                "BLE Manufacturer Name is '%s' (not 'STAR') for %s - this "
+                                "indicates a BOX25 protocol device, but configured as CB35. "
+                                "Auto-correcting to BOX25. Source: com.okin.bedding.adjustbed "
+                                "2A29 detection",
+                                ble_manufacturer,
+                                self._address,
+                            )
+                            self._bed_type = BED_TYPE_SLEEPYS_BOX25
 
                 # If remote is set to auto, infer Richmat remote code from BLE name at runtime.
                 # This preserves compatibility for existing entries created before auto-code storage.

--- a/custom_components/adjustable_bed/cover.py
+++ b/custom_components/adjustable_bed/cover.py
@@ -120,6 +120,17 @@ COVER_DESCRIPTIONS: tuple[AdjustableBedCoverEntityDescription, ...] = (
         min_motors=2,  # Pillow is independent of motor count
     ),
     AdjustableBedCoverEntityDescription(
+        key="neck",
+        translation_key="neck",
+        icon="mdi:head-outline",
+        device_class=CoverDeviceClass.DAMPER,
+        open_fn=lambda ctrl: ctrl.move_neck_up(),
+        close_fn=lambda ctrl: ctrl.move_neck_down(),
+        stop_fn=lambda ctrl: ctrl.move_neck_stop(),
+        min_motors=2,  # Neck is independent of motor count
+        max_angle=30,
+    ),
+    AdjustableBedCoverEntityDescription(
         key="tilt",
         translation_key="tilt",
         icon="mdi:angle-acute",

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -683,23 +683,23 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
         return DetectionResult(bed_type=BED_TYPE_OCTO, confidence=1.0, signals=signals)
 
     # Check for DewertOkin Star controllers - name pattern + Nordic UART service.
-    # Star* devices use the CB35 protocol (Sealy Posturematic, and possibly other
-    # DewertOkin-branded beds). The BOX25 multi-subsystem protocol (sleepys_box25)
-    # has never been confirmed on real hardware and remains an alternative.
+    # Both CB35 (Sealy Posturematic) and BOX25 Star (Sleepy's Elite) use Star* names
+    # with Nordic UART. They can't be distinguished from BLE advertisements alone,
+    # so both are presented as ambiguous options.
     if any(device_name.startswith(pattern) for pattern in SLEEPYS_BOX25_NAME_PATTERNS):
         from .const import NORDIC_UART_SERVICE_UUID
 
-        signals.append("name:okin_cb35")
+        signals.append("name:dewertokin_star")
         if NORDIC_UART_SERVICE_UUID.lower() in service_uuids:
             signals.append("uuid:nordic_uart")
             _LOGGER.info(
-                "Detected DewertOkin CB35 Star bed at %s (name: %s) with Nordic UART service",
+                "Detected DewertOkin Star bed at %s (name: %s) with Nordic UART service",
                 service_info.address,
                 service_info.name,
             )
             return DetectionResult(
                 bed_type=BED_TYPE_OKIN_CB35,
-                confidence=0.9,
+                confidence=0.65,
                 signals=signals,
                 ambiguous_types=[BED_TYPE_SLEEPYS_BOX25],
             )

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -47,6 +47,7 @@ from .const import (
     BED_TYPE_OKIN_64BIT,
     # Protocol-based bed types (new)
     BED_TYPE_OKIN_CB24,
+    BED_TYPE_OKIN_CB35,
     BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_FFE,
     BED_TYPE_OKIN_HANDLE,
@@ -338,6 +339,7 @@ BED_TYPE_DISPLAY_NAMES: dict[str, str] = {
     BED_TYPE_OKIN_FFE: "Okin FFE (13/15 series)",
     BED_TYPE_OKIN_ORE: "Okin ORE (Dynasty, INNOVA)",
     BED_TYPE_OKIN_64BIT: "Okin 64-Bit (10-byte commands)",
+    BED_TYPE_OKIN_CB35: "Okin CB35 (Sealy Posturematic, DewertOkin Star)",
     BED_TYPE_OKIN_CST: "Okin CST (Rize MF900, 14-byte dual-field)",
     # Protocol-based types (Leggett & Platt family)
     BED_TYPE_LEGGETT_GEN2: "Leggett & Platt Gen2",
@@ -680,35 +682,38 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
         )
         return DetectionResult(bed_type=BED_TYPE_OCTO, confidence=1.0, signals=signals)
 
-    # Check for Sleepy's Elite BOX25 Star - name pattern + Nordic UART service
-    # BOX25 Star devices advertise as "Star*" and use Nordic UART for multi-subsystem protocol
+    # Check for DewertOkin Star controllers - name pattern + Nordic UART service.
+    # Star* devices use the CB35 protocol (Sealy Posturematic, and possibly other
+    # DewertOkin-branded beds). The BOX25 multi-subsystem protocol (sleepys_box25)
+    # has never been confirmed on real hardware and remains an alternative.
     if any(device_name.startswith(pattern) for pattern in SLEEPYS_BOX25_NAME_PATTERNS):
         from .const import NORDIC_UART_SERVICE_UUID
 
-        signals.append("name:sleepys_box25")
+        signals.append("name:okin_cb35")
         if NORDIC_UART_SERVICE_UUID.lower() in service_uuids:
             signals.append("uuid:nordic_uart")
             _LOGGER.info(
-                "Detected Sleepy's Elite BOX25 Star bed at %s (name: %s) with Nordic UART service",
+                "Detected DewertOkin CB35 Star bed at %s (name: %s) with Nordic UART service",
                 service_info.address,
                 service_info.name,
             )
             return DetectionResult(
-                bed_type=BED_TYPE_SLEEPYS_BOX25,
+                bed_type=BED_TYPE_OKIN_CB35,
                 confidence=0.9,
                 signals=signals,
+                ambiguous_types=[BED_TYPE_SLEEPYS_BOX25],
             )
 
         _LOGGER.info(
-            "Detected possible Sleepy's Elite BOX25 Star bed at %s (name: %s) by name pattern only",
+            "Detected possible DewertOkin Star bed at %s (name: %s) by name pattern only",
             service_info.address,
             service_info.name,
         )
         return DetectionResult(
-            bed_type=BED_TYPE_SLEEPYS_BOX25,
+            bed_type=BED_TYPE_OKIN_CB35,
             confidence=0.3,
             signals=signals,
-            ambiguous_types=[BED_TYPE_OCTO],
+            ambiguous_types=[BED_TYPE_SLEEPYS_BOX25, BED_TYPE_OCTO],
         )
 
     # Check for TiMOTION AHF protocol by device name.

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -684,18 +684,65 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
 
     # Check for DewertOkin Star controllers - name pattern + Nordic UART service.
     # Both CB35 (Sealy Posturematic) and BOX25 Star (Sleepy's Elite) use Star* names
-    # with Nordic UART. They can't be distinguished from BLE advertisements alone,
-    # so both are presented as ambiguous options.
+    # with Nordic UART. The protocol version is encoded in positions 4-5 of the name:
+    #   Star35... = CB35 (protocol 35_22_01, 7-byte sequential commands)
+    #   Star25... = BOX25 (protocol 25_42_02, 10-byte bitmask commands)
+    # Source: com.okin.bedding.adjustbed blutter analysis; confirmed by real-world
+    # device names from Discord (Star352201011800=CB35, Star254202079996=BOX25).
+    # Post-connection, the adjustbed app also reads BLE characteristic 2A29
+    # (Manufacturer Name): exactly "STAR" confirms CB35.
     if any(device_name.startswith(pattern) for pattern in SLEEPYS_BOX25_NAME_PATTERNS):
         from .const import NORDIC_UART_SERVICE_UUID
 
         signals.append("name:dewertokin_star")
-        if NORDIC_UART_SERVICE_UUID.lower() in service_uuids:
+
+        # Parse protocol version from name digits (positions 4-5 of original name)
+        original_name = service_info.name or ""
+        star_digits = original_name[4:6] if len(original_name) >= 6 else ""
+        if star_digits:
+            signals.append(f"star_digits:{star_digits}")
+
+        has_nordic_uart = NORDIC_UART_SERVICE_UUID.lower() in service_uuids
+        if has_nordic_uart:
             signals.append("uuid:nordic_uart")
+
+        # High-confidence detection when protocol digits match a known version
+        if star_digits == "35" and has_nordic_uart:
             _LOGGER.info(
-                "Detected DewertOkin Star bed at %s (name: %s) with Nordic UART service",
+                "Detected DewertOkin CB35 Star bed at %s (name: %s, digits=%s) "
+                "with Nordic UART service",
                 service_info.address,
                 service_info.name,
+                star_digits,
+            )
+            return DetectionResult(
+                bed_type=BED_TYPE_OKIN_CB35,
+                confidence=0.95,
+                signals=signals,
+            )
+
+        if star_digits == "25" and has_nordic_uart:
+            _LOGGER.info(
+                "Detected DewertOkin BOX25 Star bed at %s (name: %s, digits=%s) "
+                "with Nordic UART service",
+                service_info.address,
+                service_info.name,
+                star_digits,
+            )
+            return DetectionResult(
+                bed_type=BED_TYPE_SLEEPYS_BOX25,
+                confidence=0.95,
+                signals=signals,
+            )
+
+        # Unknown digits or no Nordic UART -- fall back to ambiguous detection
+        if has_nordic_uart:
+            _LOGGER.info(
+                "Detected DewertOkin Star bed at %s (name: %s, digits=%s) "
+                "with Nordic UART service - unknown protocol version, presenting both options",
+                service_info.address,
+                service_info.name,
+                star_digits or "none",
             )
             return DetectionResult(
                 bed_type=BED_TYPE_OKIN_CB35,

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -417,6 +417,9 @@
       "pillow": {
         "name": "Pillow"
       },
+      "neck": {
+        "name": "Neck"
+      },
       "tilt": {
         "name": "Tilt"
       },

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -419,6 +419,9 @@
       "pillow": {
         "name": "Pillow"
       },
+      "neck": {
+        "name": "Neck"
+      },
       "tilt": {
         "name": "Tilt"
       },

--- a/custom_components/adjustable_bed/unsupported.py
+++ b/custom_components/adjustable_bed/unsupported.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_get as async_get_issue_registry,
+)
 
 from .const import DOMAIN
 
@@ -19,6 +24,10 @@ _LOGGER = logging.getLogger(__name__)
 
 GITHUB_REPO = "kristofferR/ha-adjustable-bed"
 GITHUB_NEW_ISSUE_URL = f"https://github.com/{GITHUB_REPO}/issues/new"
+
+# In-memory set of issue_ids already processed this session.
+# Prevents repeated registry lookups and log spam from BLE advertisements.
+_notified_devices: set[str] = set()
 
 
 @dataclass
@@ -136,16 +145,44 @@ def _generate_github_url(device_info: UnsupportedDeviceInfo, reason: str) -> str
     return f"{GITHUB_NEW_ISSUE_URL}{params}"
 
 
+def _make_unsupported_issue_id(device_info: UnsupportedDeviceInfo) -> str:
+    """Generate a stable issue ID, preferring device name over MAC address.
+
+    BLE devices may use randomized MAC addresses, so keying by name prevents
+    duplicate Repairs entries for the same device across address changes.
+    """
+    if device_info.name:
+        sanitized = re.sub(r"[^a-z0-9]", "_", device_info.name.lower()).strip("_")
+        if sanitized:
+            return f"unsupported_device_{sanitized}"
+    # Fallback to MAC for unnamed devices
+    return f"unsupported_device_{device_info.address.replace(':', '_').lower()}"
+
+
 async def create_unsupported_device_issue(
     hass: HomeAssistant,
     device_info: UnsupportedDeviceInfo,
     reason: str,
-) -> None:
-    """Create a persistent issue in the Repairs dashboard for an unsupported device."""
-    github_url = _generate_github_url(device_info, reason)
+) -> bool:
+    """Create a persistent issue in the Repairs dashboard for an unsupported device.
 
-    # Use address as unique identifier (normalized to avoid duplicates)
-    issue_id = f"unsupported_device_{device_info.address.replace(':', '_').lower()}"
+    Returns True if the issue was newly created, False if it already existed.
+    Deduplicates by device name (or MAC for unnamed devices) to handle BLE
+    address randomization and prevent repeated repairs after dismissal.
+    """
+    issue_id = _make_unsupported_issue_id(device_info)
+
+    # Fast path: already processed this session
+    if issue_id in _notified_devices:
+        return False
+
+    # Check if issue already exists in registry (respects dismissed state across restarts)
+    registry = async_get_issue_registry(hass)
+    if registry.async_get_issue(DOMAIN, issue_id) is not None:
+        _notified_devices.add(issue_id)
+        return False
+
+    github_url = _generate_github_url(device_info, reason)
 
     async_create_issue(
         hass,
@@ -163,10 +200,15 @@ async def create_unsupported_device_issue(
         },
     )
 
+    _notified_devices.add(issue_id)
+
     _LOGGER.debug(
-        "Created Repairs issue for unsupported device %s",
+        "Created Repairs issue for unsupported device %s (%s)",
+        device_info.name or "Unknown",
         device_info.address,
     )
+
+    return True
 
 
 async def create_pairing_required_issue(

--- a/docs/beds/okin-cb35.md
+++ b/docs/beds/okin-cb35.md
@@ -20,7 +20,7 @@
 
 Uses the same 7-byte command frame as Okin Nordic:
 
-```
+```text
 [0x5A, 0x01, 0x03, 0x10, 0x30, CMD, 0xA5]
 ```
 
@@ -31,7 +31,8 @@ Uses the same 7-byte command frame as Okin Nordic:
 ### Init Sequence
 
 Only a wake command is needed:
-```
+
+```text
 5A 0B 00 A5
 ```
 

--- a/docs/beds/okin-cb35.md
+++ b/docs/beds/okin-cb35.md
@@ -1,0 +1,123 @@
+# DewertOkin CB35 Star
+
+**Status:** Needs testing
+**Protocol version:** CB.35.22.01
+**Ref:** [#310](https://github.com/kristofferR/ha-adjustable-bed/issues/310)
+
+## Known Brands
+
+- Sealy Posturematic (Element, Ascent, Apex)
+
+## Detection
+
+| Signal | Value |
+|--------|-------|
+| Device name | Starts with `Star` (e.g., `Star352201011800`) |
+| Service UUID | Nordic UART `6E400001-B5A3-F393-E0A9-E50E24DCCA9E` |
+| Manufacturer ID | 89 (OKIN) |
+
+## Protocol
+
+Uses the same 7-byte command frame as Okin Nordic:
+
+```
+[0x5A, 0x01, 0x03, 0x10, 0x30, CMD, 0xA5]
+```
+
+**Service:** Nordic UART (6E400001)
+**Write characteristic:** 6E400002 (write-without-response)
+**Notify characteristic:** 6E400003
+
+### Init Sequence
+
+Only a wake command is needed:
+```
+5A 0B 00 A5
+```
+
+### Motor Commands
+
+| Action | CMD byte | Full packet |
+|--------|----------|-------------|
+| Head Up | 0x00 | `5A 01 03 10 30 00 A5` |
+| Head Down | 0x01 | `5A 01 03 10 30 01 A5` |
+| Foot Up | 0x02 | `5A 01 03 10 30 02 A5` |
+| Foot Down | 0x03 | `5A 01 03 10 30 03 A5` |
+| Lumbar Up | 0x06 | `5A 01 03 10 30 06 A5` |
+| Lumbar Down | 0x07 | `5A 01 03 10 30 07 A5` |
+| Hips Up | 0x08 | `5A 01 03 10 30 08 A5` |
+| Hips Down | 0x09 | `5A 01 03 10 30 09 A5` |
+| Neck Up | 0x0A | `5A 01 03 10 30 0A A5` |
+| Neck Down | 0x0B | `5A 01 03 10 30 0B A5` |
+| Head+Foot Up | 0x0C | `5A 01 03 10 30 0C A5` |
+| Head+Foot Down | 0x0D | `5A 01 03 10 30 0D A5` |
+| Stop | 0x0F | `5A 01 03 10 30 0F A5` |
+
+### Presets
+
+| Preset | CMD byte |
+|--------|----------|
+| Flat | 0x10 |
+| TV/PC | 0x11 |
+| Read | 0x12 |
+| Zero Gravity | 0x13 |
+| Inverse | 0x14 |
+| Work | 0x15 |
+| Anti-Snore | 0x16 |
+| Lounge | 0x17 |
+| Incline | 0x18 |
+| Extension | 0x19 |
+| Memory 1 | 0x1A |
+| Memory 2 | 0x1B |
+
+### Light Control
+
+| Action | CMD byte |
+|--------|----------|
+| Light Color Change | 0x70 |
+| Light Toggle | 0x71 |
+| Light On | 0x73 |
+| Light Off | 0x74 |
+| Light Brighter | 0x80 |
+| Light Dim | 0x81 |
+
+### Massage Control
+
+| Action | CMD byte |
+|--------|----------|
+| Massage Open | 0x52 |
+| Massage Toggle | 0x5A |
+| Wave Up | 0x58 |
+| Wave Down | 0x59 |
+| Strength Head Up | 0x60 |
+| Strength Head Down | 0x61 |
+| Strength Foot Up | 0x62 |
+| Strength Foot Down | 0x63 |
+| Massage Time Switch | 0x6D |
+| Massage Stop | 0x6F |
+
+### Timing
+
+Motor commands repeat every 300ms while held. Stop and massage commands send 3 times (initial + 2 repeats at 300ms).
+
+## Relationship to Other Protocols
+
+The CB35 shares the same 7-byte frame and most command bytes with **Okin Nordic** (Mattress Firm 900/iFlex). Key differences:
+
+- **Init:** CB35 uses only `5A 0B 00 A5` wake; Okin Nordic also sends `09 05 0A 23 05 00 00`
+- **Write mode:** CB35 requires write-without-response; Okin Nordic uses write-with-response
+- **Extra motors:** CB35 adds neck, hips, and head+foot simultaneous
+- **Extra presets:** TV/PC, Read, Inverse, Work, Extension
+- **Light control:** CB35 adds brightness and color control
+- **Massage:** CB35 has separate head/foot strength control
+
+## App
+
+- **Android:** Sealy Posturematic (`com.okin.sealy`) — Flutter app, protocol defined in JSON asset
+- **iOS:** Sealy Posturematic (App Store)
+- **Developer:** Star Seeds Co LTD (DewertOkin)
+
+## Source
+
+Protocol extracted from `com.okin.sealy` v1.1.1 APK analysis. Complete protocol definition at:
+`disassembly/output/com.okin.sealy/extracted/assets/flutter_assets/assets/protocol/35_22_01.json`

--- a/docs/beds/okin-cb35.md
+++ b/docs/beds/okin-cb35.md
@@ -13,8 +13,23 @@
 | Signal | Value |
 |--------|-------|
 | Device name | Starts with `Star` (e.g., `Star352201011800`) |
+| Name digits 4-5 | `35` distinguishes CB35 from BOX25 (`25`) |
 | Service UUID | Nordic UART `6E400001-B5A3-F393-E0A9-E50E24DCCA9E` |
 | Manufacturer ID | 89 (OKIN) |
+| Manufacturer Name (2A29) | Exactly `STAR` (post-connection confirmation) |
+
+### Name Encoding
+
+DewertOkin Star device names encode the protocol version: `Star` + `[protocol digits]` + `[serial]`.
+
+| Name | Digits 4-5 | Protocol | Bed Type |
+|------|-----------|----------|----------|
+| `Star352201011800` | `35` | CB.35.22.01 | CB35 (this protocol) |
+| `Star254202079996` | `25` | 25_42_02 | BOX25 (Sleepy's Elite) |
+
+### Post-Connection Verification
+
+The `com.okin.bedding.adjustbed` app (which supports both CB35 and BOX25) reads BLE characteristic `2A29` (Manufacturer Name) from the Device Information Service (`180A`) after connecting. If it returns exactly `STAR` (4 bytes: 0x53 0x54 0x41 0x52), the device uses CB35. Otherwise it uses BOX25. The integration performs the same check to auto-correct if the name-based detection was wrong.
 
 ## Protocol
 

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -242,16 +242,41 @@ class TestDetectBedTypeByServiceUUID:
         )
         assert detect_bed_type(service_info) == BED_TYPE_OCTO
 
-    def test_detect_okin_cb35_by_name_and_nordic_uart(self):
-        """Star* plus Nordic UART should detect as CB35 with BOX25 as ambiguous."""
+    def test_detect_okin_cb35_by_star35_name_and_nordic_uart(self):
+        """Star35* plus Nordic UART should detect as CB35 with high confidence."""
         service_info = _make_service_info(
-            name="Star1234",
+            name="Star352201011800",
+            service_uuids=[NORDIC_UART_SERVICE_UUID],
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type == BED_TYPE_OKIN_CB35
+        assert result.confidence == 0.95
+        assert "uuid:nordic_uart" in result.signals
+        assert "star_digits:35" in result.signals
+        assert not result.ambiguous_types
+
+    def test_detect_sleepys_box25_by_star25_name_and_nordic_uart(self):
+        """Star25* plus Nordic UART should detect as BOX25 with high confidence."""
+        service_info = _make_service_info(
+            name="Star254202079996",
+            service_uuids=[NORDIC_UART_SERVICE_UUID],
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type == BED_TYPE_SLEEPYS_BOX25
+        assert result.confidence == 0.95
+        assert "uuid:nordic_uart" in result.signals
+        assert "star_digits:25" in result.signals
+        assert not result.ambiguous_types
+
+    def test_detect_star_unknown_digits_is_ambiguous(self):
+        """Star with unknown digits plus Nordic UART should be ambiguous."""
+        service_info = _make_service_info(
+            name="Star991234567890",
             service_uuids=[NORDIC_UART_SERVICE_UUID],
         )
         result = detect_bed_type_detailed(service_info)
         assert result.bed_type == BED_TYPE_OKIN_CB35
         assert result.confidence == 0.65
-        assert "uuid:nordic_uart" in result.signals
         assert result.ambiguous_types == [BED_TYPE_SLEEPYS_BOX25]
 
     def test_detect_suta_by_fff0_uuid_and_name(self):
@@ -320,13 +345,24 @@ class TestDetectBedTypeByNamePattern:
         service_info = _make_service_info(name="HHC5678ABCD")
         assert detect_bed_type(service_info) == BED_TYPE_MOTOSLEEP
 
-    def test_detect_okin_cb35_name_only_is_ambiguous(self):
-        """Star* without Nordic UART should remain a low-confidence CB35 match."""
-        service_info = _make_service_info(name="Star1234")
+    def test_detect_star_name_only_is_ambiguous(self):
+        """Star* without Nordic UART should remain a low-confidence ambiguous match."""
+        service_info = _make_service_info(name="Star352201011800")
         result = detect_bed_type_detailed(service_info)
         assert result.bed_type == BED_TYPE_OKIN_CB35
         assert result.confidence == 0.3
         assert result.ambiguous_types == [BED_TYPE_SLEEPYS_BOX25, BED_TYPE_OCTO]
+
+    def test_detect_star_short_name_is_ambiguous(self):
+        """Short Star name (no digits to parse) should be ambiguous."""
+        service_info = _make_service_info(
+            name="Star",
+            service_uuids=[NORDIC_UART_SERVICE_UUID],
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type == BED_TYPE_OKIN_CB35
+        assert result.confidence == 0.65
+        assert result.ambiguous_types == [BED_TYPE_SLEEPYS_BOX25]
 
     def test_detect_timotion_ahf_by_name(self):
         """Test TiMOTION AHF detection by AHF prefix."""

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -243,14 +243,14 @@ class TestDetectBedTypeByServiceUUID:
         assert detect_bed_type(service_info) == BED_TYPE_OCTO
 
     def test_detect_okin_cb35_by_name_and_nordic_uart(self):
-        """Star* plus Nordic UART should detect as CB35."""
+        """Star* plus Nordic UART should detect as CB35 with BOX25 as ambiguous."""
         service_info = _make_service_info(
             name="Star1234",
             service_uuids=[NORDIC_UART_SERVICE_UUID],
         )
         result = detect_bed_type_detailed(service_info)
         assert result.bed_type == BED_TYPE_OKIN_CB35
-        assert result.confidence == 0.9
+        assert result.confidence == 0.65
         assert "uuid:nordic_uart" in result.signals
         assert result.ambiguous_types == [BED_TYPE_SLEEPYS_BOX25]
 

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -36,6 +36,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_SERTA,
     BED_TYPE_SLEEPYS_BOX15,
     BED_TYPE_SLEEPYS_BOX24,
+    BED_TYPE_OKIN_CB35,
     BED_TYPE_SLEEPYS_BOX25,
     BED_TYPE_SOLACE,
     BED_TYPE_SUTA,
@@ -241,16 +242,17 @@ class TestDetectBedTypeByServiceUUID:
         )
         assert detect_bed_type(service_info) == BED_TYPE_OCTO
 
-    def test_detect_sleepys_box25_by_name_and_nordic_uart(self):
-        """Star* plus Nordic UART should detect as BOX25."""
+    def test_detect_okin_cb35_by_name_and_nordic_uart(self):
+        """Star* plus Nordic UART should detect as CB35."""
         service_info = _make_service_info(
             name="Star1234",
             service_uuids=[NORDIC_UART_SERVICE_UUID],
         )
         result = detect_bed_type_detailed(service_info)
-        assert result.bed_type == BED_TYPE_SLEEPYS_BOX25
+        assert result.bed_type == BED_TYPE_OKIN_CB35
         assert result.confidence == 0.9
         assert "uuid:nordic_uart" in result.signals
+        assert result.ambiguous_types == [BED_TYPE_SLEEPYS_BOX25]
 
     def test_detect_suta_by_fff0_uuid_and_name(self):
         """Test SUTA detection by FFF0 UUID + SUTA name pattern."""
@@ -318,13 +320,13 @@ class TestDetectBedTypeByNamePattern:
         service_info = _make_service_info(name="HHC5678ABCD")
         assert detect_bed_type(service_info) == BED_TYPE_MOTOSLEEP
 
-    def test_detect_sleepys_box25_name_only_is_ambiguous(self):
-        """Star* without Nordic UART should remain a low-confidence BOX25 match."""
+    def test_detect_okin_cb35_name_only_is_ambiguous(self):
+        """Star* without Nordic UART should remain a low-confidence CB35 match."""
         service_info = _make_service_info(name="Star1234")
         result = detect_bed_type_detailed(service_info)
-        assert result.bed_type == BED_TYPE_SLEEPYS_BOX25
+        assert result.bed_type == BED_TYPE_OKIN_CB35
         assert result.confidence == 0.3
-        assert result.ambiguous_types == [BED_TYPE_OCTO]
+        assert result.ambiguous_types == [BED_TYPE_SLEEPYS_BOX25, BED_TYPE_OCTO]
 
     def test_detect_timotion_ahf_by_name(self):
         """Test TiMOTION AHF detection by AHF prefix."""


### PR DESCRIPTION
## Summary

- Adds new `okin_cb35` bed type for DewertOkin CB35 Star protocol (CB.35.22.01), reverse-engineered from the Sealy Posturematic app (`com.okin.sealy` v1.1.1)
- The CB35 uses the same 7-byte frame as Okin Nordic (`5A 01 03 10 30 CMD A5`) but with write-without-response, a simpler init sequence, and additional features (neck, hips, light brightness/color, extra presets)
- Star* device detection now defaults to CB35 instead of the untested BOX25 protocol, with BOX25 kept as an ambiguous alternative

Ref #310

## Test plan

- [x] All 1622 existing tests pass
- [x] Detection tests updated for CB35 as primary Star* detection
- [ ] User testing on actual Sealy Element hardware (#310)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Okin CB35 (Sealy Posturematic) beds: neck and tilt motors, per-zone massage strength, light brightness/color cycling, and presets.

* **Bug Fixes**
  * Reduced duplicate unsupported-device reports via session-level deduplication.

* **Detection**
  * Updated device detection to recognize Okin CB35 with adjusted confidence and ambiguity handling.

* **Documentation**
  * Added full Okin CB35 protocol documentation.

* **Localization**
  * Added "Neck" cover translation.

* **Tests**
  * Updated detection tests for CB35.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->