### PR TITLE
Capture misidentified discoveries + add discovery on/off toggle

### DIFF
--- a/.github/ISSUE_TEMPLATE/misidentified-bed.yml
+++ b/.github/ISSUE_TEMPLATE/misidentified-bed.yml
@@ -1,0 +1,38 @@
+name: Misidentified Device
+description: Report a Bluetooth device that was wrongly auto-detected as a bed (or detected as the wrong bed type)
+title: "[Misidentified] "
+labels: ["bug", "detection"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form when the integration **auto-discovered a device as an adjustable bed but got it wrong** - either it isn't a bed at all, or it's the wrong bed type.
+
+        If you reached this page from the "Report a misidentified device" link in Home Assistant, the **Detection details** field below is already filled in for you. Please leave it as-is - it contains the BLE signals we need to stop this happening for everyone.
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Detection details
+      description: Auto-filled from the discovery. Please leave this as-is.
+      placeholder: |
+        If this is empty, you can fill it from Settings -> Devices & Services -> Adjustable Bed -> Download diagnostics (see the "auto_discovery_log" section).
+    validations:
+      required: true
+
+  - type: input
+    id: actual_device
+    attributes:
+      label: What is this device actually?
+      description: Tell us what it really is so we can fix detection.
+      placeholder: "e.g., Wyze smart scale (not a bed), or: it IS a bed but a Foo not a Bar"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional_info
+    attributes:
+      label: Additional information
+      description: Anything else that helps (other apps that control it, where you bought it, etc.)
+    validations:
+      required: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,7 @@ custom_components/adjustable_bed/
 | `motor_pulse_delay_ms` | Delay between repeats | 100 |
 | `disconnect_after_command` | Disconnect immediately after commands | false |
 | `idle_disconnect_seconds` | Idle timeout before disconnect | 40 |
+| `disable_discovery` | Suppress automatic discovery (global, stored via `discovery_settings`) | false |
 | `position_mode` | Speed vs accuracy tradeoff | speed |
 | `octo_pin` | PIN for Octo beds | "" |
 | `jensen_pin` | PIN for Jensen beds | "" |

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -50,6 +50,7 @@ from .const import (
     CONF_BLE_BOND_ESTABLISHED,
     CONF_CONNECTION_PROFILE,
     CONF_DISABLE_ANGLE_SENSING,
+    CONF_DISABLE_DISCOVERY,
     CONF_DISCONNECT_AFTER_COMMAND,
     CONF_HAS_MASSAGE,
     CONF_IDLE_DISCONNECT_SECONDS,
@@ -104,8 +105,14 @@ from .detection import (
     get_bed_type_options,
     is_mac_like_name,
 )
+from .discovery_log import async_get_discovery_log
+from .discovery_settings import (
+    async_is_discovery_disabled,
+    async_set_discovery_disabled,
+)
 from .kaidi_metadata import add_kaidi_entry_metadata, resolve_kaidi_advertisement
 from .unsupported import (
+    build_misidentified_issue_url,
     capture_device_info,
     create_unsupported_device_issue,
     log_unsupported_device,
@@ -357,6 +364,16 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         self, discovery_info: BluetoothServiceInfoBleak
     ) -> ConfigFlowResult:
         """Handle the bluetooth discovery step."""
+        # Respect the user's global opt-out: suppress automatic discovery cards
+        # entirely (no flow, no Repairs issue, no discovery-log entry). Manual
+        # "Add Integration" is unaffected and still lists nearby devices.
+        if await async_is_discovery_disabled(self.hass):
+            _LOGGER.debug(
+                "Ignoring discovered device %s - automatic discovery is disabled",
+                discovery_info.address,
+            )
+            return self.async_abort(reason="discovery_disabled")
+
         _LOGGER.info(
             "Bluetooth discovery triggered for device: %s (name: %s, RSSI: %s)",
             discovery_info.address,
@@ -404,6 +421,21 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             discovery_info.address,
             discovery_info.name,
             detection_result.confidence,
+        )
+
+        # Persist a compact record of this auto-detection so misidentified devices
+        # can be diagnosed and reported later. Without this the signals behind a
+        # false positive are lost once the discovery card is dismissed (HA only
+        # persists the bare MAC for devices the user explicitly ignores).
+        device_info = capture_device_info(discovery_info)
+        await async_get_discovery_log(self.hass).async_record(
+            address=device_info.address,
+            name=device_info.name,
+            service_uuids=device_info.service_uuids,
+            manufacturer_data=device_info.manufacturer_data,
+            bed_type=bed_type,
+            confidence=detection_result.confidence,
+            signals=detection_result.signals,
         )
 
         self._discovery_info = discovery_info
@@ -774,6 +806,20 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders["detection_note"] = (
                 f"{description_placeholders['detection_note']}\n{octo_split_note}"
             )
+
+        # Offer a one-click "this isn't my bed" report so false-positive
+        # detections can be fixed. Built from the live (un-redacted) discovery
+        # data because the user explicitly chooses whether to open the link.
+        report_device_info = capture_device_info(self._discovery_info)
+        report_url = build_misidentified_issue_url(
+            report_device_info,
+            detected_bed_type,
+            detection_result.confidence,
+            detection_result.signals,
+        )
+        description_placeholders["report_note"] = (
+            f"Wrong device, or not a bed? [Report a misidentified device]({report_url})"
+        )
 
         return self.async_show_form(
             step_id="bluetooth_confirm",
@@ -1943,6 +1989,9 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
         if current_adapter not in adapters:
             current_adapter = ADAPTER_AUTO
 
+        # Global discovery toggle (shared across all beds, not stored per-entry)
+        discovery_disabled = await async_is_discovery_disabled(self.hass)
+
         # Build schema
         schema_dict = {
             vol.Optional(
@@ -1996,6 +2045,10 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
                     POSITION_MODE_ACCURACY: "Accuracy",
                 }
             ),
+            vol.Optional(
+                CONF_DISABLE_DISCOVERY,
+                default=discovery_disabled,
+            ): bool,
         }
 
         if supports_passive_position_reconciliation(bed_type):
@@ -2068,6 +2121,12 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
             ] = TextSelector(TextSelectorConfig())
 
         if user_input is not None:
+            # The discovery toggle is global, not per-entry: persist it to the
+            # shared store and drop it so it is never written into entry data.
+            if CONF_DISABLE_DISCOVERY in user_input:
+                await async_set_discovery_disabled(
+                    self.hass, bool(user_input.pop(CONF_DISABLE_DISCOVERY))
+                )
             if bed_type == BED_TYPE_OCTO and CONF_OCTO_PIN in user_input:
                 octo_pin = normalize_octo_pin(user_input.get(CONF_OCTO_PIN, DEFAULT_OCTO_PIN))
                 if not is_valid_octo_pin(octo_pin):

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -2121,12 +2121,13 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
             ] = TextSelector(TextSelectorConfig())
 
         if user_input is not None:
