### PR TITLE
fix: stabilize Sleep Number MCR connection lifecycle

### DIFF
--- a/custom_components/adjustable_bed/beds/sleep_number_mcr.py
+++ b/custom_components/adjustable_bed/beds/sleep_number_mcr.py
@@ -10,6 +10,7 @@ import asyncio
 import contextlib
 import logging
 import struct
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final
@@ -41,7 +42,6 @@ _MCR_FUNC_SET: Final = 17
 _MCR_FUNC_READ: Final = 18
 _MCR_FUNC_PRESET: Final = 21
 _MCR_FUNC_FOUNDATION_LIGHT_READ: Final = 20
-_MCR_FUNC_CHAMBER_TYPES: Final = 97
 _MCR_FUNC_FOUNDATION_OUTLET: Final = 19
 
 _MCR_SIDE_LEFT: Final = 0
@@ -49,6 +49,7 @@ _MCR_SIDE_RIGHT: Final = 1
 _MCR_SIDE_BOTH_CHAMBERS: Final = 2
 _MCR_SIDE_ALL: Final = 0x0F
 _MCR_OUTLET_UNDERBED_LIGHT: Final = 3
+_OPTIONAL_RESPONSE_GRACE_SECONDS: Final = 0.2
 
 _SLEEP_NUMBER_MCR_PRESETS: Final[dict[str, int]] = {
     "Favorite": 1,
@@ -63,12 +64,6 @@ _SIDE_NAME_TO_VALUE: Final[dict[str, int]] = {
     "left": _MCR_SIDE_LEFT,
     "right": _MCR_SIDE_RIGHT,
 }
-
-# Seconds to cache a bed-presence result from _async_read_chamber_types.
-# The legacy + per-side binary sensors each poll on their own update cycle
-# but ``_async_read_chamber_types`` already refreshes both sides at once,
-# so rapid follow-up polls within this window return the cached state.
-_BED_PRESENCE_POLL_TTL_SECONDS: Final = 5.0
 
 
 @dataclass(slots=True)
@@ -125,17 +120,14 @@ class SleepNumberMcrController(BedController):
         # ``(function_code, side)`` tuple matching the request that was
         # sent. ``None`` means no request is in flight.
         self._outstanding_request_key: tuple[int, int] | None = None
+        # When an optional response times out, a delayed notification for the
+        # same request key must not satisfy the next command. Keep the key
+        # quarantined for a full timeout window after the miss so late replies
+        # are drained before the key can be reused.
+        self._quarantined_response_keys: dict[tuple[int, int], float] = {}
         self._sleep_numbers: dict[str, int | None] = {"left": None, "right": None}
         self._foundation_presets: dict[str, str | None] = {"left": None, "right": None}
         self._under_bed_lights_on: bool | None = None
-        self._bed_presence: dict[str, str | None] = {"left": None, "right": None}
-        self._occupancy_supported = False
-        # Lock + TTL for dedup across the legacy + per-side bed-presence
-        # binary sensors: each polls on its own update cycle and
-        # _async_read_chamber_types already refreshes both sides in one
-        # BAM/MCR query.
-        self._bed_presence_lock = asyncio.Lock()
-        self._bed_presence_last_poll_monotonic: float = 0.0
 
     @property
     def control_characteristic_uuid(self) -> str:
@@ -174,8 +166,8 @@ class SleepNumberMcrController(BedController):
 
     @property
     def supports_bed_presence(self) -> bool:
-        """Expose bed presence only when the firmware returns occupancy bytes."""
-        return self._occupancy_supported
+        """BAM/MCR occupancy probing is intentionally disabled."""
+        return False
 
     @property
     def supports_sleep_number_setting(self) -> bool:
@@ -214,9 +206,7 @@ class SleepNumberMcrController(BedController):
 
     @property
     def bed_presence_sides(self) -> tuple[str, ...]:
-        """Return supported occupancy sides when the BAM firmware reports them."""
-        if self._occupancy_supported:
-            return ("left", "right")
+        """BAM/MCR occupancy sensors are not exposed."""
         return ()
 
     @property
@@ -269,14 +259,15 @@ class SleepNumberMcrController(BedController):
         self._response_buffer.clear()
         self._response_frames.clear()
         self._response_event.clear()
+        self._quarantined_response_keys.clear()
 
     async def query_config(self) -> None:
         """Read the current BAM/MCR state after connect.
 
         Hydration steps are independent: a transient malformed reply to
         the pump-status read must not abort the rest of init, otherwise
-        the under-bed light and chamber queries never run and the
-        corresponding entities stay silently disabled for the session.
+        the under-bed light query never runs and the corresponding
+        entity stays silently disabled for the session.
         Transport failures still propagate (those are retried at the
         coordinator level).
         """
@@ -290,7 +281,6 @@ class SleepNumberMcrController(BedController):
                 exc_info=True,
             )
         await self._async_read_underbed_light_state()
-        await self._async_read_chamber_types()
 
     async def set_sleep_number_setting_for_side(self, side: str, value: int) -> None:
         """Set firmness for one side."""
@@ -304,6 +294,7 @@ class SleepNumberMcrController(BedController):
             function_code=_MCR_FUNC_FORCE_IDLE,
             side=0,
             timeout=3.0,
+            require_response=False,
         )
         await self._async_send_frame(
             command_type=_MCR_CMD_PUMP,
@@ -312,6 +303,7 @@ class SleepNumberMcrController(BedController):
             side=side_value,
             payload=bytes([0x00, normalized]),
             timeout=5.0,
+            require_response=False,
         )
 
         self._sleep_numbers[side] = normalized
@@ -331,6 +323,7 @@ class SleepNumberMcrController(BedController):
             side=self._side_value(side),
             payload=bytes([preset_value, 0x00]),
             timeout=5.0,
+            require_response=False,
         )
 
         self._foundation_presets[side] = preset
@@ -345,50 +338,11 @@ class SleepNumberMcrController(BedController):
         await self._async_set_underbed_light(False)
 
     async def read_bed_presence(self) -> bool | None:
-        """Return the left-side occupancy when chamber occupancy is available.
-
-        Always issues a fresh BAM/MCR chamber-type read. Entity polling
-        should prefer ``read_bed_presence_cached`` below, which wraps this
-        with a TTL cache so the legacy + per-side binary sensors don't
-        double-poll.
-        """
-        if not self._occupancy_supported:
-            return None
-
-        await self._async_initialize_session()
-        await self._async_read_chamber_types()
-        self._bed_presence_last_poll_monotonic = asyncio.get_running_loop().time()
-        return self._left_presence_bool()
+        """BAM/MCR occupancy sensors are not exposed in this integration."""
+        return None
 
     async def read_bed_presence_cached(self) -> bool | None:
