### PR TITLE
fix: Sleep Number BLE connection reliability

### DIFF
--- a/custom_components/adjustable_bed/beds/sleep_number_mcr.py
+++ b/custom_components/adjustable_bed/beds/sleep_number_mcr.py
@@ -654,20 +654,35 @@ class SleepNumberMcrController(BedController):
     async def _async_write_frame(
         self, frame: bytes, *, cancel_event: asyncio.Event | None = None
     ) -> None:
-        """Write an MCR frame using fire-and-forget GATT writes.
+        """Write an MCR frame to the bed.
 
-        The BAM/MCR protocol already provides an application-level response
-        over the notify characteristic, and some ESPHome proxy paths drop the
-        BLE connection while waiting for a lower-level GATT write response.
-        Rely on the protocol frame reply for acknowledgement instead of the
-        transport-level write response.
+        ESPHome BLE proxies silently drop write-without-response packets for
+        this characteristic, so we use write-with-response.  The characteristic
+        only advertises write-without-response in its GATT properties, but
+        ESPHome's ESP-IDF BLE stack requires the response handshake to
+        reliably forward the data to the physical device.
+
+        If write-with-response fails (e.g. direct local Bluetooth adapter
+        enforcing the GATT property), fall back to write-without-response.
         """
-        await self._write_gatt_with_retry(
-            SLEEP_NUMBER_MCR_RX_CHAR_UUID,
-            frame,
-            cancel_event=cancel_event,
-            response=False,
-        )
+        try:
+            await self._write_gatt_with_retry(
+                SLEEP_NUMBER_MCR_RX_CHAR_UUID,
+                frame,
+                cancel_event=cancel_event,
+                response=True,
+            )
+        except Exception:
+            _LOGGER.debug(
+                "Write-with-response failed for MCR frame, "
+                "falling back to write-without-response"
+            )
+            await self._write_gatt_with_retry(
+                SLEEP_NUMBER_MCR_RX_CHAR_UUID,
+                frame,
+                cancel_event=cancel_event,
+                response=False,
+            )
 
     def _handle_mcr_notification(self, _sender: object, data: bytearray) -> None:
         """Handle an MCR notification frame."""

--- a/custom_components/adjustable_bed/beds/sleep_number_mcr.py
+++ b/custom_components/adjustable_bed/beds/sleep_number_mcr.py
@@ -14,6 +14,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final
 
+from bleak.exc import BleakError
+
 from ..const import (
     SLEEP_NUMBER_MCR_RX_CHAR_UUID,
     SLEEP_NUMBER_MCR_TX_CHAR_UUID,
@@ -672,10 +674,11 @@ class SleepNumberMcrController(BedController):
                 cancel_event=cancel_event,
                 response=True,
             )
-        except Exception:
+        except (BleakError, TimeoutError, OSError) as exc:
             _LOGGER.debug(
-                "Write-with-response failed for MCR frame, "
-                "falling back to write-without-response"
+                "Write-with-response failed for MCR frame (%s), "
+                "falling back to write-without-response",
+                exc,
             )
             await self._write_gatt_with_retry(
                 SLEEP_NUMBER_MCR_RX_CHAR_UUID,

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -1032,6 +1032,16 @@ class AdjustableBedCoordinator:
                 # Small delay to let connection stabilize before operations
                 await asyncio.sleep(self._post_connect_delay)
 
+                # The bed may disconnect during the stabilisation delay
+                # (the _on_disconnect callback clears self._client).
+                if self._client is None or not self._client.is_connected:
+                    _LOGGER.warning(
+                        "Connection to %s dropped during post-connect stabilisation",
+                        self._address,
+                    )
+                    self._connection_attempt_details.append(attempt_details)
+                    continue
+
                 # Log connection details
                 _LOGGER.debug(
                     "BleakClient connected: is_connected=%s, mtu_size=%s",
@@ -1073,12 +1083,26 @@ class AdjustableBedCoordinator:
                             sorted(discovered_uuids),
                         )
 
-                # Read BLE Device Information Service for manufacturer/model
-                ble_manufacturer, ble_model = await read_ble_device_info(
-                    self._client, self._address
-                )
-                self._ble_manufacturer = ble_manufacturer
-                self._ble_model = ble_model
+                # Some beds (Sleep Number MCR/Fuzion, Jensen) disconnect if
+                # there is too much delay between the BLE connection and the
+                # protocol handshake.  For those bed types we defer the
+                # Device Information Service reads until after the
+                # notification channel and handshake are established.
+                _defer_device_info = self._bed_type in {
+                    BED_TYPE_SLEEP_NUMBER_MCR,
+                    BED_TYPE_SLEEP_NUMBER,
+                    BED_TYPE_JENSEN,
+                }
+
+                ble_manufacturer: str | None = None
+                ble_model: str | None = None
+
+                if not _defer_device_info:
+                    ble_manufacturer, ble_model = await read_ble_device_info(
+                        self._client, self._address
+                    )
+                    self._ble_manufacturer = ble_manufacturer
+                    self._ble_model = ble_model
 
                 # Post-connection protocol verification for DewertOkin Star devices.
                 # The adjustbed app (com.okin.bedding.adjustbed) reads BLE characteristic
@@ -1200,6 +1224,15 @@ class AdjustableBedCoordinator:
                 }:
                     if hasattr(self._controller, "query_config"):
                         await self._controller.query_config()
+
+                # Read deferred BLE Device Information now that the
+                # notification channel and protocol handshake are done.
+                if _defer_device_info and self._client is not None and self._client.is_connected:
+                    ble_manufacturer, ble_model = await read_ble_device_info(
+                        self._client, self._address
+                    )
+                    self._ble_manufacturer = ble_manufacturer
+                    self._ble_model = ble_model
 
                 if self._should_refresh_readable_light_state(force=True):
                     await self._async_refresh_readable_light_state()

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -1029,8 +1029,17 @@ class AdjustableBedCoordinator:
                             self._preferred_adapter,
                         )
 
-                # Small delay to let connection stabilize before operations
-                await asyncio.sleep(self._post_connect_delay)
+                # Small delay to let connection stabilize before operations.
+                # Sleep Number MCR/Fuzion and Jensen beds disconnect quickly
+                # if there is idle time after connect, so skip the delay for
+                # bed types that need the notification channel established
+                # immediately.
+                if self._bed_type not in {
+                    BED_TYPE_SLEEP_NUMBER_MCR,
+                    BED_TYPE_SLEEP_NUMBER,
+                    BED_TYPE_JENSEN,
+                }:
+                    await asyncio.sleep(self._post_connect_delay)
 
                 # The bed may disconnect during the stabilisation delay
                 # (the _on_disconnect callback clears self._client).

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -909,11 +909,14 @@ class AdjustableBedCoordinator:
                     _get_fresh_device_for_connection
                 )
 
-                # Determine if this bed type needs pairing and if pairing is supported
+                # Determine if this bed type needs pairing and if pairing is supported.
+                # Only pair when we haven't tried yet (_pairing_supported is None).
+                # After a successful bond the pairing state persists at the BLE
+                # level so re-requesting pair=True on subsequent connections
+                # triggers auth failures on some ESP-IDF stacks (reason 82) and
+                # leaves the ESPHome proxy connection stuck in ESTABLISHED state.
                 bed_requires_pairing = requires_pairing(self._bed_type, self._protocol_variant)
-                # Only attempt pairing if bed requires it AND we haven't already
-                # determined that pairing is unsupported by this adapter
-                use_pairing = bed_requires_pairing and self._pairing_supported is not False
+                use_pairing = bed_requires_pairing and self._pairing_supported is None
                 if use_pairing:
                     _LOGGER.info(
                         "Pairing enabled for %s (bed type: %s, variant: %s) - "
@@ -976,6 +979,25 @@ class AdjustableBedCoordinator:
                             )
                         else:
                             raise
+                    except (BleakError, TimeoutError, OSError) as pair_err:
+                        # If pairing was requested and the connection failed,
+                        # the BLE bond may already exist from a previous
+                        # session.  Re-pairing on top of an existing bond
+                        # causes auth failures on some ESP-IDF stacks and
+                        # leaves the ESPHome proxy connection stuck.  Mark
+                        # pairing as complete and let the outer retry loop
+                        # reconnect without pair=True.
+                        if use_pairing:
+                            _LOGGER.warning(
+                                "Connection with pairing failed for %s: %s. "
+                                "Bond may already exist — next attempt will "
+                                "connect without re-pairing.",
+                                self._name,
+                                pair_err,
+                            )
+                            self._pairing_supported = True
+                            raise
+                        raise
                 finally:
                     self._connecting = False
                     # Don't notify here - the connect success/failure paths will notify

--- a/custom_components/adjustable_bed/manifest.json
+++ b/custom_components/adjustable_bed/manifest.json
@@ -150,5 +150,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/kristofferR/ha-adjustable-bed/issues",
   "requirements": ["bleak>=1.0.0", "bleak-retry-connector>=3.5.0"],
-  "version": "2.9.4"
+  "version": "2.9.5"
 }

--- a/custom_components/adjustable_bed/manifest.json
+++ b/custom_components/adjustable_bed/manifest.json
@@ -150,5 +150,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/kristofferR/ha-adjustable-bed/issues",
   "requirements": ["bleak>=1.0.0", "bleak-retry-connector>=3.5.0"],
-  "version": "2.9.5"
+  "version": "2.9.6"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-adjustable-bed"
-version = "2.9.5"
+version = "2.9.6"
 description = "Home Assistant integration for adjustable beds"
 requires-python = ">=3.13"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-adjustable-bed"
-version = "2.9.4"
+version = "2.9.5"
 description = "Home Assistant integration for adjustable beds"
 requires-python = ">=3.13"
 


### PR DESCRIPTION
## Summary

Fixes BLE connection failures for Sleep Number beds (both MCR and Fuzion) through ESPHome proxies, and a stale-connection bug affecting all beds that require BLE pairing.

**Root cause analysis** was informed by @JonGilmore's working [sleepnumber-ble](https://github.com/JonGilmore/sleepnumber-ble) integration and his detailed [PROTOCOL.md](https://github.com/JonGilmore/sleepnumber-ble/blob/main/docs/PROTOCOL.md), plus the decompiled SleepIQ APK analysis.

### Sleep Number MCR — three connection blockers (Ref #322)

1. **ESPHome silently drops write-without-response packets** for the MCR RX characteristic. The MCR init handshake frame was never reaching the bed, causing a 10s timeout on every connection. Switched to write-with-response (with fallback to write-without-response for direct adapters). Source: JonGilmore's ESPHome proxy testing documented in PROTOCOL.md.

2. **GATT reads before notification subscription caused disconnects.** After connecting, the coordinator read the Device Information Service (manufacturer/model) before subscribing to MCR notifications. The bed drops the BLE connection if there's unrelated GATT activity before the MCR handshake. Deferred `read_ble_device_info` until after `start_notify` and `query_config` for Sleep Number MCR/Fuzion and Jensen beds.

3. **0.5s post-connect stabilisation delay** gave the bed enough idle time to disconnect. JonGilmore's integration subscribes with zero delay. Skipped the delay for bed types that need the notification channel established immediately.

### Stale ESPHome proxy connections — re-pairing on existing bonds (Ref #318)

Previously, `pair=True` was passed to `establish_connection` on **every** connection for beds in `BEDS_REQUIRING_PAIRING`. After the first successful bond, re-pairing triggers ESP-IDF auth failure (reason 82) and leaves the ESPHome proxy connection stuck in ESTABLISHED state — rejecting all subsequent connection attempts until the ESP32 is factory reset.

Now BLE-level pairing is only requested on the first connection attempt (`_pairing_supported is None`). After a successful bond, the pairing state persists at the BLE level and subsequent connections reuse it without re-pairing. If pairing fails with a transport error (likely because a bond already exists from a previous HA session), the flag is set so the retry loop reconnects without `pair=True`.

This also fixes the stale-connection issue for other beds that require pairing (Okin UUID, Vibradorm, Logicdata, etc.) — BLE bonds persist across connections, so re-requesting pairing was always unnecessary after the first success.

### Additional fix

- **Post-connect `NoneType` crash**: If the bed disconnected during the post-connect stabilisation delay, the `_on_disconnect` callback nulled `self._client` and the retry loop hit `'NoneType' object has no attribute 'is_connected'`. Added a connection guard after the delay.

## Test plan

- [ ] Sleep Number MCR (i8 FlexFit) connects and completes MCR handshake through ESPHome proxy
- [ ] Sleep Number Fuzion (Climate 360) connects without stale-connection loop through ESPHome proxy
- [ ] Beds requiring pairing (Okin UUID, Vibradorm, etc.) still pair successfully on first connection and reconnect without re-pairing
- [ ] Jensen beds connect and complete PIN handshake
- [ ] Non-pairing beds (Linak, Richmat, Keeson, etc.) are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved communication reliability for Sleep Number devices with enhanced error recovery
  * Strengthened pairing mechanism with automatic fallback support
* **Performance**
  * Optimized connection startup for select Sleep Number models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->