### PR TITLE
Fix Sleep Number framed transport and presence polling

### DIFF
--- a/custom_components/adjustable_bed/beds/sleep_number.py
+++ b/custom_components/adjustable_bed/beds/sleep_number.py
@@ -327,6 +327,7 @@ class SleepNumberController(BedController):
             SleepNumberCommands.HALT_ACTUATOR,
             self._side,
             self._motor_to_actuator(motor),
+            cancel_event=asyncio.Event(),
         )
 
     async def move_head_up(self) -> None:
@@ -546,14 +547,30 @@ class SleepNumberController(BedController):
         bamkey: str,
         *args: str,
         expected_args: int = 0,
+        cancel_event: asyncio.Event | None = None,
     ) -> list[str]:
         """Send a bamkey command and parse the matching response."""
-        raw_response = await self._send_bamkey_raw_response(bamkey, *args)
+        raw_response = await self._send_bamkey_raw_response(
+            bamkey,
+            *args,
+            cancel_event=cancel_event,
+        )
         return self._parse_bamkey_response(bamkey, raw_response, expected_args)
 
-    async def _send_bamkey_raw_response(self, bamkey: str, *args: str) -> str:
+    async def _send_bamkey_raw_response(
+        self,
+        bamkey: str,
+        *args: str,
+        cancel_event: asyncio.Event | None = None,
+    ) -> str:
         """Send a bamkey command and return the raw response text."""
+        effective_cancel = cancel_event or self._coordinator.cancel_command
+        if effective_cancel.is_set():
+            raise asyncio.CancelledError
+
         await self._ensure_notifications_started()
+        if effective_cancel.is_set():
+            raise asyncio.CancelledError
         self._response_buffer.clear()
         self._drain_response_queue()
         self._drain_readback_hint_queue()
@@ -562,12 +579,13 @@ class SleepNumberController(BedController):
         await self._write_gatt_with_retry(
             SLEEP_NUMBER_BAMKEY_CHAR_UUID,
             self._build_bamkey_blob(payload),
+            cancel_event=effective_cancel,
             response=False,
         )
         deadline = asyncio.get_running_loop().time() + _BAMKEY_RESPONSE_TIMEOUT
         response_task = asyncio.create_task(self._response_queue.get())
         hint_task = asyncio.create_task(self._readback_hint_queue.get())
-        cancel_task = asyncio.create_task(self._coordinator.cancel_command.wait())
+        cancel_task = asyncio.create_task(effective_cancel.wait())
         try:
             while True:
                 timeout = deadline - asyncio.get_running_loop().time()
