### PR TITLE
fix: harden entity command handling

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -1041,6 +1041,8 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                 raise ServiceValidationError(
                     "Support bundle generation only supports one configured device at a time. "
                     "Select a single device or use target_address for an unconfigured bed.",
+                    translation_domain=DOMAIN,
+                    translation_key="multiple_device_targets_not_supported",
                 )
             selected_device_id = device_ids[0]
             target = _get_support_bundle_target_from_device(hass, selected_device_id)

--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -789,7 +789,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                         "move_up_fn": lambda ctrl: ctrl.move_back_up(),
                         "move_down_fn": lambda ctrl: ctrl.move_back_down(),
                         "move_stop_fn": lambda ctrl: ctrl.move_back_stop(),
-                        "max_value": 68.0,  # Degrees
+                        "max_value": coordinator.get_max_angle("back"),  # Degrees
                         "min_motors": 2,
                     },
                     "legs": {
@@ -797,7 +797,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                         "move_up_fn": lambda ctrl: ctrl.move_legs_up(),
                         "move_down_fn": lambda ctrl: ctrl.move_legs_down(),
                         "move_stop_fn": lambda ctrl: ctrl.move_legs_stop(),
-                        "max_value": 45.0,  # Degrees
+                        "max_value": coordinator.get_max_angle("legs"),  # Degrees
                         "min_motors": 2,
                     },
                     "head": {
@@ -805,7 +805,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                         "move_up_fn": lambda ctrl: ctrl.move_head_up(),
                         "move_down_fn": lambda ctrl: ctrl.move_head_down(),
                         "move_stop_fn": lambda ctrl: ctrl.move_head_stop(),
-                        "max_value": 68.0,  # Degrees
+                        "max_value": coordinator.get_max_angle("head"),  # Degrees
                         "min_motors": 3,
                     },
                     "feet": {
@@ -813,7 +813,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                         "move_up_fn": lambda ctrl: ctrl.move_feet_up(),
                         "move_down_fn": lambda ctrl: ctrl.move_feet_down(),
                         "move_stop_fn": lambda ctrl: ctrl.move_feet_stop(),
-                        "max_value": 45.0,  # Degrees
+                        "max_value": coordinator.get_max_angle("feet"),  # Degrees
                         "min_motors": 4,
                     },
                 }
@@ -1037,6 +1037,11 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                 address,
             )
         elif device_ids:
+            if len(device_ids) > 1:
+                raise ServiceValidationError(
+                    "Support bundle generation only supports one configured device at a time. "
+                    "Select a single device or use target_address for an unconfigured bed.",
+                )
             selected_device_id = device_ids[0]
             target = _get_support_bundle_target_from_device(hass, selected_device_id)
             if target is not None:

--- a/custom_components/adjustable_bed/button.py
+++ b/custom_components/adjustable_bed/button.py
@@ -583,13 +583,15 @@ class AdjustableBedButton(AdjustableBedEntity, ButtonEntity):
                     await self._coordinator.async_disconnect()
                     _LOGGER.info("Disconnected from bed - physical remote should now work")
                 elif self.entity_description.key == "connect":
-                    await self._coordinator.async_ensure_connected()
+                    if not await self._coordinator.async_ensure_connected():
+                        raise RuntimeError(f"Failed to connect to {self._coordinator.name}")
                     _LOGGER.info("Connected to bed")
             except Exception:
                 _LOGGER.exception(
                     "Failed to execute coordinator action %s",
                     self.entity_description.key,
                 )
+                raise
             return
 
         # Stop button gets special handling - cancels current command immediately
@@ -598,6 +600,7 @@ class AdjustableBedButton(AdjustableBedEntity, ButtonEntity):
                 await self._coordinator.async_stop_command()
             except Exception:
                 _LOGGER.exception("Failed to execute stop command")
+                raise
             return
 
         try:
