### PR TITLE
Handle generic OKIN Nectar bases

### DIFF
--- a/custom_components/adjustable_bed/beds/okin_7byte.py
+++ b/custom_components/adjustable_bed/beds/okin_7byte.py
@@ -342,8 +342,11 @@ class Okin7ByteController(BedController):
 
     # Massage controls
     async def massage_toggle(self) -> None:
-        """Start massage using the closest command exposed by this protocol."""
-        await self.massage_on()
+        """Toggle or start massage based on protocol variant."""
+        if self._config.extra_massage_modes:
+            await self.write_command(_cmd(0x5A))
+        else:
+            await self.massage_on()
 
     async def massage_on(self) -> None:
         """Turn massage on."""

--- a/custom_components/adjustable_bed/beds/okin_7byte.py
+++ b/custom_components/adjustable_bed/beds/okin_7byte.py
@@ -60,20 +60,23 @@ class Okin7ByteConfig:
     massage_up_byte: int = 0
     massage_down_byte: int = 0
     extra_massage_modes: tuple[int, ...] = ()
-    massage_stop_byte: int = 0
+    massage_off_byte: int = 0x5A
     lights_off_repeat: int = 1
     supports_tv: bool = False
+    write_with_response: bool = True
+    init_write_with_response: bool = True
 
 
 # Standard Okin 7-byte variant (Nectar beds)
 OKIN_7BYTE_CONFIG = Okin7ByteConfig(
     char_uuid=NECTAR_WRITE_CHAR_UUID,
-    lumbar_up_byte=0x06,
-    lounge_byte=0x12,
+    lumbar_up_byte=0x04,
+    lounge_byte=0x11,
     tv_byte=0x11,
     memory_1_byte=0x1A,
     memory_2_byte=0x1B,
     supports_tv=True,
+    write_with_response=False,
 )
 
 # Nordic UART variant (Mattress Firm 900 / iFlex)
@@ -92,7 +95,7 @@ OKIN_NORDIC_CONFIG = Okin7ByteConfig(
     massage_up_byte=0x60,  # Note: byte 4 is 0x40 for these, see _cmd_massage_intensity
     massage_down_byte=0x63,
     extra_massage_modes=(0x52, 0x53, 0x54),  # MASSAGE_1, MASSAGE_2, MASSAGE_3
-    massage_stop_byte=0x6F,
+    massage_off_byte=0x6F,
     lights_off_repeat=3,
     supports_tv=True,
 )
@@ -198,7 +201,9 @@ class Okin7ByteController(BedController):
                 for init_cmd in self._config.init_commands:
                     async with self._ble_lock:
                         await self.client.write_gatt_char(
-                            self._config.char_uuid, init_cmd, response=True
+                            self._config.char_uuid,
+                            init_cmd,
+                            response=self._config.init_write_with_response,
                         )
                     await asyncio.sleep(0.1)
                 self._initialized = True
@@ -212,6 +217,7 @@ class Okin7ByteController(BedController):
             repeat_count=repeat_count,
             repeat_delay_ms=repeat_delay_ms,
             cancel_event=cancel_event,
+            response=self._config.write_with_response,
         )
 
     async def _send_stop(self) -> None:
@@ -336,8 +342,8 @@ class Okin7ByteController(BedController):
 
     # Massage controls
     async def massage_toggle(self) -> None:
-        """Toggle massage on/off."""
-        await self.write_command(_cmd(0x5A))
+        """Start massage using the closest command exposed by this protocol."""
+        await self.massage_on()
 
     async def massage_on(self) -> None:
         """Turn massage on."""
@@ -349,7 +355,7 @@ class Okin7ByteController(BedController):
 
     async def massage_off(self) -> None:
         """Turn massage off."""
-        await self.write_command(_cmd(0x6F))
+        await self.write_command(_cmd(self._config.massage_off_byte))
 
     async def massage_mode_step(self) -> None:
         """Step through massage modes (wave pattern)."""

