### PR TITLE
Fix Cool Base Memory 2 for DewertOKIN

### DIFF
--- a/custom_components/adjustable_bed/beds/coolbase.py
+++ b/custom_components/adjustable_bed/beds/coolbase.py
@@ -8,6 +8,7 @@ Uses the same FFE0/FFE5 service UUIDs as Keeson BaseI5 with 8-byte command packe
 Unique features:
 - Left/Right fan control with 3 speed levels (0-3)
 - Sync fan mode for both sides
+- DewertOKIN OKIN-BLE compatibility profile with a second memory slot
 """
 
 from __future__ import annotations
@@ -47,6 +48,7 @@ class CoolBaseCommands:
     PRESET_TV = 0x00004000  # cmd1=0x40
     PRESET_ANTI_SNORE = 0x00008000  # cmd1=0x80
     PRESET_MEMORY_1 = 0x00010000  # cmd2=0x01
+    PRESET_MEMORY_2 = 0x00040000  # cmd2=0x04 on DewertOKIN OKIN-BLE devices
 
     # Light (cmd2 byte)
     TOGGLE_LIGHT = 0x00020000  # cmd2=0x02
@@ -65,13 +67,21 @@ class CoolBaseCommands:
 class CoolBaseController(BedController):
     """Controller for Cool Base beds (Keeson BaseI5 with fan control)."""
 
-    def __init__(self, coordinator: AdjustableBedCoordinator) -> None:
+    def __init__(
+        self,
+        coordinator: AdjustableBedCoordinator,
+        *,
+        dewert_okin_profile: bool = False,
+    ) -> None:
         """Initialize the Cool Base controller.
 
         Args:
             coordinator: The AdjustableBedCoordinator instance