@@ -617,3 +620,4 @@ class AdjustableBedButton(AdjustableBedEntity, ButtonEntity):
                 "Failed to execute button action %s",
                 self.entity_description.key,
             )
+            raise

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -78,6 +78,7 @@ CONF_KAIDI_VARIANT_SOURCE: Final = "kaidi_variant_source"
 # Default angle limits (from Linak beds)
 DEFAULT_BACK_MAX_ANGLE: Final = 68.0
 DEFAULT_LEGS_MAX_ANGLE: Final = 45.0
+REVERIE_BACK_MAX_ANGLE: Final = 60.0
 
 # Position mode values
 POSITION_MODE_SPEED: Final = "speed"

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -120,12 +120,13 @@ from .const import (
     POSITION_STALL_COUNT,
     POSITION_STALL_THRESHOLD,
     POSITION_TOLERANCE,
+    REVERIE_BACK_MAX_ANGLE,
     RICHMAT_REMOTE_AUTO,
     get_richmat_features,
     get_richmat_motor_count,
+    passive_position_reconciliation_default_enabled,
     requires_pairing,
     resolve_richmat_remote_code,
-    passive_position_reconciliation_default_enabled,
 )
 from .controller_factory import create_controller
 from .detection import detect_richmat_remote_from_name
@@ -388,6 +389,8 @@ class AdjustableBedCoordinator:
             Maximum angle in degrees for the specified motor.
         """
         if position_key in ("back", "head"):
+            if self._bed_type in (BED_TYPE_REVERIE, BED_TYPE_REVERIE_NIGHTSTAND):
+                return REVERIE_BACK_MAX_ANGLE
             return self.back_max_angle
         if position_key in ("legs", "feet"):
             return self.legs_max_angle

--- a/custom_components/adjustable_bed/cover.py
+++ b/custom_components/adjustable_bed/cover.py
@@ -23,6 +23,7 @@ from .const import (
     BED_TYPE_REVERIE_NIGHTSTAND,
     BEDS_WITH_PERCENTAGE_POSITIONS,
     DOMAIN,
+    REVERIE_BACK_MAX_ANGLE,
 )
 from .coordinator import AdjustableBedCoordinator
 from .entity import AdjustableBedEntity
@@ -31,10 +32,6 @@ if TYPE_CHECKING:
     from .beds.base import BedController, MotorControlSpec
 
 _LOGGER = logging.getLogger(__name__)
-
-# Bed-type-specific max angles for back/head motors
-# Reverie beds report position 0-100 which maps to 0-60 degrees (not 68)
-REVERIE_BACK_MAX_ANGLE = 60
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/adjustable_bed/cover.py
+++ b/custom_components/adjustable_bed/cover.py
@@ -377,6 +377,7 @@ class AdjustableBedCover(AdjustableBedEntity, CoverEntity):
                 "Failed to move cover %s",
                 self.entity_description.key,
             )
+            raise
         finally:
             # Only clear state if no newer movement has started
             if self._movement_generation == current_generation:
@@ -407,6 +408,7 @@ class AdjustableBedCover(AdjustableBedEntity, CoverEntity):
                 "Failed to stop cover %s",
                 self.entity_description.key,
             )
+            raise
         finally:
             # Only clear state if no newer movement has started since stop was called
             if self._movement_generation == stop_generation:

--- a/custom_components/adjustable_bed/light.py
+++ b/custom_components/adjustable_bed/light.py
@@ -127,6 +127,11 @@ class AdjustableBedLight(AdjustableBedEntity, RestoreEntity, LightEntity):
         default_rgb = (
             getattr(controller, "default_light_rgb_color", None) if controller is not None else None
         )
+        self._supports_discrete_light_control = bool(
+            getattr(controller, "supports_discrete_light_control", False)
+            if controller is not None
+            else False
+        )
         self._default_rgb_color = _normalize_rgb_color(default_rgb)
         self._attr_is_on = False
         if self._attr_color_mode == ColorMode.RGBW:
@@ -199,11 +204,7 @@ class AdjustableBedLight(AdjustableBedEntity, RestoreEntity, LightEntity):
         """Turn the light off using the controller's light-off semantics."""
         del kwargs
 