--- a/custom_components/adjustable_bed/beds/okin_cb35.py
+++ b/custom_components/adjustable_bed/beds/okin_cb35.py
@@ -67,9 +67,11 @@ OKIN_CB35_CONFIG = Okin7ByteConfig(
     massage_up_byte=0x60,
     massage_down_byte=0x61,
     extra_massage_modes=(0x52, 0x53, 0x54),
-    massage_stop_byte=0x6F,
+    massage_off_byte=0x6F,
     lights_off_repeat=3,
     supports_tv=True,
+    write_with_response=False,
+    init_write_with_response=False,
 )
 
 

--- a/custom_components/adjustable_bed/beds/okin_cb35.py
+++ b/custom_components/adjustable_bed/beds/okin_cb35.py
@@ -131,7 +131,7 @@ class OkinCB35Controller(Okin7ByteController):
             command,
             repeat_count=repeat_count,
             repeat_delay_ms=repeat_delay_ms,
-            cancel_event=cancel_event,
+            cancel_event=effective_cancel,
             response=self._config.write_with_response,
         )
 

--- a/custom_components/adjustable_bed/beds/okin_cb35.py
+++ b/custom_components/adjustable_bed/beds/okin_cb35.py
@@ -116,7 +116,9 @@ class OkinCB35Controller(Okin7ByteController):
                 for init_cmd in self._config.init_commands:
                     async with self._ble_lock:
                         await self.client.write_gatt_char(
-                            self._config.char_uuid, init_cmd, response=False
+                            self._config.char_uuid,
+                            init_cmd,
+                            response=self._config.init_write_with_response,
                         )
                     await asyncio.sleep(0.1)
                 self._initialized = True
@@ -130,7 +132,7 @@ class OkinCB35Controller(Okin7ByteController):
             repeat_count=repeat_count,
             repeat_delay_ms=repeat_delay_ms,
             cancel_event=cancel_event,
-            response=False,
+            response=self._config.write_with_response,
         )
 
     # ─── Extra capability properties ──────────────────────────────────

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -166,6 +166,10 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
 
     def _prepare_disambiguation(self, detection_result: DetectionResult) -> bool:
         """Prepare the focused bed-type chooser for an ambiguous detection."""