-        """Read bed presence with a short TTL cache for entity polling.
-
-        Home Assistant polls the legacy ``bed_presence`` sensor alongside
-        the new per-side sensors on their own update cycles. One
-        ``_async_read_chamber_types`` call already refreshes both sides,
-        so rapid follow-up polls inside the TTL window return the cached
-        state rather than re-issuing the BAM/MCR query. This mirrors the
-        Fuzion controller's behaviour.
-        """
-        if not self._occupancy_supported:
-            return None
-
-        async with self._bed_presence_lock:
-            now = asyncio.get_running_loop().time()
-            if (
-                self._bed_presence["left"] is not None
-                and now - self._bed_presence_last_poll_monotonic
-                < _BED_PRESENCE_POLL_TTL_SECONDS
-            ):
-                return self._left_presence_bool()
-            return await self.read_bed_presence()
-
-    def _left_presence_bool(self) -> bool | None:
-        """Normalize the cached left-side presence state to a bool/None."""
-        if self._bed_presence["left"] == "in":
-            return True
-        if self._bed_presence["left"] == "out":
-            return False
+        """BAM/MCR occupancy sensors are not exposed in this integration."""
         return None
 
     async def move_head_up(self) -> None:
@@ -483,6 +437,7 @@ class SleepNumberMcrController(BedController):
             function_code=_MCR_FUNC_READ,
             side=_MCR_SIDE_ALL,
             timeout=5.0,
+            require_response=False,
         )
 
         for frame in frames:
@@ -508,6 +463,7 @@ class SleepNumberMcrController(BedController):
             function_code=_MCR_FUNC_FOUNDATION_LIGHT_READ,
             side=_MCR_OUTLET_UNDERBED_LIGHT,
             timeout=5.0,
+            require_response=False,
         )
 
         for frame in frames:
@@ -523,43 +479,6 @@ class SleepNumberMcrController(BedController):
 
         _LOGGER.debug("Sleep Number MCR under-bed light query returned no state")
 
-    async def _async_read_chamber_types(self) -> None:
-        """Read chamber/occupancy state when the BAM firmware exposes it."""
-        frames = await self._async_send_frame(
-            command_type=_MCR_CMD_PUMP,
-            status=_MCR_STATUS_PUMP,
-            function_code=_MCR_FUNC_CHAMBER_TYPES,
-            side=_MCR_SIDE_BOTH_CHAMBERS,
-            payload=b"\x00\x00",
-            timeout=5.0,
-        )
-
-        for frame in frames:
-            if frame.function_code != _MCR_FUNC_CHAMBER_TYPES:
-                continue
-            if len(frame.payload) < 8:
-                _LOGGER.debug(
-                    "Sleep Number MCR chamber query returned %d bytes; occupancy not available",
-                    len(frame.payload),
-                )
-                return
-            self._occupancy_supported = True
-            self._bed_presence["right"] = "in" if frame.payload[4] else "out"
-            self._bed_presence["left"] = "in" if frame.payload[6] else "out"
-            # Also publish the generic ``bed_presence`` key so the legacy
-            # compatibility sensor (kept for non-breaking upgrades) reflects
-            # fresh data. MCR has no "configured side" concept — we mirror
-            # the left side to match ``read_bed_presence()`` /
-            # ``_left_presence_bool()``.
-            self.forward_controller_state_updates(
-                {
-                    "bed_presence": self._bed_presence["left"],
-                    "bed_presence_left": self._bed_presence["left"],
-                    "bed_presence_right": self._bed_presence["right"],
-                }
-            )
-            return
-
     async def _async_set_underbed_light(self, is_on: bool) -> None:
         """Write the under-bed light outlet state."""
         await self._async_initialize_session()
@@ -570,6 +489,7 @@ class SleepNumberMcrController(BedController):
             side=_MCR_OUTLET_UNDERBED_LIGHT,
             payload=bytes([1 if is_on else 0, 0, 0]),
             timeout=5.0,
+            require_response=False,
         )
 
         self._under_bed_lights_on = is_on
@@ -586,19 +506,25 @@ class SleepNumberMcrController(BedController):
         sub_address: int | None = None,
         timeout: float = 5.0,
         cancel_event: asyncio.Event | None = None,
+        require_response: bool = True,
     ) -> list[_McrFrame]:
         """Write an MCR frame and wait for the matching notification response.
 
         Replies are correlated to the outstanding request via
-        ``(function_code, side)``. The notification handler ignores any
-        unrelated parsed frames (late replies from prior commands, stray
-        broadcasts) so the waiter only wakes once a frame that actually
-        matches this request is reassembled and parsed.
+        ``(function_code, side)``. When an optional response times out,
+        the same request key is quarantined for a full timeout window so
+        a delayed reply cannot satisfy the next command that reuses that
+        key.
 
         The response wait races ``_response_event`` against the caller's
         ``cancel_event`` and the coordinator's cancel signal so that a
         cancellation or disconnect exits the wait promptly instead of
         holding the serialized BLE path until ``timeout`` expires.
+
+        Optional responses only wait a short grace window. This keeps
+        BAM/MCR write-only operations from holding the coordinator's
+        serialized BLE path for the full 3-5 second timeout when the
+        firmware simply never echoes an acknowledgement.
         """
         frame = self._build_frame(
             command_type=command_type,
@@ -608,9 +534,13 @@ class SleepNumberMcrController(BedController):
             payload=payload,
             sub_address=self._bed_address if sub_address is None else sub_address,
         )
+        request_key = self._request_key(function_code, side)
+        await self._async_wait_for_response_quarantine(
+            request_key, function_code=function_code, side=side, cancel_event=cancel_event
+        )
         # Set correlation BEFORE clearing state, so any in-flight notification
         # parsing on the event loop sees the new key.
-        self._outstanding_request_key = (function_code & 0x7F, side & 0x0F)
+        self._outstanding_request_key = request_key
         self._response_buffer.clear()
         self._response_frames.clear()
         self._response_event.clear()
@@ -626,10 +556,16 @@ class SleepNumberMcrController(BedController):
             if cancel_event is not None and cancel_event is not coordinator_cancel:
                 cancel_tasks.append(asyncio.create_task(cancel_event.wait()))
 