+            dewert_okin_profile: True for OKIN-BLE/DewertOKIN devices using the
+                Cool Base packet format without Cool Base fan controls.
         """
         super().__init__(coordinator)
+        self._dewert_okin_profile = dewert_okin_profile
         self._notify_callback: Callable[[str, float], None] | None = None
         self._motor_state: dict[str, bool | None] = {}
 
@@ -114,7 +124,7 @@ class CoolBaseController(BedController):
 
     @property
     def memory_slot_count(self) -> int:
-        return 1  # Only Memory 1 confirmed in the app
+        return 2 if self._dewert_okin_profile else 1
 
     @property
     def supports_memory_programming(self) -> bool:
@@ -135,7 +145,7 @@ class CoolBaseController(BedController):
     @property
     def supports_fan_control(self) -> bool:
         """Return True - Cool Base has fan control."""
-        return True
+        return not self._dewert_okin_profile
 
     @property
     def fan_level_max(self) -> int:
@@ -357,10 +367,18 @@ class CoolBaseController(BedController):
 
     async def preset_memory(self, memory_num: int) -> None:
         """Go to memory preset."""
-        if memory_num == 1:
-            await self.write_command(self._build_command_from_value(CoolBaseCommands.PRESET_MEMORY_1))
+        commands = {1: CoolBaseCommands.PRESET_MEMORY_1}
+        if self._dewert_okin_profile:
+            commands[2] = CoolBaseCommands.PRESET_MEMORY_2
+
+        if command := commands.get(memory_num):
+            await self.write_command(self._build_command_from_value(command))
         else:
-            _LOGGER.warning("Cool Base only supports Memory 1, requested: %d", memory_num)
+            _LOGGER.warning(
+                "Cool Base memory slot %d not supported (valid: %s)",
+                memory_num,
+                sorted(commands),
+            )
 
     async def program_memory(self, memory_num: int) -> None:
         """Program current position to memory (not supported)."""

--- a/custom_components/adjustable_bed/controller_factory.py
+++ b/custom_components/adjustable_bed/controller_factory.py
@@ -808,8 +808,15 @@ async def create_controller(
     if bed_type == BED_TYPE_COOLBASE:
         from .beds.coolbase import CoolBaseController
 
-        _LOGGER.debug("Using Cool Base controller")
-        return CoolBaseController(coordinator)
+        normalized_name = (device_name or "").lower()
+        dewert_okin_profile = normalized_name.startswith(("okin-ble", "btcb")) or (
+            (ble_manufacturer or "").strip().lower() == "dewertokin"
+        )
+        _LOGGER.debug(
+            "Using Cool Base controller (dewert_okin_profile=%s)",
+            dewert_okin_profile,
+        )
+        return CoolBaseController(coordinator, dewert_okin_profile=dewert_okin_profile)
 
     if bed_type == BED_TYPE_SCOTT_LIVING:
         from .beds.scott_living import ScottLivingController

--- a/docs/beds/coolbase.md
+++ b/docs/beds/coolbase.md
@@ -7,6 +7,8 @@
 ## Known Models
 
 - Cool Base adjustable bed bases (Keeson BaseI5 with cooling fan)
+- DewertOKIN `OKIN-BLE` / `BTCB` controllers that use the same 8-byte packet
+  format without fan controls
 
 ## Apps
 
@@ -20,7 +22,7 @@
 |---------|-----------|
 | Motor Control | ✅ (2 motors: head, foot) |
 | Position Feedback | ❌ |
-| Memory Presets | ✅ (1 slot) |
+| Memory Presets | ✅ (1 slot on BaseI5, 2 slots on DewertOKIN OKIN-BLE) |
 | Factory Presets | ✅ (Flat, Zero-G, TV, Anti-Snore, Lounge) |
 | Massage | ✅ |
 | Light Control | ✅ (toggle) |
@@ -35,7 +37,11 @@
 
 ## Detection
 
-Devices are auto-detected by device name starting with `base-i5` (case-insensitive).
+Cool Base bed-type detection uses the `base-i5` device-name prefix. For configured
+Cool Base entries, the DewertOKIN profile is selected when the connected BLE name
+matches `okin-ble*` / `btcb*` or the BLE manufacturer value is `DewertOKIN`.
+`OKIN-BLE` / `DewertOKIN` devices may need manual Cool Base selection only when
+they advertise overlapping OKIN UUIDs.
 
 Note: Cool Base shares the same service UUID (FFE5) as Keeson and other beds, but is distinguished by the device name pattern.
 
@@ -73,6 +79,7 @@ Where:
 | TV | 0x00004000 | cmd1=0x40 |
 | Anti-Snore | 0x00008000 | cmd1=0x80 |
 | Memory 1 | 0x00010000 | cmd2=0x01 |
+| Memory 2 | 0x00040000 | cmd2=0x04, DewertOKIN OKIN-BLE profile only |
 
 ### Light & Massage
 
@@ -117,3 +124,7 @@ Where:
 3. Fan levels are reported in notifications, allowing the integration to track current state.
 
 4. The sync fan command controls both left and right fans together.
+
+5. On DewertOKIN `OKIN-BLE` / `BTCB` devices, `0x00040000` is Memory 2 instead
+   of sync fan. The integration exposes Memory 2 and suppresses fan controls for
+   that profile to avoid showing both meanings for the same packet.

--- a/tests/test_controller_contract.py
+++ b/tests/test_controller_contract.py
@@ -11,6 +11,7 @@ import pytest
 
 from custom_components.adjustable_bed.beds.base import BedController
 from custom_components.adjustable_bed.const import (
+    BED_TYPE_COOLBASE,
     BED_TYPE_KEESON,
     BED_TYPE_LEGGETT_PLATT,
     BED_TYPE_OCTO,
@@ -354,6 +355,43 @@ async def test_factory_auto_detects_cb1322_dewertokin_manufacturer() -> None:
     assert isinstance(controller, BedController)
     assert getattr(controller, "_variant", None) == KEESON_VARIANT_OKIN
     assert getattr(controller, "_cb1322_presets", None) is True
+
+
+async def test_factory_enables_coolbase_dewert_okin_profile() -> None:
+    """OKIN-BLE/DewertOKIN devices using Cool Base expose Memory 2, not fan sync."""
+    coordinator = _FactoryCoordinator()
+
+    controller = await create_controller(
+        coordinator=coordinator,
+        bed_type=BED_TYPE_COOLBASE,
+        protocol_variant=VARIANT_AUTO,
+        client=None,
+        device_name="OKIN-BLE00016084",
+        ble_manufacturer="DewertOKIN",
+    )
+
+    assert isinstance(controller, BedController)
+    assert getattr(controller, "_dewert_okin_profile", None) is True
+    assert controller.memory_slot_count == 2
+    assert controller.supports_fan_control is False
+
+
+async def test_factory_enables_coolbase_dewert_okin_profile_for_btcb_name() -> None:
+    """BTCB-named Cool Base entries should select the DewertOKIN profile by name."""
+    coordinator = _FactoryCoordinator()
+
+    controller = await create_controller(
+        coordinator=coordinator,
+        bed_type=BED_TYPE_COOLBASE,
+        protocol_variant=VARIANT_AUTO,
+        client=None,
+        device_name="BTCB.03",
+        ble_manufacturer=None,
+    )
+
+    assert isinstance(controller, BedController)
+    assert getattr(controller, "_dewert_okin_profile", None) is True
+    assert controller.memory_slot_count == 2
 
 
 async def test_betterliving_preset_commands() -> None:

--- a/tests/test_coolbase.py
+++ b/tests/test_coolbase.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
@@ -24,7 +24,6 @@ from custom_components.adjustable_bed.const import (
     KEESON_BASE_WRITE_CHAR_UUID,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
-
 
 # -----------------------------------------------------------------------------
 # Test Fixtures
@@ -83,6 +82,7 @@ class TestCoolBaseCommands:
         assert CoolBaseCommands.PRESET_TV == 0x00004000
         assert CoolBaseCommands.PRESET_ANTI_SNORE == 0x00008000
         assert CoolBaseCommands.PRESET_MEMORY_1 == 0x00010000
+        assert CoolBaseCommands.PRESET_MEMORY_2 == 0x00040000
 
     def test_light_command(self):
         """Light toggle command should be correct value."""
@@ -249,6 +249,45 @@ class TestCoolBaseController:
         await coordinator.async_connect()
 
         assert coordinator.controller.fan_level_max == 3
+
+    async def test_default_memory_slot_count_is_one(
+        self,
+        hass: HomeAssistant,
+        mock_coolbase_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Base-I5 Cool Base should expose only the app-confirmed memory slot."""
+        coordinator = AdjustableBedCoordinator(hass, mock_coolbase_config_entry)
+        await coordinator.async_connect()
+
+        assert coordinator.controller.memory_slot_count == 1
+
+    def test_dewert_okin_profile_exposes_memory_two_without_fan_control(self):
+        """DewertOKIN OKIN-BLE profile reuses sync-wind command as Memory 2."""
+        controller = CoolBaseController(MagicMock(), dewert_okin_profile=True)
+
+        assert controller.memory_slot_count == 2
+        assert controller.supports_fan_control is False
+
+    async def test_default_profile_rejects_memory_two(self):
+        """Base-I5 profile should not send the sync-wind command as Memory 2."""
+        controller = CoolBaseController(MagicMock())
+        controller.write_command = AsyncMock()
+
+        await controller.preset_memory(2)
+
+        controller.write_command.assert_not_awaited()
+
+    async def test_dewert_okin_profile_memory_two_sends_correct_packet(self):
+        """DewertOKIN profile should send cmd2=0x04 for Memory 2."""
+        controller = CoolBaseController(MagicMock(), dewert_okin_profile=True)
+        controller.write_command = AsyncMock()
+
+        await controller.preset_memory(2)
+
+        controller.write_command.assert_awaited_once_with(
+            controller._build_command_from_value(CoolBaseCommands.PRESET_MEMORY_2)
+        )
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a DewertOKIN OKIN-BLE profile for Cool Base packets.
- Expose Memory 2 only for that profile and suppress fan controls because the Memory 2 packet overlaps Cool Base sync wind.
- Update Cool Base docs and regression coverage.

## Tests
- uv run pytest tests/test_coolbase.py tests/test_controller_contract.py -q
- uv run ruff check custom_components/adjustable_bed/beds/coolbase.py custom_components/adjustable_bed/controller_factory.py tests/test_coolbase.py tests/test_controller_contract.py
- git diff --check

Ref #341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for DewertOKIN OKIN-BLE/BTCB adjustable bed controllers with automatic detection.
  * Additional memory preset slot available for DewertOKIN devices.

* **Improvements**
  * Fan control disabled for DewertOKIN devices to prevent conflicts.
  * Enhanced error messages when requesting unsupported memory slots.

* **Documentation**
  * Updated Cool Base documentation with DewertOKIN device details and detection guidance.

* **Tests**
  * Added test coverage for new DewertOKIN profile and memory functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kristofferR/ha-adjustable-bed/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->