-            # The discovery toggle is global, not per-entry: persist it to the
-            # shared store and drop it so it is never written into entry data.
+            # The discovery toggle is global, not per-entry: pull it out of
+            # user_input now so it is never written into entry data, but only
+            # persist it on the success path below - otherwise a later
+            # validation failure would partially apply the rejected form.
+            discovery_disabled_input: bool | None = None
             if CONF_DISABLE_DISCOVERY in user_input:
-                await async_set_discovery_disabled(
-                    self.hass, bool(user_input.pop(CONF_DISABLE_DISCOVERY))
-                )
+                discovery_disabled_input = bool(user_input.pop(CONF_DISABLE_DISCOVERY))
             if bed_type == BED_TYPE_OCTO and CONF_OCTO_PIN in user_input:
                 octo_pin = normalize_octo_pin(user_input.get(CONF_OCTO_PIN, DEFAULT_OCTO_PIN))
                 if not is_valid_octo_pin(octo_pin):
@@ -2193,6 +2194,9 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
                         data_schema=vol.Schema(schema_dict),
                         errors={CONF_LEGS_MAX_ANGLE: "invalid_angle"},
                     )
+            # All validations passed - now it is safe to commit global state.
+            if discovery_disabled_input is not None:
+                await async_set_discovery_disabled(self.hass, discovery_disabled_input)
             # Update the config entry with new options
             new_data = {**self.config_entry.data, **user_input}
             self.hass.config_entries.async_update_entry(

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -60,6 +60,10 @@ CONF_DISCONNECT_AFTER_COMMAND: Final = "disconnect_after_command"
 CONF_IDLE_DISCONNECT_SECONDS: Final = "idle_disconnect_seconds"
 CONF_POSITION_MODE: Final = "position_mode"
 CONF_PASSIVE_POSITION_RECONCILIATION: Final = "passive_position_reconciliation"
+# Global (not per-entry) toggle to suppress automatic Bluetooth discovery cards.
+# Stored separately via discovery_settings, surfaced as a checkbox in the options
+# flow. Manual "Add Integration" is unaffected.
+CONF_DISABLE_DISCOVERY: Final = "disable_discovery"
 CONF_OCTO_PIN: Final = "octo_pin"
 CONF_RICHMAT_REMOTE: Final = "richmat_remote"
 CONF_JENSEN_PIN: Final = "jensen_pin"

--- a/custom_components/adjustable_bed/diagnostics.py
+++ b/custom_components/adjustable_bed/diagnostics.py
@@ -30,6 +30,8 @@ from .const import (
 )
 from .coordinator import AdjustableBedCoordinator
 from .diagnostics_utils import get_gatt_summary
+from .discovery_log import async_get_discovery_log
+from .discovery_settings import async_is_discovery_disabled
 from .kaidi_protocol import extract_kaidi_advertisement, kaidi_advertisement_to_dict
 from .redaction import redact_data
 
@@ -124,6 +126,25 @@ async def async_get_config_entry_diagnostics(
         if hasattr(service_info, "source"):
             advertisement_info["source"] = service_info.source
 
+    # Recent auto-detections across all devices (global, not entry-specific).
+    # Useful for diagnosing/reporting misidentified discoveries. "device_name"
+    # is used so the redactor keeps the name (the key debugging signal); the
+    # "address" key is still partially redacted to its OUI.
+    discovery_log = await async_get_discovery_log(hass).async_all()
+    auto_discovery_log = [
+        {
+            "detected_at": record["detected_at"],
+            "address": record["address"],
+            "device_name": record["name"],
+            "service_uuids": record["service_uuids"],
+            "manufacturer_data": record["manufacturer_data"],
+            "bed_type": record["bed_type"],
+            "confidence": record["confidence"],
+            "signals": record["signals"],
+        }
+        for record in discovery_log
+    ]
+
     # Build the diagnostic data
     data = {
         "system": {
@@ -165,6 +186,8 @@ async def async_get_config_entry_diagnostics(
         "controller": controller_info,
         "position_data": position_data,
         "supported_bed_types": list(SUPPORTED_BED_TYPES),
+        "auto_discovery_disabled": await async_is_discovery_disabled(hass),
+        "auto_discovery_log": auto_discovery_log,
     }
 
     # Redact sensitive data (partial MAC redaction - keeps OUI for debugging)

--- a/custom_components/adjustable_bed/discovery_log.py
+++ b/custom_components/adjustable_bed/discovery_log.py
@@ -15,6 +15,7 @@ See: https://github.com/kristofferR/ha-adjustable-bed/discussions/342
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any, TypedDict
 
@@ -57,6 +58,9 @@ class DiscoveryLog:
         """Initialise the backing store (loaded lazily on first use)."""
         self._store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, STORAGE_KEY)
         self._entries: list[DiscoveryLogEntry] | None = None
+        # Serialises concurrent async_record() calls so an interleaved
+        # load/mutate/save cannot drop an append.
+        self._write_lock = asyncio.Lock()
 
     async def _async_ensure_loaded(self) -> list[DiscoveryLogEntry]:
         """Load entries from disk on first access, then keep them in memory."""
@@ -82,28 +86,29 @@ class DiscoveryLog:
         Records are deduped by MAC so that a single device re-advertising cannot
         flood the log and the most recent detection always wins.
         """
-        entries = await self._async_ensure_loaded()
         normalized = address.upper()
-        entries = [entry for entry in entries if entry.get("address") != normalized]
-        entries.append(
-            DiscoveryLogEntry(
-                detected_at=dt_util.utcnow().isoformat(),
-                address=normalized,
-                name=name,
-                service_uuids=list(service_uuids),
-                manufacturer_data={
-                    f"0x{company_id:04X}": bytes(value).hex()
-                    for company_id, value in (manufacturer_data or {}).items()
-                },
-                bed_type=bed_type,
-                confidence=round(confidence, 3),
-                signals=list(signals),
+        async with self._write_lock:
+            entries = await self._async_ensure_loaded()
+            entries = [entry for entry in entries if entry.get("address") != normalized]
+            entries.append(
+                DiscoveryLogEntry(
+                    detected_at=dt_util.utcnow().isoformat(),
+                    address=normalized,
+                    name=name,
+                    service_uuids=list(service_uuids),
+                    manufacturer_data={
+                        f"0x{company_id:04X}": bytes(value).hex()
+                        for company_id, value in (manufacturer_data or {}).items()
+                    },
+                    bed_type=bed_type,
+                    confidence=round(confidence, 3),
+                    signals=list(signals),
+                )
             )
-        )
-        if len(entries) > MAX_ENTRIES:
-            entries = entries[-MAX_ENTRIES:]
-        self._entries = entries
-        await self._store.async_save({"entries": entries})
+            if len(entries) > MAX_ENTRIES:
+                entries = entries[-MAX_ENTRIES:]
+            self._entries = entries
+            await self._store.async_save({"entries": entries})
         _LOGGER.debug(
             "Recorded auto-detection of %s as %s (confidence %.2f); log holds %d device(s)",
             normalized,

--- a/custom_components/adjustable_bed/discovery_log.py
+++ b/custom_components/adjustable_bed/discovery_log.py
@@ -1,0 +1,135 @@
+"""Persistent log of auto-detected BLE devices for diagnosing misidentification.
+
+When the integration auto-detects a device as a supported bed during Bluetooth
+discovery, a compact record (device name, advertised service UUIDs, manufacturer
+data, the bed type guessed, confidence, and the detection signals) is appended
+here. This gives users and maintainers the data needed to report and fix
+false-positive detections.
+
+Without this, those signals are lost once a discovery card is dismissed: Home
+Assistant only persists the bare MAC for devices the user explicitly ignores,
+which is not enough to tell *why* a device was misidentified.
+
+See: https://github.com/kristofferR/ha-adjustable-bed/discussions/342
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, TypedDict
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STORAGE_VERSION = 1
+STORAGE_KEY = f"{DOMAIN}_discovery_log"
+# Most recent auto-detections to retain. Deduped by MAC, so this is a cap on
+# distinct devices, not raw advertisements.
+MAX_ENTRIES = 100
+# Key under hass.data for the per-instance singleton. Kept separate from
+# hass.data[DOMAIN] (which holds coordinators keyed by entry_id) to avoid
+# colliding with config-entry storage.
+_DATA_KEY = f"{DOMAIN}_discovery_log"
+
+
+class DiscoveryLogEntry(TypedDict):
+    """A single auto-detection record."""
+
+    detected_at: str
+    address: str
+    name: str | None
+    service_uuids: list[str]
+    manufacturer_data: dict[str, str]
+    bed_type: str | None
+    confidence: float
+    signals: list[str]
+
+
+class DiscoveryLog:
+    """Stores the most recent auto-detected devices (capped, deduped by MAC)."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialise the backing store (loaded lazily on first use)."""
+        self._store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._entries: list[DiscoveryLogEntry] | None = None
+
+    async def _async_ensure_loaded(self) -> list[DiscoveryLogEntry]:
+        """Load entries from disk on first access, then keep them in memory."""
+        if self._entries is None:
+            data = await self._store.async_load()
+            entries = data.get("entries", []) if isinstance(data, dict) else []
+            self._entries = list(entries)
+        return self._entries
+
+    async def async_record(
+        self,
+        *,
+        address: str,
+        name: str | None,
+        service_uuids: list[str],
+        manufacturer_data: dict[int, bytes] | None,
+        bed_type: str | None,
+        confidence: float,
+        signals: list[str],
+    ) -> None:
+        """Append a detection record, keeping only the latest MAX_ENTRIES.
+
+        Records are deduped by MAC so that a single device re-advertising cannot
+        flood the log and the most recent detection always wins.
+        """
+        entries = await self._async_ensure_loaded()
+        normalized = address.upper()
+        entries = [entry for entry in entries if entry.get("address") != normalized]
+        entries.append(
+            DiscoveryLogEntry(
+                detected_at=dt_util.utcnow().isoformat(),
+                address=normalized,
+                name=name,
+                service_uuids=list(service_uuids),
+                manufacturer_data={
+                    f"0x{company_id:04X}": bytes(value).hex()
+                    for company_id, value in (manufacturer_data or {}).items()
+                },
+                bed_type=bed_type,
+                confidence=round(confidence, 3),
+                signals=list(signals),
+            )
+        )
+        if len(entries) > MAX_ENTRIES:
+            entries = entries[-MAX_ENTRIES:]
+        self._entries = entries
+        await self._store.async_save({"entries": entries})
+        _LOGGER.debug(
+            "Recorded auto-detection of %s as %s (confidence %.2f); log holds %d device(s)",
+            normalized,
+            bed_type,
+            confidence,
+            len(entries),
+        )
+
+    async def async_get(self, address: str) -> DiscoveryLogEntry | None:
+        """Return the most recent record for an address, if any."""
+        normalized = address.upper()
+        for entry in await self._async_ensure_loaded():
+            if entry.get("address") == normalized:
+                return entry
+        return None
+
+    async def async_all(self) -> list[DiscoveryLogEntry]:
+        """Return all records, most recent first."""
+        return list(reversed(await self._async_ensure_loaded()))
+
+
+@callback
+def async_get_discovery_log(hass: HomeAssistant) -> DiscoveryLog:
+    """Return the singleton discovery log for this Home Assistant instance."""
+    log: DiscoveryLog | None = hass.data.get(_DATA_KEY)
+    if log is None:
+        log = DiscoveryLog(hass)
+        hass.data[_DATA_KEY] = log
+    return log

--- a/custom_components/adjustable_bed/discovery_settings.py
+++ b/custom_components/adjustable_bed/discovery_settings.py
@@ -1,0 +1,79 @@
+"""Global, user-toggleable discovery settings for the Adjustable Bed integration.
+
+Home Assistant has no built-in per-integration "stop discovering" switch, so this
+module stores one small global flag (``disable_discovery``) in its own Store. The
+flag is edited via the options flow of any configured bed and read by
+``config_flow.async_step_bluetooth`` to suppress automatic discovery cards.
+
+It is intentionally global (a single source of truth shared by all beds) rather
+than per-entry, so a user with several beds does not have to toggle it on each
+one. Manual "Add Integration" is unaffected - only push discovery is gated.
+
+See: https://github.com/kristofferR/ha-adjustable-bed/discussions/342
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STORAGE_VERSION = 1
+STORAGE_KEY = f"{DOMAIN}_discovery_settings"
+_DATA_KEY = f"{DOMAIN}_discovery_settings"
+
+KEY_DISABLE_DISCOVERY = "disable_discovery"
+
+
+class DiscoverySettings:
+    """Persisted, integration-wide discovery preferences."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialise the backing store (loaded lazily on first use)."""
+        self._store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._data: dict[str, Any] | None = None
+
+    async def _async_ensure_loaded(self) -> dict[str, Any]:
+        if self._data is None:
+            loaded = await self._store.async_load()
+            self._data = dict(loaded) if isinstance(loaded, dict) else {}
+        return self._data
+
+    async def async_is_discovery_disabled(self) -> bool:
+        """Return whether automatic discovery is currently suppressed."""
+        return bool((await self._async_ensure_loaded()).get(KEY_DISABLE_DISCOVERY, False))
+
+    async def async_set_discovery_disabled(self, disabled: bool) -> None:
+        """Persist the discovery-disabled flag."""
+        data = await self._async_ensure_loaded()
+        if bool(data.get(KEY_DISABLE_DISCOVERY, False)) == bool(disabled):
+            return
+        data[KEY_DISABLE_DISCOVERY] = bool(disabled)
+        self._data = data
+        await self._store.async_save(data)
+        _LOGGER.debug("Automatic Bluetooth discovery %s", "disabled" if disabled else "enabled")
+
+
+def _async_get_settings(hass: HomeAssistant) -> DiscoverySettings:
+    """Return the singleton settings object for this Home Assistant instance."""
+    settings: DiscoverySettings | None = hass.data.get(_DATA_KEY)
+    if settings is None:
+        settings = DiscoverySettings(hass)
+        hass.data[_DATA_KEY] = settings
+    return settings
+
+
+async def async_is_discovery_disabled(hass: HomeAssistant) -> bool:
+    """Return whether automatic Bluetooth discovery is suppressed."""
+    return await _async_get_settings(hass).async_is_discovery_disabled()
+
+
+async def async_set_discovery_disabled(hass: HomeAssistant, disabled: bool) -> None:
+    """Set whether automatic Bluetooth discovery is suppressed."""
+    await _async_get_settings(hass).async_set_discovery_disabled(disabled)

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -41,7 +41,7 @@
       },
       "bluetooth_confirm": {
         "title": "Confirm Adjustable Bed",
-        "description": "Do you want to set up {name}?\n{detection_note}",
+        "description": "Do you want to set up {name}?\n{detection_note}\n\n{report_note}",
         "data": {
           "bed_type": "Bed type",
           "name": "Name",
@@ -227,6 +227,7 @@
       "configured_retrying_suffix": "[already configured, setup retry]",
       "configured_retrying": "**{name}** is already configured at `{address}`, but Home Assistant is still retrying its previous setup.\n\nUse **Generate Support Bundle** for the existing device entry, or run `adjustable_bed.generate_support_bundle` with `target_address: {address}`. Then reload or reconfigure the existing entry instead of adding it again.",
       "not_supported": "Device is not supported. The required Bluetooth service was not found.",
+      "discovery_disabled": "Automatic discovery is turned off for the Adjustable Bed integration. Re-enable it in any bed's options if you want new devices to be discovered.",
       "diagnostic_browser_ready": "**{name}**\n\nAddress: `{address}`\nSource: `{source}`\nScanner connectable: `{connectable}`\n\nRun `adjustable_bed.generate_support_bundle` with `target_address: {address}` to capture the full support bundle."
     },
     "error": {
@@ -255,6 +256,7 @@
           "disable_angle_sensing": "Disable angle sensing",
           "passive_position_reconciliation": "Refresh positions while idle",
           "position_mode": "Position update mode",
+          "disable_discovery": "Stop discovering new Bluetooth devices",
           "preferred_adapter": "Bluetooth adapter",
           "connection_profile": "Connection profile",
           "protocol_variant": "Protocol variant",
@@ -273,6 +275,7 @@
           "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "passive_position_reconciliation": "Periodically reconnect and read positions while idle so Home Assistant catches up with moves made using the physical remote. This is enabled by default for Linak beds and may briefly use the BLE connection in the background.",
           "position_mode": "Speed: faster button response. Accuracy: extra position read after each command.",
+          "disable_discovery": "When enabled, Home Assistant stops automatically suggesting newly seen Bluetooth devices as adjustable beds. This applies to the whole integration, not just this bed. You can still add a new bed at any time with 'Add Integration'.",
           "preferred_adapter": "Select a specific Bluetooth adapter or proxy, or let Home Assistant choose automatically.",
           "connection_profile": "Balanced is faster to connect. Reliable uses longer timeouts and backoff for flaky beds.",
           "protocol_variant": "Change the protocol variant if the bed isn't responding correctly.",

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -41,7 +41,7 @@
       },
       "bluetooth_confirm": {
         "title": "Confirm Adjustable Bed",
-        "description": "Do you want to set up {name}?\n{detection_note}",
+        "description": "Do you want to set up {name}?\n{detection_note}\n\n{report_note}",
         "data": {
           "bed_type": "Bed type",
           "name": "Name",
@@ -227,6 +227,7 @@
       "configured_retrying_suffix": "[already configured, setup retry]",
       "configured_retrying": "**{name}** is already configured at `{address}`, but Home Assistant is still retrying its previous setup.\n\nUse **Generate Support Bundle** for the existing device entry, or run `adjustable_bed.generate_support_bundle` with `target_address: {address}`. Then reload or reconfigure the existing entry instead of adding it again.",
       "not_supported": "Device is not supported. The required Bluetooth service was not found.",
+      "discovery_disabled": "Automatic discovery is turned off for the Adjustable Bed integration. Re-enable it in any bed's options if you want new devices to be discovered.",
       "diagnostic_browser_ready": "**{name}**\n\nAddress: `{address}`\nSource: `{source}`\nScanner connectable: `{connectable}`\n\nRun `adjustable_bed.generate_support_bundle` with `target_address: {address}` to capture the full support bundle."
     },
     "error": {
@@ -255,6 +256,7 @@
           "disable_angle_sensing": "Disable angle sensing",
           "passive_position_reconciliation": "Refresh positions while idle",
           "position_mode": "Position update mode",
+          "disable_discovery": "Stop discovering new Bluetooth devices",
           "preferred_adapter": "Bluetooth adapter",
           "connection_profile": "Connection profile",
           "protocol_variant": "Protocol variant",
@@ -273,6 +275,7 @@
           "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "passive_position_reconciliation": "Periodically reconnect and read positions while idle so Home Assistant catches up with moves made using the physical remote. This is enabled by default for Linak beds and may briefly use the BLE connection in the background.",
           "position_mode": "Speed: faster button response. Accuracy: extra position read after each command.",
+          "disable_discovery": "When enabled, Home Assistant stops automatically suggesting newly seen Bluetooth devices as adjustable beds. This applies to the whole integration, not just this bed. You can still add a new bed at any time with 'Add Integration'.",
           "preferred_adapter": "Select a specific Bluetooth adapter or proxy, or let Home Assistant choose automatically.",
           "connection_profile": "Balanced is faster to connect. Reliable uses longer timeouts and backoff for flaky beds.",
           "protocol_variant": "Change the protocol variant if the bed isn't responding correctly.",

--- a/custom_components/adjustable_bed/unsupported.py
+++ b/custom_components/adjustable_bed/unsupported.py
@@ -103,6 +103,60 @@ Please provide the following information about your bed:
 
 """
 
+    def to_misidentified_details(
+        self,
+        detected_bed_type: str | None,
+        confidence: float,
+        signals: list[str],
+    ) -> str:
+        """Format GitHub issue details for a device wrongly auto-detected as a bed."""
+        if self.manufacturer_data:
+            mfr_str = "\n".join(
+                f"  - `{hex(k)}`: `{v.hex()}`" for k, v in self.manufacturer_data.items()
+            )
+        else:
+            mfr_str = "  None"
+
+        if self.service_uuids:
+            uuid_str = "\n".join(f"  - `{uuid}`" for uuid in self.service_uuids)
+        else:
+            uuid_str = "  None"
+
+        signal_str = "\n".join(f"  - `{signal}`" for signal in signals) if signals else "  None"
+        confidence_pct = int(confidence * 100)
+
+        return f"""## Misidentified device
+
+The integration auto-detected this device as **`{detected_bed_type or "a bed"}`** \
+(confidence {confidence_pct}%), but the detection is wrong: it may not be a bed at \
+all, or it is a different brand/model.
+
+| Property | Value |
+|----------|-------|
+| Detected as | `{detected_bed_type or "unknown"}` |
+| Confidence | {confidence_pct}% |
+| Address | `{self.address}` |
+| Name | `{self.name or "Unknown"}` |
+| RSSI | {self.rssi or "N/A"} |
+
+### Detection signals
+{signal_str}
+
+### Advertised service UUIDs
+{uuid_str}
+
+### Manufacturer data
+{mfr_str}
+
+## What is this device actually?
+
+<!-- Tell us what this device really is, e.g.:
+- "It's a Bluetooth scale / speaker / fitness tracker, not a bed"
+- "It IS a bed, but the wrong type was detected - it's actually a <brand/model>"
+-->
+
+"""
+
 
 def capture_device_info(
     discovery_info: BluetoothServiceInfoBleak,
@@ -142,6 +196,25 @@ def _generate_github_url(device_info: UnsupportedDeviceInfo, reason: str) -> str
 
     # URL encode the parameters
     params = f"?template=new-bed-support.yml&title={quote(title)}&body={quote(body)}"
+    return f"{GITHUB_NEW_ISSUE_URL}{params}"
+
+
+def build_misidentified_issue_url(
+    device_info: UnsupportedDeviceInfo,
+    detected_bed_type: str | None,
+    confidence: float,
+    signals: list[str],
+) -> str:
+    """Generate a pre-filled GitHub issue URL for a misidentified (false-positive) device.
+
+    Targets the ``misidentified-bed.yml`` issue form, prefilling its ``details``
+    textarea (field id) with the captured detection data.
+    """
+    title = f"[Misidentified] {device_info.name or device_info.address}"
+    details = device_info.to_misidentified_details(detected_bed_type, confidence, signals)
+    params = (
+        f"?template=misidentified-bed.yml&title={quote(title)}&details={quote(details)}"
+    )
     return f"{GITHUB_NEW_ISSUE_URL}{params}"
 
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -63,6 +63,7 @@ To adjust settings after setup:
 | **Position Mode** | Speed / Accuracy | Speed | How position updates after commands |
 | **Disconnect After Command** | On/Off | Off | Disconnect immediately after each command |
 | **Idle Disconnect Seconds** | 10-300 | 40 | Auto-disconnect timeout when idle |
+| **Stop Discovering New Bluetooth Devices** | On/Off | Off | Suppress automatic discovery of new beds (integration-wide) |
 
 ### Setting Details
 
@@ -84,6 +85,12 @@ To adjust settings after setup:
 - How long to wait before automatically disconnecting when idle
 - Lower values free the connection faster for physical remotes
 - Higher values reduce reconnection overhead for frequent Home Assistant use
+
+**Stop Discovering New Bluetooth Devices** (Default: Off)
+- Turn on once all your beds are added to stop Home Assistant suggesting new Bluetooth devices as adjustable beds
+- This is a global setting that applies to the whole integration, not just the bed whose options you are editing — so you only need to set it on one bed
+- You can still add a bed at any time with **Settings → Devices & Services → Add Integration → Adjustable Bed**; only the automatic discovery notifications are suppressed
+- To turn discovery back on, uncheck this option in any bed's settings
 
 ---
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -47,6 +47,7 @@ from custom_components.adjustable_bed.const import (
     CONF_KAIDI_TARGET_VADDR,
     CONF_KAIDI_VARIANT_SOURCE,
     CONF_MOTOR_COUNT,
+    CONF_MOTOR_PULSE_COUNT,
     CONF_PASSIVE_POSITION_RECONCILIATION,
     CONF_PREFERRED_ADAPTER,
     DOMAIN,
@@ -1462,3 +1463,36 @@ class TestOptionsFlow:
         # Stored globally, not as per-entry data.
         assert await async_is_discovery_disabled(hass) is True
         assert CONF_DISABLE_DISCOVERY not in mock_config_entry.data
+
+    async def test_options_flow_toggle_not_applied_on_validation_error(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """A rejected form must not partially apply the global discovery toggle."""
+        await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+        assert await async_is_discovery_disabled(hass) is False
+
+        with patch(
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
+            return_value=[],
+        ):
+            result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+            result = await hass.config_entries.options.async_configure(
+                result["flow_id"],
+                user_input={
+                    CONF_MOTOR_COUNT: 2,
+                    CONF_DISABLE_DISCOVERY: True,
+                    CONF_MOTOR_PULSE_COUNT: "not-a-number",
+                },
+            )
+
+        # Form is rejected for the invalid number...
+        assert result["type"] == FlowResultType.FORM
+        assert result["errors"]
+        # ...and the discovery toggle was NOT persisted.
+        assert await async_is_discovery_disabled(hass) is False

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -37,6 +37,7 @@ from custom_components.adjustable_bed.const import (
     CONF_BED_TYPE,
     CONF_BLE_BOND_ESTABLISHED,
     CONF_DISABLE_ANGLE_SENSING,
+    CONF_DISABLE_DISCOVERY,
     CONF_HAS_MASSAGE,
     CONF_KAIDI_ADV_TYPE,
     CONF_KAIDI_PRODUCT_ID,
@@ -55,6 +56,10 @@ from custom_components.adjustable_bed.const import (
     TIMOTION_AHF_SERVICE_UUID,
 )
 from custom_components.adjustable_bed.detection import detect_bed_type
+from custom_components.adjustable_bed.discovery_settings import (
+    async_is_discovery_disabled,
+    async_set_discovery_disabled,
+)
 from custom_components.adjustable_bed.kaidi_protocol import (
     KAIDI_ADV_TYPE_BROADCAST,
     KaidiAdvertisement,
@@ -644,6 +649,41 @@ class TestBluetoothDiscoveryFlow:
 
         assert result["type"] == FlowResultType.ABORT
         assert result["reason"] == "not_supported"
+
+    async def test_bluetooth_discovery_disabled_aborts(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info: BluetoothServiceInfoBleak,
+        enable_custom_integrations,
+    ):
+        """Discovery is suppressed entirely when the user has disabled it."""
+        await async_set_discovery_disabled(hass, True)
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_BLUETOOTH},
+            data=mock_bluetooth_service_info,
+        )
+
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "discovery_disabled"
+
+    async def test_bluetooth_discovery_confirm_offers_misidentified_report(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info: BluetoothServiceInfoBleak,
+        enable_custom_integrations,
+    ):
+        """The confirm step exposes a pre-filled 'report misidentified device' link."""
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_BLUETOOTH},
+            data=mock_bluetooth_service_info,
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        report_note = result["description_placeholders"]["report_note"]
+        assert "issues/new?template=misidentified-bed.yml" in report_note
 
     async def test_bluetooth_discovery_already_configured(
         self,
@@ -1391,3 +1431,34 @@ class TestOptionsFlow:
         assert mock_config_entry.data[CONF_HAS_MASSAGE] is True
         assert mock_config_entry.data[CONF_DISABLE_ANGLE_SENSING] is False
         assert mock_config_entry.data[CONF_PASSIVE_POSITION_RECONCILIATION] is False
+
+    async def test_options_flow_toggles_discovery(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """The discovery toggle persists globally and never lands in entry data."""
+        await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+        assert await async_is_discovery_disabled(hass) is False
+
+        with patch(
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
+            return_value=[],
+        ):
+            result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+            result = await hass.config_entries.options.async_configure(
+                result["flow_id"],
+                user_input={
+                    CONF_MOTOR_COUNT: 2,
+                    CONF_DISABLE_DISCOVERY: True,
+                },
+            )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        # Stored globally, not as per-entry data.
+        assert await async_is_discovery_disabled(hass) is True
+        assert CONF_DISABLE_DISCOVERY not in mock_config_entry.data


### PR DESCRIPTION
Addresses the discovery noise raised in discussion #342, where auto-discovery keeps surfacing non-bed BLE devices that the user has to repeatedly ignore.

## 1. Capture & report misidentified devices

When a device is auto-detected as a bed, the signals behind that decision were previously only available in debug logs — once a discovery card was dismissed or ignored, HA only kept the bare MAC, which isn't enough to diagnose a false positive.

- **`discovery_log.py` (new):** a `Store`-backed log of the **last 100** auto-detected devices, **deduped by MAC**, capturing name, advertised service UUIDs, manufacturer data, the detected bed type, confidence, and detection signals. Recorded in `async_step_bluetooth` *before* the discovery card is shown, so it survives dismissal/ignore.
- **"Report a misidentified device" link** in the discovery confirm step → opens a pre-filled GitHub issue using a new `misidentified-bed.yml` issue form (detected type, confidence, signals, UUIDs, manufacturer data prefilled).
- **Diagnostics:** added `auto_discovery_log` (device names preserved via `device_name`; MACs partially redacted to OUI).

## 2. Disable auto-discovery toggle (the feature oapy123 asked for)

- **`discovery_settings.py` (new):** a **global** `Store`-backed `disable_discovery` flag (one source of truth across all beds, so multi-bed users only set it once).
- **"Stop discovering new Bluetooth devices"** checkbox in the options flow. Stored globally and explicitly kept out of per-entry data.
- `async_step_bluetooth` aborts with reason `discovery_disabled` when set — no discovery card, no Repairs issue, no log entry. **Manual "Add Integration" is unaffected**, so a new bed can still be added at any time. To re-enable, uncheck it in any bed's options.
- **Diagnostics:** added `auto_discovery_disabled`.

## Tests

3 new tests in `tests/test_config_flow.py` (all green):
- `test_bluetooth_discovery_disabled_aborts` — disabled → `ABORT` `discovery_disabled`
- `test_options_flow_toggles_discovery` — toggle persists globally, never written into entry data
- `test_bluetooth_discovery_confirm_offers_misidentified_report` — confirm step exposes the report link

`tests/test_config_flow.py` + `tests/test_diagnostics.py`: **85 passed**. Ruff clean on all new/changed files.

## Notes

- No version bump in this PR — happy to add one when cutting a release.
- Docs updated: `docs/CONFIGURATION.md` and the options table in `AGENTS.md`.

Ref #342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added option to disable automatic Bluetooth device discovery suggestions
  * Discovery logging for diagnostics and troubleshooting
  * Quick "report misidentified device" link in device confirmation
  * New GitHub issue template for reporting misidentified devices

* **Documentation**
  * Updated configuration guide for the new discovery disable option

* **Tests**
  * Added test coverage for discovery toggle and misidentification reporting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kristofferR/ha-adjustable-bed/pull/349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->