-        controller = self._coordinator.controller
-        if controller is None:
-            return
-
-        if not self._attr_is_on and not getattr(controller, "supports_discrete_light_control", False):
+        if not self._attr_is_on and not self._supports_discrete_light_control:
             _LOGGER.debug(
                 "Skipping toggle-based light off for %s because HA already believes it is off",
                 self._coordinator.name,

--- a/custom_components/adjustable_bed/switch.py
+++ b/custom_components/adjustable_bed/switch.py
@@ -252,9 +252,6 @@ class AdjustableBedSwitch(AdjustableBedEntity, SwitchEntity):
             self._coordinator.name,
         )
 
-        # Cancel any pending auto-off timer since we're manually turning off
-        self._cancel_auto_off_timer()
-
         try:
             _LOGGER.debug("Sending turn off command for %s", self.entity_description.key)
             await self._coordinator.async_execute_controller_command(
@@ -264,6 +261,10 @@ class AdjustableBedSwitch(AdjustableBedEntity, SwitchEntity):
             # Only update assumed state if controller supports discrete on/off
             # Toggle-only controllers can't reliably track state
             if self._supports_discrete_control():
+                # Cancel any pending auto-off timer only after the command succeeds.
+                # If transport fails, keep the timer so HA can still reflect the
+                # hardware-enforced auto-off when it happens.
+                self._cancel_auto_off_timer()
                 self._attr_is_on = False
                 self.async_write_ha_state()
             else:

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -744,6 +744,9 @@
     },
     "invalid_position_range": {
       "message": "Position {position} is out of range for motor \"{motor}\". Valid range: 0-{max_value}{unit}."
+    },
+    "multiple_device_targets_not_supported": {
+      "message": "Support bundle generation only supports one configured device at a time. Select a single device or use target_address for an unconfigured bed."
     }
   },
   "issues": {

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, call, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
+
+import pytest
 
 from homeassistant.components.climate import HVACMode
-from homeassistant.const import CONF_ADDRESS, CONF_NAME, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.const import CONF_ADDRESS, CONF_NAME, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -304,6 +307,64 @@ class TestCoverEntities:
         )
 
         mock_bleak_client.write_gatt_char.assert_called()