+        self._disambiguation_types = None
+        self._disambiguated_bed_type = None
+        self._show_full_bed_type_list = False
+
         bed_type = detection_result.bed_type
         if (
             bed_type is None
@@ -176,7 +180,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
 
         seen: set[str] = set()
         disambiguation_types: list[str] = []
-        for candidate in [bed_type] + list(detection_result.ambiguous_types):
+        for candidate in (bed_type, *detection_result.ambiguous_types):
             if candidate not in seen:
                 seen.add(candidate)
                 disambiguation_types.append(candidate)

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -88,11 +88,12 @@ from .const import (
     RICHMAT_REMOTES,
     SUPPORTED_BED_TYPES,
     VARIANT_AUTO,
+    DetectionResult,
     get_richmat_features,
-    passive_position_reconciliation_default_enabled,
-    supports_passive_position_reconciliation,
     get_richmat_motor_count,
+    passive_position_reconciliation_default_enabled,
     requires_pairing,
+    supports_passive_position_reconciliation,
 )
 from .detection import (
     BED_TYPE_DISPLAY_NAMES,
@@ -162,6 +163,25 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         self._show_full_bed_type_list: bool = False
         self._retrying_devices: dict[str, tuple[ConfigEntry, BluetoothServiceInfoBleak | None]] = {}
         _LOGGER.debug("AdjustableBedConfigFlow initialized")
+
+    def _prepare_disambiguation(self, detection_result: DetectionResult) -> bool:
+        """Prepare the focused bed-type chooser for an ambiguous detection."""
+        bed_type = detection_result.bed_type
+        if (
+            bed_type is None
+            or detection_result.confidence >= 0.7
+            or not detection_result.ambiguous_types
+        ):
+            return False
+
+        seen: set[str] = set()
+        disambiguation_types: list[str] = []
+        for candidate in [bed_type] + list(detection_result.ambiguous_types):
+            if candidate not in seen:
+                seen.add(candidate)
+                disambiguation_types.append(candidate)
+        self._disambiguation_types = disambiguation_types
+        return True
 
     async def _get_config_translation(self, key: str, default: str) -> str:
         """Return a config-flow translation with a safe English fallback."""
@@ -386,15 +406,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         self.context["title_placeholders"] = {"name": discovery_info.name or discovery_info.address}
 
         # Check if disambiguation is needed (low confidence with alternatives)
-        if detection_result.confidence < 0.7 and detection_result.ambiguous_types:
-            # Build list of all candidate types (detected + alternatives), deduplicated
-            seen: set[str] = set()
-            disambiguation_types: list[str] = []
-            for t in [bed_type] + list(detection_result.ambiguous_types):
-                if t not in seen:
-                    seen.add(t)
-                    disambiguation_types.append(t)
-            self._disambiguation_types = disambiguation_types
+        if self._prepare_disambiguation(detection_result):
             _LOGGER.debug(
                 "Ambiguous detection for %s - showing disambiguation UI with options: %s",
                 discovery_info.address,
@@ -474,6 +486,19 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         # Use disambiguated type if user selected one, otherwise use detected type
         bed_type = self._disambiguated_bed_type or detected_bed_type
         errors: dict[str, str] = {}
+
+        if (
+            user_input is None
+            and self._disambiguated_bed_type is None
+            and not self._show_full_bed_type_list
+            and self._prepare_disambiguation(detection_result)
+        ):
+            _LOGGER.debug(
+                "Ambiguous detection for %s - showing disambiguation UI with options: %s",
+                self._discovery_info.address,
+                self._disambiguation_types,
+            )
+            return await self.async_step_bluetooth_disambiguate()
 
         if user_input is not None:
             # Get user-selected bed type (may differ from auto-detected)

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -598,9 +598,12 @@ MALOUF_LEGACY_OKIN_NOTIFY_CHAR_UUID: Final = "0000ffe4-0000-1000-8000-00805f9b34
 # Detection priority: name patterns first, then UUID fallback to Okimat
 LEGGETT_OKIN_NAME_PATTERNS: Final = ("leggett", "l&p")
 LEGGETT_RICHMAT_NAME_PATTERNS: Final = ("mlrm",)  # MlRM prefix beds
-# Okimat devices: "Okimat", "OKIN RF", "OKIN BLE", "OKIN-XXXXXX" (e.g., OKIN-346311), "OKIN luis",
-# or "Smartbed" (Malouf/Lucid/CVB beds using OKIN protocol)
-OKIMAT_NAME_PATTERNS: Final = ("okimat", "okin rf", "okin ble", "okin-", "okin luis", "smartbed")
+# Okimat devices: "Okimat", "OKIN RF", "OKIN BLE", "OKIN luis",
+# or "Smartbed" (Malouf/Lucid/CVB beds using OKIN protocol).
+# Generic "OKIN-XXXXXX" names are ambiguous: confirmed Nectar 7-byte bases can
+# advertise this way too, so detection handles that prefix as low-confidence.
+OKIMAT_NAME_PATTERNS: Final = ("okimat", "okin rf", "okin ble", "okin luis", "smartbed")
+OKIN_GENERIC_NAME_PATTERNS: Final = ("okin-",)
 
 # OKIN 64-bit name patterns (from com.okin.bedding.adjustbed app disassembly)
 # Note: Most OKIN 64-bit devices don't have distinctive names - they require

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -115,6 +115,7 @@ from .const import (
     OKIMAT_NOTIFY_CHAR_UUID,
     OKIMAT_SERVICE_UUID,
     OKIN_FFE_NAME_PATTERNS,
+    OKIN_GENERIC_NAME_PATTERNS,
     OKIN_ORE_SERVICE_UUID,
     REMACRO_SERVICE_UUID,
     REVERIE_NIGHTSTAND_SERVICE_UUID,
@@ -964,11 +965,34 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
             )
             return DetectionResult(bed_type=BED_TYPE_OKIMAT, confidence=0.9, signals=signals)
 
+        # Generic OKIN-XXXXXX names are not enough to pick a protocol. They can
+        # be classic Okimat 6-byte devices or Nectar-style 7-byte bases.
+        if any(device_name.startswith(pattern) for pattern in OKIN_GENERIC_NAME_PATTERNS):
+            signals.append("name:okin_generic")
+            _LOGGER.warning(
+                "Generic OKIN device name '%s' at %s uses shared Okin UUID. "
+                "Prompting for protocol because this can be Okimat, Nectar, or another Okin variant.",
+                service_info.name,
+                service_info.address,
+            )
+            return DetectionResult(
+                bed_type=BED_TYPE_OKIMAT,
+                confidence=0.6,
+                signals=signals,
+                ambiguous_types=[
+                    BED_TYPE_NECTAR,
+                    BED_TYPE_LEGGETT_OKIN,
+                    BED_TYPE_OKIN_64BIT,
+                    BED_TYPE_OKIN_CST,
+                ],
+                requires_characteristic_check=True,
+            )
+
         # Fallback: default to Okimat with warning about ambiguity
         # This UUID is shared by Okimat, Leggett Okin, OKIN 64-bit, and OKIN CST
         _LOGGER.warning(
             "Okin UUID detected but device name '%s' at %s doesn't match known patterns. "
-            "Defaulting to Okimat. Change to Leggett & Platt, OKIN 64-bit, or OKIN CST in settings if needed.",
+            "Defaulting to Okimat. Change to Nectar, Leggett & Platt, OKIN 64-bit, or OKIN CST in settings if needed.",
             service_info.name,
             service_info.address,
         )
@@ -976,7 +1000,12 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
             bed_type=BED_TYPE_OKIMAT,
             confidence=0.5,
             signals=signals,
-            ambiguous_types=[BED_TYPE_LEGGETT_OKIN, BED_TYPE_OKIN_64BIT, BED_TYPE_OKIN_CST],
+            ambiguous_types=[
+                BED_TYPE_NECTAR,
+                BED_TYPE_LEGGETT_OKIN,
+                BED_TYPE_OKIN_64BIT,
+                BED_TYPE_OKIN_CST,
+            ],
             requires_characteristic_check=True,
         )
 

--- a/docs/SUPPORTED_ACTUATORS.md
+++ b/docs/SUPPORTED_ACTUATORS.md
@@ -55,7 +55,7 @@ Several bed brands use Okin-based BLE controllers. While they share common roots
 | [Okimat](beds/okimat.md) | 6-byte (32-bit cmd) | UUID `62741525-...` | ✅ Yes | Name patterns or fallback |
 | [Okin 64-bit](beds/sleepys.md#box24-protocol-7-byte-packets) | 10-byte (64-bit cmd) | Nordic UART or UUID | ❌ No | Manual selection |
 | [Leggett & Platt Okin](beds/leggett-platt.md) | 6-byte (32-bit cmd) | UUID `62741525-...` | ✅ Yes | Name patterns |
-| [Nectar](beds/nectar.md) | 7-byte (32-bit cmd) | UUID `62741525-...` | ❌ No | Name contains "nectar" |
+| [Nectar](beds/nectar.md) | 7-byte (32-bit cmd) | UUID `62741525-...` without response | ❌ No | Name contains "nectar" or generic `OKIN-*` disambiguation |
 | [DewertOkin](beds/dewertokin.md) | 6-byte (32-bit cmd) | Handle `0x0013` | ❌ No | Name patterns |
 | [Mattress Firm 900](beds/mattressfirm.md) | 7-byte (32-bit cmd) | Nordic UART | ❌ No | Name starts with "iflex" |
 | [Malouf](beds/malouf.md) | 8-byte (32-bit cmd) | Nordic UART or FFE5 | ❌ No | Service UUID detection |
@@ -75,7 +75,8 @@ Several bed brands use Okin-based BLE controllers. While they share common roots
 1. Name contains "nectar" → Nectar
 2. Name contains "leggett", "l&p", or "adjustable base" → Leggett & Platt Okin
 3. Name contains "okimat", "okin rf", or "okin ble" → Okimat
-4. Fallback → Okimat (with warning logged)
+4. Name starts with `OKIN-` → prompt for Okin-family protocol (confirmed Nectar bases can advertise this way)
+5. Fallback → Okimat (with warning logged)
 
 ---
 

--- a/docs/beds/nectar.md
+++ b/docs/beds/nectar.md
@@ -32,6 +32,7 @@
 **Service UUID:** `62741523-52f9-8864-b1ab-3b3a8d65950b` (OKIN Primary Service)
 **Write Characteristic:** `62741525-52f9-8864-b1ab-3b3a8d65950b`
 **Format:** 7-byte commands: `5A 01 03 10 30 [XX] A5`
+**Write Mode:** write without response
 
 **Note:** Nectar beds share the Okin service UUID with Okimat but use a **7-byte command format** (vs Okimat's 6-byte format). This means commands are not interchangeable - if your bed is detected as the wrong type, change it in integration settings.
 
@@ -73,7 +74,11 @@
 
 ## Detection
 
-Detected by device name containing: `nectar` (case-insensitive) AND Okin service UUID present
+Detected by device name containing: `nectar` (case-insensitive) AND Okin service UUID present.
+
+Some Nectar bases advertise only as `OKIN-XXXXXX`. Those names are ambiguous
+with classic Okimat controllers, so setup prompts for the Okin-family protocol.
+Choose `Nectar` for the 7-byte protocol.
 
 Or manually configured with bed type: `nectar`
 
@@ -88,6 +93,6 @@ Nectar is part of the [Okin Protocol Family](../SUPPORTED_ACTUATORS.md#okin-prot
 ## Notes
 
 - Nectar beds share the Okin service UUID with Okimat beds but use a different command protocol
-- Detection requires both the "nectar" device name AND the Okin service UUID to avoid false positives
+- Generic `OKIN-XXXXXX` names require user confirmation because several Okin protocols share the same advertised UUID
 - Massage control is global (no separate head/foot control)
 - Lights have separate on/off commands (no toggle)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1268,6 +1268,8 @@ class TestUserFlow:
         enable_custom_integrations,
     ):
         """Selecting an ambiguous discovered device should use the focused chooser."""
+        del enable_custom_integrations
+
         with patch(
             "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
             return_value=[mock_bluetooth_service_info_ambiguous_okin],

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1261,6 +1261,30 @@ class TestUserFlow:
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "manual"
 
+    async def test_user_flow_select_ambiguous_okin_device_shows_disambiguation(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info_ambiguous_okin: MagicMock,
+        enable_custom_integrations,
+    ):
+        """Selecting an ambiguous discovered device should use the focused chooser."""
+        with patch(
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
+            return_value=[mock_bluetooth_service_info_ambiguous_okin],
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_USER},
+            )
+
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADDRESS: mock_bluetooth_service_info_ambiguous_okin.address},
+            )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "bluetooth_disambiguate"
+
     async def test_user_flow_retrying_device_aborts_with_support_bundle_instructions(
         self,
         hass: HomeAssistant,

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -660,6 +660,19 @@ class TestOkinUUIDDisambiguation:
         )
         assert detect_bed_type(service_info) == BED_TYPE_OKIMAT
 
+    def test_okin_uuid_with_generic_okin_prefix_is_ambiguous(self):
+        """Generic OKIN-* names should not be hard-forced to Okimat."""
+        service_info = _make_service_info(
+            name="OKIN-441954",
+            service_uuids=[OKIMAT_SERVICE_UUID],
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type == BED_TYPE_OKIMAT
+        assert result.confidence == 0.6
+        assert result.requires_characteristic_check is True
+        assert "name:okin_generic" in result.signals
+        assert BED_TYPE_NECTAR in result.ambiguous_types
+
     def test_okin_uuid_defaults_to_okimat(self):
         """Test OKIN UUID defaults to Okimat with low confidence for unknown name."""
         service_info = _make_service_info(
@@ -670,6 +683,7 @@ class TestOkinUUIDDisambiguation:
         assert result.bed_type == BED_TYPE_OKIMAT
         assert result.confidence == 0.5
         assert result.requires_characteristic_check is True
+        assert BED_TYPE_NECTAR in result.ambiguous_types
 
 
 class TestFFE5UUIDDisambiguation:

--- a/tests/test_okin_7byte.py
+++ b/tests/test_okin_7byte.py
@@ -9,7 +9,6 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adjustable_bed.beds.okin_7byte import (
     OKIN_7BYTE_CONFIG,
-    Okin7ByteController,
     _cmd,
 )
 from custom_components.adjustable_bed.const import (
@@ -23,7 +22,6 @@ from custom_components.adjustable_bed.const import (
     NECTAR_WRITE_CHAR_UUID,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
-
 
 # -----------------------------------------------------------------------------
 # Test Fixtures
@@ -107,12 +105,16 @@ class TestOkin7ByteCommands:
         assert _cmd(0x74)[5] == 0x74  # LIGHT_OFF
 
     def test_config_lumbar_up_byte(self):
-        """7-byte config should use 0x06 for lumbar up."""
-        assert OKIN_7BYTE_CONFIG.lumbar_up_byte == 0x06
+        """7-byte config should use the verified Nectar lumbar-up byte."""
+        assert OKIN_7BYTE_CONFIG.lumbar_up_byte == 0x04
 
     def test_config_lounge_byte(self):
-        """7-byte config should use 0x12 for lounge."""
-        assert OKIN_7BYTE_CONFIG.lounge_byte == 0x12
+        """7-byte config should use the verified Nectar TV/lounge byte."""
+        assert OKIN_7BYTE_CONFIG.lounge_byte == 0x11
+
+    def test_config_uses_write_without_response(self):
+        """Nectar traffic uses ATT write command / no response."""
+        assert OKIN_7BYTE_CONFIG.write_with_response is False
 
 
 # -----------------------------------------------------------------------------
@@ -257,7 +259,23 @@ class TestOkin7ByteMovement:
 
         calls = mock_client.write_gatt_char.call_args_list
         first_call_data = calls[0][0][1]
-        assert first_call_data == _cmd(0x06)
+        assert first_call_data == _cmd(0x04)
+
+    async def test_move_head_up_writes_without_response(
+        self,
+        hass: HomeAssistant,
+        mock_okin_7byte_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Nectar commands should use write-without-response."""
+        coordinator = AdjustableBedCoordinator(hass, mock_okin_7byte_config_entry)
+        await coordinator.async_connect()
+        mock_client = coordinator._client
+
+        await coordinator.controller.move_head_up()
+
+        first_call = mock_client.write_gatt_char.call_args_list[0]
+        assert first_call.kwargs["response"] is False
 
     async def test_stop_all_sends_stop_command(
         self,
@@ -331,6 +349,44 @@ class TestOkin7BytePresets:
         calls = mock_client.write_gatt_char.call_args_list
         first_call_data = calls[0][0][1]
         assert first_call_data == _cmd(0x13)
+
+
+class TestOkin7ByteMassage:
+    """Test Okin 7-byte massage commands."""
+
+    async def test_massage_toggle_starts_massage(
+        self,
+        hass: HomeAssistant,
+        mock_okin_7byte_config_entry,
+        mock_coordinator_connected,
+    ):
+        """The exposed massage toggle button should send the verified on command."""
+        coordinator = AdjustableBedCoordinator(hass, mock_okin_7byte_config_entry)
+        await coordinator.async_connect()
+        mock_client = coordinator._client
+
+        await coordinator.controller.massage_toggle()
+
+        calls = mock_client.write_gatt_char.call_args_list
+        call_data = calls[0][0][1]
+        assert call_data == _cmd(0x58)
+
+    async def test_massage_off_sends_verified_off_command(
+        self,
+        hass: HomeAssistant,
+        mock_okin_7byte_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Nectar massage off is 0x5A; 0x6F was captured as no-op."""
+        coordinator = AdjustableBedCoordinator(hass, mock_okin_7byte_config_entry)
+        await coordinator.async_connect()
+        mock_client = coordinator._client
+
+        await coordinator.controller.massage_off()
+
+        calls = mock_client.write_gatt_char.call_args_list
+        call_data = calls[0][0][1]
+        assert call_data == _cmd(0x5A)
 
 
 class TestOkin7ByteLights:

--- a/tests/test_okin_7byte.py
+++ b/tests/test_okin_7byte.py
@@ -268,6 +268,8 @@ class TestOkin7ByteMovement:
         mock_coordinator_connected,
     ):
         """Nectar commands should use write-without-response."""
+        del mock_coordinator_connected
+
         coordinator = AdjustableBedCoordinator(hass, mock_okin_7byte_config_entry)
         await coordinator.async_connect()
         mock_client = coordinator._client
@@ -361,6 +363,8 @@ class TestOkin7ByteMassage:
         mock_coordinator_connected,
     ):
         """The exposed massage toggle button should send the verified on command."""
+        del mock_coordinator_connected
+
         coordinator = AdjustableBedCoordinator(hass, mock_okin_7byte_config_entry)
         await coordinator.async_connect()
         mock_client = coordinator._client
@@ -378,6 +382,8 @@ class TestOkin7ByteMassage:
         mock_coordinator_connected,
     ):
         """Nectar massage off is 0x5A; 0x6F was captured as no-op."""
+        del mock_coordinator_connected
+
         coordinator = AdjustableBedCoordinator(hass, mock_okin_7byte_config_entry)
         await coordinator.async_connect()
         mock_client = coordinator._client

--- a/tests/test_okin_cb35.py
+++ b/tests/test_okin_cb35.py
@@ -1,0 +1,101 @@
+"""Tests for Okin CB35 Star bed controller."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.const import CONF_ADDRESS, CONF_NAME
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adjustable_bed.beds.okin_7byte import _cmd
+from custom_components.adjustable_bed.beds.okin_cb35 import (
+    OKIN_CB35_CONFIG,
+    OkinCB35Controller,
+)
+from custom_components.adjustable_bed.const import (
+    BED_TYPE_OKIN_CB35,
+    CONF_BED_TYPE,
+    CONF_DISABLE_ANGLE_SENSING,
+    CONF_HAS_MASSAGE,
+    CONF_MOTOR_COUNT,
+    CONF_PREFERRED_ADAPTER,
+    DOMAIN,
+)
+from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
+
+
+@pytest.fixture
+def mock_okin_cb35_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Return a mock config entry for an Okin CB35 bed."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Okin CB35 Test Bed",
+        data={
+            CONF_ADDRESS: "AA:BB:CC:DD:EE:FF",
+            CONF_NAME: "Okin CB35 Test Bed",
+            CONF_BED_TYPE: BED_TYPE_OKIN_CB35,
+            CONF_MOTOR_COUNT: 4,
+            CONF_HAS_MASSAGE: True,
+            CONF_DISABLE_ANGLE_SENSING: True,
+            CONF_PREFERRED_ADAPTER: "auto",
+        },
+        unique_id="AA:BB:CC:DD:EE:FF",
+        entry_id="okin_cb35_test_entry",
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.fixture
+def mock_cb35_client() -> AsyncMock:
+    """Return a connected BLE client mock for CB35 tests."""
+    client = AsyncMock()
+    client.is_connected = True
+    client.services = []
+    return client
+
+
+@pytest.mark.asyncio
+class TestOkinCB35Controller:
+    """Test Okin CB35 controller behavior."""
+
+    async def test_write_command_passes_effective_cancel_event(
+        self,
+        hass: HomeAssistant,
+        mock_okin_cb35_config_entry: MockConfigEntry,
+        mock_cb35_client: AsyncMock,
+    ) -> None:
+        """write_command should propagate the coordinator cancel event explicitly."""
+        coordinator = AdjustableBedCoordinator(hass, mock_okin_cb35_config_entry)
+        coordinator._client = mock_cb35_client
+        controller = OkinCB35Controller(coordinator)
+        controller._initialized = True
+
+        with patch.object(
+            controller, "_write_gatt_with_retry", new=AsyncMock()
+        ) as write_mock:
+            await controller.write_command(_cmd(0x00))
+
+        write_mock.assert_awaited_once()
+        assert write_mock.await_args.kwargs["cancel_event"] is coordinator.cancel_command
+        assert write_mock.await_args.kwargs["response"] is OKIN_CB35_CONFIG.write_with_response
+
+    async def test_cancelled_movement_sends_stop_with_fresh_event(
+        self,
+        hass: HomeAssistant,
+        mock_okin_cb35_config_entry: MockConfigEntry,
+        mock_cb35_client: AsyncMock,
+    ) -> None:
+        """A pre-cancelled CB35 movement should skip motion and still send STOP."""
+        coordinator = AdjustableBedCoordinator(hass, mock_okin_cb35_config_entry)
+        coordinator._client = mock_cb35_client
+        controller = OkinCB35Controller(coordinator)
+        coordinator.cancel_command.set()
+
+        await controller.move_head_up()
+
+        payloads = [call.args[1] for call in mock_cb35_client.write_gatt_char.call_args_list]
+        assert _cmd(0x00) not in payloads
+        assert payloads[-1] == _cmd(0x0F)

--- a/tests/test_okin_nordic.py
+++ b/tests/test_okin_nordic.py
@@ -202,6 +202,13 @@ class TestOkinNordicController:
 
         mock_client.reset_mock()
 
+        # Test massage toggle (variants with modes use the shared 0x5A toggle).
+        await controller.massage_toggle()
+        assert mock_client.write_gatt_char.called
+        assert mock_client.write_gatt_char.call_args_list[0][0][1] == _cmd(0x5A)
+
+        mock_client.reset_mock()
+
         # Test massage intensity up (Nordic: byte 4 = 0x40, byte 5 = 0x60)
         await controller.massage_intensity_up()
         assert mock_client.write_gatt_char.called


### PR DESCRIPTION
## Summary
- Treat generic `OKIN-*` devices on the shared Okin UUID as ambiguous so setup prompts for Nectar/Okimat-family protocol selection.
- Reuse that focused disambiguation path for user-selected discovered devices.
- Align the standard Okin 7-byte/Nectar command config with verified traffic: write-without-response, lumbar up, TV/lounge, and massage off.
- Update Nectar/Okin docs and regression coverage.

Ref #346

## Testing
- `uv run ruff check custom_components/adjustable_bed/const.py custom_components/adjustable_bed/detection.py custom_components/adjustable_bed/config_flow.py custom_components/adjustable_bed/beds/okin_7byte.py custom_components/adjustable_bed/beds/okin_cb35.py tests/test_okin_7byte.py tests/test_detection.py tests/test_config_flow.py`
- `python -m pytest tests/test_okin_7byte.py tests/test_detection.py::TestOkinUUIDDisambiguation tests/test_config_flow.py::TestBluetoothDiscoveryFlow::test_bluetooth_discovery_ambiguous_shows_disambiguation tests/test_config_flow.py::TestBluetoothDiscoveryFlow::test_bluetooth_disambiguate_selects_type tests/test_config_flow.py::TestBluetoothDiscoveryFlow::test_bluetooth_disambiguate_show_all_option tests/test_config_flow.py::TestBluetoothDiscoveryFlow::test_bluetooth_disambiguate_creates_entry_with_selected_type tests/test_config_flow.py::TestDetectBedType::test_detect_okimat_okin_prefix_name tests/test_config_flow.py::TestUserFlow::test_user_flow_select_ambiguous_okin_device_shows_disambiguation tests/test_okin_nordic.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable Okin/Nectar handling: refined device detection and disambiguation for ambiguous OKIN names, prompting user confirmation when needed.
  * BLE write behavior made configurable per device variant, improving movement and massage commands and ensuring correct on/off behavior across bed models.

* **Documentation**
  * Clarified Nectar/Okin detection guidance and characteristic write-mode guidance in setup docs.

* **Tests**
  * Added and extended tests covering detection disambiguation, write-mode behavior, movement, and massage commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kristofferR/ha-adjustable-bed/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->