### PR TITLE
Detect pairing-only OKIN receivers

### DIFF
--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -44,6 +44,7 @@ from .const import (
     BED_TYPE_LEGGETT_PLATT,
     BED_TYPE_OCTO,
     BED_TYPE_OKIMAT,
+    BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_UUID,
     BED_TYPE_RICHMAT,
     BED_TYPE_SLEEP_NUMBER,
@@ -208,6 +209,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             )
         if bed_type in {
             BED_TYPE_OKIMAT,
+            BED_TYPE_OKIN_CST,
             BED_TYPE_OKIN_UUID,
             BED_TYPE_LEGGETT_OKIN,
             BED_TYPE_LEGGETT_PLATT,

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -40,7 +40,11 @@ from .const import (
     BED_TYPE_JENSEN,
     BED_TYPE_KAIDI,
     BED_TYPE_KEESON,
+    BED_TYPE_LEGGETT_OKIN,
+    BED_TYPE_LEGGETT_PLATT,
     BED_TYPE_OCTO,
+    BED_TYPE_OKIMAT,
+    BED_TYPE_OKIN_UUID,
     BED_TYPE_RICHMAT,
     BED_TYPE_SLEEP_NUMBER,
     BEDS_WITH_PERCENTAGE_POSITIONS,
@@ -200,6 +204,17 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             return await self._get_config_translation(
                 "step.bluetooth_pairing.data_description.pairing_instructions_sleep_number",
                 "1. Put your bed in pairing mode (hold the side pairing button until the blue light blinks)\n"
+                "2. Click 'Pair Now'",
+            )
+        if bed_type in {
+            BED_TYPE_OKIMAT,
+            BED_TYPE_OKIN_UUID,
+            BED_TYPE_LEGGETT_OKIN,
+            BED_TYPE_LEGGETT_PLATT,
+        }:
+            return await self._get_config_translation(
+                "step.bluetooth_pairing.data_description.pairing_instructions_okin",
+                "1. Put the OKIN receiver/control box in pairing mode (press or hold the receiver pairing button until the LED blinks)\n"
                 "2. Click 'Pair Now'",
             )
         return await self._get_config_translation(

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -598,9 +598,10 @@ MALOUF_LEGACY_OKIN_NOTIFY_CHAR_UUID: Final = "0000ffe4-0000-1000-8000-00805f9b34
 # Detection priority: name patterns first, then UUID fallback to Okimat
 LEGGETT_OKIN_NAME_PATTERNS: Final = ("leggett", "l&p")
 LEGGETT_RICHMAT_NAME_PATTERNS: Final = ("mlrm",)  # MlRM prefix beds
-# Okimat devices: "Okimat", "OKIN RF", "OKIN BLE", "OKIN-Receiver" /
-# "OKIN - Receiver", "OKIN luis", or "Smartbed" (Malouf/Lucid/CVB beds
-# using OKIN protocol).
+# Okimat devices: "Okimat", "OKIN RF", "OKIN BLE", "OKIN luis", or
+# "Smartbed" (Malouf/Lucid/CVB beds using OKIN protocol).
+# "OKIN-Receiver" / "OKIN - Receiver" stays in OKIMAT_NAME_ONLY_PATTERNS
+# because the shared OKIN service UUID does not disambiguate the protocol.
 # Generic "OKIN-XXXXXX" names are ambiguous: confirmed Nectar 7-byte bases can
 # advertise this way too, so detection handles that prefix as low-confidence.
 OKIMAT_NAME_PATTERNS: Final = (
@@ -608,9 +609,6 @@ OKIMAT_NAME_PATTERNS: Final = (
     "okin rf",
     "okin ble",
     "okin luis",
-    "okin-receiver",
-    "okin - receiver",
-    "okin receiver",
     "smartbed",
 )
 # Name-only matches must stay narrower than OKIMAT_NAME_PATTERNS because some
@@ -1497,6 +1495,7 @@ ALL_PROTOCOL_VARIANTS: Final = [
 # These beds use encrypted connections and must be paired at the OS level
 BEDS_REQUIRING_PAIRING: Final[set[str]] = {
     BED_TYPE_OKIN_UUID,
+    BED_TYPE_OKIN_CST,
     BED_TYPE_LEGGETT_OKIN,
     BED_TYPE_OKIMAT,
     BED_TYPE_VIBRADORM,

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -598,11 +598,25 @@ MALOUF_LEGACY_OKIN_NOTIFY_CHAR_UUID: Final = "0000ffe4-0000-1000-8000-00805f9b34
 # Detection priority: name patterns first, then UUID fallback to Okimat
 LEGGETT_OKIN_NAME_PATTERNS: Final = ("leggett", "l&p")
 LEGGETT_RICHMAT_NAME_PATTERNS: Final = ("mlrm",)  # MlRM prefix beds
-# Okimat devices: "Okimat", "OKIN RF", "OKIN BLE", "OKIN luis",
-# or "Smartbed" (Malouf/Lucid/CVB beds using OKIN protocol).
+# Okimat devices: "Okimat", "OKIN RF", "OKIN BLE", "OKIN-Receiver" /
+# "OKIN - Receiver", "OKIN luis", or "Smartbed" (Malouf/Lucid/CVB beds
+# using OKIN protocol).
 # Generic "OKIN-XXXXXX" names are ambiguous: confirmed Nectar 7-byte bases can
 # advertise this way too, so detection handles that prefix as low-confidence.
-OKIMAT_NAME_PATTERNS: Final = ("okimat", "okin rf", "okin ble", "okin luis", "smartbed")
+OKIMAT_NAME_PATTERNS: Final = (
+    "okimat",
+    "okin rf",
+    "okin ble",
+    "okin luis",
+    "okin-receiver",
+    "okin - receiver",
+    "okin receiver",
+    "smartbed",
+)
+# Name-only matches must stay narrower than OKIMAT_NAME_PATTERNS because some
+# OKIN families only become distinguishable once service UUIDs/manufacturer data
+# are present.
+OKIMAT_NAME_ONLY_PATTERNS: Final = ("okin-receiver", "okin - receiver", "okin receiver")
 OKIN_GENERIC_NAME_PATTERNS: Final = ("okin-",)
 
 # OKIN 64-bit name patterns (from com.okin.bedding.adjustbed app disassembly)

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -888,6 +888,10 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
     if (
         any(pattern in device_name for pattern in OKIMAT_NAME_ONLY_PATTERNS)
         and set(service_uuids).issubset({DEVICE_INFO_SERVICE_UUID.lower()})
+        and (
+            not service_info.manufacturer_data
+            or MANUFACTURER_ID_OKIN not in service_info.manufacturer_data
+        )
     ):
         if service_uuids:
             signals.append("uuid:device_info")
@@ -899,7 +903,7 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
         )
         return DetectionResult(
             bed_type=BED_TYPE_OKIN_UUID,
-            confidence=0.7,
+            confidence=0.6,
             signals=signals,
             ambiguous_types=[BED_TYPE_LEGGETT_OKIN, BED_TYPE_OKIN_64BIT, BED_TYPE_OKIN_CST],
             requires_characteristic_check=True,

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -79,6 +79,7 @@ from .const import (
     COMFORT_MOTION_LIERDA3_SERVICE_UUID,
     COMFORT_MOTION_SERVICE_UUID,
     COOLBASE_NAME_PATTERNS,
+    DEVICE_INFO_SERVICE_UUID,
     DEWERTOKIN_NAME_PATTERNS,
     DEWERTOKIN_SERVICE_UUID,
     ERGOMOTION_NAME_PATTERNS,
@@ -111,6 +112,7 @@ from .const import (
     MANUFACTURER_ID_VIBRADORM,
     OCTO_NAME_PATTERNS,
     OCTO_STAR2_SERVICE_UUID,
+    OKIMAT_NAME_ONLY_PATTERNS,
     OKIMAT_NAME_PATTERNS,
     OKIMAT_NOTIFY_CHAR_UUID,
     OKIMAT_SERVICE_UUID,
@@ -879,6 +881,29 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
             service_info.name,
         )
         return DetectionResult(bed_type=BED_TYPE_LEGGETT_GEN2, confidence=1.0, signals=signals)
+
+    # Some Okin receiver modules only advertise a local name, and sometimes
+    # the generic Device Information service, until paired. They expose the
+    # 62741523 service after OS-level bonding.
+    if (
+        any(pattern in device_name for pattern in OKIMAT_NAME_ONLY_PATTERNS)
+        and set(service_uuids).issubset({DEVICE_INFO_SERVICE_UUID.lower()})
+    ):
+        if service_uuids:
+            signals.append("uuid:device_info")
+        signals.append("name:okin_receiver")
+        _LOGGER.info(
+            "Detected Okin UUID bed at %s (name: %s) by receiver name",
+            service_info.address,
+            service_info.name,
+        )
+        return DetectionResult(
+            bed_type=BED_TYPE_OKIN_UUID,
+            confidence=0.7,
+            signals=signals,
+            ambiguous_types=[BED_TYPE_LEGGETT_OKIN, BED_TYPE_OKIN_64BIT, BED_TYPE_OKIN_CST],
+            requires_characteristic_check=True,
+        )
 
     # Check for Reverie Nightstand (Protocol 110) - more specific UUID
     if REVERIE_NIGHTSTAND_SERVICE_UUID.lower() in service_uuids:

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -984,6 +984,24 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
             )
             return DetectionResult(bed_type=BED_TYPE_LEGGETT_OKIN, confidence=0.9, signals=signals)
 
+        # Receiver names are still ambiguous even after the shared OKIN service
+        # appears, because Okimat, CST, 64-bit, and Leggett Okin can share it.
+        if any(pattern in device_name for pattern in OKIMAT_NAME_ONLY_PATTERNS):
+            signals.append("name:okin_receiver")
+            _LOGGER.warning(
+                "OKIN receiver name '%s' at %s uses shared Okin UUID. "
+                "Prompting for protocol because this can be Okimat, CST, or another Okin variant.",
+                service_info.name,
+                service_info.address,
+            )
+            return DetectionResult(
+                bed_type=BED_TYPE_OKIN_UUID,
+                confidence=0.6,
+                signals=signals,
+                ambiguous_types=[BED_TYPE_LEGGETT_OKIN, BED_TYPE_OKIN_64BIT, BED_TYPE_OKIN_CST],
+                requires_characteristic_check=True,
+            )
+
         # Check for Okimat-specific name patterns
         if any(pattern in device_name for pattern in OKIMAT_NAME_PATTERNS):
             signals.append("name:okimat")

--- a/custom_components/adjustable_bed/manifest.json
+++ b/custom_components/adjustable_bed/manifest.json
@@ -48,6 +48,21 @@
       "local_name": "OKIN*Receiver*"
     },
     {
+      "local_name": "OKIN*receiver*"
+    },
+    {
+      "local_name": "Okin*Receiver*"
+    },
+    {
+      "local_name": "Okin*receiver*"
+    },
+    {
+      "local_name": "okin*Receiver*"
+    },
+    {
+      "local_name": "okin*receiver*"
+    },
+    {
       "service_uuid": "1b1d9641-b942-4da8-89cc-98e6a58fbd93"
     },
     {

--- a/custom_components/adjustable_bed/manifest.json
+++ b/custom_components/adjustable_bed/manifest.json
@@ -45,6 +45,9 @@
       "service_uuid": "62741523-52f9-8864-b1ab-3b3a8d65950b"
     },
     {
+      "local_name": "OKIN*Receiver*"
+    },
+    {
       "service_uuid": "1b1d9641-b942-4da8-89cc-98e6a58fbd93"
     },
     {

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -182,10 +182,12 @@
         "data": {
           "action": "Action",
           "pairing_instructions_generic": "Pairing instructions (generic)",
+          "pairing_instructions_okin": "Pairing instructions (Okin)",
           "pairing_instructions_sleep_number": "Pairing instructions (Sleep Number)"
         },
         "data_description": {
           "pairing_instructions_generic": "1. Put your bed in pairing mode (hold lamp button until blue light blinks, or unplug for 30+ seconds)\n2. Click 'Pair Now'",
+          "pairing_instructions_okin": "1. Put the OKIN receiver/control box in pairing mode (press or hold the receiver pairing button until the LED blinks)\n2. Click 'Pair Now'",
           "pairing_instructions_sleep_number": "1. Put your bed in pairing mode (hold the side pairing button until the blue light blinks)\n2. Click 'Pair Now'"
         }
       },

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -182,10 +182,12 @@
         "data": {
           "action": "Action",
           "pairing_instructions_generic": "Pairing instructions (generic)",
+          "pairing_instructions_okin": "Pairing instructions (Okin)",
           "pairing_instructions_sleep_number": "Pairing instructions (Sleep Number)"
         },
         "data_description": {
           "pairing_instructions_generic": "1. Put your bed in pairing mode (hold lamp button until blue light blinks, or unplug for 30+ seconds)\n2. Click 'Pair Now'",
+          "pairing_instructions_okin": "1. Put the OKIN receiver/control box in pairing mode (press or hold the receiver pairing button until the LED blinks)\n2. Click 'Pair Now'",
           "pairing_instructions_sleep_number": "1. Put your bed in pairing mode (hold the side pairing button until the blue light blinks)\n2. Click 'Pair Now'"
         }
       },

--- a/docs/CONNECTION_GUIDE.md
+++ b/docs/CONNECTION_GUIDE.md
@@ -46,7 +46,7 @@ Some beds require OS-level Bluetooth pairing before the integration can communic
 **How to pair (if required):**
 1. Put your bed in pairing mode (usually hold a button on the remote for 3-5 seconds)
 2. On your Home Assistant host or phone, open Bluetooth settings
-3. Pair with the bed (may appear as `OKIN`, `Okimat`, `Smart bed 123456`, or similar)
+3. Pair with the bed (may appear as `OKIN`, `OKIN-Receiver`, `OKIN - Receiver`, `Okimat`, `Smart bed 123456`, or similar)
 4. Then add the integration in Home Assistant
 
 For Sleep Number Climate 360 / FlexFit Fuzion bases, hold the side pairing button until the blue light blinks.

--- a/docs/SUPPORTED_ACTUATORS.md
+++ b/docs/SUPPORTED_ACTUATORS.md
@@ -74,7 +74,7 @@ Several bed brands use Okin-based BLE controllers. While they share common roots
 **Detection priority** (for beds with Okin service UUID):
 1. Name contains "nectar" → Nectar
 2. Name contains "leggett", "l&p", or "adjustable base" → Leggett & Platt Okin
-3. Name contains "okimat", "okin rf", or "okin ble" → Okimat
+3. Name contains "okimat", "okin rf", "okin ble", "okin-receiver", or "okin - receiver" → Okimat/Okin UUID
 4. Name starts with `OKIN-` → prompt for Okin-family protocol (confirmed Nectar bases can advertise this way)
 5. Fallback → Okimat (with warning logged)
 
@@ -114,7 +114,7 @@ These beds have their own dedicated integrations:
    - `DPG*` or `Desk*` → Linak
    - `Mouselet*` → Kaidi
    - `Nectar*` → Nectar
-   - `Okimat*`, `Okin RF*`, `Okin BLE*` → Okimat
+   - `Okimat*`, `Okin RF*`, `Okin BLE*`, `OKIN-Receiver`, `OKIN - Receiver` → Okimat/Okin UUID
    - `Leggett*`, `L&P*`, `Adjustable Base*` → Leggett & Platt
    - `Ergomotion*` or `Ergo*` → Keeson/Ergomotion
    - `KSBT03*` or `KSBT04*` → Keeson KSBT (includes some Ergomotion Sync beds such as Rio 6.0)

--- a/docs/SUPPORTED_ACTUATORS.md
+++ b/docs/SUPPORTED_ACTUATORS.md
@@ -74,9 +74,10 @@ Several bed brands use Okin-based BLE controllers. While they share common roots
 **Detection priority** (for beds with Okin service UUID):
 1. Name contains "nectar" → Nectar
 2. Name contains "leggett", "l&p", or "adjustable base" → Leggett & Platt Okin
-3. Name contains "okimat", "okin rf", "okin ble", "okin-receiver", or "okin - receiver" → Okimat/Okin UUID
+3. Name contains "okimat", "okin rf", or "okin ble" → Okimat
 4. Name starts with `OKIN-` → prompt for Okin-family protocol (confirmed Nectar bases can advertise this way)
-5. Fallback → Okimat (with warning logged)
+5. Name is `OKIN-Receiver` / `OKIN - Receiver` → prompt for Okin-family protocol
+6. Fallback → Okimat (with warning logged)
 
 ---
 
@@ -114,7 +115,8 @@ These beds have their own dedicated integrations:
    - `DPG*` or `Desk*` → Linak
    - `Mouselet*` → Kaidi
    - `Nectar*` → Nectar
-   - `Okimat*`, `Okin RF*`, `Okin BLE*`, `OKIN-Receiver`, `OKIN - Receiver` → Okimat/Okin UUID
+   - `Okimat*`, `Okin RF*`, `Okin BLE*` → Okimat/Okin UUID
+   - `OKIN-Receiver`, `OKIN - Receiver` → prompted Okin-family protocol selection
    - `Leggett*`, `L&P*`, `Adjustable Base*` → Leggett & Platt
    - `Ergomotion*` or `Ergo*` → Keeson/Ergomotion
    - `KSBT03*` or `KSBT04*` → Keeson KSBT (includes some Ergomotion Sync beds such as Rio 6.0)

--- a/docs/beds/okimat.md
+++ b/docs/beds/okimat.md
@@ -60,10 +60,14 @@
 
 ## Detection
 
-Okimat is the fallback for beds using the Okin service UUID. Detection priority:
+Okimat is the fallback for beds using the Okin service UUID. Some receiver modules only
+advertise a local name such as `OKIN-Receiver` or `OKIN - Receiver` until paired; those are
+detected as the pairing-required Okin UUID protocol.
+
+Detection priority:
 1. Device name contains "nectar" → Nectar
 2. Device name contains "leggett", "l&p", or "adjustable base" → Leggett & Platt
-3. Device name contains "okimat", "okin rf", or "okin ble" → Okimat
+3. Device name contains "okimat", "okin rf", "okin ble", "okin-receiver", or "okin - receiver" → Okimat/Okin UUID
 4. Fallback → Okimat (with warning)
 
 **If your bed is misidentified:** Change the bed type in integration settings.

--- a/docs/beds/okimat.md
+++ b/docs/beds/okimat.md
@@ -62,13 +62,15 @@
 
 Okimat is the fallback for beds using the Okin service UUID. Some receiver modules only
 advertise a local name such as `OKIN-Receiver` or `OKIN - Receiver` until paired; those are
-detected as the pairing-required Okin UUID protocol.
+shown as a pairing-required Okin-family protocol selection because the receiver name and
+shared Okin service UUID do not identify the packet format by themselves.
 
 Detection priority:
 1. Device name contains "nectar" → Nectar
 2. Device name contains "leggett", "l&p", or "adjustable base" → Leggett & Platt
-3. Device name contains "okimat", "okin rf", "okin ble", "okin-receiver", or "okin - receiver" → Okimat/Okin UUID
-4. Fallback → Okimat (with warning)
+3. Device name contains "okimat", "okin rf", or "okin ble" → Okimat/Okin UUID
+4. Device name is `OKIN-Receiver` / `OKIN - Receiver` → prompt for Okin-family protocol
+5. Fallback → Okimat (with warning)
 
 **If your bed is misidentified:** Change the bed type in integration settings.
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -27,6 +27,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_MOTOSLEEP,
     BED_TYPE_OCTO,
     BED_TYPE_OKIMAT,
+    BED_TYPE_OKIN_UUID,
     BED_TYPE_REVERIE,
     BED_TYPE_RICHMAT,
     BED_TYPE_SERTA,
@@ -34,6 +35,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_SOLACE,
     BED_TYPE_SUTA,
     BED_TYPE_TIMOTION_AHF,
+    BED_TYPE_VIBRADORM,
     CONF_BED_TYPE,
     CONF_BLE_BOND_ESTABLISHED,
     CONF_DISABLE_ANGLE_SENSING,
@@ -109,10 +111,36 @@ class TestPairingInstructions:
                 }
             ),
         ):
-            instructions = await flow._get_pairing_instructions(BED_TYPE_OKIMAT)
+            instructions = await flow._get_pairing_instructions(BED_TYPE_VIBRADORM)
 
         assert "lamp button" in instructions
         assert "unplug for 30+ seconds" in instructions
+
+    async def test_okin_pairing_instructions_use_receiver_button(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Okin UUID beds should show receiver/control-box pairing guidance."""
+        flow = AdjustableBedConfigFlow()
+        flow.hass = hass
+
+        with patch(
+            "custom_components.adjustable_bed.config_flow.async_get_translations",
+            new=AsyncMock(
+                return_value={
+                    (
+                        "component.adjustable_bed.config.step.bluetooth_pairing."
+                        "data_description.pairing_instructions_okin"
+                    ): (
+                        "1. Put the OKIN receiver/control box in pairing mode (press or hold the receiver pairing button until the LED blinks)\n"
+                        "2. Click 'Pair Now'"
+                    )
+                }
+            ),
+        ):
+            instructions = await flow._get_pairing_instructions(BED_TYPE_OKIN_UUID)
+
+        assert "OKIN receiver/control box" in instructions
+        assert "receiver pairing button" in instructions
 
 
 class TestPairingPersistence:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -27,6 +27,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_MOTOSLEEP,
     BED_TYPE_OCTO,
     BED_TYPE_OKIMAT,
+    BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_UUID,
     BED_TYPE_REVERIE,
     BED_TYPE_RICHMAT,
@@ -55,6 +56,7 @@ from custom_components.adjustable_bed.const import (
     RICHMAT_WILINKE_SERVICE_UUIDS,
     SUTA_SERVICE_UUID,
     TIMOTION_AHF_SERVICE_UUID,
+    requires_pairing,
 )
 from custom_components.adjustable_bed.detection import detect_bed_type
 from custom_components.adjustable_bed.kaidi_protocol import (
@@ -116,10 +118,11 @@ class TestPairingInstructions:
         assert "lamp button" in instructions
         assert "unplug for 30+ seconds" in instructions
 
+    @pytest.mark.parametrize("bed_type", [BED_TYPE_OKIN_UUID, BED_TYPE_OKIN_CST])
     async def test_okin_pairing_instructions_use_receiver_button(
-        self, hass: HomeAssistant
+        self, hass: HomeAssistant, bed_type: str
     ) -> None:
-        """Okin UUID beds should show receiver/control-box pairing guidance."""
+        """Okin UUID/CST beds should show receiver/control-box pairing guidance."""
         flow = AdjustableBedConfigFlow()
         flow.hass = hass
 
@@ -137,7 +140,7 @@ class TestPairingInstructions:
                 }
             ),
         ):
-            instructions = await flow._get_pairing_instructions(BED_TYPE_OKIN_UUID)
+            instructions = await flow._get_pairing_instructions(bed_type)
 
         assert "OKIN receiver/control box" in instructions
         assert "receiver pairing button" in instructions
@@ -841,6 +844,44 @@ class TestBluetoothDiscoveryFlow:
         # Should create entry with the disambiguated type
         assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_BED_TYPE] == BED_TYPE_OKIN_64BIT
+
+    async def test_bluetooth_disambiguate_okin_cst_requires_pairing(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info_ambiguous_okin: MagicMock,
+        enable_custom_integrations,
+    ):
+        """Selecting Okin CST from an ambiguous receiver should continue to pairing."""
+        del enable_custom_integrations
+
+        assert requires_pairing(BED_TYPE_OKIN_CST)
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_BLUETOOTH},
+            data=mock_bluetooth_service_info_ambiguous_okin,
+        )
+        assert result["step_id"] == "bluetooth_disambiguate"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"bed_type_choice": BED_TYPE_OKIN_CST},
+        )
+        assert result["step_id"] == "bluetooth_confirm"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_NAME: "My CST Bed",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "bluetooth_pairing"
 
 
 class TestManualFlow:

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -30,6 +30,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_OKIN_CB24,
     BED_TYPE_OKIN_CB35,
     BED_TYPE_OKIN_FFE,
+    BED_TYPE_OKIN_UUID,
     BED_TYPE_REMACRO,
     BED_TYPE_REVERIE,
     BED_TYPE_REVERIE_NIGHTSTAND,
@@ -47,6 +48,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_VIBRADORM,
     BEDTECH_SERVICE_UUID,
     COMFORT_MOTION_LIERDA3_SERVICE_UUID,
+    DEVICE_INFO_SERVICE_UUID,
     JENSEN_SERVICE_UUID,
     KAIDI_DISCOVERY_SERVICE_UUID,
     KAIDI_MESH_SERVICE_UUID,
@@ -394,6 +396,26 @@ class TestDetectBedTypeByNamePattern:
         """Test MotoSleep detection by HHC prefix (uppercase)."""
         service_info = _make_service_info(name="HHC5678ABCD")
         assert detect_bed_type(service_info) == BED_TYPE_MOTOSLEEP
+
+    @pytest.mark.parametrize(
+        ("name", "service_uuids"),
+        [
+            ("OKIN-Receiver", []),
+            ("OKIN - Receiver", []),
+            ("OKIN - Receiver", [DEVICE_INFO_SERVICE_UUID]),
+        ],
+    )
+    def test_detect_okin_receiver_before_pairing(
+        self, name: str, service_uuids: list[str]
+    ):
+        """OKIN receiver modules can require pairing before bed service UUIDs are visible."""
+        service_info = _make_service_info(name=name, service_uuids=service_uuids)
+        result = detect_bed_type_detailed(service_info)
+
+        assert result.bed_type == BED_TYPE_OKIN_UUID
+        assert result.confidence == 0.7
+        assert "name:okin_receiver" in result.signals
+        assert result.requires_characteristic_check is True
 
     def test_detect_star_name_only_is_ambiguous(self):
         """Star* without Nordic UART should remain a low-confidence ambiguous match."""

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -413,9 +413,23 @@ class TestDetectBedTypeByNamePattern:
         result = detect_bed_type_detailed(service_info)
 
         assert result.bed_type == BED_TYPE_OKIN_UUID
-        assert result.confidence == 0.7
+        assert result.confidence == 0.6
         assert "name:okin_receiver" in result.signals
         assert result.requires_characteristic_check is True
+
+    def test_okin_receiver_with_okin_manufacturer_data_uses_cb24_fallback(self):
+        """OKIN manufacturer ID should win over the receiver-name shortcut."""
+        service_info = _make_service_info(
+            name="OKIN - Receiver",
+            service_uuids=[],
+            manufacturer_data={MANUFACTURER_ID_OKIN: b"\x01\x02\x03"},
+        )
+        result = detect_bed_type_detailed(service_info)
+
+        assert result.bed_type == BED_TYPE_OKIN_CB24
+        assert result.confidence == 0.7
+        assert result.manufacturer_id == MANUFACTURER_ID_OKIN
+        assert f"manufacturer_id:{MANUFACTURER_ID_OKIN}" in result.signals
 
     def test_detect_star_name_only_is_ambiguous(self):
         """Star* without Nordic UART should remain a low-confidence ambiguous match."""

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -29,6 +29,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_OKIMAT,
     BED_TYPE_OKIN_CB24,
     BED_TYPE_OKIN_CB35,
+    BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_FFE,
     BED_TYPE_OKIN_UUID,
     BED_TYPE_REMACRO,
@@ -695,6 +696,22 @@ class TestOkinUUIDDisambiguation:
             service_uuids=[OKIMAT_SERVICE_UUID],
         )
         assert detect_bed_type(service_info) == BED_TYPE_OKIMAT
+
+    @pytest.mark.parametrize("name", ["OKIN-Receiver", "OKIN - Receiver"])
+    def test_okin_uuid_with_receiver_name_is_ambiguous(self, name: str):
+        """Receiver names should not become high-confidence Okimat after pairing."""
+        service_info = _make_service_info(
+            name=name,
+            service_uuids=[OKIMAT_SERVICE_UUID],
+        )
+        result = detect_bed_type_detailed(service_info)
+
+        assert result.bed_type == BED_TYPE_OKIN_UUID
+        assert result.confidence == 0.6
+        assert result.requires_characteristic_check is True
+        assert "uuid:okin" in result.signals
+        assert "name:okin_receiver" in result.signals
+        assert BED_TYPE_OKIN_CST in result.ambiguous_types
 
     def test_okin_uuid_with_generic_okin_prefix_is_ambiguous(self):
         """Generic OKIN-* names should not be hard-forced to Okimat."""

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,16 @@
+"""Tests for integration manifest discovery hints."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_manifest_discovers_okin_receiver_name_only_advertisements() -> None:
+    """Name-only OKIN receiver advertisements must start the Bluetooth flow."""
+    manifest_path = (
+        Path(__file__).parents[1] / "custom_components" / "adjustable_bed" / "manifest.json"
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert {"local_name": "OKIN*Receiver*"} in manifest["bluetooth"]

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -13,4 +13,13 @@ def test_manifest_discovers_okin_receiver_name_only_advertisements() -> None:
     )
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
-    assert {"local_name": "OKIN*Receiver*"} in manifest["bluetooth"]
+    assert {
+        "OKIN*Receiver*",
+        "OKIN*receiver*",
+        "Okin*Receiver*",
+        "Okin*receiver*",
+        "okin*Receiver*",
+        "okin*receiver*",
+    }.issubset(
+        {entry["local_name"] for entry in manifest["bluetooth"] if "local_name" in entry}
+    )


### PR DESCRIPTION
Summary:
- Add a Bluetooth local-name trigger for OKIN receiver advertisements that do not expose bed service UUIDs before pairing.
- Detect OKIN receiver name-only / Device Information-only advertisements as pairing-required Okin UUID beds.
- Add Okin-specific receiver/control-box pairing guidance, docs, and regression tests.

Validation:
- uv run pytest tests/test_detection.py tests/test_config_flow.py tests/test_manifest.py
- uv run --with ruff ruff check custom_components/adjustable_bed/config_flow.py custom_components/adjustable_bed/const.py custom_components/adjustable_bed/detection.py tests/test_config_flow.py tests/test_detection.py tests/test_manifest.py
- uv run --with pyright pyright custom_components/adjustable_bed/config_flow.py custom_components/adjustable_bed/const.py custom_components/adjustable_bed/detection.py tests/test_manifest.py

Ref #338