+
+    async def test_cover_open_propagates_command_errors(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """Cover open should surface transport failures to HA callers."""
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        cover_entities = [
+            state.entity_id
+            for state in hass.states.async_all()
+            if state.entity_id.startswith("cover.")
+        ]
+        entity_id = cover_entities[0]
+
+        coordinator = hass.data[DOMAIN][mock_config_entry.entry_id]
+        coordinator.async_execute_controller_command = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await hass.services.async_call(
+                "cover",
+                "open_cover",
+                {"entity_id": entity_id},
+                blocking=True,
+            )
+
+    async def test_cover_stop_propagates_command_errors(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """Cover stop should surface transport failures to HA callers."""
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        cover_entities = [
+            state.entity_id
+            for state in hass.states.async_all()
+            if state.entity_id.startswith("cover.")
+        ]
+        entity_id = cover_entities[0]
+
+        coordinator = hass.data[DOMAIN][mock_config_entry.entry_id]
+        coordinator.async_execute_controller_command = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await hass.services.async_call(
+                "cover",
+                "stop_cover",
+                {"entity_id": entity_id},
+                blocking=True,
+            )
 
 
 class TestNumberEntities:
@@ -1053,6 +1114,65 @@ class TestButtonEntities:
 
         mock_bleak_client.write_gatt_char.assert_called()
 
+    async def test_preset_button_press_propagates_command_errors(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """Preset button presses should surface transport failures to HA callers."""
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        button_entities = [
+            state.entity_id
+            for state in hass.states.async_all()
+            if state.entity_id.startswith("button.") and "memory_1" in state.entity_id
+        ]
+        entity_id = button_entities[0]
+
+        coordinator = hass.data[DOMAIN][mock_config_entry.entry_id]
+        coordinator.async_execute_controller_command = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await hass.services.async_call(
+                "button",
+                "press",
+                {"entity_id": entity_id},
+                blocking=True,
+            )
+
+    async def test_connect_button_press_raises_when_reconnect_fails(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """Connect button should not report success when reconnect fails."""
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        button_entities = [
+            state.entity_id
+            for state in hass.states.async_all()
+            if state.entity_id.startswith("button.") and state.entity_id.endswith("_connect")
+        ]
+        assert len(button_entities) == 1
+        entity_id = button_entities[0]
+
+        coordinator = hass.data[DOMAIN][mock_config_entry.entry_id]
+        coordinator.async_ensure_connected = AsyncMock(return_value=False)
+
+        with pytest.raises(RuntimeError, match="Failed to connect"):
+            await hass.services.async_call(
+                "button",
+                "press",
+                {"entity_id": entity_id},
+                blocking=True,
+            )
+
 
 class TestSwitchEntities:
     """Test switch entities."""
@@ -1074,6 +1194,57 @@ class TestSwitchEntities:
 
         # Should have under-bed lights switch
         assert len(switch_states) == 1
+
+    async def test_failed_switch_turn_off_keeps_auto_off_timer(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """A failed turn-off should not drop the hardware auto-off fallback timer."""
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        switch_entities = [
+            state.entity_id
+            for state in hass.states.async_all()
+            if state.entity_id.startswith("switch.")
+        ]
+        assert len(switch_entities) == 1
+        entity_id = switch_entities[0]
+
+        coordinator = hass.data[DOMAIN][mock_config_entry.entry_id]
+        with patch.object(
+            type(coordinator.controller),
+            "light_auto_off_seconds",
+            new_callable=PropertyMock,
+            return_value=0.01,
+        ):
+            await hass.services.async_call(
+                "switch",
+                "turn_on",
+                {"entity_id": entity_id},
+                blocking=True,
+            )
+            assert hass.states.get(entity_id).state == STATE_ON
+
+            coordinator.async_execute_controller_command = AsyncMock(side_effect=RuntimeError("boom"))
+
+            with pytest.raises(RuntimeError, match="boom"):
+                await hass.services.async_call(
+                    "switch",
+                    "turn_off",
+                    {"entity_id": entity_id},
+                    blocking=True,
+                )
+
+            assert hass.states.get(entity_id).state == STATE_ON
+
+            await asyncio.sleep(0.05)
+            await hass.async_block_till_done()
+
+        assert hass.states.get(entity_id).state == STATE_OFF
 
 
 class TestLightEntities:
@@ -1678,6 +1849,73 @@ class TestLightEntities:
                 response=True,
             )
         ]
+
+    async def test_leggett_gen2_light_turn_off_reconnects_after_idle_disconnect(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """Turn-off should still execute when the coordinator has already idle-disconnected."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Leggett Gen2 Reconnect Light",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:13",
+                CONF_NAME: "Leggett Gen2 Reconnect Light",
+                CONF_BED_TYPE: BED_TYPE_LEGGETT_GEN2,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:13",
+            entry_id="leggett_gen2_light_idle_disconnect_entry",
+        )
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        entity_id = registry.async_get_entity_id(
+            "light", DOMAIN, "AA:BB:CC:DD:EE:13_under_bed_lights"
+        )
+        assert entity_id is not None
+
+        await hass.services.async_call(
+            "light",
+            "turn_on",
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        fake_controller = MagicMock()
+        fake_controller.supports_discrete_light_control = True
+        fake_controller.supports_light_toggle_control = False
+        fake_controller.lights_off = AsyncMock()
+
+        async def _fake_execute(command_fn, **_kwargs):
+            await command_fn(fake_controller)
+
+        coordinator._controller = None
+        coordinator.async_execute_controller_command = AsyncMock(side_effect=_fake_execute)
+
+        await hass.services.async_call(
+            "light",
+            "turn_off",
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+
+        coordinator.async_execute_controller_command.assert_awaited_once()
+        fake_controller.lights_off.assert_awaited_once()
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == STATE_OFF
 
     async def test_switch_turn_on_off(
         self,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
 
 import pytest
@@ -316,6 +316,7 @@ class TestCoverEntities:
         enable_custom_integrations,
     ):
         """Cover open should surface transport failures to HA callers."""
+        del mock_coordinator_connected, enable_custom_integrations
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -345,6 +346,7 @@ class TestCoverEntities:
         enable_custom_integrations,
     ):
         """Cover stop should surface transport failures to HA callers."""
+        del mock_coordinator_connected, enable_custom_integrations
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -1092,6 +1094,7 @@ class TestButtonEntities:
         enable_custom_integrations,
     ):
         """Test pressing a preset button sends command."""
+        del mock_coordinator_connected, enable_custom_integrations
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -1122,6 +1125,7 @@ class TestButtonEntities:
         enable_custom_integrations,
     ):
         """Preset button presses should surface transport failures to HA callers."""
+        del mock_coordinator_connected, enable_custom_integrations
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -1151,6 +1155,7 @@ class TestButtonEntities:
         enable_custom_integrations,
     ):
         """Connect button should not report success when reconnect fails."""
+        del mock_coordinator_connected, enable_custom_integrations
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -1203,6 +1208,7 @@ class TestSwitchEntities:
         enable_custom_integrations,
     ):
         """A failed turn-off should not drop the hardware auto-off fallback timer."""
+        del mock_coordinator_connected, enable_custom_integrations
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
@@ -1232,7 +1238,10 @@ class TestSwitchEntities:
             ) -> object:
                 nonlocal scheduled_auto_off
                 if getattr(callback, "__name__", "") == "auto_off_callback":
-                    scheduled_auto_off = lambda: callback(*args)
+                    def invoke_auto_off() -> None:
+                        callback(*args)
+
+                    scheduled_auto_off = invoke_auto_off
                     return auto_off_handle
                 return original_call_later(delay, callback, *args)
 
@@ -1751,6 +1760,7 @@ class TestLightEntities:
         enable_custom_integrations,
     ):
         """Leggett Gen2 light turn_on with rgb_color should send lights_on + RGBSET."""
+        del mock_coordinator_connected, enable_custom_integrations
         entry = MockConfigEntry(
             domain=DOMAIN,
             title="Leggett Gen2 Bed",
@@ -1816,6 +1826,7 @@ class TestLightEntities:
         enable_custom_integrations,
     ):
         """Leggett Gen2 light turn_off should send RGBENABLE 0:0."""
+        del mock_coordinator_connected, enable_custom_integrations
         entry = MockConfigEntry(
             domain=DOMAIN,
             title="Leggett Gen2 Bed",
@@ -1876,6 +1887,7 @@ class TestLightEntities:
         enable_custom_integrations,
     ):
         """Turn-off should still execute when the coordinator has already idle-disconnected."""
+        del mock_coordinator_connected, enable_custom_integrations
         entry = MockConfigEntry(
             domain=DOMAIN,
             title="Leggett Gen2 Reconnect Light",
@@ -1917,7 +1929,10 @@ class TestLightEntities:
         fake_controller.supports_light_toggle_control = False
         fake_controller.lights_off = AsyncMock()
 
-        async def _fake_execute(command_fn, **_kwargs):
+        async def _fake_execute(
+            command_fn: Callable[[object], Awaitable[None]],
+            **_kwargs: object,
+        ) -> None:
             await command_fn(fake_controller)
 
         coordinator._controller = None

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
+from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
 
 import pytest
@@ -1221,27 +1221,46 @@ class TestSwitchEntities:
             new_callable=PropertyMock,
             return_value=0.01,
         ):
-            await hass.services.async_call(
-                "switch",
-                "turn_on",
-                {"entity_id": entity_id},
-                blocking=True,
-            )
-            assert hass.states.get(entity_id).state == STATE_ON
+            scheduled_auto_off: Callable[[], None] | None = None
+            auto_off_handle = MagicMock()
+            original_call_later = hass.loop.call_later
 
-            coordinator.async_execute_controller_command = AsyncMock(side_effect=RuntimeError("boom"))
+            def capture_auto_off(
+                delay: float,
+                callback: Callable[..., None],
+                *args: object,
+            ) -> object:
+                nonlocal scheduled_auto_off
+                if getattr(callback, "__name__", "") == "auto_off_callback":
+                    scheduled_auto_off = lambda: callback(*args)
+                    return auto_off_handle
+                return original_call_later(delay, callback, *args)
 
-            with pytest.raises(RuntimeError, match="boom"):
+            with patch.object(hass.loop, "call_later", side_effect=capture_auto_off):
                 await hass.services.async_call(
                     "switch",
-                    "turn_off",
+                    "turn_on",
                     {"entity_id": entity_id},
                     blocking=True,
                 )
+                assert hass.states.get(entity_id).state == STATE_ON
 
-            assert hass.states.get(entity_id).state == STATE_ON
+                coordinator.async_execute_controller_command = AsyncMock(
+                    side_effect=RuntimeError("boom")
+                )
 
-            await asyncio.sleep(0.05)
+                with pytest.raises(RuntimeError, match="boom"):
+                    await hass.services.async_call(
+                        "switch",
+                        "turn_off",
+                        {"entity_id": entity_id},
+                        blocking=True,
+                    )
+
+                assert hass.states.get(entity_id).state == STATE_ON
+
+            assert scheduled_auto_off is not None
+            scheduled_auto_off()
             await hass.async_block_till_done()
 
         assert hass.states.get(entity_id).state == STATE_OFF

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -30,6 +30,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_SLEEPYS_BOX25,
     BED_TYPE_VIBRADORM,
     BEDTECH_SERVICE_UUID,
+    CONF_BACK_MAX_ANGLE,
     CONF_BED_TYPE,
     CONF_DISABLE_ANGLE_SENSING,
     CONF_HAS_MASSAGE,
@@ -579,6 +580,35 @@ class TestServices:
         assert kwargs["coordinator"] is None
         mock_save_support_bundle.assert_called_once()
 
+    async def test_generate_support_bundle_service_rejects_multiple_device_targets(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """Support bundle generation should fail fast instead of silently ignoring extra devices."""
+        import pytest
+        from homeassistant.exceptions import ServiceValidationError
+
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        from homeassistant.helpers import device_registry as dr
+
+        device_registry = dr.async_get(hass)
+        devices = dr.async_entries_for_config_entry(device_registry, mock_config_entry.entry_id)
+        assert len(devices) == 1
+        device_id = devices[0].id
+
+        with pytest.raises(ServiceValidationError, match="only supports one configured device"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_GENERATE_SUPPORT_BUNDLE,
+                {"device_id": [device_id, "other-device-id"]},
+                blocking=True,
+            )
+
     async def test_goto_preset_service(
         self,
         hass: HomeAssistant,
@@ -979,6 +1009,132 @@ class TestServices:
         )
 
         assert coordinator.async_seek_position.await_count == 2
+
+    async def test_set_position_service_uses_configured_back_max_angle(
+        self,
+        hass: HomeAssistant,
+    ):
+        """Standard set_position validation should honor configured back/head calibration."""
+        from homeassistant.helpers import device_registry as dr
+
+        from custom_components.adjustable_bed import _async_register_services
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Calibrated Service Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:32",
+                CONF_NAME: "Calibrated Service Bed",
+                CONF_BED_TYPE: BED_TYPE_LINAK,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: False,
+                CONF_PREFERRED_ADAPTER: "auto",
+                CONF_BACK_MAX_ANGLE: 80.0,
+            },
+            unique_id="AA:BB:CC:DD:EE:32",
+            entry_id="calibrated_service_entry",
+        )
+        entry.add_to_hass(hass)
+
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, entry.unique_id)},
+            name=entry.title,
+        )
+
+        coordinator = MagicMock()
+        coordinator.controller = MagicMock()
+        coordinator.name = entry.title
+        coordinator.disable_angle_sensing = False
+        coordinator.get_max_angle.side_effect = lambda motor: {
+            "back": 80.0,
+            "head": 80.0,
+            "legs": 45.0,
+            "feet": 45.0,
+        }[motor]
+        coordinator.async_seek_position = AsyncMock()
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+
+        await _async_register_services(hass)
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_POSITION,
+            {
+                "device_id": [device.id],
+                "motor": "back",
+                "position": 75,
+            },
+            blocking=True,
+        )
+
+        coordinator.async_seek_position.assert_awaited_once()
+        assert coordinator.async_seek_position.await_args.kwargs["position_key"] == "back"
+        assert coordinator.async_seek_position.await_args.kwargs["target_angle"] == 75
+
+    async def test_set_position_service_rejects_targets_above_configured_back_max_angle(
+        self,
+        hass: HomeAssistant,
+    ):
+        """Standard set_position validation should reject targets above configured calibration."""
+        import pytest
+        from homeassistant.exceptions import ServiceValidationError
+        from homeassistant.helpers import device_registry as dr
+
+        from custom_components.adjustable_bed import _async_register_services
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Tight Calibration Service Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:33",
+                CONF_NAME: "Tight Calibration Service Bed",
+                CONF_BED_TYPE: BED_TYPE_LINAK,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: False,
+                CONF_PREFERRED_ADAPTER: "auto",
+                CONF_BACK_MAX_ANGLE: 50.0,
+            },
+            unique_id="AA:BB:CC:DD:EE:33",
+            entry_id="tight_calibration_service_entry",
+        )
+        entry.add_to_hass(hass)
+
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, entry.unique_id)},
+            name=entry.title,
+        )
+
+        coordinator = MagicMock()
+        coordinator.controller = MagicMock()
+        coordinator.name = entry.title
+        coordinator.disable_angle_sensing = False
+        coordinator.get_max_angle.side_effect = lambda motor: {
+            "back": 50.0,
+            "head": 50.0,
+            "legs": 45.0,
+            "feet": 45.0,
+        }[motor]
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+
+        await _async_register_services(hass)
+
+        with pytest.raises(ServiceValidationError, match=r"Valid range: 0-50.0°"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_SET_POSITION,
+                {
+                    "device_id": [device.id],
+                    "motor": "back",
+                    "position": 60,
+                },
+                blocking=True,
+            )
 
     async def test_set_position_service_rejects_kaidi_head_and_feet(
         self,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -26,6 +26,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_KAIDI,
     BED_TYPE_LINAK,
     BED_TYPE_MALOUF_LEGACY_OKIN,
+    BED_TYPE_REVERIE,
     BED_TYPE_RICHMAT,
     BED_TYPE_SLEEPYS_BOX25,
     BED_TYPE_VIBRADORM,
@@ -601,13 +602,18 @@ class TestServices:
         assert len(devices) == 1
         device_id = devices[0].id
 
-        with pytest.raises(ServiceValidationError, match="only supports one configured device"):
+        with pytest.raises(
+            ServiceValidationError, match="only supports one configured device"
+        ) as err:
             await hass.services.async_call(
                 DOMAIN,
                 SERVICE_GENERATE_SUPPORT_BUNDLE,
                 {"device_id": [device_id, "other-device-id"]},
                 blocking=True,
             )
+
+        assert err.value.translation_domain == DOMAIN
+        assert err.value.translation_key == "multiple_device_targets_not_supported"
 
     async def test_goto_preset_service(
         self,
@@ -1073,6 +1079,36 @@ class TestServices:
         coordinator.async_seek_position.assert_awaited_once()
         assert coordinator.async_seek_position.await_args.kwargs["position_key"] == "back"
         assert coordinator.async_seek_position.await_args.kwargs["target_angle"] == 75
+
+    async def test_reverie_get_max_angle_uses_protocol_specific_back_limit(
+        self,
+        hass: HomeAssistant,
+    ):
+        """Reverie back/head validation should match the 60-degree protocol limit."""
+        from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Reverie Service Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:34",
+                CONF_NAME: "Reverie Service Bed",
+                CONF_BED_TYPE: BED_TYPE_REVERIE,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: False,
+                CONF_PREFERRED_ADAPTER: "auto",
+                CONF_BACK_MAX_ANGLE: 80.0,
+            },
+            unique_id="AA:BB:CC:DD:EE:34",
+            entry_id="reverie_service_entry",
+        )
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+
+        assert coordinator.get_max_angle("back") == 60.0
+        assert coordinator.get_max_angle("head") == 60.0
+        assert coordinator.get_max_angle("legs") == 45.0
 
     async def test_set_position_service_rejects_targets_above_configured_back_max_angle(
         self,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -589,6 +589,7 @@ class TestServices:
         enable_custom_integrations,
     ):
         """Support bundle generation should fail fast instead of silently ignoring extra devices."""
+        del mock_coordinator_connected, enable_custom_integrations
         import pytest
         from homeassistant.exceptions import ServiceValidationError
 


### PR DESCRIPTION
## Summary
- propagate cover and button command failures instead of swallowing them
- honor configured max angles in `set_position` and reject multi-device support-bundle requests
- keep light/switch state handling correct across idle disconnects and failed manual turn-off
- add regression coverage for the service and entity failure paths

## Validation
- `./.venv/bin/python -m pytest -n0 -q tests/test_entities.py::TestCoverEntities::test_cover_open_propagates_command_errors tests/test_entities.py::TestCoverEntities::test_cover_stop_propagates_command_errors tests/test_entities.py::TestButtonEntities::test_preset_button_press_propagates_command_errors tests/test_entities.py::TestButtonEntities::test_connect_button_press_raises_when_reconnect_fails tests/test_entities.py::TestSwitchEntities::test_failed_switch_turn_off_keeps_auto_off_timer tests/test_entities.py::TestLightEntities::test_leggett_gen2_light_turn_off_reconnects_after_idle_disconnect tests/test_init.py::TestServices::test_set_position_service_uses_configured_back_max_angle tests/test_init.py::TestServices::test_set_position_service_rejects_targets_above_configured_back_max_angle tests/test_init.py::TestServices::test_generate_support_bundle_service_rejects_multiple_device_targets`
- `./.venv/bin/python -m compileall custom_components/adjustable_bed/__init__.py custom_components/adjustable_bed/button.py custom_components/adjustable_bed/cover.py custom_components/adjustable_bed/light.py custom_components/adjustable_bed/switch.py tests/test_entities.py tests/test_init.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Motor position limits now use per-motor, per-device calibrated maxima (Reverie-specific back/head limit included).
  * Service calls and control actions surface transport/controller failures instead of swallowing them.
  * Connection failures are detected and reported; auto-off timer handling updated to preserve state on failed turns.

* **Documentation**
  * Added user-facing translation for multi-device support-bundle validation.

* **Tests**
  * Expanded tests for error propagation, validation, and regression scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->