### PR TITLE
fix: keep setup-retry beds diagnosable

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -200,6 +200,28 @@ def _maybe_cache_kaidi_metadata(hass: HomeAssistant, entry: ConfigEntry) -> None
     )
 
 
+def _async_ensure_device_registry_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coordinator: AdjustableBedCoordinator,
+) -> None:
+    """Ensure the bed has a device-registry entry even before first connect.
+
+    This keeps device-targeted diagnostics, especially support bundles,
+    available when the initial connection fails and Home Assistant leaves the
+    config entry in SETUP_RETRY.
+    """
+    device_registry = dr.async_get(hass)
+    device_info = coordinator.device_info
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers=device_info["identifiers"],
+        name=device_info.get("name"),
+        manufacturer=device_info.get("manufacturer"),
+        model=device_info.get("model"),
+    )
+
+
 async def _async_finish_entry_setup(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -263,6 +285,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     coordinator = AdjustableBedCoordinator(hass, entry)
+    _async_ensure_device_registry_entry(hass, entry, coordinator)
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
     # Helper to create pairing issue — only when there's actual evidence of a pairing
@@ -421,6 +444,29 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         for entry_id in device.config_entries:
             if entry_id in hass.data.get(DOMAIN, {}):
                 return cast(AdjustableBedCoordinator, hass.data[DOMAIN][entry_id])
+        return None
+
+    def _get_support_bundle_target_from_device(
+        hass: HomeAssistant, device_id: str
+    ) -> tuple[str, AdjustableBedCoordinator | None, ConfigEntry] | None:
+        """Resolve support-bundle target details from a device registry ID."""
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get(device_id)
+        if not device:
+            return None
+
+        for entry_id in device.config_entries:
+            entry = hass.config_entries.async_get_entry(entry_id)
+            if entry is None or entry.domain != DOMAIN:
+                continue
+
+            address = entry.data.get(CONF_ADDRESS)
+            if not isinstance(address, str):
+                continue
+
+            coordinator = cast(AdjustableBedCoordinator | None, hass.data.get(DOMAIN, {}).get(entry_id))
+            return address, coordinator, entry
+
         return None
 
     async def _get_controller_for_service(
@@ -989,16 +1035,13 @@ async def _async_register_services(hass: HomeAssistant) -> None:
             )
         elif device_ids:
             selected_device_id = device_ids[0]
-            coordinator = await _get_coordinator_from_device(hass, selected_device_id)
-            if coordinator:
-                address = coordinator.address
-                for entry_id, coord in hass.data.get(DOMAIN, {}).items():
-                    if coord is coordinator:
-                        entry = hass.config_entries.async_get_entry(entry_id)
-                        break
+            target = _get_support_bundle_target_from_device(hass, selected_device_id)
+            if target is not None:
+                address, coordinator, entry = target
+                device_name = coordinator.name if coordinator is not None else entry.title
                 _LOGGER.info(
                     "Generating support bundle for configured device %s at %s",
-                    coordinator.name,
+                    device_name,
                     address,
                 )
             else:

--- a/custom_components/adjustable_bed/binary_sensor.py
+++ b/custom_components/adjustable_bed/binary_sensor.py
@@ -17,6 +17,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -67,15 +68,12 @@ async def async_setup_entry(
         if description.key == "bed_presence":
             if controller is None or not getattr(controller, "supports_bed_presence", False):
                 continue
-            # Always create the legacy single-side sensor as a compatibility
-            # alias. The controller already publishes its `bed_presence`
-            # state for the configured side, so existing dashboards and
-            # automations referencing `..._bed_presence` keep working after
-            # upgrading to the split-sensor build. The sensor is still
-            # disabled by default, matching the previous release.
-            entities.append(AdjustableBedPresenceSensor(coordinator, description))
 
             bed_presence_sides = tuple(getattr(controller, "bed_presence_sides", ()))
+            if bed_presence_sides:
+                _async_remove_stale_presence_entity(hass, coordinator)
+            else:
+                entities.append(AdjustableBedPresenceSensor(coordinator, description))
             for side in bed_presence_sides:
                 entities.append(
                     AdjustableBedPresenceSensor(
@@ -94,6 +92,21 @@ async def async_setup_entry(
         entities.append(AdjustableBedConnectionSensor(coordinator, description))
 
     async_add_entities(entities)
+
+
+def _async_remove_stale_presence_entity(
+    hass: HomeAssistant,
+    coordinator: AdjustableBedCoordinator,
+) -> None:
+    """Remove the legacy single-side presence entity when split sensors exist."""
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "binary_sensor",
+        DOMAIN,
+        f"{coordinator.address}_bed_presence",
+    )
+    if entity_id is not None:
+        registry.async_remove(entity_id)
 
 
 class AdjustableBedConnectionSensor(AdjustableBedEntity, BinarySensorEntity):

--- a/custom_components/adjustable_bed/climate.py
+++ b/custom_components/adjustable_bed/climate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.climate import (
@@ -16,6 +16,7 @@ from homeassistant.components.climate import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -161,14 +162,10 @@ async def async_setup_entry(
 
     thermal_sides = tuple(getattr(controller, "thermal_climate_sides", ()))
     if thermal_sides:
-        entities.append(
-            AdjustableBedClimate(
-                coordinator,
-                replace(
-                    SLEEP_NUMBER_THERMAL_CLIMATE_DESCRIPTION,
-                    entity_registry_enabled_default=False,
-                ),
-            )
+        _async_remove_stale_split_climate_entity(
+            hass,
+            coordinator,
+            SLEEP_NUMBER_THERMAL_CLIMATE_DESCRIPTION.key,
         )
         entities.extend(
             AdjustableBedClimate(
@@ -182,14 +179,10 @@ async def async_setup_entry(
 
     footwarming_sides = tuple(getattr(controller, "footwarming_climate_sides", ()))
     if footwarming_sides:
-        entities.append(
-            AdjustableBedClimate(
-                coordinator,
-                replace(
-                    FOOTWARMING_CLIMATE_DESCRIPTION,
-                    entity_registry_enabled_default=False,
-                ),
-            )
+        _async_remove_stale_split_climate_entity(
+            hass,
+            coordinator,
+            FOOTWARMING_CLIMATE_DESCRIPTION.key,
         )
         entities.extend(
             AdjustableBedClimate(
@@ -203,6 +196,22 @@ async def async_setup_entry(
 
     if entities:
         async_add_entities(entities)
+
+
+def _async_remove_stale_split_climate_entity(
+    hass: HomeAssistant,
+    coordinator: AdjustableBedCoordinator,
+    key: str,
+) -> None:
+    """Remove a legacy non-sided climate entity when split entities exist."""
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "climate",
+        DOMAIN,
+        f"{coordinator.address}_{key}",
+    )
+    if entity_id is not None:
+        registry.async_remove(entity_id)
 
 
 class AdjustableBedClimate(AdjustableBedEntity, ClimateEntity):

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -247,7 +247,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
     async def _get_retrying_option_suffix(self) -> str:
         """Return the localized selector hint for retrying configured beds."""
         return await self._get_config_translation(
-            "step.user.data_description.configured_retrying_suffix",
+            "abort.configured_retrying_suffix",
             "[already configured, setup retry]",
         )
 
@@ -963,7 +963,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             len(self._all_ble_devices),
         )
 
-        if not self._all_ble_devices:
+        if not self._all_ble_devices and not self._retrying_devices:
             _LOGGER.info("No BLE devices found in either scanner view, showing manual entry form")
             return await self.async_step_manual_entry()
 

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.components.bluetooth import (
 )
 from homeassistant.config_entries import (
     ConfigEntry,
+    ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
     OptionsFlow,
@@ -115,6 +116,8 @@ from .validators import (
 
 _LOGGER = logging.getLogger(__name__)
 
+CONFIGURED_RETRY_PREFIX = "configured_retry::"
+
 CONNECTION_PROFILE_OPTIONS: dict[str, str] = {
     CONNECTION_PROFILE_BALANCED: "Balanced (recommended)",
     CONNECTION_PROFILE_RELIABLE: "Reliable (slower connect)",
@@ -145,6 +148,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         self._disambiguation_types: list[str] | None = None
         self._disambiguated_bed_type: str | None = None
         self._show_full_bed_type_list: bool = False
+        self._retrying_devices: dict[str, tuple[ConfigEntry, BluetoothServiceInfoBleak | None]] = {}
         _LOGGER.debug("AdjustableBedConfigFlow initialized")
 
     async def _get_pairing_instructions(self, bed_type: str | None) -> str:
@@ -206,6 +210,35 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 "connectable": connectable_text,
             },
         )
+
+    def _configured_entries_by_address(self) -> dict[str, ConfigEntry]:
+        """Return configured entries keyed by normalized Bluetooth address."""
+        configured: dict[str, ConfigEntry] = {}
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            candidate = entry.unique_id or entry.data.get(CONF_ADDRESS)
+            if isinstance(candidate, str):
+                configured[candidate.upper()] = entry
+        return configured
+
+    def _async_abort_retrying_entry(self, address: str) -> ConfigFlowResult:
+        """Explain how to recover when the bed is already stuck retrying setup."""
+        entry, info = self._retrying_devices[address]
+        display_name = entry.title or (info.name if info is not None else None) or "Unknown"
+        return self.async_abort(
+            reason="configured_retrying",
+            description_placeholders={
+                "name": display_name,
+                "address": address,
+            },
+        )
+
+    def _retrying_display_name(
+        self,
+        entry: ConfigEntry,
+        info: BluetoothServiceInfoBleak | None,
+    ) -> str:
+        """Return the most helpful name for a retrying config entry."""
+        return entry.title or (info.name if info is not None else None) or "Unknown"
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
@@ -630,6 +663,10 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             address = user_input[CONF_ADDRESS]
+            if address.startswith(CONFIGURED_RETRY_PREFIX):
+                return self._async_abort_retrying_entry(
+                    address.removeprefix(CONFIGURED_RETRY_PREFIX)
+                )
             if address == "manual":
                 _LOGGER.debug("User selected manual entry (full list)")
                 # Reset two-tier selection state - show all BLE devices with full bed type dropdown
@@ -680,12 +717,23 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
         # Convert to upper-case for case-insensitive comparison
-        # (configured IDs are upper-case, but discovered addresses may be lower-case)
-        current_addresses = {addr.upper() for addr in self._async_current_ids() if addr is not None}
+        configured_entries = self._configured_entries_by_address()
+        self._retrying_devices.clear()
         for discovery_info in all_discovered:
-            if discovery_info.address.upper() in current_addresses:
+            normalized_address = discovery_info.address.upper()
+            configured_entry = configured_entries.get(normalized_address)
+            if configured_entry is not None:
+                if configured_entry.state == ConfigEntryState.SETUP_RETRY:
+                    self._retrying_devices[normalized_address] = (configured_entry, discovery_info)
+                else:
+                    _LOGGER.debug(
+                        "Skipping already configured device: %s",
+                        discovery_info.address,
+                    )
+                continue
+            if normalized_address in self._retrying_devices:
                 _LOGGER.debug(
-                    "Skipping already configured device: %s",
+                    "Skipping duplicate retrying device snapshot: %s",
                     discovery_info.address,
                 )
                 continue
@@ -710,6 +758,13 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             self._discovered_devices.items(),
             key=lambda x: (is_mac_like_name(x[1].name), (x[1].name or "").lower()),
         )
+        sorted_retrying_devices = sorted(
+            self._retrying_devices.items(),
+            key=lambda item: (
+                is_mac_like_name(self._retrying_display_name(item[1][0], item[1][1])),
+                self._retrying_display_name(item[1][0], item[1][1]).lower(),
+            ),
+        )
 
         # Build device list - discovered beds first when available, then manual options
         devices: dict[str, str] = {}
@@ -717,8 +772,26 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             devices.update(
                 {address: f"{info.name or 'Unknown'} ({address})" for address, info in sorted_beds}
             )
+            devices.update(
+                {
+                    f"{CONFIGURED_RETRY_PREFIX}{address}": (
+                        f"{self._retrying_display_name(entry, info)} ({address}) "
+                        "[already configured, setup retry]"
+                    )
+                    for address, (entry, info) in sorted_retrying_devices
+                }
+            )
             devices["select_by_brand"] = "Select by actuator brand"
         else:
+            devices.update(
+                {
+                    f"{CONFIGURED_RETRY_PREFIX}{address}": (
+                        f"{self._retrying_display_name(entry, info)} ({address}) "
+                        "[already configured, setup retry]"
+                    )
+                    for address, (entry, info) in sorted_retrying_devices
+                }
+            )
             devices["select_by_brand"] = "Select by actuator brand (recommended)"
         devices["manual"] = "Show all BLE devices"
         devices["diagnostic"] = "Browse unsupported BLE devices"
@@ -819,6 +892,10 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         """
         if user_input is not None:
             address = user_input[CONF_ADDRESS]
+            if address.startswith(CONFIGURED_RETRY_PREFIX):
+                return self._async_abort_retrying_entry(
+                    address.removeprefix(CONFIGURED_RETRY_PREFIX)
+                )
             if address == "manual_entry":
                 _LOGGER.debug("User selected manual address entry")
                 return await self.async_step_manual_entry()
@@ -843,13 +920,18 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             len(all_discovered),
         )
 
-        # Filter out already configured devices
-        current_addresses = {addr.upper() for addr in self._async_current_ids() if addr is not None}
-
+        configured_entries = self._configured_entries_by_address()
         self._all_ble_devices = {}
+        self._retrying_devices.clear()
         for discovery_info in all_discovered:
-            if discovery_info.address.upper() not in current_addresses:
-                self._all_ble_devices[discovery_info.address] = discovery_info
+            normalized_address = discovery_info.address.upper()
+            configured_entry = configured_entries.get(normalized_address)
+            if configured_entry is not None:
+                if configured_entry.state == ConfigEntryState.SETUP_RETRY:
+                    self._retrying_devices[normalized_address] = (configured_entry, discovery_info)
+                continue
+
+            self._all_ble_devices[discovery_info.address] = discovery_info
 
         _LOGGER.info(
             "Manual selection: found %d unconfigured BLE devices",
@@ -865,12 +947,24 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             self._all_ble_devices.items(),
             key=lambda x: (is_mac_like_name(x[1].name), (x[1].name or "").lower()),
         )
+        sorted_retrying_devices = sorted(
+            self._retrying_devices.items(),
+            key=lambda item: (
+                is_mac_like_name(self._retrying_display_name(item[1][0], item[1][1])),
+                self._retrying_display_name(item[1][0], item[1][1]).lower(),
+            ),
+        )
         devices = {}
         for address, info in sorted_devices:
             label = f"{info.name or 'Unknown'} ({address})"
             if getattr(info, "connectable", True) is False:
                 label += " [scanner says non-connectable]"
             devices[address] = label
+        for address, (entry, info) in sorted_retrying_devices:
+            devices[f"{CONFIGURED_RETRY_PREFIX}{address}"] = (
+                f"{self._retrying_display_name(entry, info)} ({address}) "
+                "[already configured, setup retry]"
+            )
         devices["manual_entry"] = "Enter address manually"
 
         return self.async_show_form(
@@ -1106,6 +1200,11 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                     errors["base"] = "invalid_number"
 
                 if not errors:
+                    retrying_entry = self._configured_entries_by_address().get(address)
+                    if retrying_entry is not None and retrying_entry.state == ConfigEntryState.SETUP_RETRY:
+                        self._retrying_devices[address] = (retrying_entry, None)
+                        return self._async_abort_retrying_entry(address)
+
                     await self.async_set_unique_id(address)
                     self._abort_if_unique_id_configured()
 

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -151,19 +151,23 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         self._retrying_devices: dict[str, tuple[ConfigEntry, BluetoothServiceInfoBleak | None]] = {}
         _LOGGER.debug("AdjustableBedConfigFlow initialized")
 
-    async def _get_pairing_instructions(self, bed_type: str | None) -> str:
-        """Return pairing instructions tailored to the selected bed type."""
+    async def _get_config_translation(self, key: str, default: str) -> str:
+        """Return a config-flow translation with a safe English fallback."""
         translations = await async_get_translations(
             self.hass, self.hass.config.language, "config", {DOMAIN}
         )
+        return translations.get(f"component.{DOMAIN}.config.{key}", default)
+
+    async def _get_pairing_instructions(self, bed_type: str | None) -> str:
+        """Return pairing instructions tailored to the selected bed type."""
         if bed_type == BED_TYPE_SLEEP_NUMBER:
-            return translations.get(
-                f"component.{DOMAIN}.config.step.bluetooth_pairing.data_description.pairing_instructions_sleep_number",
+            return await self._get_config_translation(
+                "step.bluetooth_pairing.data_description.pairing_instructions_sleep_number",
                 "1. Put your bed in pairing mode (hold the side pairing button until the blue light blinks)\n"
                 "2. Click 'Pair Now'",
             )
-        return translations.get(
-            f"component.{DOMAIN}.config.step.bluetooth_pairing.data_description.pairing_instructions_generic",
+        return await self._get_config_translation(
+            "step.bluetooth_pairing.data_description.pairing_instructions_generic",
             "1. Put your bed in pairing mode (hold lamp button until blue light blinks, or unplug for 30+ seconds)\n"
             "2. Click 'Pair Now'",
         )
@@ -239,6 +243,24 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> str:
         """Return the most helpful name for a retrying config entry."""
         return entry.title or (info.name if info is not None else None) or "Unknown"
+
+    async def _get_retrying_option_suffix(self) -> str:
+        """Return the localized selector hint for retrying configured beds."""
+        return await self._get_config_translation(
+            "step.user.data_description.configured_retrying_suffix",
+            "[already configured, setup retry]",
+        )
+
+    def _format_retrying_option_label(
+        self,
+        address: str,
+        entry: ConfigEntry,
+        info: BluetoothServiceInfoBleak | None,
+        *,
+        suffix: str,
+    ) -> str:
+        """Format the selector label for a retrying configured bed."""
+        return f"{self._retrying_display_name(entry, info)} ({address}) {suffix}"
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
@@ -349,11 +371,8 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             options.append(SelectOptionDict(value=bed_type, label=display_name))
 
         # Add "Show all bed types" fallback option with translated label
-        translations = await async_get_translations(
-            self.hass, self.hass.config.language, "config", {DOMAIN}
-        )
-        show_all_label = translations.get(
-            f"component.{DOMAIN}.config.step.bluetooth_disambiguate.data.show_all_option",
+        show_all_label = await self._get_config_translation(
+            "step.bluetooth_disambiguate.data.show_all_option",
             "Show all bed types...",
         )
         options.append(SelectOptionDict(value="show_all", label=show_all_label))
@@ -766,6 +785,8 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
         )
 
+        retrying_suffix = await self._get_retrying_option_suffix()
+
         # Build device list - discovered beds first when available, then manual options
         devices: dict[str, str] = {}
         if sorted_beds:
@@ -774,9 +795,11 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             devices.update(
                 {
-                    f"{CONFIGURED_RETRY_PREFIX}{address}": (
-                        f"{self._retrying_display_name(entry, info)} ({address}) "
-                        "[already configured, setup retry]"
+                    f"{CONFIGURED_RETRY_PREFIX}{address}": self._format_retrying_option_label(
+                        address,
+                        entry,
+                        info,
+                        suffix=retrying_suffix,
                     )
                     for address, (entry, info) in sorted_retrying_devices
                 }
@@ -785,9 +808,11 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         else:
             devices.update(
                 {
-                    f"{CONFIGURED_RETRY_PREFIX}{address}": (
-                        f"{self._retrying_display_name(entry, info)} ({address}) "
-                        "[already configured, setup retry]"
+                    f"{CONFIGURED_RETRY_PREFIX}{address}": self._format_retrying_option_label(
+                        address,
+                        entry,
+                        info,
+                        suffix=retrying_suffix,
                     )
                     for address, (entry, info) in sorted_retrying_devices
                 }
@@ -954,6 +979,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 self._retrying_display_name(item[1][0], item[1][1]).lower(),
             ),
         )
+        retrying_suffix = await self._get_retrying_option_suffix()
         devices = {}
         for address, info in sorted_devices:
             label = f"{info.name or 'Unknown'} ({address})"
@@ -961,9 +987,11 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 label += " [scanner says non-connectable]"
             devices[address] = label
         for address, (entry, info) in sorted_retrying_devices:
-            devices[f"{CONFIGURED_RETRY_PREFIX}{address}"] = (
-                f"{self._retrying_display_name(entry, info)} ({address}) "
-                "[already configured, setup retry]"
+            devices[f"{CONFIGURED_RETRY_PREFIX}{address}"] = self._format_retrying_option_label(
+                address,
+                entry,
+                info,
+                suffix=retrying_suffix,
             )
         devices["manual_entry"] = "Enter address manually"
 

--- a/custom_components/adjustable_bed/number.py
+++ b/custom_components/adjustable_bed/number.py
@@ -14,6 +14,7 @@ from homeassistant.components.number import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
@@ -490,22 +491,7 @@ async def async_setup_entry(
             coordinator.name,
             sleep_number_sides,
         )
-        if controller is not None and getattr(controller, "supports_sleep_number_setting", False):
-            entities.append(
-                AdjustableBedSleepNumberSettingNumber(
-                    coordinator,
-                    NumberEntityDescription(
-                        key=SLEEP_NUMBER_SETTING_DESCRIPTION.key,
-                        translation_key=SLEEP_NUMBER_SETTING_DESCRIPTION.translation_key,
-                        icon=SLEEP_NUMBER_SETTING_DESCRIPTION.icon,
-                        native_min_value=getattr(controller, "sleep_number_setting_min", 5),
-                        native_max_value=getattr(controller, "sleep_number_setting_max", 100),
-                        native_step=getattr(controller, "sleep_number_setting_step", 5),
-                        mode=SLEEP_NUMBER_SETTING_DESCRIPTION.mode,
-                        entity_registry_enabled_default=False,
-                    ),
-                )
-            )
+        _async_remove_stale_sleep_number_entity(hass, coordinator)
         for side_description in (
             SLEEP_NUMBER_SETTING_LEFT_DESCRIPTION,
             SLEEP_NUMBER_SETTING_RIGHT_DESCRIPTION,
@@ -548,6 +534,21 @@ async def async_setup_entry(
 
     if entities:
         async_add_entities(entities)
+
+
+def _async_remove_stale_sleep_number_entity(
+    hass: HomeAssistant,
+    coordinator: AdjustableBedCoordinator,
+) -> None:
+    """Remove the legacy single-side Sleep Number entity when side controls exist."""
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "number",
+        DOMAIN,
+        f"{coordinator.address}_{SLEEP_NUMBER_SETTING_DESCRIPTION.key}",
+    )
+    if entity_id is not None:
+        registry.async_remove(entity_id)
 
 
 class AdjustableBedPositionNumber(AdjustableBedEntity, NumberEntity):

--- a/custom_components/adjustable_bed/select.py
+++ b/custom_components/adjustable_bed/select.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
@@ -190,22 +191,7 @@ async def async_setup_entry(
                 thermal_sides,
                 thermal_timer_options,
             )
-            entities.append(
-                AdjustableBedControllerStateSelect(
-                    coordinator,
-                    AdjustableBedControllerStateSelectDescription(
-                        key=THERMAL_TIMER_DESCRIPTION.key,
-                        translation_key=THERMAL_TIMER_DESCRIPTION.translation_key,
-                        icon=THERMAL_TIMER_DESCRIPTION.icon,
-                        required_capability=THERMAL_TIMER_DESCRIPTION.required_capability,
-                        options_attr=THERMAL_TIMER_DESCRIPTION.options_attr,
-                        state_key=THERMAL_TIMER_DESCRIPTION.state_key,
-                        setter_name=THERMAL_TIMER_DESCRIPTION.setter_name,
-                        entity_registry_enabled_default=False,
-                    ),
-                    thermal_timer_options,
-                )
-            )
+            _async_remove_stale_split_select_entity(hass, coordinator, THERMAL_TIMER_DESCRIPTION.key)
             for side_description in (
                 THERMAL_TIMER_LEFT_DESCRIPTION,
                 THERMAL_TIMER_RIGHT_DESCRIPTION,
@@ -246,21 +232,10 @@ async def async_setup_entry(
                 footwarming_sides,
                 footwarming_timer_options,
             )
-            entities.append(
-                AdjustableBedControllerStateSelect(
-                    coordinator,
-                    AdjustableBedControllerStateSelectDescription(
-                        key=FOOTWARMING_TIMER_DESCRIPTION.key,
-                        translation_key=FOOTWARMING_TIMER_DESCRIPTION.translation_key,
-                        icon=FOOTWARMING_TIMER_DESCRIPTION.icon,
-                        required_capability=FOOTWARMING_TIMER_DESCRIPTION.required_capability,
-                        options_attr=FOOTWARMING_TIMER_DESCRIPTION.options_attr,
-                        state_key=FOOTWARMING_TIMER_DESCRIPTION.state_key,
-                        setter_name=FOOTWARMING_TIMER_DESCRIPTION.setter_name,
-                        entity_registry_enabled_default=False,
-                    ),
-                    footwarming_timer_options,
-                )
+            _async_remove_stale_split_select_entity(
+                hass,
+                coordinator,
+                FOOTWARMING_TIMER_DESCRIPTION.key,
             )
             for side_description in (
                 FOOTWARMING_TIMER_LEFT_DESCRIPTION,
@@ -316,6 +291,22 @@ async def async_setup_entry(
 
     if entities:
         async_add_entities(entities)
+
+
+def _async_remove_stale_split_select_entity(
+    hass: HomeAssistant,
+    coordinator: AdjustableBedCoordinator,
+    key: str,
+) -> None:
+    """Remove a legacy non-sided select when side-specific entities exist."""
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "select",
+        DOMAIN,
+        f"{coordinator.address}_{key}",
+    )
+    if entity_id is not None:
+        registry.async_remove(entity_id)
 
 
 class AdjustableBedMassageTimerSelect(AdjustableBedEntity, SelectEntity):

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -6,6 +6,9 @@
         "description": "Select a discovered bed or choose how to add your bed.",
         "data": {
           "address": "Device"
+        },
+        "data_description": {
+          "configured_retrying_suffix": "[already configured, setup retry]"
         }
       },
       "select_actuator": {

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -224,6 +224,7 @@
     },
     "abort": {
       "already_configured": "Device is already configured",
+      "configured_retrying": "**{name}** is already configured at `{address}`, but Home Assistant is still retrying its previous setup.\n\nUse **Generate Support Bundle** for the existing device entry, or run `adjustable_bed.generate_support_bundle` with `target_address: {address}`. Then reload or reconfigure the existing entry instead of adding it again.",
       "not_supported": "Device is not supported. The required Bluetooth service was not found.",
       "diagnostic_browser_ready": "**{name}**\n\nAddress: `{address}`\nSource: `{source}`\nScanner connectable: `{connectable}`\n\nRun `adjustable_bed.generate_support_bundle` with `target_address: {address}` to capture the full support bundle."
     },

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -6,9 +6,6 @@
         "description": "Select a discovered bed or choose how to add your bed.",
         "data": {
           "address": "Device"
-        },
-        "data_description": {
-          "configured_retrying_suffix": "[already configured, setup retry]"
         }
       },
       "select_actuator": {
@@ -227,6 +224,7 @@
     },
     "abort": {
       "already_configured": "Device is already configured",
+      "configured_retrying_suffix": "[already configured, setup retry]",
       "configured_retrying": "**{name}** is already configured at `{address}`, but Home Assistant is still retrying its previous setup.\n\nUse **Generate Support Bundle** for the existing device entry, or run `adjustable_bed.generate_support_bundle` with `target_address: {address}`. Then reload or reconfigure the existing entry instead of adding it again.",
       "not_supported": "Device is not supported. The required Bluetooth service was not found.",
       "diagnostic_browser_ready": "**{name}**\n\nAddress: `{address}`\nSource: `{source}`\nScanner connectable: `{connectable}`\n\nRun `adjustable_bed.generate_support_bundle` with `target_address: {address}` to capture the full support bundle."

--- a/custom_components/adjustable_bed/support_bundle.py
+++ b/custom_components/adjustable_bed/support_bundle.py
@@ -78,7 +78,7 @@ async def generate_support_bundle(
             "integration_domain": DOMAIN,
         },
         "target": {
-            "mode": "configured_device" if coordinator is not None and entry is not None else "target_address",
+            "mode": "configured_device" if entry is not None else "target_address",
             "address": address,
             "device_id": device_id,
             "entry_id": entry.entry_id if entry is not None else None,

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -6,6 +6,9 @@
         "description": "Select a discovered bed or choose how to add your bed.",
         "data": {
           "address": "Device"
+        },
+        "data_description": {
+          "configured_retrying_suffix": "[already configured, setup retry]"
         }
       },
       "select_actuator": {

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -224,6 +224,7 @@
     },
     "abort": {
       "already_configured": "Device is already configured",
+      "configured_retrying": "**{name}** is already configured at `{address}`, but Home Assistant is still retrying its previous setup.\n\nUse **Generate Support Bundle** for the existing device entry, or run `adjustable_bed.generate_support_bundle` with `target_address: {address}`. Then reload or reconfigure the existing entry instead of adding it again.",
       "not_supported": "Device is not supported. The required Bluetooth service was not found.",
       "diagnostic_browser_ready": "**{name}**\n\nAddress: `{address}`\nSource: `{source}`\nScanner connectable: `{connectable}`\n\nRun `adjustable_bed.generate_support_bundle` with `target_address: {address}` to capture the full support bundle."
     },

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -6,9 +6,6 @@
         "description": "Select a discovered bed or choose how to add your bed.",
         "data": {
           "address": "Device"
-        },
-        "data_description": {
-          "configured_retrying_suffix": "[already configured, setup retry]"
         }
       },
       "select_actuator": {
@@ -227,6 +224,7 @@
     },
     "abort": {
       "already_configured": "Device is already configured",
+      "configured_retrying_suffix": "[already configured, setup retry]",
       "configured_retrying": "**{name}** is already configured at `{address}`, but Home Assistant is still retrying its previous setup.\n\nUse **Generate Support Bundle** for the existing device entry, or run `adjustable_bed.generate_support_bundle` with `target_address: {address}`. Then reload or reconfigure the existing entry instead of adding it again.",
       "not_supported": "Device is not supported. The required Bluetooth service was not found.",
       "diagnostic_browser_ready": "**{name}**\n\nAddress: `{address}`\nSource: `{source}`\nScanner connectable: `{connectable}`\n\nRun `adjustable_bed.generate_support_bundle` with `target_address: {address}` to capture the full support bundle."

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1112,6 +1112,7 @@ class TestUserFlow:
         enable_custom_integrations,
     ):
         """Retrying entries should surface recovery instructions instead of disappearing."""
+        del mock_bluetooth_adapters, enable_custom_integrations
         existing_entry = MockConfigEntry(
             domain=DOMAIN,
             title="Retrying Bed",
@@ -1146,9 +1147,17 @@ class TestUserFlow:
                 DOMAIN,
                 context={"source": SOURCE_USER},
             )
+            retrying_option = (
+                f"configured_retry::{mock_bluetooth_service_info.address.upper()}"
+            )
+            assert result["type"] == FlowResultType.FORM
+            selector_options = next(iter(result["data_schema"].schema.values())).container
+            assert retrying_option in selector_options
+            assert selector_options[retrying_option].startswith("Retrying Bed")
+
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"],
-                user_input={CONF_ADDRESS: f"configured_retry::{mock_bluetooth_service_info.address.upper()}"},
+                user_input={CONF_ADDRESS: retrying_option},
             )
 
         assert result["type"] == FlowResultType.ABORT

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,11 +6,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
-from homeassistant.config_entries import SOURCE_BLUETOOTH, SOURCE_USER
+from homeassistant.config_entries import SOURCE_BLUETOOTH, SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adjustable_bed.config_flow import AdjustableBedConfigFlow
 from custom_components.adjustable_bed.const import (
@@ -1102,6 +1103,58 @@ class TestUserFlow:
 
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "manual"
+
+    async def test_user_flow_retrying_device_aborts_with_support_bundle_instructions(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info: BluetoothServiceInfoBleak,
+        mock_bluetooth_adapters,
+        enable_custom_integrations,
+    ):
+        """Retrying entries should surface recovery instructions instead of disappearing."""
+        existing_entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Retrying Bed",
+            data={
+                CONF_ADDRESS: mock_bluetooth_service_info.address.upper(),
+                CONF_NAME: "Retrying Bed",
+                CONF_BED_TYPE: BED_TYPE_LINAK,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=mock_bluetooth_service_info.address.upper(),
+            entry_id="retrying_entry_id",
+        )
+        existing_entry.add_to_hass(hass)
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator.bluetooth.async_ble_device_from_address",
+            return_value=None,
+        ):
+            await hass.config_entries.async_setup(existing_entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert existing_entry.state == ConfigEntryState.SETUP_RETRY
+
+        with patch(
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
+            return_value=[mock_bluetooth_service_info],
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_USER},
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADDRESS: f"configured_retry::{mock_bluetooth_service_info.address.upper()}"},
+            )
+
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "configured_retrying"
+        assert result["description_placeholders"]["address"] == mock_bluetooth_service_info.address.upper()
+        assert result["description_placeholders"]["name"] == "Retrying Bed"
 
 
 class TestOptionsFlow:

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, patch
 
 from homeassistant.components.climate import HVACMode
 from homeassistant.const import CONF_ADDRESS, CONF_NAME, STATE_ON, STATE_UNAVAILABLE
@@ -792,6 +792,80 @@ class TestSleepNumberEntities:
                 "binary_sensor",
                 DOMAIN,
                 "AA:BB:CC:DD:EE:57_bed_presence_left",
+            )
+            is None
+        )
+
+    async def test_sleep_number_mcr_entities_include_split_presence_when_supported(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """MCR occupancy sensors should be created when query_config discovers chamber bytes."""
+        del mock_coordinator_connected, enable_custom_integrations
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Sleep Number MCR Occupancy Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:59",
+                CONF_NAME: "64:DB:A0:07:DD:0A",
+                CONF_BED_TYPE: BED_TYPE_SLEEP_NUMBER_MCR,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:59",
+            entry_id="sleep_number_mcr_presence_entry",
+        )
+        entry.add_to_hass(hass)
+
+        async def _mock_read_chamber_types(self) -> None:
+            self._occupancy_supported = True
+            self._bed_presence["left"] = "in"
+            self._bed_presence["right"] = "out"
+            self.forward_controller_state_updates(
+                {
+                    "bed_presence": "in",
+                    "bed_presence_left": "in",
+                    "bed_presence_right": "out",
+                }
+            )
+
+        with patch(
+            "custom_components.adjustable_bed.beds.sleep_number_mcr."
+            "SleepNumberMcrController._async_read_chamber_types",
+            new=_mock_read_chamber_types,
+        ):
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+
+        assert (
+            registry.async_get_entity_id(
+                "binary_sensor",
+                DOMAIN,
+                "AA:BB:CC:DD:EE:59_bed_presence_left",
+            )
+            is not None
+        )
+        assert (
+            registry.async_get_entity_id(
+                "binary_sensor",
+                DOMAIN,
+                "AA:BB:CC:DD:EE:59_bed_presence_right",
+            )
+            is not None
+        )
+        assert (
+            registry.async_get_entity_id(
+                "binary_sensor",
+                DOMAIN,
+                "AA:BB:CC:DD:EE:59_bed_presence",
             )
             is None
         )

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -405,13 +405,14 @@ class TestSleepNumberEntities:
             registry.async_get_entity_id("select", DOMAIN, "AA:BB:CC:DD:EE:41_light_timer")
             is not None
         )
-        sleep_number_entity_id = registry.async_get_entity_id(
-            "number",
-            DOMAIN,
-            "AA:BB:CC:DD:EE:41_sleep_number_setting",
+        assert (
+            registry.async_get_entity_id(
+                "number",
+                DOMAIN,
+                "AA:BB:CC:DD:EE:41_sleep_number_setting",
+            )
+            is None
         )
-        assert sleep_number_entity_id is not None
-        assert hass.states.get(sleep_number_entity_id) is None
         left_sleep_number_entity_id = registry.async_get_entity_id(
             "number",
             DOMAIN,
@@ -441,32 +442,30 @@ class TestSleepNumberEntities:
         )
         assert right_presence_entity_id is not None
         assert hass.states.get(right_presence_entity_id) is None
-        # The legacy single-side ``bed_presence`` entity must still be
-        # registered so users upgrading from the pre-split release keep
-        # their dashboards/automations working. Like the per-side
-        # sensors, it is disabled by default.
-        legacy_presence_entity_id = registry.async_get_entity_id(
-            "binary_sensor",
-            DOMAIN,
-            "AA:BB:CC:DD:EE:41_bed_presence",
+        assert (
+            registry.async_get_entity_id(
+                "binary_sensor",
+                DOMAIN,
+                "AA:BB:CC:DD:EE:41_bed_presence",
+            )
+            is None
         )
-        assert legacy_presence_entity_id is not None
-        assert hass.states.get(legacy_presence_entity_id) is None
-
-        legacy_thermal_timer_entity_id = registry.async_get_entity_id(
-            "select",
-            DOMAIN,
-            "AA:BB:CC:DD:EE:41_thermal_timer",
+        assert (
+            registry.async_get_entity_id(
+                "select",
+                DOMAIN,
+                "AA:BB:CC:DD:EE:41_thermal_timer",
+            )
+            is None
         )
-        assert legacy_thermal_timer_entity_id is not None
-        assert hass.states.get(legacy_thermal_timer_entity_id) is None
-        legacy_footwarming_timer_entity_id = registry.async_get_entity_id(
-            "select",
-            DOMAIN,
-            "AA:BB:CC:DD:EE:41_footwarming_timer",
+        assert (
+            registry.async_get_entity_id(
+                "select",
+                DOMAIN,
+                "AA:BB:CC:DD:EE:41_footwarming_timer",
+            )
+            is None
         )
-        assert legacy_footwarming_timer_entity_id is not None
-        assert hass.states.get(legacy_footwarming_timer_entity_id) is None
         thermal_timer_left_entity_id = registry.async_get_entity_id(
             "select",
             DOMAIN,
@@ -496,20 +495,22 @@ class TestSleepNumberEntities:
         assert hass.states.get(footwarming_timer_left_entity_id).state == "2 hr"
         assert hass.states.get(footwarming_timer_right_entity_id).state == "2 hr"
 
-        thermal_entity_id = registry.async_get_entity_id(
-            "climate",
-            DOMAIN,
-            "AA:BB:CC:DD:EE:41_sleep_number_thermal_climate",
+        assert (
+            registry.async_get_entity_id(
+                "climate",
+                DOMAIN,
+                "AA:BB:CC:DD:EE:41_sleep_number_thermal_climate",
+            )
+            is None
         )
-        footwarming_entity_id = registry.async_get_entity_id(
-            "climate",
-            DOMAIN,
-            "AA:BB:CC:DD:EE:41_footwarming_climate",
+        assert (
+            registry.async_get_entity_id(
+                "climate",
+                DOMAIN,
+                "AA:BB:CC:DD:EE:41_footwarming_climate",
+            )
+            is None
         )
-        assert thermal_entity_id is not None
-        assert footwarming_entity_id is not None
-        assert hass.states.get(thermal_entity_id) is None
-        assert hass.states.get(footwarming_entity_id) is None
         thermal_left_entity_id = registry.async_get_entity_id(
             "climate",
             DOMAIN,
@@ -552,6 +553,112 @@ class TestSleepNumberEntities:
         assert thermal_right_state.attributes["side"] == "right"
         assert hass.states.get(footwarming_left_entity_id).state == "heat"
         assert hass.states.get(footwarming_right_entity_id).state == "off"
+
+    async def test_sleep_number_setup_removes_legacy_single_side_entities(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ) -> None:
+        """Sleep Number split entities should remove old generic registry entries."""
+        del mock_coordinator_connected, enable_custom_integrations
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Sleep Number Feature Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:42",
+                CONF_NAME: "Sleep Number Feature Bed",
+                CONF_BED_TYPE: BED_TYPE_SLEEP_NUMBER,
+                CONF_PROTOCOL_VARIANT: SLEEP_NUMBER_VARIANT_LEFT,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:42",
+            entry_id="sleep_number_cleanup_entry",
+        )
+        entry.add_to_hass(hass)
+
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        registry.async_get_or_create(
+            "binary_sensor",
+            DOMAIN,
+            "AA:BB:CC:DD:EE:42_bed_presence",
+            config_entry=entry,
+            suggested_object_id="sleep_number_feature_bed_bed_presence",
+        )
+        registry.async_get_or_create(
+            "number",
+            DOMAIN,
+            "AA:BB:CC:DD:EE:42_sleep_number_setting",
+            config_entry=entry,
+            suggested_object_id="sleep_number_feature_bed_sleep_number_setting",
+        )
+        registry.async_get_or_create(
+            "select",
+            DOMAIN,
+            "AA:BB:CC:DD:EE:42_thermal_timer",
+            config_entry=entry,
+            suggested_object_id="sleep_number_feature_bed_thermal_timer",
+        )
+        registry.async_get_or_create(
+            "select",
+            DOMAIN,
+            "AA:BB:CC:DD:EE:42_footwarming_timer",
+            config_entry=entry,
+            suggested_object_id="sleep_number_feature_bed_footwarming_timer",
+        )
+        registry.async_get_or_create(
+            "climate",
+            DOMAIN,
+            "AA:BB:CC:DD:EE:42_sleep_number_thermal_climate",
+            config_entry=entry,
+            suggested_object_id="sleep_number_feature_bed_sleep_number_thermal_climate",
+        )
+        registry.async_get_or_create(
+            "climate",
+            DOMAIN,
+            "AA:BB:CC:DD:EE:42_footwarming_climate",
+            config_entry=entry,
+            suggested_object_id="sleep_number_feature_bed_footwarming_climate",
+        )
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert (
+            registry.async_get_entity_id("binary_sensor", DOMAIN, "AA:BB:CC:DD:EE:42_bed_presence")
+            is None
+        )
+        assert (
+            registry.async_get_entity_id(
+                "number", DOMAIN, "AA:BB:CC:DD:EE:42_sleep_number_setting"
+            )
+            is None
+        )
+        assert (
+            registry.async_get_entity_id("select", DOMAIN, "AA:BB:CC:DD:EE:42_thermal_timer")
+            is None
+        )
+        assert (
+            registry.async_get_entity_id("select", DOMAIN, "AA:BB:CC:DD:EE:42_footwarming_timer")
+            is None
+        )
+        assert (
+            registry.async_get_entity_id(
+                "climate",
+                DOMAIN,
+                "AA:BB:CC:DD:EE:42_sleep_number_thermal_climate",
+            )
+            is None
+        )
+        assert (
+            registry.async_get_entity_id("climate", DOMAIN, "AA:BB:CC:DD:EE:42_footwarming_climate")
+            is None
+        )
 
     async def test_sleep_number_thermal_climate_resume_uses_cached_side_preset(
         self,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -468,8 +468,10 @@ class TestServices:
         mock_config_entry,
         mock_coordinator_connected,
         enable_custom_integrations,
+        tmp_path: Path,
     ):
         """Test generate_support_bundle service delegates to the bundle generator."""
+        del enable_custom_integrations
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -487,7 +489,7 @@ class TestServices:
             ) as mock_generate_support_bundle,
             patch(
                 "custom_components.adjustable_bed.support_bundle.save_support_bundle",
-                return_value=Path("/tmp/support_bundle.json"),
+                return_value=tmp_path / "support_bundle.json",
             ) as mock_save_support_bundle,
         ):
             await hass.services.async_call(
@@ -532,8 +534,10 @@ class TestServices:
         mock_config_entry,
         mock_bluetooth_adapters,
         enable_custom_integrations,
+        tmp_path: Path,
     ):
         """Support bundles should still target devices whose entry is in SETUP_RETRY."""
+        del mock_bluetooth_adapters, enable_custom_integrations
         from homeassistant.helpers import device_registry as dr
 
         with patch(
@@ -557,7 +561,7 @@ class TestServices:
             ) as mock_generate_support_bundle,
             patch(
                 "custom_components.adjustable_bed.support_bundle.save_support_bundle",
-                return_value=Path("/tmp/support_bundle_retry.json"),
+                return_value=tmp_path / "support_bundle_retry.json",
             ) as mock_save_support_bundle,
         ):
             await hass.services.async_call(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -117,6 +117,29 @@ class TestIntegrationSetup:
         assert hass.services.has_service(DOMAIN, SERVICE_GOTO_PRESET)
         assert hass.services.has_service(DOMAIN, SERVICE_GENERATE_SUPPORT_BUNDLE)
 
+    async def test_setup_entry_connection_failed_still_creates_device(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_bluetooth_adapters,
+        enable_custom_integrations,
+    ):
+        """Setup-retry entries should still have a device registry target for diagnostics."""
+        from homeassistant.helpers import device_registry as dr
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator.bluetooth.async_ble_device_from_address",
+            return_value=None,
+        ):
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+        device_registry = dr.async_get(hass)
+        devices = dr.async_entries_for_config_entry(device_registry, mock_config_entry.entry_id)
+        assert len(devices) == 1
+        assert devices[0].name == mock_config_entry.title
+
     async def test_setup_entry_loads_diagnostic_device_without_connection(
         self,
         hass: HomeAssistant,
@@ -502,6 +525,55 @@ class TestServices:
                 {"target_address": "not-a-mac"},
                 blocking=True,
             )
+
+    async def test_generate_support_bundle_service_accepts_setup_retry_device(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_bluetooth_adapters,
+        enable_custom_integrations,
+    ):
+        """Support bundles should still target devices whose entry is in SETUP_RETRY."""
+        from homeassistant.helpers import device_registry as dr
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator.bluetooth.async_ble_device_from_address",
+            return_value=None,
+        ):
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+
+        device_registry = dr.async_get(hass)
+        devices = dr.async_entries_for_config_entry(device_registry, mock_config_entry.entry_id)
+        assert len(devices) == 1
+        device_id = devices[0].id
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+                new=AsyncMock(return_value={"notifications": [], "errors": []}),
+            ) as mock_generate_support_bundle,
+            patch(
+                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
+                return_value=Path("/tmp/support_bundle_retry.json"),
+            ) as mock_save_support_bundle,
+        ):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_GENERATE_SUPPORT_BUNDLE,
+                {"device_id": [device_id]},
+                blocking=True,
+            )
+
+        mock_generate_support_bundle.assert_awaited_once()
+        kwargs = mock_generate_support_bundle.await_args.kwargs
+        assert kwargs["address"] == mock_config_entry.data[CONF_ADDRESS]
+        assert kwargs["device_id"] == device_id
+        assert kwargs["entry"] == mock_config_entry
+        assert kwargs["coordinator"] is None
+        mock_save_support_bundle.assert_called_once()
 
     async def test_goto_preset_service(
         self,

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -238,6 +238,70 @@ class TestSupportBundle:
         assert report["bluetooth"]["advertisements_by_source"] == [{"source": "proxy_1"}]
         assert report["connection_attempt_details"][0]["result"] == "connected"
 
+    async def test_generate_support_bundle_configured_device_without_coordinator_keeps_target(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        enable_custom_integrations,
+    ):
+        """Configured-device bundles should still identify the entry when setup is retrying."""
+        del enable_custom_integrations
+        diagnostic_report = DiagnosticReport(
+            metadata={"version": "2.0"},
+            device={
+                "address": mock_config_entry.data["address"],
+                "selected_source": "proxy_1",
+                "actual_source": "proxy_1",
+                "scanner_count": 1,
+                "visible_sources": ["proxy_1"],
+                "non_connectable_fallback_used": False,
+            },
+            advertisement={"address": mock_config_entry.data["address"], "selected_for_connection": True},
+            advertisements_by_source=[{"source": "proxy_1"}],
+            detection={"bed_type": "linak", "supported_match": True},
+            gatt_services=[{"uuid": LINAK_CONTROL_SERVICE_UUID}],
+            gatt_summary={"available": True, "service_count": 1},
+            device_information={"manufacturer_name": "Linak"},
+            notifications=[],
+            notification_summary={"total_notifications": 0, "by_characteristic": {}},
+            adapter_details={},
+            connection_history={},
+            connection_attempt_details=[{"attempt": 1, "result": "connected"}],
+            command_trace=[],
+            errors=[],
+        )
+
+        with (
+            patch.object(
+                BLEDiagnosticRunner,
+                "run_diagnostics",
+                new=AsyncMock(return_value=diagnostic_report),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.bluetooth.async_current_scanners",
+                return_value=[MagicMock(source="proxy_1", name="Proxy 1", scanning=True)],
+            ),
+        ):
+            report = await generate_support_bundle(
+                hass,
+                address=mock_config_entry.data["address"],
+                capture_duration=0,
+                include_logs=False,
+                coordinator=None,
+                entry=mock_config_entry,
+                device_id="retry-device-id",
+            )
+
+        assert report["target"]["mode"] == "configured_device"
+        assert report["target"]["address"] == mock_config_entry.data["address"]
+        assert report["target"]["device_id"] == "retry-device-id"
+        assert report["target"]["entry_id"] == mock_config_entry.entry_id
+        assert report["target"]["title"] == mock_config_entry.title
+        assert report["integration"]["entry_id"] == mock_config_entry.entry_id
+        assert report["integration"]["address"] == mock_config_entry.data["address"]
+        assert report["controller"]["initialized"] is False
+        assert report["command_trace"] == []
+
     async def test_coordinator_records_command_trace(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## Summary
- create the device-registry entry before the first BLE connection attempt so setup-retry entries remain targetable
- allow `generate_support_bundle` to resolve adjustable-bed devices whose config entry is in `SETUP_RETRY`
- surface retrying beds in the add-flow with explicit recovery instructions instead of silently hiding their MAC address

## Testing
- `uv run --extra dev ruff check custom_components/adjustable_bed/__init__.py custom_components/adjustable_bed/config_flow.py custom_components/adjustable_bed/support_bundle.py tests/test_init.py tests/test_config_flow.py`
- `uv run --extra dev pytest -o addopts='' tests/test_init.py tests/test_config_flow.py -vv`

Ref #322


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrying devices now appear in the config flow with clear localized retry labels and an immediate abort path.
  * Device-registry entries are created earlier for retrying devices so diagnostics remain available.

* **Bug Fixes**
  * Support-bundle generation correctly targets configured devices when setup is retrying.
  * Legacy single‑side entities are removed when side-specific controls exist to avoid duplicate entries.

* **Tests**
  * Added/updated tests covering retrying flows, support-bundle targeting, registry preservation, and legacy-entity removal.

* **Documentation**
  * Added UI translations and abort text for the configured-retrying state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->