+            response_timeout = (
+                timeout
+                if require_response
+                else min(timeout, _OPTIONAL_RESPONSE_GRACE_SECONDS)
+            )
+
             try:
                 done, _pending = await asyncio.wait(
                     {response_task, *cancel_tasks},
-                    timeout=timeout,
+                    timeout=response_timeout,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
             finally:
@@ -641,6 +577,20 @@ class SleepNumberMcrController(BedController):
                         await task
 
             if not done:
+                if not require_response:
+                    self._quarantine_response_key(
+                        request_key,
+                        deadline=time.monotonic() + timeout,
+                    )
+                    _LOGGER.debug(
+                        "Sleep Number MCR frame timed out without a matching response "
+                        "during the optional %.3fs grace window (func=%s side=%s); "
+                        "continuing without retry",
+                        response_timeout,
+                        function_code,
+                        side,
+                    )
+                    return list(self._response_frames)
                 raise TimeoutError(
                     f"Timed out waiting for Sleep Number MCR response func={function_code}"
                 )
@@ -695,6 +645,15 @@ class SleepNumberMcrController(BedController):
         parsed_frame = False
         for frame in self._extract_response_frames():
             parsed_frame = True
+            if (quarantined_key := self._matching_quarantined_request_key(frame)) is not None:
+                _LOGGER.debug(
+                    "Ignoring late Sleep Number MCR notification for quarantined request "
+                    "(func=%s side=%s quarantined=%s)",
+                    frame.function_code,
+                    frame.side,
+                    quarantined_key,
+                )
+                continue
             if not self._frame_matches_outstanding_request(frame):
                 _LOGGER.debug(
                     "Ignoring Sleep Number MCR notification that does not match"
@@ -716,9 +675,17 @@ class SleepNumberMcrController(BedController):
         """Return True when ``frame`` is the response to the in-flight request."""
         if self._outstanding_request_key is None:
             return False
+        return self._frame_matches_request_key(frame, self._outstanding_request_key)
+
+    def _frame_matches_request_key(
+        self,
+        frame: _McrFrame,
+        request_key: tuple[int, int],
+    ) -> bool:
+        """Return True when ``frame`` matches ``request_key``."""
         if not frame.is_response:
             return False
-        expected_func, expected_side = self._outstanding_request_key
+        expected_func, expected_side = request_key
         if frame.function_code != expected_func:
             return False
         # The MCR firmware sometimes echoes a different side nibble for
@@ -729,6 +696,95 @@ class SleepNumberMcrController(BedController):
         if expected_side in {_MCR_SIDE_ALL, _MCR_SIDE_BOTH_CHAMBERS}:
             return True
         return frame.side == expected_side
+
+    @staticmethod
+    def _request_key(function_code: int, side: int) -> tuple[int, int]:
+        """Normalize the request correlation tuple."""
+        return (function_code & 0x7F, side & 0x0F)
+
+    def _prune_response_quarantine(self) -> None:
+        """Drop expired quarantined request keys."""
+        now = time.monotonic()
+        expired_keys = [
+            request_key
+            for request_key, deadline in self._quarantined_response_keys.items()
+            if deadline <= now
+        ]
+        for request_key in expired_keys:
+            self._quarantined_response_keys.pop(request_key, None)
+
+    def _quarantine_response_key(self, request_key: tuple[int, int], *, deadline: float) -> None:
+        """Ignore late replies for ``request_key`` until ``deadline``."""
+        current_deadline = self._quarantined_response_keys.get(request_key)
+        if current_deadline is None or deadline > current_deadline:
+            self._quarantined_response_keys[request_key] = deadline
+
+    def _matching_quarantined_request_key(
+        self, frame: _McrFrame
+    ) -> tuple[int, int] | None:
+        """Return the quarantined request key that ``frame`` matches, if any."""
+        self._prune_response_quarantine()
+        for request_key in self._quarantined_response_keys:
+            if self._frame_matches_request_key(frame, request_key):
+                return request_key
+        return None
+
+    async def _async_wait_for_response_quarantine(
+        self,
+        request_key: tuple[int, int],
+        *,
+        function_code: int,
+        side: int,
+        cancel_event: asyncio.Event | None,
+    ) -> None:
+        """Wait until a timed-out optional request key is safe to reuse."""
+        while True:
+            self._prune_response_quarantine()
+            deadline = self._quarantined_response_keys.get(request_key)
+            if deadline is None:
+                return
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                self._quarantined_response_keys.pop(request_key, None)
+                return
+
+            _LOGGER.debug(
+                "Waiting %.3fs before reusing Sleep Number MCR request key "
+                "(func=%s side=%s) after an optional timeout",
+                remaining,
+                function_code,
+                side,
+            )
+
+            coordinator_cancel = self._coordinator.cancel_command
+            wait_task = asyncio.create_task(asyncio.sleep(remaining))
+            cancel_tasks: list[asyncio.Task[bool]] = [
+                asyncio.create_task(coordinator_cancel.wait())
+            ]
+            if cancel_event is not None and cancel_event is not coordinator_cancel:
+                cancel_tasks.append(asyncio.create_task(cancel_event.wait()))
+
+            try:
+                done, _pending = await asyncio.wait(
+                    {wait_task, *cancel_tasks},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+            finally:
+                for task in (wait_task, *cancel_tasks):
+                    if not task.done():
+                        task.cancel()
+                for task in (wait_task, *cancel_tasks):
+                    with contextlib.suppress(asyncio.CancelledError, Exception):
+                        await task
+
+            if wait_task in done:
+                self._quarantined_response_keys.pop(request_key, None)
+                return
+
+            raise asyncio.CancelledError(
+                f"Sleep Number MCR request reuse cancelled func={function_code}"
+            )
 
     def _extract_response_frames(self) -> list[_McrFrame]:
         """Parse as many complete MCR frames as possible from the notification buffer."""

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -24,6 +24,7 @@ try:
 except ImportError:
     # Older bleak-retry-connector versions may not expose this helper.
     close_stale_connections_by_address = None
+
 from homeassistant.components import bluetooth
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
@@ -123,9 +124,9 @@ from .const import (
     RICHMAT_REMOTE_AUTO,
     get_richmat_features,
     get_richmat_motor_count,
+    passive_position_reconciliation_default_enabled,
     requires_pairing,
     resolve_richmat_remote_code,
-    passive_position_reconciliation_default_enabled,
 )
 from .controller_factory import create_controller
 from .detection import detect_richmat_remote_from_name
@@ -714,6 +715,18 @@ class AdjustableBedCoordinator:
         async with self._lock:
             return await self._async_connect_locked()
 
+    def _uses_persistent_connection(self) -> bool:
+        """Return True when this controller should stay connected indefinitely."""
+        return self._bed_type == BED_TYPE_SLEEP_NUMBER_MCR
+
+    def _disconnect_after_operation_enabled(self) -> bool:
+        """Return True when commands should disconnect immediately after completion."""
+        return self._disconnect_after_command and not self._uses_persistent_connection()
+
+    def _auto_reconnect_enabled(self) -> bool:
+        """Return True when unexpected disconnects should schedule a reconnect timer."""
+        return not self._uses_persistent_connection()
+
     async def _async_connect_locked(self, reset_timer: bool = True) -> bool:
         """Connect to the bed (must hold lock)."""
         # Clear any prior manual/idle disconnect marker before a fresh connect attempt.
@@ -999,6 +1012,7 @@ class AdjustableBedCoordinator:
                     and not self._ble_bond_established
                     and self._pairing_supported is not False
                 )
+                keep_connecting_through_startup = self._uses_persistent_connection()
                 if use_pairing:
                     _LOGGER.info(
                         "Pairing enabled for %s (bed type: %s, variant: %s) - "
@@ -1083,7 +1097,8 @@ class AdjustableBedCoordinator:
                             raise
                         raise
                 finally:
-                    self._connecting = False
+                    if not keep_connecting_through_startup:
+                        self._connecting = False
                     # Don't notify here - the connect success/failure paths will notify
 
                 # Determine which adapter was actually used for connection
@@ -1154,6 +1169,7 @@ class AdjustableBedCoordinator:
                         "Connection to %s dropped during post-connect stabilisation",
                         self._address,
                     )
+                    self._connecting = False
                     self._connection_attempt_details.append(attempt_details)
                     continue
 
@@ -1299,6 +1315,13 @@ class AdjustableBedCoordinator:
                 self._controller_state_refresh_completed = False
                 _LOGGER.debug("Controller created successfully")
 
+                if self._bed_type == BED_TYPE_SLEEP_NUMBER_MCR:
+                    # Older BAM/MCR firmware is sensitive to idle time between
+                    # the BLE connect, notify subscribe, and init/query frames.
+                    await self.async_start_notify()
+                    if hasattr(self._controller, "query_config"):
+                        await self._controller.query_config()
+
                 if (
                     self._bed_type == BED_TYPE_VIBRADORM
                     and not self._disable_angle_sensing
@@ -1320,8 +1343,10 @@ class AdjustableBedCoordinator:
 
                 self._refresh_passive_position_reconciliation_schedule()
 
-                # Start position notifications (no-op if angle sensing disabled)
-                await self.async_start_notify()
+                # Start position notifications (no-op if angle sensing disabled).
+                # Sleep Number MCR performs its notify+init startup earlier.
+                if self._bed_type != BED_TYPE_SLEEP_NUMBER_MCR:
+                    await self.async_start_notify()
 
                 # For Octo beds: discover features and handle PIN if needed
                 if self._bed_type == BED_TYPE_OCTO:
@@ -1334,13 +1359,11 @@ class AdjustableBedCoordinator:
                         await self._controller.start_keepalive()  # type: ignore[attr-defined]
 
                 # Beds with connect-time feature discovery/state hydration.
-                if self._bed_type in {
-                    BED_TYPE_JENSEN,
-                    BED_TYPE_SLEEP_NUMBER,
-                    BED_TYPE_SLEEP_NUMBER_MCR,
-                }:
-                    if hasattr(self._controller, "query_config"):
-                        await self._controller.query_config()
+                if (
+                    self._bed_type in {BED_TYPE_JENSEN, BED_TYPE_SLEEP_NUMBER}
+                    and hasattr(self._controller, "query_config")
+                ):
+                    await self._controller.query_config()
 
                 # Read deferred BLE Device Information now that the
                 # notification channel and protocol handshake are done.
@@ -1351,13 +1374,38 @@ class AdjustableBedCoordinator:
                     self._ble_manufacturer = ble_manufacturer
                     self._ble_model = ble_model
 
-                if self._should_refresh_readable_light_state(force=True):
+                if (
+                    self._bed_type != BED_TYPE_SLEEP_NUMBER_MCR
+                    and self._should_refresh_readable_light_state(force=True)
+                ):
                     await self._async_refresh_readable_light_state()
+
+                if self._client is None or not self._client.is_connected:
+                    _LOGGER.warning(
+                        "Connection to %s dropped during controller startup",
+                        self._address,
+                    )
+                    self._connecting = False
+                    self._last_connection_error = "Connection dropped during controller startup"
+                    self._last_connection_error_type = ConnectionError.__name__
+                    attempt_details["total_elapsed_seconds"] = round(
+                        time.monotonic() - attempt_start, 3
+                    )
+                    attempt_details["result"] = "failed"
+                    attempt_details["error"] = self._last_connection_error
+                    attempt_details["error_type"] = self._last_connection_error_type
+                    attempt_details["error_category"] = "CONNECTION DROPPED"
+                    self._client = None
+                    self._controller = None
+                    self._notify_connection_state_change(False)
+                    self._connection_attempt_details.append(attempt_details)
+                    continue
 
                 if reset_timer:
                     self._reset_disconnect_timer()
 
                 # Store connection metadata for binary sensor
+                self._connecting = False
                 self._last_connected = datetime.now(UTC)
                 self._connection_source = actual_adapter
                 self._connection_rssi = adapter_result.rssi
@@ -1396,6 +1444,7 @@ class AdjustableBedCoordinator:
                         )
 
                 # Track connection error for diagnostics (issue #168)
+                self._connecting = False
                 self._last_connection_error = str(err)
                 self._last_connection_error_type = type(err).__name__
 
@@ -1425,10 +1474,12 @@ class AdjustableBedCoordinator:
                             type(disconnect_err).__name__,
                         )
                     self._client = None
+                    self._controller = None
                 self._connection_attempt_details.append(attempt_details)
                 # Delay is handled at the start of the next iteration with progressive backoff
-            except Exception as err:
+            except Exception as err:  # noqa: BLE001 - preserve retry diagnostics for unexpected connect failures
                 # Track connection error for diagnostics (issue #168)
+                self._connecting = False
                 self._last_connection_error = str(err)
                 self._last_connection_error_type = type(err).__name__
                 attempt_details["total_elapsed_seconds"] = round(
@@ -1465,6 +1516,7 @@ class AdjustableBedCoordinator:
                             type(disconnect_err).__name__,
                         )
                     self._client = None
+                    self._controller = None
                 self._connection_attempt_details.append(attempt_details)
                 # Delay is handled at the start of the next iteration with progressive backoff
 
@@ -1545,6 +1597,16 @@ class AdjustableBedCoordinator:
         self._cancel_disconnect_timer()
         self._notify_connection_state_change(False)
         _LOGGER.debug("Disconnect cleanup complete for %s", self._address)
+
+        if not self._auto_reconnect_enabled():
+            _LOGGER.debug(
+                "Skipping auto-reconnect timer for persistent connection bed type %s",
+                self._bed_type,
+            )
+            if self._reconnect_timer is not None:
+                self._reconnect_timer.cancel()
+                self._reconnect_timer = None
+            return
 
         # Schedule automatic reconnection attempt
         # Cancel any existing reconnect timer first to prevent multiple concurrent reconnects
@@ -1822,6 +1884,14 @@ class AdjustableBedCoordinator:
 
     def _reset_disconnect_timer(self) -> None:
         """Reset the disconnect timer."""
+        if self._uses_persistent_connection():
+            self._cancel_disconnect_timer()
+            _LOGGER.debug(
+                "Skipping idle disconnect timer for persistent connection on %s",
+                self._address,
+            )
+            return
+
         self._cancel_disconnect_timer()
         _LOGGER.debug(
             "Setting idle disconnect timer for %s (%d seconds)",
@@ -2021,7 +2091,7 @@ class AdjustableBedCoordinator:
             finally:
                 if self._client is not None and self._client.is_connected:
                     # Disconnect immediately if configured to do so
-                    if self._disconnect_after_command:
+                    if self._disconnect_after_operation_enabled():
                         _LOGGER.debug(
                             "Disconnecting after stop command (disconnect_after_command=True) for %s",
                             self._address,
@@ -2059,7 +2129,11 @@ class AdjustableBedCoordinator:
             return
 
         command_preempted = self._cancel_counter > entry_cancel_count
-        if self._disconnect_after_command and not skip_disconnect and not command_preempted:
+        if (
+            self._disconnect_after_operation_enabled()
+            and not skip_disconnect
+            and not command_preempted
+        ):
             _LOGGER.debug(
                 "Disconnecting after %s (disconnect_after_command=True) for %s",
                 operation_name,
@@ -2204,7 +2278,7 @@ class AdjustableBedCoordinator:
                 if (
                     self._client is not None
                     and self._client.is_connected
-                    and not self._disconnect_after_command
+                    and not self._disconnect_after_operation_enabled()
                 ):
                     self._reset_disconnect_timer()
                 raise
@@ -3047,7 +3121,7 @@ class AdjustableBedCoordinator:
 
             finally:
                 if self._client is not None and self._client.is_connected:
-                    if self._disconnect_after_command:
+                    if self._disconnect_after_operation_enabled():
                         _LOGGER.debug(
                             "Disconnecting after seek (disconnect_after_command=True) for %s",
                             self._address,

--- a/custom_components/adjustable_bed/light.py
+++ b/custom_components/adjustable_bed/light.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.light import (
@@ -14,12 +15,12 @@ from homeassistant.components.light import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_ON
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import DOMAIN
+from .const import BED_TYPE_SLEEP_NUMBER_MCR, DOMAIN
 from .coordinator import AdjustableBedCoordinator
 from .entity import AdjustableBedEntity
 
@@ -75,11 +76,24 @@ async def async_setup_entry(
     coordinator: AdjustableBedCoordinator = hass.data[DOMAIN][entry.entry_id]
     controller = coordinator.controller
 
-    if controller is None or not getattr(controller, "supports_light_color_control", False):
+    if controller is None:
         _async_remove_stale_light_entity(hass, coordinator)
         return
 
-    async_add_entities([AdjustableBedLight(coordinator, LIGHT_DESCRIPTION)])
+    if getattr(controller, "supports_light_color_control", False):
+        _async_remove_stale_switch_entity(hass, coordinator)
+        async_add_entities([AdjustableBedLight(coordinator, LIGHT_DESCRIPTION)])
+        return
+
+    if (
+        coordinator.bed_type == BED_TYPE_SLEEP_NUMBER_MCR
+        and getattr(controller, "supports_discrete_light_control", False)
+    ):
+        _async_remove_stale_switch_entity(hass, coordinator)
+        async_add_entities([AdjustableBedOnOffLight(coordinator, LIGHT_DESCRIPTION)])
+        return
+
+    _async_remove_stale_light_entity(hass, coordinator)
 
 
 def _async_remove_stale_light_entity(
@@ -89,6 +103,20 @@ def _async_remove_stale_light_entity(
     registry = er.async_get(hass)
     entity_id = registry.async_get_entity_id(
         "light",
+        DOMAIN,
+        f"{coordinator.address}_{LIGHT_DESCRIPTION.key}",
+    )
+    if entity_id is not None:
+        registry.async_remove(entity_id)
+
+
+def _async_remove_stale_switch_entity(
+    hass: HomeAssistant, coordinator: AdjustableBedCoordinator
+) -> None:
+    """Remove the legacy switch when a light entity owns under-bed lights."""
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "switch",
         DOMAIN,
         f"{coordinator.address}_{LIGHT_DESCRIPTION.key}",
     )
@@ -220,5 +248,70 @@ class AdjustableBedLight(AdjustableBedEntity, RestoreEntity, LightEntity):
             raise NotImplementedError("Light off control not supported on this bed")
 
         await self._coordinator.async_execute_controller_command(_turn_off, cancel_running=False)
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+
+class AdjustableBedOnOffLight(AdjustableBedEntity, RestoreEntity, LightEntity):
+    """On/off under-bed light for BAM/MCR-style beds."""
+
+    entity_description: LightEntityDescription
+
+    _attr_color_mode = ColorMode.ONOFF
+    _attr_supported_color_modes = frozenset({ColorMode.ONOFF})
+
+    def __init__(
+        self,
+        coordinator: AdjustableBedCoordinator,
+        description: LightEntityDescription,
+    ) -> None:
+        """Initialize the on/off light."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.address}_{description.key}"
+        self._attr_is_on: bool | None = None
+        self._unregister_callback: Callable[[], None] | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to controller-state updates for the light."""
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_is_on = last_state.state == STATE_ON
+        self._unregister_callback = self._coordinator.register_controller_state_callback(
+            self._handle_controller_state_update
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Clean up controller-state callback registration."""
+        if self._unregister_callback is not None:
+            self._unregister_callback()
+            self._unregister_callback = None
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _handle_controller_state_update(self, state: dict[str, Any]) -> None:
+        """Update state from controller light telemetry when available."""
+        if "under_bed_lights_on" not in state:
+            return
+        self._attr_is_on = bool(state["under_bed_lights_on"])
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: object) -> None:
+        """Turn the under-bed light on."""
+        del kwargs
+        await self._coordinator.async_execute_controller_command(
+            lambda ctrl: ctrl.lights_on(),
+            cancel_running=False,
+        )
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: object) -> None:
+        """Turn the under-bed light off."""
+        del kwargs
+        await self._coordinator.async_execute_controller_command(
+            lambda ctrl: ctrl.lights_off(),
+            cancel_running=False,
+        )
         self._attr_is_on = False
         self.async_write_ha_state()

--- a/custom_components/adjustable_bed/switch.py
+++ b/custom_components/adjustable_bed/switch.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import BED_TYPE_SLEEP_NUMBER_MCR, DOMAIN
 from .coordinator import AdjustableBedCoordinator
 from .entity import AdjustableBedEntity
 
@@ -76,7 +76,13 @@ async def async_setup_entry(
         if (
             description.key == "under_bed_lights"
             and controller is not None
-            and getattr(controller, "supports_light_color_control", False)
+            and (
+                getattr(controller, "supports_light_color_control", False)
+                or (
+                    coordinator.bed_type == BED_TYPE_SLEEP_NUMBER_MCR
+                    and getattr(controller, "supports_discrete_light_control", False)
+                )
+            )
         ):
             entity_id = registry.async_get_entity_id(
                 "switch",

--- a/docs/beds/sleep_number.md
+++ b/docs/beds/sleep_number.md
@@ -55,7 +55,7 @@ For Fuzion bases, enter pairing mode by holding the side pairing button until th
 | Side-specific Firmness | ✅ |
 | Side-specific Foundation Presets | ✅ |
 | Under Bed Lights | ✅ |
-| Presence Detection | ⚠️ Only if the firmware exposes chamber occupancy bytes |
+| Presence Detection | ❌ |
 | Cooling / Heating / Footwarming | ❌ |
 
 ## Current Integration Scope
@@ -68,7 +68,7 @@ The Fuzion controller currently controls one side of the base per config entry.
 
 This keeps the implementation compatible with the current entity model while still exposing split-base control.
 
-Older BAM/MCR bases use a different controller path. They expose both firmness sides from one config entry and create separate left/right firmness numbers plus left/right foundation preset selects.
+Older BAM/MCR bases use a different controller path. They expose both firmness sides from one config entry, create separate left/right firmness numbers plus left/right foundation preset selects, and intentionally keep the BLE connection open once established.
 
 ## Protocol Details
 
@@ -237,10 +237,11 @@ Implemented BAM/MCR operations:
 - set left/right firmness
 - trigger left/right foundation presets (`Favorite`, `Read`, `Watch TV`, `Flat`, `Zero G`, `Snore`)
 - read and write under-bed light state
-- chamber-type query for optional occupancy support
 
 Current BAM/MCR limitations:
 
 - no live head/foot cover entities yet
 - no climate entities
-- tested 0.4.x BAM firmware returns only a short chamber payload, so occupancy sensors are not created unless the firmware exposes real occupancy bytes
+- no occupancy sensors or chamber polling in normal operation
+
+The BAM/MCR controller intentionally keeps a persistent BLE connection once startup succeeds. Idle disconnects, disconnect-after-command, and timer-based auto-reconnect are disabled for this path because older BAM/MCR firmware is sensitive to reconnect churn between the notify subscribe, init handshake, and follow-up reads.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -633,6 +633,14 @@ def mock_bluetooth_adapters() -> Generator[None]:
             "custom_components.adjustable_bed.coordinator.bluetooth.async_register_connection_params",
             create=True,  # Allow patching even if attribute doesn't exist
         ),
+        patch(
+            "homeassistant.components.bluetooth.async_setup",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "homeassistant.components.bluetooth_adapters.async_setup",
+            new=AsyncMock(return_value=True),
+        ),
     ]
 
     for p in patches:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -17,6 +17,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_LINAK,
     BED_TYPE_OKIMAT,
     BED_TYPE_RICHMAT,
+    BED_TYPE_SLEEP_NUMBER_MCR,
     CONF_BED_TYPE,
     CONF_BLE_BOND_ESTABLISHED,
     CONF_DISABLE_ANGLE_SENSING,
@@ -1375,6 +1376,209 @@ class TestCoordinatorDisconnectTimer:
 
         assert coordinator._reconnect_timer is None
         assert coordinator._intentional_disconnect is False
+
+    async def test_sleep_number_mcr_skips_disconnect_timer_on_connect(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+    ):
+        """Sleep Number MCR should keep a persistent connection without an idle timer."""
+        del mock_coordinator_connected
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Sleep Number MCR Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:51",
+                CONF_NAME: "64:DB:A0:07:DD:02",
+                CONF_BED_TYPE: BED_TYPE_SLEEP_NUMBER_MCR,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:51",
+            entry_id="sleep_number_mcr_disconnect_timer_test",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        await coordinator.async_connect()
+
+        assert coordinator._disconnect_timer is None
+
+
+class TestSleepNumberMcrCoordinatorLifecycle:
+    """Test Sleep Number MCR coordinator lifecycle behavior."""
+
+    async def test_sleep_number_mcr_ignores_disconnect_after_command(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+    ):
+        """Sleep Number MCR should stay connected even when disconnect_after_command is set."""
+        del mock_coordinator_connected
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Sleep Number MCR Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:52",
+                CONF_NAME: "64:DB:A0:07:DD:03",
+                CONF_BED_TYPE: BED_TYPE_SLEEP_NUMBER_MCR,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+                CONF_DISCONNECT_AFTER_COMMAND: True,
+            },
+            unique_id="AA:BB:CC:DD:EE:52",
+            entry_id="sleep_number_mcr_disconnect_after_command_test",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        await coordinator.async_connect()
+        coordinator.async_disconnect = AsyncMock()
+
+        async def _noop_command(controller) -> None:
+            del controller
+
+        await coordinator.async_execute_controller_command(_noop_command)
+
+        coordinator.async_disconnect.assert_not_awaited()
+        assert coordinator._disconnect_timer is None
+
+    async def test_sleep_number_mcr_unexpected_disconnect_skips_auto_reconnect(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Sleep Number MCR should not schedule timer-based auto-reconnect."""
+        del mock_coordinator_connected
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Sleep Number MCR Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:53",
+                CONF_NAME: "64:DB:A0:07:DD:04",
+                CONF_BED_TYPE: BED_TYPE_SLEEP_NUMBER_MCR,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:53",
+            entry_id="sleep_number_mcr_auto_reconnect_test",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        await coordinator.async_connect()
+        mock_bleak_client.is_connected = False
+
+        coordinator._on_disconnect(mock_bleak_client)
+
+        assert coordinator._reconnect_timer is None
+        assert coordinator.client is None
+        assert coordinator.controller is None
+
+    async def test_sleep_number_mcr_keeps_connecting_guard_through_startup_disconnect(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """A disconnect during MCR startup should not clear state mid-handshake."""
+        del mock_coordinator_connected
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Sleep Number MCR Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:54",
+                CONF_NAME: "64:DB:A0:07:DD:05",
+                CONF_BED_TYPE: BED_TYPE_SLEEP_NUMBER_MCR,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:54",
+            entry_id="sleep_number_mcr_startup_disconnect_test",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        coordinator._max_retries = 1
+
+        async def _disconnect_during_query(controller) -> None:
+            del controller
+            assert coordinator.is_connecting is True
+            assert coordinator.client is mock_bleak_client
+            assert coordinator.controller is not None
+            coordinator._on_disconnect(mock_bleak_client)
+            assert coordinator.controller is not None
+            raise TimeoutError
+
+        with patch(
+            "custom_components.adjustable_bed.beds.sleep_number_mcr."
+            "SleepNumberMcrController.query_config",
+            new=_disconnect_during_query,
+        ):
+            connected = await coordinator.async_connect()
+
+        assert connected is False
+        assert coordinator.is_connecting is False
+        assert coordinator._reconnect_timer is None
+        assert coordinator.client is None
+        assert coordinator.controller is None
+
+    async def test_sleep_number_mcr_startup_disconnect_not_marked_connected(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """A silent disconnect during MCR startup should fail the attempt."""
+        del mock_coordinator_connected
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Sleep Number MCR Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:55",
+                CONF_NAME: "64:DB:A0:07:DD:06",
+                CONF_BED_TYPE: BED_TYPE_SLEEP_NUMBER_MCR,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:55",
+            entry_id="sleep_number_mcr_startup_disconnect_guard_test",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        coordinator._max_retries = 1
+
+        async def _disconnect_during_query_without_exception(controller) -> None:
+            del controller
+            assert coordinator.client is mock_bleak_client
+            mock_bleak_client.is_connected = False
+            coordinator._on_disconnect(mock_bleak_client)
+
+        with patch(
+            "custom_components.adjustable_bed.beds.sleep_number_mcr."
+            "SleepNumberMcrController.query_config",
+            new=_disconnect_during_query_without_exception,
+        ):
+            connected = await coordinator.async_connect()
+
+        assert connected is False
+        assert coordinator.is_connecting is False
+        assert coordinator.is_connected is False
+        assert coordinator.client is None
+        assert coordinator.controller is None
+        assert coordinator._last_connected is None
 
 
 class TestCoordinatorWriteCommand:

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from homeassistant.components.climate import HVACMode
-from homeassistant.const import CONF_ADDRESS, CONF_NAME, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.const import CONF_ADDRESS, CONF_NAME, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -749,7 +749,7 @@ class TestSleepNumberEntities:
         registry = er.async_get(hass)
 
         under_bed_lights = registry.async_get_entity_id(
-            "switch",
+            "light",
             DOMAIN,
             "AA:BB:CC:DD:EE:57_under_bed_lights",
         )
@@ -775,6 +775,10 @@ class TestSleepNumberEntities:
         )
 
         assert under_bed_lights is not None
+        assert (
+            registry.async_get_entity_id("switch", DOMAIN, "AA:BB:CC:DD:EE:57_under_bed_lights")
+            is None
+        )
         assert left_sleep_number is not None
         assert right_sleep_number is not None
         assert left_preset is not None
@@ -796,17 +800,176 @@ class TestSleepNumberEntities:
             is None
         )
 
-    async def test_sleep_number_mcr_entities_include_split_presence_when_supported(
+    async def test_sleep_number_mcr_setup_removes_stale_under_bed_light_switch(
         self,
         hass: HomeAssistant,
         mock_coordinator_connected,
         enable_custom_integrations,
     ):
-        """MCR occupancy sensors should be created when query_config discovers chamber bytes."""
+        """BAM/MCR should expose an under-bed light entity instead of the legacy switch."""
         del mock_coordinator_connected, enable_custom_integrations
         entry = MockConfigEntry(
             domain=DOMAIN,
-            title="Sleep Number MCR Occupancy Bed",
+            title="Sleep Number MCR Light Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:58",
+                CONF_NAME: "64:DB:A0:07:DD:09",
+                CONF_BED_TYPE: BED_TYPE_SLEEP_NUMBER_MCR,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:58",
+            entry_id="sleep_number_mcr_light_entity_entry",
+        )
+        entry.add_to_hass(hass)
+
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        registry.async_get_or_create(
+            "switch",
+            DOMAIN,
+            "AA:BB:CC:DD:EE:58_under_bed_lights",
+            config_entry=entry,
+            suggested_object_id="sleep_number_mcr_bed_under_bed_lights",
+        )
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert (
+            registry.async_get_entity_id("light", DOMAIN, "AA:BB:CC:DD:EE:58_under_bed_lights")
+            is not None
+        )
+        assert (
+            registry.async_get_entity_id("switch", DOMAIN, "AA:BB:CC:DD:EE:58_under_bed_lights")
+            is None
+        )
+
+    async def test_sleep_number_mcr_under_bed_light_turn_on_and_off(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+        enable_custom_integrations,
+    ):
+        """BAM/MCR under-bed light should behave like a normal on/off light entity."""
+        del mock_coordinator_connected, enable_custom_integrations
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Sleep Number MCR Light Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:5A",
+                CONF_NAME: "64:DB:A0:07:DD:0B",
+                CONF_BED_TYPE: BED_TYPE_SLEEP_NUMBER_MCR,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:5A",
+            entry_id="sleep_number_mcr_light_service_entry",
+        )
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        entity_id = registry.async_get_entity_id(
+            "light", DOMAIN, "AA:BB:CC:DD:EE:5A_under_bed_lights"
+        )
+        assert entity_id is not None
+
+        mock_bleak_client.write_gatt_char.reset_mock()
+        await hass.services.async_call(
+            "light",
+            "turn_on",
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+        assert hass.states.get(entity_id).state == STATE_ON
+        assert mock_bleak_client.write_gatt_char.call_count >= 1
+
+        mock_bleak_client.write_gatt_char.reset_mock()
+        await hass.services.async_call(
+            "light",
+            "turn_off",
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+        assert hass.states.get(entity_id).state == STATE_OFF
+        assert mock_bleak_client.write_gatt_char.call_count >= 1
+
+    async def test_sleep_number_mcr_under_bed_light_restores_last_state(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """BAM/MCR light entities should restore their last known on/off state."""
+        del mock_coordinator_connected, enable_custom_integrations
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Sleep Number MCR Light Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:5B",
+                CONF_NAME: "64:DB:A0:07:DD:0C",
+                CONF_BED_TYPE: BED_TYPE_SLEEP_NUMBER_MCR,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:5B",
+            entry_id="sleep_number_mcr_light_restore_entry",
+        )
+        entry.add_to_hass(hass)
+
+        def _register_without_initial_state(_coordinator, callback_fn):
+            _coordinator._controller_state_callbacks.add(callback_fn)
+
+            def unregister() -> None:
+                _coordinator._controller_state_callbacks.discard(callback_fn)
+
+            return unregister
+
+        with patch(
+            "custom_components.adjustable_bed.light."
+            "AdjustableBedOnOffLight.async_get_last_state",
+            new=AsyncMock(return_value=MagicMock(state=STATE_OFF)),
+        ), patch(
+            "custom_components.adjustable_bed.coordinator."
+            "AdjustableBedCoordinator.register_controller_state_callback",
+            new=_register_without_initial_state,
+        ):
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        entity_id = registry.async_get_entity_id(
+            "light", DOMAIN, "AA:BB:CC:DD:EE:5B_under_bed_lights"
+        )
+        assert entity_id is not None
+        assert hass.states.get(entity_id).state == STATE_OFF
+
+    async def test_sleep_number_mcr_entities_do_not_include_presence_sensors(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """BAM/MCR should not create presence sensors during normal setup."""
+        del mock_coordinator_connected, enable_custom_integrations
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Sleep Number MCR Presence Bed",
             data={
                 CONF_ADDRESS: "AA:BB:CC:DD:EE:59",
                 CONF_NAME: "64:DB:A0:07:DD:0A",
@@ -821,25 +984,8 @@ class TestSleepNumberEntities:
         )
         entry.add_to_hass(hass)
 
-        async def _mock_read_chamber_types(self) -> None:
-            self._occupancy_supported = True
-            self._bed_presence["left"] = "in"
-            self._bed_presence["right"] = "out"
-            self.forward_controller_state_updates(
-                {
-                    "bed_presence": "in",
-                    "bed_presence_left": "in",
-                    "bed_presence_right": "out",
-                }
-            )
-
-        with patch(
-            "custom_components.adjustable_bed.beds.sleep_number_mcr."
-            "SleepNumberMcrController._async_read_chamber_types",
-            new=_mock_read_chamber_types,
-        ):
-            await hass.config_entries.async_setup(entry.entry_id)
-            await hass.async_block_till_done()
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
         from homeassistant.helpers import entity_registry as er
 
@@ -851,7 +997,7 @@ class TestSleepNumberEntities:
                 DOMAIN,
                 "AA:BB:CC:DD:EE:59_bed_presence_left",
             )
-            is not None
+            is None
         )
         assert (
             registry.async_get_entity_id(
@@ -859,7 +1005,7 @@ class TestSleepNumberEntities:
                 DOMAIN,
                 "AA:BB:CC:DD:EE:59_bed_presence_right",
             )
-            is not None
+            is None
         )
         assert (
             registry.async_get_entity_id(

--- a/tests/test_sleep_number_mcr.py
+++ b/tests/test_sleep_number_mcr.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, call
 
 import pytest
@@ -78,19 +79,34 @@ class TestSleepNumberMcrController:
         assert coordinator.controller.requires_notification_channel is True
         assert coordinator.controller.supports_motor_control is False
 
-    async def test_query_config_hydrates_state(self, sleep_number_mcr_coordinator) -> None:
+    async def test_query_config_hydrates_state(
+        self,
+        sleep_number_mcr_coordinator,
+        mock_bleak_client,
+    ) -> None:
         """Connect-time hydration should read firmness and under-bed light state."""
         coordinator = await sleep_number_mcr_coordinator(
             address="AA:BB:CC:DD:EE:52",
             name="64:DB:A0:07:DD:03",
             entry_id="sleep_number_mcr_query_config",
         )
+        controller = coordinator.controller
+        assert isinstance(controller, SleepNumberMcrController)
+
+        request_function_codes: list[int] = []
+        for write_call in mock_bleak_client.write_gatt_char.await_args_list:
+            if str(write_call.args[0]) != SLEEP_NUMBER_MCR_RX_CHAR_UUID:
+                continue
+            frame = controller._parse_frame(write_call.args[1])
+            if frame is not None:
+                request_function_codes.append(frame.function_code)
 
         assert coordinator.controller_state["sleep_number_left"] == 35
         assert coordinator.controller_state["sleep_number_right"] == 65
         assert coordinator.controller_state["under_bed_lights_on"] is True
         assert coordinator.controller.supports_bed_presence is False
         assert coordinator.controller.bed_presence_sides == ()
+        assert 97 not in request_function_codes
 
     async def test_set_sleep_number_setting_for_side_rounds_and_updates_state(
         self,
@@ -106,6 +122,30 @@ class TestSleepNumberMcrController:
         await coordinator.controller.set_sleep_number_setting_for_side("right", 63)
 
         assert coordinator.controller_state["sleep_number_right"] == 65
+
+    async def test_set_sleep_number_setting_tolerates_missing_write_responses(
+        self,
+        sleep_number_mcr_coordinator,
+    ) -> None:
+        """Missing write responses should not force a reconnect for normal MCR writes."""
+        coordinator = await sleep_number_mcr_coordinator(
+            address="AA:BB:CC:DD:EE:5B",
+            name="64:DB:A0:07:DD:0C",
+            entry_id="sleep_number_mcr_sleep_number_no_response",
+        )
+        controller = coordinator.controller
+        assert isinstance(controller, SleepNumberMcrController)
+        controller._initialized = True
+        controller._async_send_frame = AsyncMock(return_value=[])
+
+        await controller.set_sleep_number_setting_for_side("left", 42)
+
+        assert coordinator.controller_state["sleep_number_left"] == 40
+        assert controller._async_send_frame.await_count == 2
+        assert all(
+            awaited.kwargs["require_response"] is False
+            for awaited in controller._async_send_frame.await_args_list
+        )
 
     async def test_set_foundation_preset_for_side_updates_state(
         self,
@@ -137,6 +177,159 @@ class TestSleepNumberMcrController:
 
         assert await coordinator.controller.read_bed_presence() is None
         assert coordinator.controller.supports_bed_presence is False
+
+    async def test_query_config_tolerates_missing_underbed_light_response(
+        self,
+        sleep_number_mcr_coordinator,
+    ) -> None:
+        """Connect-time hydration should not fail when the light read returns no response."""
+        coordinator = await sleep_number_mcr_coordinator(
+            address="AA:BB:CC:DD:EE:5C",
+            name="64:DB:A0:07:DD:0D",
+            entry_id="sleep_number_mcr_query_config_no_light_response",
+        )
+        controller = coordinator.controller
+        assert isinstance(controller, SleepNumberMcrController)
+        controller._initialized = True
+        controller._under_bed_lights_on = None
+
+        pump_frame = controller._parse_frame(
+            controller._build_frame(
+                command_type=1,
+                status=0x02,
+                function_code=0x80 | 18,
+                side=0x0F,
+                payload=bytes([1, 40, 60, 0, 0]),
+                sub_address=_mcr_address_from_mac("AA:BB:CC:DD:EE:5C"),
+            )
+        )
+        assert pump_frame is not None
+        controller._async_send_frame = AsyncMock(side_effect=[[pump_frame], []])
+
+        await controller.query_config()
+
+        assert coordinator.controller_state["sleep_number_left"] == 40
+        assert coordinator.controller_state["sleep_number_right"] == 60
+        assert controller._under_bed_lights_on is None
+        assert controller._async_send_frame.await_args_list[1].kwargs["require_response"] is False
+
+    async def test_async_send_frame_timeout_is_nonfatal_when_response_not_required(
+        self,
+        sleep_number_mcr_coordinator,
+    ) -> None:
+        """Optional BAM/MCR responses should not hold the BLE path for the full timeout."""
+        coordinator = await sleep_number_mcr_coordinator(
+            address="AA:BB:CC:DD:EE:5D",
+            name="64:DB:A0:07:DD:0E",
+            entry_id="sleep_number_mcr_optional_response_timeout",
+        )
+        controller = coordinator.controller
+        assert isinstance(controller, SleepNumberMcrController)
+        controller._async_write_frame = AsyncMock()
+
+        start = asyncio.get_running_loop().time()
+        result = await controller._async_send_frame(
+            command_type=0x02,
+            status=0x02,
+            function_code=0x12,
+            side=0x0F,
+            timeout=5.0,
+            require_response=False,
+        )
+        elapsed = asyncio.get_running_loop().time() - start
+
+        assert result == []
+        assert elapsed < 1.0
+        assert controller._outstanding_request_key is None
+
+    async def test_async_send_frame_timeout_still_raises_for_required_response(
+        self,
+        sleep_number_mcr_coordinator,
+    ) -> None:
+        """The init handshake should still fail fast when its response never arrives."""
+        coordinator = await sleep_number_mcr_coordinator(
+            address="AA:BB:CC:DD:EE:5E",
+            name="64:DB:A0:07:DD:0F",
+            entry_id="sleep_number_mcr_required_response_timeout",
+        )
+        controller = coordinator.controller
+        assert isinstance(controller, SleepNumberMcrController)
+        controller._async_write_frame = AsyncMock()
+
+        with pytest.raises(TimeoutError):
+            await controller._async_send_frame(
+                command_type=0x02,
+                status=0x02,
+                function_code=0x00,
+                side=0x00,
+                timeout=0.01,
+                require_response=True,
+            )
+
+        assert controller._outstanding_request_key is None
+
+    async def test_async_send_frame_ignores_late_optional_response_for_next_same_key_request(
+        self,
+        sleep_number_mcr_coordinator,
+    ) -> None:
+        """A late optional reply must not satisfy the next request that reuses the same key."""
+        coordinator = await sleep_number_mcr_coordinator(
+            address="AA:BB:CC:DD:EE:5F",
+            name="64:DB:A0:07:DD:10",
+            entry_id="sleep_number_mcr_late_optional_response",
+        )
+        controller = coordinator.controller
+        assert isinstance(controller, SleepNumberMcrController)
+        controller._async_write_frame = AsyncMock()
+
+        request_kwargs = {
+            "command_type": 0x02,
+            "status": 0x02,
+            "function_code": 0x12,
+            "side": 0x0F,
+        }
+
+        first_result = await controller._async_send_frame(
+            **request_kwargs,
+            timeout=0.02,
+            require_response=False,
+        )
+        assert first_result == []
+
+        stale_response = controller._build_frame(
+            command_type=0x02,
+            status=0x02,
+            function_code=0x80 | 0x12,
+            side=0x0F,
+            payload=b"\x01",
+            sub_address=_mcr_address_from_mac("AA:BB:CC:DD:EE:5F"),
+        )
+        real_response = controller._build_frame(
+            command_type=0x02,
+            status=0x02,
+            function_code=0x80 | 0x12,
+            side=0x0F,
+            payload=b"\x02",
+            sub_address=_mcr_address_from_mac("AA:BB:CC:DD:EE:5F"),
+        )
+
+        async def _deliver_notification(delay: float, frame: bytes) -> None:
+            await asyncio.sleep(delay)
+            controller._handle_mcr_notification(None, bytearray(frame))
+
+        stale_task = asyncio.create_task(_deliver_notification(0.005, stale_response))
+        real_task = asyncio.create_task(_deliver_notification(0.03, real_response))
+
+        try:
+            second_result = await controller._async_send_frame(
+                **request_kwargs,
+                timeout=0.1,
+            )
+        finally:
+            await stale_task
+            await real_task
+
+        assert [frame.payload for frame in second_result] == [b"\x02"]
 
     async def test_notification_handler_reassembles_split_mcr_frames(
         self,


### PR DESCRIPTION
Re-lands the Sleep Number MCR lifecycle fixes on a clean branch after the previous merge was removed from `master`.

Ref #333.