@@ -592,7 +610,8 @@ class SleepNumberController(BedController):
                     hint_task = asyncio.create_task(self._readback_hint_queue.get())
                     try:
                         return await self._read_bamkey_response_after_hint(
-                            timeout=deadline - asyncio.get_running_loop().time()
+                            remaining_timeout=deadline - asyncio.get_running_loop().time(),
+                            cancel_event=effective_cancel,
                         )
                     except (TimeoutError, ValueError):
                         _LOGGER.debug(
@@ -617,15 +636,20 @@ class SleepNumberController(BedController):
         while not self._readback_hint_queue.empty():
             self._readback_hint_queue.get_nowait()
 
-    async def _read_bamkey_response_after_hint(self, *, timeout: float) -> str:
+    async def _read_bamkey_response_after_hint(
+        self,
+        *,
+        remaining_timeout: float,
+        cancel_event: asyncio.Event,
+    ) -> str:
         """Read the BamKey characteristic after a notification indicates fresh data."""
         client = self.client
         if client is None or not client.is_connected:
             raise ConnectionError("Not connected to bed")
 
-        deadline = asyncio.get_running_loop().time() + timeout
+        deadline = asyncio.get_running_loop().time() + remaining_timeout
         while True:
-            if self._coordinator.cancel_command.is_set():
+            if cancel_event.is_set():
                 raise asyncio.CancelledError
 
             remaining = deadline - asyncio.get_running_loop().time()
@@ -640,7 +664,13 @@ class SleepNumberController(BedController):
             if not raw_response:
                 continue
 
-            return self._decode_bamkey_text(raw_response)
+            try:
+                decoded = self._decode_bamkey_text(raw_response)
+            except ValueError:
+                continue
+            if not self._looks_like_bamkey_response(decoded):
+                continue
+            return decoded
 
     def _parse_bamkey_response(
         self,

--- a/custom_components/adjustable_bed/beds/sleep_number.py
+++ b/custom_components/adjustable_bed/beds/sleep_number.py
@@ -1,22 +1,29 @@
 """Sleep Number Climate 360 / FlexFit controller.
 
 This implements Select Comfort's Fuzion "bamkey" BLE protocol used by the
-SleepIQ app. Commands are UTF-8 text sent to a single GATT characteristic and
-responses arrive as notifications on that same characteristic.
+SleepIQ app. Commands are UTF-8 text wrapped in the app's `fUzIoN` blob framing
+and sent to a single GATT characteristic. Responses normally arrive as
+notifications on that same characteristic, with a readable fallback used for
+bed-presence polling.
 """
 
 from __future__ import annotations
 
 import asyncio
+import binascii
 import contextlib
+import json
 import logging
+import struct
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from bleak.exc import BleakError
 
 from ..const import (
+    SLEEP_NUMBER_AUTH_CHAR_UUID,
     SLEEP_NUMBER_BAMKEY_CHAR_UUID,
+    SLEEP_NUMBER_TRANSFER_INFO_CHAR_UUID,
     SLEEP_NUMBER_VARIANT_LEFT,
     SLEEP_NUMBER_VARIANT_RIGHT,
     VARIANT_AUTO,
@@ -29,6 +36,9 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 _BAMKEY_RESPONSE_TIMEOUT = 7.5
+_BAMKEY_BLOB_PREAMBLE = b"fUzIoN"
+_BAMKEY_BLOB_HEADER_LENGTH = len(_BAMKEY_BLOB_PREAMBLE) + 4
+_BAMKEY_BLOB_MIN_LENGTH = _BAMKEY_BLOB_HEADER_LENGTH + 4
 _SLEEP_NUMBER_MIN_POSITION = 0
 _SLEEP_NUMBER_MAX_POSITION = 100
 _SLEEP_NUMBER_LIGHT_TIMER_OPTIONS = (0, 15, 30, 45, 60, 120, 180)
@@ -47,6 +57,7 @@ _SLEEP_NUMBER_LIGHT_VALUE_TO_LEVEL = {
 class SleepNumberCommands:
     """Fuzion bamkey command names used by Adjustable Bed support."""
 
+    MULTIPLE_BAMKEYS_VIA_JSON = "BAMG"
     GET_ACTUATOR_POSITION = "ACTG"
     SET_ACTUATOR_TARGET_POSITION = "ACTS"
     HALT_ACTUATOR = "ACTH"
@@ -80,10 +91,12 @@ class SleepNumberController(BedController):
         self._side = self._normalize_side(side)
         self._notify_started = False
         self._response_queue: asyncio.Queue[str] = asyncio.Queue()
+        self._response_buffer = bytearray()
         self._underbed_light_level: str | None = None
         self._underbed_light_timer_minutes: int | None = None
         self._underbed_light_last_active_level = "high"
         self._bed_presence_state: str | None = None
+        self._bed_presence_channel_primed = False
 
     @staticmethod
     def _normalize_side(side: str | None) -> str:
@@ -231,6 +244,7 @@ class SleepNumberController(BedController):
         if client is None or not client.is_connected:
             raise ConnectionError("Not connected to bed")
 
+        self._response_buffer.clear()
         await client.start_notify(
             SLEEP_NUMBER_BAMKEY_CHAR_UUID,
             self._handle_bamkey_notification,
@@ -250,6 +264,8 @@ class SleepNumberController(BedController):
             _LOGGER.debug("Failed to stop Sleep Number notifications", exc_info=True)
         finally:
             self._notify_started = False
+            self._response_buffer.clear()
+            self._drain_response_queue()
 
     async def read_positions(self, motor_count: int = 2) -> None:  # noqa: ARG002
         """Read the current head and foot target positions for the selected side."""
@@ -356,24 +372,32 @@ class SleepNumberController(BedController):
 
     async def read_bed_presence(self) -> bool | None:
         """Read occupancy state for the configured bed side."""
-        response = await self._send_bamkey_command(
-            SleepNumberCommands.GET_BED_PRESENCE,
-            self._side,
-            expected_args=1,
+        await self._ensure_bed_presence_channel_primed()
+
+        try:
+            response = await self._send_bamkey_command(
+                SleepNumberCommands.GET_BED_PRESENCE,
+                self._side,
+                expected_args=1,
+            )
+            return self._publish_bed_presence(response[0])
+        except (TimeoutError, ValueError) as err:
+            _LOGGER.debug(
+                "Sleep Number LBPG notify query failed for %s, falling back to characteristic read: %s",
+                self._coordinator.address,
+                err,
+            )
+
+        grouped_response = await self._send_bamkey_read_query(
+            SleepNumberCommands.MULTIPLE_BAMKEYS_VIA_JSON,
+            json.dumps(
+                [{"bamkey": SleepNumberCommands.GET_BED_PRESENCE, "args": self._side}],
+                separators=(",", ":"),
+            ),
         )
-        presence = self._normalize_bed_presence(response[0])
-        self._bed_presence_state = presence
-        self.forward_controller_state_updates(
-            {
-                "bed_presence": presence,
-                "bed_presence_side": self._side,
-            }
+        return self._publish_bed_presence(
+            self._parse_grouped_bed_presence_response(grouped_response)
         )
-        if presence == "in":
-            return True
-        if presence == "out":
-            return False
-        return None
 
     async def preset_flat(self) -> None:
         await self._send_preset(SleepNumberPresets.FLAT)
@@ -486,6 +510,21 @@ class SleepNumberController(BedController):
         if not self._notify_started:
             await self.start_notify(self._notify_callback)
 
+    async def _ensure_bed_presence_channel_primed(self) -> None:
+        """Prime the BLE side channels Sleep Number needs before LBPG polls."""
+        if self._bed_presence_channel_primed:
+            return
+
+        client = self.client
+        if client is None or not client.is_connected:
+            raise ConnectionError("Not connected to bed")
+
+        for char_uuid in (SLEEP_NUMBER_AUTH_CHAR_UUID, SLEEP_NUMBER_TRANSFER_INFO_CHAR_UUID):
+            async with self.ble_lock:
+                await client.read_gatt_char(char_uuid)
+
+        self._bed_presence_channel_primed = True
+
     async def _send_bamkey_command(
         self,
         bamkey: str,
@@ -496,10 +535,10 @@ class SleepNumberController(BedController):
         await self._ensure_notifications_started()
         self._drain_response_queue()
 
-        payload = bamkey if not args else f"{bamkey} {' '.join(args)}"
+        payload = self._format_bamkey_command(bamkey, *args)
         await self._write_gatt_with_retry(
             SLEEP_NUMBER_BAMKEY_CHAR_UUID,
-            payload.encode("utf-8"),
+            self._build_bamkey_blob(payload),
             response=True,
         )
 
@@ -535,6 +574,31 @@ class SleepNumberController(BedController):
                 with contextlib.suppress(asyncio.CancelledError):
                     await task
         return self._parse_bamkey_response(bamkey, raw_response, expected_args)
+
+    async def _send_bamkey_read_query(self, bamkey: str, *args: str) -> str:
+        """Send a bamkey command and read the response directly from the characteristic."""
+        await self._ensure_notifications_started()
+        self._drain_response_queue()
+
+        payload = self._format_bamkey_command(bamkey, *args)
+        await self._write_gatt_with_retry(
+            SLEEP_NUMBER_BAMKEY_CHAR_UUID,
+            self._build_bamkey_blob(payload),
+            response=True,
+        )
+
+        client = self.client
+        if client is None or not client.is_connected:
+            raise ConnectionError("Not connected to bed")
+
+        try:
+            async with asyncio.timeout(_BAMKEY_RESPONSE_TIMEOUT):
+                async with self.ble_lock:
+                    raw_response = bytes(await client.read_gatt_char(SLEEP_NUMBER_BAMKEY_CHAR_UUID))
+        except TimeoutError as err:
+            raise TimeoutError(f"{bamkey} timed out waiting for readable response") from err
+
+        return self._decode_bamkey_text(raw_response)
 
     def _drain_response_queue(self) -> None:
         """Discard stale bamkey responses before sending a new command."""
@@ -582,11 +646,136 @@ class SleepNumberController(BedController):
         raw = bytes(data)
         self.forward_raw_notification(SLEEP_NUMBER_BAMKEY_CHAR_UUID, raw)
 
+        try:
+            for decoded in self._extract_bamkey_text_responses(raw):
+                self._response_queue.put_nowait(decoded)
+        except ValueError:
+            _LOGGER.debug("Failed to decode Sleep Number bamkey notification", exc_info=True)
+
+    def _extract_bamkey_text_responses(self, raw: bytes) -> list[str]:
+        """Extract zero or more decoded bamkey payloads from the notification stream."""
+        if not raw:
+            return []
+
+        if not self._response_buffer and not raw.startswith(_BAMKEY_BLOB_PREAMBLE):
+            decoded = raw.decode("utf-8", errors="ignore").strip()
+            return [decoded] if decoded else []
+
+        self._response_buffer.extend(raw)
+        responses: list[str] = []
+
+        while self._response_buffer:
+            preamble_index = self._response_buffer.find(_BAMKEY_BLOB_PREAMBLE)
+            if preamble_index == -1:
+                self._response_buffer.clear()
+                return responses
+            if preamble_index > 0:
+                del self._response_buffer[:preamble_index]
+
+            if len(self._response_buffer) < _BAMKEY_BLOB_HEADER_LENGTH:
+                return responses
+
+            total_length = struct.unpack("<I", self._response_buffer[6:10])[0]
+            if total_length < _BAMKEY_BLOB_MIN_LENGTH:
+                raise ValueError(f"Invalid Sleep Number blob length: {total_length}")
+            if len(self._response_buffer) < total_length:
+                return responses
+
+            frame = bytes(self._response_buffer[:total_length])
+            del self._response_buffer[:total_length]
+            responses.append(self._parse_bamkey_blob(frame))
+
+        return responses
+
+    @staticmethod
+    def _format_bamkey_command(bamkey: str, *args: str) -> str:
+        """Format a bamkey request payload."""
+        return bamkey if not args else f"{bamkey} {' '.join(args)}"
+
+    @staticmethod
+    def _build_bamkey_blob(payload: str) -> bytes:
+        """Wrap a bamkey payload in the Fuzion blob framing used by SleepIQ."""
+        encoded_payload = payload.encode("utf-8")
+        total_length = _BAMKEY_BLOB_HEADER_LENGTH + len(encoded_payload) + 4
+        header = _BAMKEY_BLOB_PREAMBLE + struct.pack("<I", total_length)
+        checksum = binascii.crc32(header + encoded_payload) & 0xFFFFFFFF
+        return header + encoded_payload + struct.pack("<I", checksum)
+
+    @staticmethod
+    def _decode_bamkey_text(raw: bytes) -> str:
+        """Decode either a framed blob or a plain-text bamkey response."""
+        if raw.startswith(_BAMKEY_BLOB_PREAMBLE):
+            return SleepNumberController._parse_bamkey_blob(raw)
+
         decoded = raw.decode("utf-8", errors="ignore").strip()
         if not decoded:
-            return
+            raise ValueError("Sleep Number returned an empty response")
+        return decoded
 
-        self._response_queue.put_nowait(decoded)
+    @staticmethod
+    def _parse_bamkey_blob(frame: bytes) -> str:
+        """Decode and validate a single Sleep Number Fuzion blob."""
+        if len(frame) < _BAMKEY_BLOB_MIN_LENGTH:
+            raise ValueError("Sleep Number response blob is too short")
+        if not frame.startswith(_BAMKEY_BLOB_PREAMBLE):
+            raise ValueError("Sleep Number response blob is missing the Fuzion preamble")
+
+        total_length = struct.unpack("<I", frame[6:10])[0]
+        if total_length != len(frame):
+            raise ValueError(
+                f"Sleep Number response blob length mismatch: {len(frame)} != {total_length}"
+            )
+
+        payload = frame[_BAMKEY_BLOB_HEADER_LENGTH:-4]
+        expected_crc = struct.unpack("<I", frame[-4:])[0]
+        actual_crc = binascii.crc32(frame[:-4]) & 0xFFFFFFFF
+        if actual_crc != expected_crc:
+            raise ValueError("Sleep Number response blob failed CRC validation")
+
+        decoded = payload.decode("utf-8", errors="ignore").strip()
+        if not decoded:
+            raise ValueError("Sleep Number response blob contained an empty payload")
+        return decoded
+
+    def _publish_bed_presence(self, value: str) -> bool | None:
+        """Normalize and publish a Sleep Number bed presence state."""
+        presence = self._normalize_bed_presence(value)
+        self._bed_presence_state = presence
+        self.forward_controller_state_updates(
+            {
+                "bed_presence": presence,
+                "bed_presence_side": self._side,
+            }
+        )
+        if presence == "in":
+            return True
+        if presence == "out":
+            return False
+        return None
+
+    @staticmethod
+    def _parse_grouped_bed_presence_response(response: str) -> str:
+        """Extract the first LBPG result from a grouped BAMG response."""
+        payload = response.strip()
+        if payload.startswith("PASS:"):
+            payload = payload.removeprefix("PASS:").strip()
+
+        try:
+            values = json.loads(payload)
+        except json.JSONDecodeError as err:
+            raise ValueError(f"Invalid Sleep Number BAMG response: {response}") from err
+
+        if not isinstance(values, list) or len(values) != 1:
+            raise ValueError(f"Unexpected Sleep Number BAMG bed-presence response: {response}")
+
+        value = values[0]
+        if not isinstance(value, str):
+            raise ValueError(f"Unexpected Sleep Number BAMG bed-presence item: {value!r}")
+        if value.startswith("PASS:"):
+            return value.removeprefix("PASS:").strip()
+        if value.startswith("FAIL"):
+            raise ValueError(f"Sleep Number BAMG bed-presence query failed: {value}")
+        return value.strip()
 
     @staticmethod
     def _motor_to_actuator(motor: str) -> str:

--- a/custom_components/adjustable_bed/beds/sleep_number.py
+++ b/custom_components/adjustable_bed/beds/sleep_number.py
@@ -768,7 +768,9 @@ class SleepNumberController(BedController):
 
             frame = bytes(self._response_buffer[:total_length])
             del self._response_buffer[:total_length]
-            responses.append(self._parse_bamkey_blob(frame))
+            decoded = self._parse_bamkey_blob(frame)
+            if self._looks_like_bamkey_response(decoded):
+                responses.append(decoded)
 
         return responses
 

--- a/custom_components/adjustable_bed/beds/sleep_number.py
+++ b/custom_components/adjustable_bed/beds/sleep_number.py
@@ -275,15 +275,14 @@ class SleepNumberController(BedController):
         """Unsubscribe from bamkey notifications."""
         self._notify_callback = None
         client = self.client
-        if client is None or not client.is_connected or not self._notify_started:
-            return
-
         try:
+            if client is None or not client.is_connected or not self._notify_started:
+                return
             await client.stop_notify(SLEEP_NUMBER_BAMKEY_CHAR_UUID)
         except BleakError:
             _LOGGER.debug("Failed to stop Sleep Number notifications", exc_info=True)
         finally:
-            if self._bulk_notify_started:
+            if client is not None and client.is_connected and self._bulk_notify_started:
                 try:
                     await client.stop_notify(SLEEP_NUMBER_BULK_TRANSFER_CHAR_UUID)
                 except BleakError:
@@ -293,6 +292,7 @@ class SleepNumberController(BedController):
                     )
             self._notify_started = False
             self._bulk_notify_started = False
+            self._bed_presence_channel_primed = False
             self._response_buffer.clear()
             self._drain_response_queue()
             self._drain_readback_hint_queue()
@@ -554,6 +554,7 @@ class SleepNumberController(BedController):
     async def _send_bamkey_raw_response(self, bamkey: str, *args: str) -> str:
         """Send a bamkey command and return the raw response text."""
         await self._ensure_notifications_started()
+        self._response_buffer.clear()
         self._drain_response_queue()
         self._drain_readback_hint_queue()
 

--- a/custom_components/adjustable_bed/beds/sleep_number.py
+++ b/custom_components/adjustable_bed/beds/sleep_number.py
@@ -2,9 +2,9 @@
 
 This implements Select Comfort's Fuzion "bamkey" BLE protocol used by the
 SleepIQ app. Commands are UTF-8 text wrapped in the app's `fUzIoN` blob framing
-and sent to a single GATT characteristic. Responses normally arrive as
-notifications on that same characteristic, with a readable fallback used for
-bed-presence polling.
+and sent to the BamKey characteristic. Some beds deliver full framed responses
+as notifications, while others use notifications as a readback trigger, so the
+controller supports both patterns.
 """
 
 from __future__ import annotations
@@ -23,6 +23,7 @@ from bleak.exc import BleakError
 from ..const import (
     SLEEP_NUMBER_AUTH_CHAR_UUID,
     SLEEP_NUMBER_BAMKEY_CHAR_UUID,
+    SLEEP_NUMBER_BULK_TRANSFER_CHAR_UUID,
     SLEEP_NUMBER_TRANSFER_INFO_CHAR_UUID,
     SLEEP_NUMBER_VARIANT_LEFT,
     SLEEP_NUMBER_VARIANT_RIGHT,
@@ -39,6 +40,7 @@ _BAMKEY_RESPONSE_TIMEOUT = 7.5
 _BAMKEY_BLOB_PREAMBLE = b"fUzIoN"
 _BAMKEY_BLOB_HEADER_LENGTH = len(_BAMKEY_BLOB_PREAMBLE) + 4
 _BAMKEY_BLOB_MIN_LENGTH = _BAMKEY_BLOB_HEADER_LENGTH + 4
+_BAMKEY_READBACK_TRIGGER_DELAY = 0.05
 _SLEEP_NUMBER_MIN_POSITION = 0
 _SLEEP_NUMBER_MAX_POSITION = 100
 _SLEEP_NUMBER_LIGHT_TIMER_OPTIONS = (0, 15, 30, 45, 60, 120, 180)
@@ -90,7 +92,9 @@ class SleepNumberController(BedController):
         self._notify_callback: Callable[[str, float], None] | None = None
         self._side = self._normalize_side(side)
         self._notify_started = False
+        self._bulk_notify_started = False
         self._response_queue: asyncio.Queue[str] = asyncio.Queue()
+        self._readback_hint_queue: asyncio.Queue[None] = asyncio.Queue()
         self._response_buffer = bytearray()
         self._underbed_light_level: str | None = None
         self._underbed_light_timer_minutes: int | None = None
@@ -245,11 +249,27 @@ class SleepNumberController(BedController):
             raise ConnectionError("Not connected to bed")
 
         self._response_buffer.clear()
+        self._drain_response_queue()
+        self._drain_readback_hint_queue()
         await client.start_notify(
             SLEEP_NUMBER_BAMKEY_CHAR_UUID,
             self._handle_bamkey_notification,
         )
         self._notify_started = True
+
+        if self._has_characteristic(SLEEP_NUMBER_BULK_TRANSFER_CHAR_UUID):
+            try:
+                await client.start_notify(
+                    SLEEP_NUMBER_BULK_TRANSFER_CHAR_UUID,
+                    self._handle_bamkey_readback_hint_notification,
+                )
+            except BleakError:
+                _LOGGER.debug(
+                    "Failed to start Sleep Number bulk-transfer notifications",
+                    exc_info=True,
+                )
+            else:
+                self._bulk_notify_started = True
 
     async def stop_notify(self) -> None:
         """Unsubscribe from bamkey notifications."""
@@ -263,9 +283,19 @@ class SleepNumberController(BedController):
         except BleakError:
             _LOGGER.debug("Failed to stop Sleep Number notifications", exc_info=True)
         finally:
+            if self._bulk_notify_started:
+                try:
+                    await client.stop_notify(SLEEP_NUMBER_BULK_TRANSFER_CHAR_UUID)
+                except BleakError:
+                    _LOGGER.debug(
+                        "Failed to stop Sleep Number bulk-transfer notifications",
+                        exc_info=True,
+                    )
             self._notify_started = False
+            self._bulk_notify_started = False
             self._response_buffer.clear()
             self._drain_response_queue()
+            self._drain_readback_hint_queue()
 
     async def read_positions(self, motor_count: int = 2) -> None:  # noqa: ARG002
         """Read the current head and foot target positions for the selected side."""
@@ -374,21 +404,7 @@ class SleepNumberController(BedController):
         """Read occupancy state for the configured bed side."""
         await self._ensure_bed_presence_channel_primed()
 
-        try:
-            response = await self._send_bamkey_command(
-                SleepNumberCommands.GET_BED_PRESENCE,
-                self._side,
-                expected_args=1,
-            )
-            return self._publish_bed_presence(response[0])
-        except (TimeoutError, ValueError) as err:
-            _LOGGER.debug(
-                "Sleep Number LBPG notify query failed for %s, falling back to characteristic read: %s",
-                self._coordinator.address,
-                err,
-            )
-
-        grouped_response = await self._send_bamkey_read_query(
+        grouped_response = await self._send_bamkey_raw_response(
             SleepNumberCommands.MULTIPLE_BAMKEYS_VIA_JSON,
             json.dumps(
                 [{"bamkey": SleepNumberCommands.GET_BED_PRESENCE, "args": self._side}],
@@ -532,78 +548,98 @@ class SleepNumberController(BedController):
         expected_args: int = 0,
     ) -> list[str]:
         """Send a bamkey command and parse the matching response."""
+        raw_response = await self._send_bamkey_raw_response(bamkey, *args)
+        return self._parse_bamkey_response(bamkey, raw_response, expected_args)
+
+    async def _send_bamkey_raw_response(self, bamkey: str, *args: str) -> str:
+        """Send a bamkey command and return the raw response text."""
         await self._ensure_notifications_started()
         self._drain_response_queue()
+        self._drain_readback_hint_queue()
 
         payload = self._format_bamkey_command(bamkey, *args)
         await self._write_gatt_with_retry(
             SLEEP_NUMBER_BAMKEY_CHAR_UUID,
             self._build_bamkey_blob(payload),
-            response=True,
+            response=False,
         )
-
+        deadline = asyncio.get_running_loop().time() + _BAMKEY_RESPONSE_TIMEOUT
         response_task = asyncio.create_task(self._response_queue.get())
+        hint_task = asyncio.create_task(self._readback_hint_queue.get())
         cancel_task = asyncio.create_task(self._coordinator.cancel_command.wait())
         try:
-            done, pending = await asyncio.wait(
-                {response_task, cancel_task},
-                timeout=_BAMKEY_RESPONSE_TIMEOUT,
-                return_when=asyncio.FIRST_COMPLETED,
-            )
+            while True:
+                timeout = deadline - asyncio.get_running_loop().time()
+                if timeout <= 0:
+                    raise TimeoutError(f"{bamkey} timed out waiting for response")
 
-            for task in pending:
-                task.cancel()
-            for task in pending:
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
+                done, _ = await asyncio.wait(
+                    {response_task, hint_task, cancel_task},
+                    timeout=timeout,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if not done:
+                    raise TimeoutError(f"{bamkey} timed out waiting for response")
 
-            if response_task in done:
-                raw_response = response_task.result()
-            elif cancel_task in done:
-                response_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await response_task
-                raise asyncio.CancelledError
-            else:
-                raise TimeoutError(f"{bamkey} timed out waiting for response")
+                if cancel_task in done:
+                    raise asyncio.CancelledError
+
+                if response_task in done:
+                    return response_task.result()
+
+                if hint_task in done:
+                    hint_task = asyncio.create_task(self._readback_hint_queue.get())
+                    try:
+                        return await self._read_bamkey_response_after_hint(
+                            timeout=deadline - asyncio.get_running_loop().time()
+                        )
+                    except (TimeoutError, ValueError):
+                        _LOGGER.debug(
+                            "Sleep Number readback after notification hint did not yield a full response",
+                            exc_info=True,
+                        )
         finally:
-            for task in (response_task, cancel_task):
+            for task in (response_task, hint_task, cancel_task):
                 if task.done():
                     continue
                 task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await task
-        return self._parse_bamkey_response(bamkey, raw_response, expected_args)
-
-    async def _send_bamkey_read_query(self, bamkey: str, *args: str) -> str:
-        """Send a bamkey command and read the response directly from the characteristic."""
-        await self._ensure_notifications_started()
-        self._drain_response_queue()
-
-        payload = self._format_bamkey_command(bamkey, *args)
-        await self._write_gatt_with_retry(
-            SLEEP_NUMBER_BAMKEY_CHAR_UUID,
-            self._build_bamkey_blob(payload),
-            response=True,
-        )
-
-        client = self.client
-        if client is None or not client.is_connected:
-            raise ConnectionError("Not connected to bed")
-
-        try:
-            async with asyncio.timeout(_BAMKEY_RESPONSE_TIMEOUT):
-                async with self.ble_lock:
-                    raw_response = bytes(await client.read_gatt_char(SLEEP_NUMBER_BAMKEY_CHAR_UUID))
-        except TimeoutError as err:
-            raise TimeoutError(f"{bamkey} timed out waiting for readable response") from err
-
-        return self._decode_bamkey_text(raw_response)
 
     def _drain_response_queue(self) -> None:
         """Discard stale bamkey responses before sending a new command."""
         while not self._response_queue.empty():
             self._response_queue.get_nowait()
+
+    def _drain_readback_hint_queue(self) -> None:
+        """Discard stale readback hints before sending a new command."""
+        while not self._readback_hint_queue.empty():
+            self._readback_hint_queue.get_nowait()
+
+    async def _read_bamkey_response_after_hint(self, *, timeout: float) -> str:
+        """Read the BamKey characteristic after a notification indicates fresh data."""
+        client = self.client
+        if client is None or not client.is_connected:
+            raise ConnectionError("Not connected to bed")
+
+        deadline = asyncio.get_running_loop().time() + timeout
+        while True:
+            if self._coordinator.cancel_command.is_set():
+                raise asyncio.CancelledError
+
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                raise TimeoutError("Timed out waiting for Sleep Number readback response")
+
+            await asyncio.sleep(min(_BAMKEY_READBACK_TRIGGER_DELAY, remaining))
+            async with asyncio.timeout(remaining):
+                async with self.ble_lock:
+                    raw_response = bytes(await client.read_gatt_char(SLEEP_NUMBER_BAMKEY_CHAR_UUID))
+
+            if not raw_response:
+                continue
+
+            return self._decode_bamkey_text(raw_response)
 
     def _parse_bamkey_response(
         self,
@@ -647,10 +683,26 @@ class SleepNumberController(BedController):
         self.forward_raw_notification(SLEEP_NUMBER_BAMKEY_CHAR_UUID, raw)
 
         try:
-            for decoded in self._extract_bamkey_text_responses(raw):
+            responses = self._extract_bamkey_text_responses(raw)
+            for decoded in responses:
                 self._response_queue.put_nowait(decoded)
         except ValueError:
             _LOGGER.debug("Failed to decode Sleep Number bamkey notification", exc_info=True)
+            self._queue_readback_hint()
+            return
+
+        if not responses and not self._response_buffer:
+            self._queue_readback_hint()
+
+    def _handle_bamkey_readback_hint_notification(self, _sender: object, data: bytearray) -> None:
+        """Treat secondary Sleep Number notifications as readback triggers."""
+        raw = bytes(data)
+        self.forward_raw_notification(SLEEP_NUMBER_BULK_TRANSFER_CHAR_UUID, raw)
+        self._queue_readback_hint()
+
+    def _queue_readback_hint(self) -> None:
+        """Queue a notification hint that the BamKey characteristic should be read."""
+        self._readback_hint_queue.put_nowait(None)
 
     def _extract_bamkey_text_responses(self, raw: bytes) -> list[str]:
         """Extract zero or more decoded bamkey payloads from the notification stream."""
@@ -659,7 +711,9 @@ class SleepNumberController(BedController):
 
         if not self._response_buffer and not raw.startswith(_BAMKEY_BLOB_PREAMBLE):
             decoded = raw.decode("utf-8", errors="ignore").strip()
-            return [decoded] if decoded else []
+            if self._looks_like_bamkey_response(decoded):
+                return [decoded]
+            return []
 
         self._response_buffer.extend(raw)
         responses: list[str] = []
@@ -711,6 +765,23 @@ class SleepNumberController(BedController):
         if not decoded:
             raise ValueError("Sleep Number returned an empty response")
         return decoded
+
+    def _has_characteristic(self, char_uuid: str) -> bool:
+        """Return True if the current connection exposed the characteristic UUID."""
+        client = self.client
+        if client is None or not client.services:
+            return False
+
+        for service in client.services:
+            for characteristic in service.characteristics:
+                if characteristic.uuid == char_uuid:
+                    return True
+        return False
+
+    @staticmethod
+    def _looks_like_bamkey_response(decoded: str) -> bool:
+        """Return True when a decoded plain-text notification looks like a real response."""
+        return decoded.startswith(("PASS:", "FAIL:", "["))
 
     @staticmethod
     def _parse_bamkey_blob(frame: bytes) -> str:

--- a/custom_components/adjustable_bed/beds/sleep_number.py
+++ b/custom_components/adjustable_bed/beds/sleep_number.py
@@ -576,6 +576,8 @@ class SleepNumberController(BedController):
         self._drain_readback_hint_queue()
 
         payload = self._format_bamkey_command(bamkey, *args)
+        # Sleep Number returns BamKey results over the notify/readback path on the
+        # same characteristic, so waiting for a GATT write response only adds latency.
         await self._write_gatt_with_retry(
             SLEEP_NUMBER_BAMKEY_CHAR_UUID,
             self._build_bamkey_blob(payload),

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -749,6 +749,8 @@ JENSEN_CHAR_UUID: Final = "00001111-0000-1000-8000-00805f9b34fb"
 # arrive as notifications in PASS:/FAIL: form on the same characteristic.
 SLEEP_NUMBER_SERVICE_UUID: Final = "09d23fae-90e6-44c2-95b6-0b3d0f1abf25"
 SLEEP_NUMBER_BAMKEY_CHAR_UUID: Final = "421e00f3-ae76-4c49-ab6e-39e4df4a5333"
+SLEEP_NUMBER_AUTH_CHAR_UUID: Final = "8d4675a5-b5fa-42b2-b587-0ee71c46b709"
+SLEEP_NUMBER_TRANSFER_INFO_CHAR_UUID: Final = "e8d06e2a-c987-48f8-93a8-4d18d56b4337"
 
 # Svane LinonPI specific UUIDs (multi-service architecture)
 # Protocol reverse-engineered from com.produktide.svane.svaneremote APK

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -751,6 +751,7 @@ SLEEP_NUMBER_SERVICE_UUID: Final = "09d23fae-90e6-44c2-95b6-0b3d0f1abf25"
 SLEEP_NUMBER_BAMKEY_CHAR_UUID: Final = "421e00f3-ae76-4c49-ab6e-39e4df4a5333"
 SLEEP_NUMBER_AUTH_CHAR_UUID: Final = "8d4675a5-b5fa-42b2-b587-0ee71c46b709"
 SLEEP_NUMBER_TRANSFER_INFO_CHAR_UUID: Final = "e8d06e2a-c987-48f8-93a8-4d18d56b4337"
+SLEEP_NUMBER_BULK_TRANSFER_CHAR_UUID: Final = "0ec9a5a3-8ac3-4582-92f3-1666421f323d"
 
 # Svane LinonPI specific UUIDs (multi-service architecture)
 # Protocol reverse-engineered from com.produktide.svane.svaneremote APK

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import binascii
+import struct
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -83,8 +85,30 @@ def mock_bleak_client() -> MagicMock:
     """Mock BleakClient."""
     from bleak import BleakClient
 
+    sleep_number_preamble = b"fUzIoN"
     client = MagicMock(spec=BleakClient)
     notify_callbacks: dict[str, object] = {}
+    readable_values: dict[str, bytes] = {}
+
+    def _build_sleep_number_blob(payload: str) -> bytes:
+        encoded = payload.encode("utf-8")
+        total_length = len(sleep_number_preamble) + 4 + len(encoded) + 4
+        header = sleep_number_preamble + struct.pack("<I", total_length)
+        checksum = binascii.crc32(header + encoded) & 0xFFFFFFFF
+        return header + encoded + struct.pack("<I", checksum)
+
+    def _decode_sleep_number_payload(data: bytes) -> str | None:
+        if data.startswith(sleep_number_preamble):
+            total_length = struct.unpack("<I", data[6:10])[0]
+            if total_length != len(data):
+                return None
+            expected_crc = struct.unpack("<I", data[-4:])[0]
+            if binascii.crc32(data[:-4]) & 0xFFFFFFFF != expected_crc:
+                return None
+            return data[10:-4].decode("utf-8", errors="ignore").strip()
+
+        decoded = data.decode("utf-8", errors="ignore").strip()
+        return decoded or None
 
     client.is_connected = True
     client.address = TEST_ADDRESS
@@ -103,17 +127,23 @@ def mock_bleak_client() -> MagicMock:
 
     async def _write_gatt_char(char_uuid: str, data: bytes, response: bool = False) -> None:
         del response
+        decoded_payload = _decode_sleep_number_payload(data)
         callback = notify_callbacks.get(char_uuid)
-        if callback is None:
+        if callback is None or decoded_payload is None:
             return
 
-        if data.decode("utf-8", errors="ignore").strip() == "UBLG":
-            callback(char_uuid, bytearray(b"PASS:high 15"))
+        if decoded_payload == "UBLG":
+            response_payload = _build_sleep_number_blob("PASS:high 15")
+            readable_values[char_uuid] = response_payload
+            callback(char_uuid, bytearray(response_payload))
+
+    async def _read_gatt_char(target) -> bytes:
+        return readable_values.get(str(target), b"")
 
     client.connect = AsyncMock(return_value=True)
     client.disconnect = AsyncMock()
     client.write_gatt_char = AsyncMock(side_effect=_write_gatt_char)
-    client.read_gatt_char = AsyncMock(return_value=b"")
+    client.read_gatt_char = AsyncMock(side_effect=_read_gatt_char)
     client.start_notify = AsyncMock(side_effect=_start_notify)
     client.stop_notify = AsyncMock(side_effect=_stop_notify)
 

--- a/tests/test_sleep_number.py
+++ b/tests/test_sleep_number.py
@@ -581,6 +581,14 @@ class TestSleepNumberController:
 
         assert await coordinator.controller._response_queue.get() == "PASS:ACK"
 
+    def test_parse_bamkey_blob_rejects_invalid_crc(self) -> None:
+        """Framed blobs with a corrupted checksum should fail CRC validation."""
+        blob = bytearray(_build_sleep_number_blob("PASS:ACK"))
+        blob[-1] ^= 0xFF
+
+        with pytest.raises(ValueError):
+            SleepNumberController._parse_bamkey_blob(bytes(blob))
+
     async def test_read_underbed_light_settings_updates_cached_state(
         self,
         sleep_number_coordinator,

--- a/tests/test_sleep_number.py
+++ b/tests/test_sleep_number.py
@@ -9,6 +9,7 @@ from homeassistant.const import CONF_ADDRESS, CONF_NAME
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.adjustable_bed.beds.sleep_number import SleepNumberController
 from custom_components.adjustable_bed.const import (
     BED_TYPE_SLEEP_NUMBER,
     CONF_BED_TYPE,
@@ -18,12 +19,24 @@ from custom_components.adjustable_bed.const import (
     CONF_PREFERRED_ADAPTER,
     CONF_PROTOCOL_VARIANT,
     DOMAIN,
+    SLEEP_NUMBER_AUTH_CHAR_UUID,
     SLEEP_NUMBER_BAMKEY_CHAR_UUID,
+    SLEEP_NUMBER_TRANSFER_INFO_CHAR_UUID,
     SLEEP_NUMBER_VARIANT_LEFT,
     SLEEP_NUMBER_VARIANT_RIGHT,
     VARIANT_AUTO,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
+
+
+def _build_sleep_number_blob(payload: str) -> bytes:
+    """Return a framed Sleep Number blob for transport assertions."""
+    return SleepNumberController._build_bamkey_blob(payload)
+
+
+def _decode_sleep_number_payload(payload: bytes) -> str:
+    """Decode a framed Sleep Number blob back to its text payload."""
+    return SleepNumberController._decode_bamkey_text(payload)
 
 
 @pytest.fixture
@@ -139,10 +152,10 @@ class TestSleepNumberController:
             _char_uuid: str, payload: bytes, response: bool = False
         ) -> None:
             del response
-            assert payload == b"ACTS left head 57"
+            assert _decode_sleep_number_payload(payload) == "ACTS left head 57"
             coordinator.controller._handle_bamkey_notification(
                 None,
-                bytearray(b"PASS:ACK"),
+                bytearray(_build_sleep_number_blob("PASS:ACK")),
             )
 
         mock_bleak_client.write_gatt_char.side_effect = _write_side_effect
@@ -155,7 +168,7 @@ class TestSleepNumberController:
         )
         mock_bleak_client.write_gatt_char.assert_awaited_once_with(
             SLEEP_NUMBER_BAMKEY_CHAR_UUID,
-            b"ACTS left head 57",
+            _build_sleep_number_blob("ACTS left head 57"),
             response=True,
         )
 
@@ -270,6 +283,87 @@ class TestSleepNumberController:
         )
         assert coordinator.controller.get_light_state()["light_timer_option"] == "15 min"
         assert coordinator.controller._coordinator.controller_state["bed_presence"] == "in"
+
+    async def test_read_bed_presence_primes_required_characteristics_once(
+        self,
+        sleep_number_coordinator,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """LBPG should prime the Auth and TransferInfo reads once per connection."""
+        coordinator = await sleep_number_coordinator(
+            address="AA:BB:CC:DD:EE:2E",
+            name="Smart bed 0074F4",
+            entry_id="sleep_number_presence_prime",
+        )
+        coordinator.controller._send_bamkey_command = AsyncMock(side_effect=[["out"], ["in"]])
+        mock_bleak_client.read_gatt_char.reset_mock()
+
+        first = await coordinator.controller.read_bed_presence()
+        second = await coordinator.controller.read_bed_presence()
+
+        assert first is False
+        assert second is True
+        mock_bleak_client.read_gatt_char.assert_has_awaits(
+            [
+                call(SLEEP_NUMBER_AUTH_CHAR_UUID),
+                call(SLEEP_NUMBER_TRANSFER_INFO_CHAR_UUID),
+            ]
+        )
+        assert mock_bleak_client.read_gatt_char.await_count == 2
+
+    async def test_read_bed_presence_falls_back_to_readable_bamg_response(
+        self,
+        sleep_number_coordinator,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """LBPG should fall back to the readable BAMG path when notify polling times out."""
+        coordinator = await sleep_number_coordinator(
+            address="AA:BB:CC:DD:EE:2F",
+            name="Smart bed 0074F5",
+            entry_id="sleep_number_presence_fallback",
+        )
+        coordinator.controller._send_bamkey_command = AsyncMock(
+            side_effect=TimeoutError("notify timeout")
+        )
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        async def _read_side_effect(target) -> bytes:
+            if str(target) in {
+                SLEEP_NUMBER_AUTH_CHAR_UUID,
+                SLEEP_NUMBER_TRANSFER_INFO_CHAR_UUID,
+            }:
+                return b""
+            if str(target) == SLEEP_NUMBER_BAMKEY_CHAR_UUID:
+                return _build_sleep_number_blob('PASS:["PASS:in"]')
+            return b""
+
+        mock_bleak_client.read_gatt_char = AsyncMock(side_effect=_read_side_effect)
+
+        presence = await coordinator.controller.read_bed_presence()
+
+        assert presence is True
+        assert _decode_sleep_number_payload(
+            mock_bleak_client.write_gatt_char.await_args.args[1]
+        ) == 'BAMG [{"bamkey":"LBPG","args":"left"}]'
+
+    async def test_bamkey_notification_handler_reassembles_blob_chunks(
+        self,
+        sleep_number_coordinator,
+    ) -> None:
+        """Chunked bamkey notifications should be reassembled before parsing."""
+        coordinator = await sleep_number_coordinator(
+            address="AA:BB:CC:DD:EE:30",
+            name="Smart bed 0074F6",
+            entry_id="sleep_number_chunked_notification",
+        )
+        blob = _build_sleep_number_blob("PASS:ACK")
+
+        coordinator.controller._handle_bamkey_notification(None, bytearray(blob[:8]))
+        assert coordinator.controller._response_queue.empty()
+
+        coordinator.controller._handle_bamkey_notification(None, bytearray(blob[8:]))
+
+        assert await coordinator.controller._response_queue.get() == "PASS:ACK"
 
     async def test_read_underbed_light_settings_updates_cached_state(
         self,

--- a/tests/test_sleep_number.py
+++ b/tests/test_sleep_number.py
@@ -36,7 +36,7 @@ def _build_sleep_number_blob(payload: str) -> bytes:
 
 def _decode_sleep_number_payload(payload: bytes) -> str:
     """Decode a framed Sleep Number blob back to its text payload."""
-    return SleepNumberController._decode_bamkey_text(payload)
+    return SleepNumberController._parse_bamkey_blob(payload)
 
 
 @pytest.fixture
@@ -401,6 +401,34 @@ class TestSleepNumberController:
         )
 
         assert await coordinator.controller._readback_hint_queue.get() is None
+
+    async def test_stop_notify_clears_session_state_when_client_is_already_disconnected(
+        self,
+        sleep_number_coordinator,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """stop_notify should clear local Sleep Number session state even on early return."""
+        coordinator = await sleep_number_coordinator(
+            address="AA:BB:CC:DD:EE:33",
+            name="Smart bed 0074F9",
+            entry_id="sleep_number_stop_notify_cleanup",
+        )
+        coordinator.controller._notify_started = True
+        coordinator.controller._bulk_notify_started = True
+        coordinator.controller._bed_presence_channel_primed = True
+        coordinator.controller._response_buffer.extend(_build_sleep_number_blob("PASS:ACK"))
+        coordinator.controller._response_queue.put_nowait("PASS:ACK")
+        coordinator.controller._readback_hint_queue.put_nowait(None)
+        mock_bleak_client.is_connected = False
+
+        await coordinator.controller.stop_notify()
+
+        assert coordinator.controller._notify_started is False
+        assert coordinator.controller._bulk_notify_started is False
+        assert coordinator.controller._bed_presence_channel_primed is False
+        assert coordinator.controller._response_buffer == bytearray()
+        assert coordinator.controller._response_queue.empty()
+        assert coordinator.controller._readback_hint_queue.empty()
 
     async def test_bamkey_notification_handler_reassembles_blob_chunks(
         self,

--- a/tests/test_sleep_number.py
+++ b/tests/test_sleep_number.py
@@ -225,11 +225,17 @@ class TestSleepNumberController:
             assert _decode_sleep_number_payload(payload) == "ACTS left head 43"
             coordinator.controller._handle_bamkey_notification(None, bytearray(b"hint"))
 
-        read_responses = iter((b"hint", _build_sleep_number_blob("PASS:ACK")))
+        read_responses = [b"hint", _build_sleep_number_blob("PASS:ACK")]
+        read_call_count = 0
 
         async def _read_side_effect(target) -> bytes:
+            nonlocal read_call_count
             if str(target) == SLEEP_NUMBER_BAMKEY_CHAR_UUID:
-                return next(read_responses)
+                if read_call_count >= len(read_responses):
+                    pytest.fail(f"Unexpected extra read call #{read_call_count + 1}")
+                response = read_responses[read_call_count]
+                read_call_count += 1
+                return response
             return b""
 
         mock_bleak_client.write_gatt_char.side_effect = _write_side_effect
@@ -238,6 +244,41 @@ class TestSleepNumberController:
         await coordinator.controller.set_motor_position("back", 43)
 
         assert mock_bleak_client.read_gatt_char.await_count == 2
+
+    async def test_set_motor_position_ignores_framed_placeholder_notification(
+        self,
+        sleep_number_coordinator,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """Framed trigger tokens should fall through to readback instead of completing early."""
+        coordinator = await sleep_number_coordinator(
+            address="AA:BB:CC:DD:EE:37",
+            name="Smart bed 0074FD",
+            entry_id="sleep_number_set_position_framed_placeholder",
+        )
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        async def _write_side_effect(
+            _char_uuid: str, payload: bytes, response: bool = False
+        ) -> None:
+            assert response is False
+            assert _decode_sleep_number_payload(payload) == "ACTS left head 45"
+            coordinator.controller._handle_bamkey_notification(
+                None,
+                bytearray(_build_sleep_number_blob("hint")),
+            )
+
+        async def _read_side_effect(target) -> bytes:
+            if str(target) == SLEEP_NUMBER_BAMKEY_CHAR_UUID:
+                return _build_sleep_number_blob("PASS:ACK")
+            return b""
+
+        mock_bleak_client.write_gatt_char.side_effect = _write_side_effect
+        mock_bleak_client.read_gatt_char = AsyncMock(side_effect=_read_side_effect)
+
+        await coordinator.controller.set_motor_position("back", 45)
+
+        mock_bleak_client.read_gatt_char.assert_awaited_with(SLEEP_NUMBER_BAMKEY_CHAR_UUID)
 
     async def test_cancelled_bamkey_command_does_not_write(
         self,

--- a/tests/test_sleep_number.py
+++ b/tests/test_sleep_number.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, call
+import asyncio
+from unittest.mock import ANY, AsyncMock, MagicMock, call
 
 import pytest
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
@@ -204,6 +205,96 @@ class TestSleepNumberController:
 
         mock_bleak_client.read_gatt_char.assert_awaited_with(SLEEP_NUMBER_BAMKEY_CHAR_UUID)
 
+    async def test_set_motor_position_ignores_placeholder_readback_until_ack(
+        self,
+        sleep_number_coordinator,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """Hint-driven readback should keep polling until a real bamkey response arrives."""
+        coordinator = await sleep_number_coordinator(
+            address="AA:BB:CC:DD:EE:34",
+            name="Smart bed 0074FA",
+            entry_id="sleep_number_set_position_readback_placeholder",
+        )
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        async def _write_side_effect(
+            _char_uuid: str, payload: bytes, response: bool = False
+        ) -> None:
+            assert response is False
+            assert _decode_sleep_number_payload(payload) == "ACTS left head 43"
+            coordinator.controller._handle_bamkey_notification(None, bytearray(b"hint"))
+
+        read_responses = iter((b"hint", _build_sleep_number_blob("PASS:ACK")))
+
+        async def _read_side_effect(target) -> bytes:
+            if str(target) == SLEEP_NUMBER_BAMKEY_CHAR_UUID:
+                return next(read_responses)
+            return b""
+
+        mock_bleak_client.write_gatt_char.side_effect = _write_side_effect
+        mock_bleak_client.read_gatt_char = AsyncMock(side_effect=_read_side_effect)
+
+        await coordinator.controller.set_motor_position("back", 43)
+
+        assert mock_bleak_client.read_gatt_char.await_count == 2
+
+    async def test_cancelled_bamkey_command_does_not_write(
+        self,
+        sleep_number_coordinator,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """Regular bamkey commands should abort before writing when already cancelled."""
+        coordinator = await sleep_number_coordinator(
+            address="AA:BB:CC:DD:EE:35",
+            name="Smart bed 0074FB",
+            entry_id="sleep_number_cancelled_command",
+        )
+        mock_bleak_client.write_gatt_char.reset_mock()
+        cancel_event = asyncio.Event()
+        cancel_event.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await coordinator.controller._send_bamkey_raw_response(
+                "ACTS",
+                "left",
+                "head",
+                "44",
+                cancel_event=cancel_event,
+            )
+
+        mock_bleak_client.write_gatt_char.assert_not_awaited()
+
+    async def test_stop_motor_uses_fresh_cancel_event(
+        self,
+        sleep_number_coordinator,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """HALT should still be sent even when the coordinator cancel signal is already set."""
+        coordinator = await sleep_number_coordinator(
+            address="AA:BB:CC:DD:EE:36",
+            name="Smart bed 0074FC",
+            entry_id="sleep_number_stop_fresh_cancel",
+        )
+        mock_bleak_client.write_gatt_char.reset_mock()
+        coordinator.cancel_command.set()
+
+        async def _write_side_effect(
+            _char_uuid: str, payload: bytes, response: bool = False
+        ) -> None:
+            assert response is False
+            assert _decode_sleep_number_payload(payload) == "ACTH left head"
+            coordinator.controller._handle_bamkey_notification(
+                None,
+                bytearray(_build_sleep_number_blob("PASS:ACK")),
+            )
+
+        mock_bleak_client.write_gatt_char.side_effect = _write_side_effect
+
+        await coordinator.controller.move_back_stop()
+
+        mock_bleak_client.write_gatt_char.assert_awaited_once()
+
     async def test_stop_all_only_stops_the_configured_side(
         self,
         sleep_number_coordinator,
@@ -221,8 +312,8 @@ class TestSleepNumberController:
 
         coordinator.controller._send_bamkey_command.assert_has_awaits(
             [
-                call("ACTH", "right", "head"),
-                call("ACTH", "right", "foot"),
+                call("ACTH", "right", "head", cancel_event=ANY),
+                call("ACTH", "right", "foot", cancel_event=ANY),
             ]
         )
 

--- a/tests/test_sleep_number.py
+++ b/tests/test_sleep_number.py
@@ -169,8 +169,40 @@ class TestSleepNumberController:
         mock_bleak_client.write_gatt_char.assert_awaited_once_with(
             SLEEP_NUMBER_BAMKEY_CHAR_UUID,
             _build_sleep_number_blob("ACTS left head 57"),
-            response=True,
+            response=False,
         )
+
+    async def test_set_motor_position_reads_ack_after_notification_hint(
+        self,
+        sleep_number_coordinator,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """Commands should support the notify-then-readback response flow."""
+        coordinator = await sleep_number_coordinator(
+            address="AA:BB:CC:DD:EE:31",
+            name="Smart bed 0074F7",
+            entry_id="sleep_number_set_position_readback",
+        )
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        async def _write_side_effect(
+            _char_uuid: str, payload: bytes, response: bool = False
+        ) -> None:
+            assert response is False
+            assert _decode_sleep_number_payload(payload) == "ACTS left head 42"
+            coordinator.controller._handle_bamkey_notification(None, bytearray(b"hint"))
+
+        async def _read_side_effect(target) -> bytes:
+            if str(target) == SLEEP_NUMBER_BAMKEY_CHAR_UUID:
+                return _build_sleep_number_blob("PASS:ACK")
+            return b""
+
+        mock_bleak_client.write_gatt_char.side_effect = _write_side_effect
+        mock_bleak_client.read_gatt_char = AsyncMock(side_effect=_read_side_effect)
+
+        await coordinator.controller.set_motor_position("back", 42)
+
+        mock_bleak_client.read_gatt_char.assert_awaited_with(SLEEP_NUMBER_BAMKEY_CHAR_UUID)
 
     async def test_stop_all_only_stops_the_configured_side(
         self,
@@ -264,22 +296,21 @@ class TestSleepNumberController:
         self,
         sleep_number_coordinator,
     ) -> None:
-        """LBPG should map `in` to an occupied binary sensor state."""
+        """Grouped BAMG LBPG responses should map `in` to an occupied state."""
         coordinator = await sleep_number_coordinator(
             address="AA:BB:CC:DD:EE:28",
             name="Smart bed 0074EE",
             entry_id="sleep_number_presence",
         )
-        coordinator.controller._send_bamkey_command = AsyncMock(return_value=["in"])
+        coordinator.controller._send_bamkey_raw_response = AsyncMock(return_value='PASS:["PASS:in"]')
 
         presence = await coordinator.controller.read_bed_presence()
 
         assert presence is True
         assert coordinator.controller._bed_presence_state == "in"
-        assert coordinator.controller._send_bamkey_command.await_args == call(
-            "LBPG",
-            "left",
-            expected_args=1,
+        assert coordinator.controller._send_bamkey_raw_response.await_args == call(
+            "BAMG",
+            '[{"bamkey":"LBPG","args":"left"}]',
         )
         assert coordinator.controller.get_light_state()["light_timer_option"] == "15 min"
         assert coordinator.controller._coordinator.controller_state["bed_presence"] == "in"
@@ -295,7 +326,9 @@ class TestSleepNumberController:
             name="Smart bed 0074F4",
             entry_id="sleep_number_presence_prime",
         )
-        coordinator.controller._send_bamkey_command = AsyncMock(side_effect=[["out"], ["in"]])
+        coordinator.controller._send_bamkey_raw_response = AsyncMock(
+            side_effect=['PASS:["PASS:out"]', 'PASS:["PASS:in"]']
+        )
         mock_bleak_client.read_gatt_char.reset_mock()
 
         first = await coordinator.controller.read_bed_presence()
@@ -311,21 +344,25 @@ class TestSleepNumberController:
         )
         assert mock_bleak_client.read_gatt_char.await_count == 2
 
-    async def test_read_bed_presence_falls_back_to_readable_bamg_response(
+    async def test_read_bed_presence_reads_characteristic_after_notification_hint(
         self,
         sleep_number_coordinator,
         mock_bleak_client: MagicMock,
     ) -> None:
-        """LBPG should fall back to the readable BAMG path when notify polling times out."""
+        """LBPG should use a notify-triggered readback when the notification is only a hint."""
         coordinator = await sleep_number_coordinator(
             address="AA:BB:CC:DD:EE:2F",
             name="Smart bed 0074F5",
             entry_id="sleep_number_presence_fallback",
         )
-        coordinator.controller._send_bamkey_command = AsyncMock(
-            side_effect=TimeoutError("notify timeout")
-        )
         mock_bleak_client.write_gatt_char.reset_mock()
+
+        async def _write_side_effect(
+            _char_uuid: str, payload: bytes, response: bool = False
+        ) -> None:
+            assert response is False
+            assert _decode_sleep_number_payload(payload) == 'BAMG [{"bamkey":"LBPG","args":"left"}]'
+            coordinator.controller._handle_bamkey_notification(None, bytearray(b"hint"))
 
         async def _read_side_effect(target) -> bytes:
             if str(target) in {
@@ -337,6 +374,7 @@ class TestSleepNumberController:
                 return _build_sleep_number_blob('PASS:["PASS:in"]')
             return b""
 
+        mock_bleak_client.write_gatt_char.side_effect = _write_side_effect
         mock_bleak_client.read_gatt_char = AsyncMock(side_effect=_read_side_effect)
 
         presence = await coordinator.controller.read_bed_presence()
@@ -345,6 +383,24 @@ class TestSleepNumberController:
         assert _decode_sleep_number_payload(
             mock_bleak_client.write_gatt_char.await_args.args[1]
         ) == 'BAMG [{"bamkey":"LBPG","args":"left"}]'
+
+    async def test_bulk_transfer_notification_triggers_readback_hint(
+        self,
+        sleep_number_coordinator,
+    ) -> None:
+        """Secondary Sleep Number notifications should queue a BamKey readback."""
+        coordinator = await sleep_number_coordinator(
+            address="AA:BB:CC:DD:EE:32",
+            name="Smart bed 0074F8",
+            entry_id="sleep_number_bulk_hint",
+        )
+
+        coordinator.controller._handle_bamkey_readback_hint_notification(
+            None,
+            bytearray(b"\x01"),
+        )
+
+        assert await coordinator.controller._readback_hint_queue.get() is None
 
     async def test_bamkey_notification_handler_reassembles_blob_chunks(
         self,


### PR DESCRIPTION
## Summary
- switch Sleep Number BamKey traffic to the framed Fuzion transport with CRC validation and write-without-response behavior
- support notify-triggered BamKey readback plus grouped `BAMG` occupancy queries after the required auth/transfer priming reads
- add regression coverage for framed writes, notification chunking, readback-trigger hints, and presence polling behavior

Ref #318

## Testing
- uv run ruff check custom_components/adjustable_bed/beds/sleep_number.py custom_components/adjustable_bed/const.py tests/test_sleep_number.py tests/conftest.py
- uv run mypy --python-version 3.14 --explicit-package-bases custom_components/adjustable_bed/beds/sleep_number.py
- uv run pytest -q tests/test_sleep_number.py tests/test_coordinator.py tests/test_entities.py
- uv run pytest -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Framed BLE payload support with length + CRC framing and optional bulk-transfer notifications for more reliable bed communication.
  * One-time channel priming before presence checks to improve detection accuracy.

* **Bug Fixes**
  * Robust handling of chunked/multi-part responses, validation, notify-then-readback flows, and cancellation-aware operations.
  * Proper cleanup of notification state and buffers on stop.

* **Tests**
  * Expanded tests for framing, readback hints, priming, multipart reassembly, and cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->