### PR TITLE
fix: accept any echo for Sleep Number MCR init handshake (#322)

### DIFF
--- a/custom_components/adjustable_bed/beds/sleep_number_mcr.py
+++ b/custom_components/adjustable_bed/beds/sleep_number_mcr.py
@@ -66,6 +66,17 @@ _SIDE_NAME_TO_VALUE: Final[dict[str, int]] = {
 }
 
 
+class _ResponseTimeout(TimeoutError):
+    """Raised when a required MCR *response* does not arrive in time.
+
+    Distinct from a write/transport ``TimeoutError`` (raised by
+    ``_async_write_frame``/``write_gatt_char``) so the init handshake can treat
+    a missing *echo* as non-fatal while still forcing a reconnect when the init
+    *write* itself fails. Subclasses ``TimeoutError`` so existing callers that
+    catch ``TimeoutError`` keep working.
+    """
+
+
 @dataclass(slots=True)
 class _McrFrame:
     """Parsed MCR frame."""
@@ -433,8 +444,10 @@ class SleepNumberMcrController(BedController):
 
         If the firmware sends no echo at all but the BLE link stays up, proceed
         anyway: the write itself primes the bed and the follow-up commands are
-        fire-and-forget. Only a dropped link should fail the connection so the
-        coordinator can cleanly reconnect.
+        fire-and-forget. Only a missing *echo* is tolerated — a failed init
+        *write* (transport ``TimeoutError``/``BleakError``/``OSError`` from
+        ``_async_write_frame``) propagates so the coordinator reconnects rather
+        than priming the controller against a bed that never received the init.
         """
         if self._initialized:
             return
@@ -450,7 +463,10 @@ class SleepNumberMcrController(BedController):
                 timeout=_INIT_HANDSHAKE_TIMEOUT_SECONDS,
                 accept_any_response=True,
             )
-        except TimeoutError:
+        except _ResponseTimeout:
+            # The write reached the transport but the bed sent no echo. Some
+            # BAM/MCR firmware does not echo the init frame; the write itself
+            # primes the bed, so proceed as long as the link is still up.
             client = self.client
             if client is None or not client.is_connected:
                 raise
@@ -626,7 +642,7 @@ class SleepNumberMcrController(BedController):
                         side,
                     )
                     return list(self._response_frames)
-                raise TimeoutError(
+                raise _ResponseTimeout(
                     f"Timed out waiting for Sleep Number MCR response func={function_code}"
                 )
             if response_task not in done:

--- a/custom_components/adjustable_bed/beds/sleep_number_mcr.py
+++ b/custom_components/adjustable_bed/beds/sleep_number_mcr.py
@@ -46,7 +46,6 @@ _MCR_FUNC_FOUNDATION_OUTLET: Final = 19
 
 _MCR_SIDE_LEFT: Final = 0
 _MCR_SIDE_RIGHT: Final = 1
-_MCR_SIDE_BOTH_CHAMBERS: Final = 2
 _MCR_SIDE_ALL: Final = 0x0F
 _MCR_OUTLET_UNDERBED_LIGHT: Final = 3
 _OPTIONAL_RESPONSE_GRACE_SECONDS: Final = 0.2
@@ -728,20 +727,20 @@ class SleepNumberMcrController(BedController):
         frame: _McrFrame,
         request_key: tuple[int, int],
     ) -> bool:
-        """Return True when ``frame`` matches ``request_key``."""
-        if not frame.is_response:
-            return False
-        expected_func, expected_side = request_key
-        if frame.function_code != expected_func:
-            return False
-        # The MCR firmware sometimes echoes a different side nibble for
-        # bed-wide queries (e.g. ``_MCR_SIDE_ALL`` reads). Treat the request
-        # as matching whenever the side either matches exactly or the
-        # request was sent against ``_MCR_SIDE_ALL`` /
-        # ``_MCR_SIDE_BOTH_CHAMBERS``.
-        if expected_side in {_MCR_SIDE_ALL, _MCR_SIDE_BOTH_CHAMBERS}:
-            return True
-        return frame.side == expected_side
+        """Return True when ``frame`` is the response to ``request_key``.
+
+        Correlates by **function code only**, mirroring the reference
+        implementation that works against this hardware (it parses responses by
+        ``hdr[8] & 0x7F`` and never checks the response bit or side nibble). The
+        bed is purely request/response with a single outstanding request at a
+        time, so the function code is enough to confirm a reply. Some BAM/MCR
+        firmware replies without the response bit set (``byte 8 & 0x80``) and
+        echoes a different side nibble than the request was sent with;
+        requiring either would discard otherwise-valid responses — the same
+        root cause that broke the init handshake (issue #322).
+        """
+        expected_func, _expected_side = request_key
+        return frame.function_code == expected_func
 
     @staticmethod
     def _request_key(function_code: int, side: int) -> tuple[int, int]:

--- a/custom_components/adjustable_bed/beds/sleep_number_mcr.py
+++ b/custom_components/adjustable_bed/beds/sleep_number_mcr.py
@@ -50,6 +50,7 @@ _MCR_SIDE_BOTH_CHAMBERS: Final = 2
 _MCR_SIDE_ALL: Final = 0x0F
 _MCR_OUTLET_UNDERBED_LIGHT: Final = 3
 _OPTIONAL_RESPONSE_GRACE_SECONDS: Final = 0.2
+_INIT_HANDSHAKE_TIMEOUT_SECONDS: Final = 10.0
 
 _SLEEP_NUMBER_MCR_PRESETS: Final[dict[str, int]] = {
     "Favorite": 1,
@@ -120,6 +121,13 @@ class SleepNumberMcrController(BedController):
         # ``(function_code, side)`` tuple matching the request that was
         # sent. ``None`` means no request is in flight.
         self._outstanding_request_key: tuple[int, int] | None = None
+        # During the connection-priming init handshake, accept ANY notification
+        # from the bed as confirmation, bypassing the strict per-frame
+        # correlation below. Older BAM/MCR firmware echoes the init frame
+        # without the response bit set (byte 8 & 0x80) or with a different side
+        # nibble, which the strict matcher would otherwise discard — leaving the
+        # handshake to time out and the connection stuck in a reconnect loop.
+        self._accept_any_response = False
         # When an optional response times out, a delayed notification for the
         # same request key must not satisfy the next command. Keep the key
         # quarantined for a full timeout window after the miss so late replies
@@ -412,21 +420,47 @@ class SleepNumberMcrController(BedController):
         )
 
     async def _async_initialize_session(self) -> None:
-        """Run the required MCR init handshake once per connection."""
+        """Run the required MCR init handshake once per connection.
+
+        The handshake primes the bed for subsequent commands. Following the
+        behaviour of the reference implementation that works against this
+        hardware, ANY notification from the bed confirms the handshake — the
+        echo contents are not inspected. Older BAM/MCR firmware replies to the
+        init frame without the response bit set, or echoes a different side
+        nibble, so the strict ``(function_code, side, is_response)`` correlation
+        used for normal commands would reject the echo. That manifested as
+        "Timed out waiting for Sleep Number MCR response func=0" followed by a
+        permanent reconnect loop (issue #322).
+
+        If the firmware sends no echo at all but the BLE link stays up, proceed
+        anyway: the write itself primes the bed and the follow-up commands are
+        fire-and-forget. Only a dropped link should fail the connection so the
+        coordinator can cleanly reconnect.
+        """
         if self._initialized:
             return
 
-        frames = await self._async_send_frame(
-            command_type=_MCR_CMD_PUMP,
-            status=_MCR_STATUS_PUMP,
-            function_code=_MCR_FUNC_INIT,
-            side=0,
-            payload=b"\x00" * 8,
-            sub_address=0x0000,
-            timeout=10.0,
-        )
-        if not any(frame.function_code == _MCR_FUNC_INIT for frame in frames):
-            raise RuntimeError("Sleep Number MCR init handshake failed")
+        try:
+            await self._async_send_frame(
+                command_type=_MCR_CMD_PUMP,
+                status=_MCR_STATUS_PUMP,
+                function_code=_MCR_FUNC_INIT,
+                side=0,
+                payload=b"\x00" * 8,
+                sub_address=0x0000,
+                timeout=_INIT_HANDSHAKE_TIMEOUT_SECONDS,
+                accept_any_response=True,
+            )
+        except TimeoutError:
+            client = self.client
+            if client is None or not client.is_connected:
+                raise
+            _LOGGER.debug(
+                "Sleep Number MCR init handshake received no echo from %s; "
+                "proceeding (BLE link still up)",
+                self._coordinator.address,
+            )
+
         self._initialized = True
 
     async def _async_read_pump_status(self) -> None:
@@ -507,6 +541,7 @@ class SleepNumberMcrController(BedController):
         timeout: float = 5.0,
         cancel_event: asyncio.Event | None = None,
         require_response: bool = True,
+        accept_any_response: bool = False,
     ) -> list[_McrFrame]:
         """Write an MCR frame and wait for the matching notification response.
 
@@ -541,6 +576,7 @@ class SleepNumberMcrController(BedController):
         # Set correlation BEFORE clearing state, so any in-flight notification
         # parsing on the event loop sees the new key.
         self._outstanding_request_key = request_key
+        self._accept_any_response = accept_any_response
         self._response_buffer.clear()
         self._response_frames.clear()
         self._response_event.clear()
@@ -602,6 +638,7 @@ class SleepNumberMcrController(BedController):
             return list(self._response_frames)
         finally:
             self._outstanding_request_key = None
+            self._accept_any_response = False
 
     async def _async_write_frame(
         self, frame: bytes, *, cancel_event: asyncio.Event | None = None
@@ -642,6 +679,15 @@ class SleepNumberMcrController(BedController):
         raw = bytes(data)
         self.forward_raw_notification(SLEEP_NUMBER_MCR_TX_CHAR_UUID, raw)
         self._response_buffer.extend(raw)
+        if self._accept_any_response and self._outstanding_request_key is not None:
+            # Init handshake: mirror the reference implementation that works
+            # against this hardware. ANY notification confirms the bed is alive
+            # and primed, so wake the waiter immediately. This deliberately
+            # bypasses the strict (function_code, side, is_response) correlation
+            # below, which some firmware violates for the init echo (no response
+            # bit, or a different side nibble) — without this the frame is
+            # discarded before it reaches _response_frames and init times out.
+            self._response_event.set()
         parsed_frame = False
         for frame in self._extract_response_frames():
             parsed_frame = True

--- a/tests/test_sleep_number_mcr.py
+++ b/tests/test_sleep_number_mcr.py
@@ -362,6 +362,52 @@ class TestSleepNumberMcrController:
 
         assert controller._initialized is False
 
+    async def test_read_response_correlates_by_function_code_only(
+        self,
+        sleep_number_mcr_coordinator,
+    ) -> None:
+        """Read responses correlate by function code, ignoring response bit and side.
+
+        Mirrors the reference implementation, which parses replies by
+        ``hdr[8] & 0x7F`` without checking the response bit or side nibble. The
+        same firmware quirk that broke the init handshake (#322) — no response
+        bit, mismatched side — must not stop normal read replies from matching.
+        """
+        coordinator = await sleep_number_mcr_coordinator(
+            address="AA:BB:CC:DD:EE:63",
+            name="64:DB:A0:07:DD:14",
+            entry_id="sleep_number_mcr_lenient_read",
+        )
+        controller = coordinator.controller
+        assert isinstance(controller, SleepNumberMcrController)
+        controller._initialized = True
+
+        # func=18 reply with NO response bit (0x80 unset) and side=1, even though
+        # the read below is issued with side=_MCR_SIDE_ALL (0x0F).
+        echo = controller._build_frame(
+            command_type=1,
+            status=0x02,
+            function_code=18,
+            side=1,
+            payload=bytes([1, 35, 65, 0, 0]),
+            sub_address=_mcr_address_from_mac("AA:BB:CC:DD:EE:63"),
+        )
+
+        def _deliver(_frame: bytes, *, cancel_event=None) -> None:
+            controller._handle_mcr_notification(None, bytearray(echo))
+
+        controller._async_write_frame = AsyncMock(side_effect=_deliver)
+
+        frames = await controller._async_send_frame(
+            command_type=0x02,
+            status=0x02,
+            function_code=18,
+            side=0x0F,
+            timeout=1.0,
+        )
+
+        assert [frame.payload for frame in frames] == [bytes([1, 35, 65, 0, 0])]
+
     async def test_async_send_frame_ignores_late_optional_response_for_next_same_key_request(
         self,
         sleep_number_mcr_coordinator,

--- a/tests/test_sleep_number_mcr.py
+++ b/tests/test_sleep_number_mcr.py
@@ -246,7 +246,7 @@ class TestSleepNumberMcrController:
         self,
         sleep_number_mcr_coordinator,
     ) -> None:
-        """The init handshake should still fail fast when its response never arrives."""
+        """A required-response frame should still raise TimeoutError when it never arrives."""
         coordinator = await sleep_number_mcr_coordinator(
             address="AA:BB:CC:DD:EE:5E",
             name="64:DB:A0:07:DD:0F",
@@ -267,6 +267,100 @@ class TestSleepNumberMcrController:
             )
 
         assert controller._outstanding_request_key is None
+
+    async def test_init_handshake_accepts_non_matching_echo(
+        self,
+        sleep_number_mcr_coordinator,
+    ) -> None:
+        """Init must succeed on ANY notification, even one the strict matcher rejects.
+
+        Regression test for issue #322: older BAM/MCR firmware echoes the init
+        frame without the response bit set and/or with a different side nibble,
+        which the per-command correlation discards. The handshake must still be
+        recognised so the connection is not stuck in a reconnect loop.
+        """
+        coordinator = await sleep_number_mcr_coordinator(
+            address="AA:BB:CC:DD:EE:60",
+            name="64:DB:A0:07:DD:11",
+            entry_id="sleep_number_mcr_lenient_init",
+        )
+        controller = coordinator.controller
+        assert isinstance(controller, SleepNumberMcrController)
+        controller._initialized = False
+
+        # A frame the strict matcher would reject: function_code 18 (not init),
+        # no response bit (0x80 unset -> is_response False), side 1 (not 0).
+        non_matching_echo = controller._build_frame(
+            command_type=1,
+            status=0x02,
+            function_code=18,
+            side=1,
+            payload=b"",
+            sub_address=_mcr_address_from_mac("AA:BB:CC:DD:EE:60"),
+        )
+
+        def _deliver_echo(_frame: bytes, *, cancel_event=None) -> None:
+            controller._handle_mcr_notification(None, bytearray(non_matching_echo))
+
+        controller._async_write_frame = AsyncMock(side_effect=_deliver_echo)
+
+        await controller._async_initialize_session()
+
+        assert controller._initialized is True
+        assert controller._accept_any_response is False
+        assert controller._outstanding_request_key is None
+
+    async def test_init_handshake_proceeds_optimistically_without_echo(
+        self,
+        sleep_number_mcr_coordinator,
+        monkeypatch,
+    ) -> None:
+        """No init echo but a live BLE link should not abort the connection."""
+        monkeypatch.setattr(
+            "custom_components.adjustable_bed.beds.sleep_number_mcr._INIT_HANDSHAKE_TIMEOUT_SECONDS",
+            0.02,
+        )
+        coordinator = await sleep_number_mcr_coordinator(
+            address="AA:BB:CC:DD:EE:61",
+            name="64:DB:A0:07:DD:12",
+            entry_id="sleep_number_mcr_optimistic_init",
+        )
+        controller = coordinator.controller
+        assert isinstance(controller, SleepNumberMcrController)
+        controller._initialized = False
+        controller._async_write_frame = AsyncMock()  # never delivers a notification
+
+        await controller._async_initialize_session()
+
+        assert controller._initialized is True
+        assert controller._accept_any_response is False
+
+    async def test_init_handshake_raises_when_link_dropped(
+        self,
+        sleep_number_mcr_coordinator,
+        monkeypatch,
+        mock_bleak_client,
+    ) -> None:
+        """A dropped link during init must fail so the coordinator reconnects."""
+        monkeypatch.setattr(
+            "custom_components.adjustable_bed.beds.sleep_number_mcr._INIT_HANDSHAKE_TIMEOUT_SECONDS",
+            0.02,
+        )
+        coordinator = await sleep_number_mcr_coordinator(
+            address="AA:BB:CC:DD:EE:62",
+            name="64:DB:A0:07:DD:13",
+            entry_id="sleep_number_mcr_dropped_init",
+        )
+        controller = coordinator.controller
+        assert isinstance(controller, SleepNumberMcrController)
+        controller._initialized = False
+        controller._async_write_frame = AsyncMock()
+        mock_bleak_client.is_connected = False
+
+        with pytest.raises(TimeoutError):
+            await controller._async_initialize_session()
+
+        assert controller._initialized is False
 
     async def test_async_send_frame_ignores_late_optional_response_for_next_same_key_request(
         self,

--- a/tests/test_sleep_number_mcr.py
+++ b/tests/test_sleep_number_mcr.py
@@ -362,6 +362,36 @@ class TestSleepNumberMcrController:
 
         assert controller._initialized is False
 
+    async def test_init_handshake_propagates_write_timeout(
+        self,
+        sleep_number_mcr_coordinator,
+    ) -> None:
+        """A failed init *write* must not be treated as success, even if connected.
+
+        Distinguishes a transport write timeout (init frame never reached the
+        bed) from a missing echo (write succeeded, no reply). The former must
+        propagate so the coordinator reconnects instead of priming the
+        controller against an uninitialised bed.
+        """
+        coordinator = await sleep_number_mcr_coordinator(
+            address="AA:BB:CC:DD:EE:64",
+            name="64:DB:A0:07:DD:15",
+            entry_id="sleep_number_mcr_write_timeout_init",
+        )
+        controller = coordinator.controller
+        assert isinstance(controller, SleepNumberMcrController)
+        controller._initialized = False
+        # The write itself times out at the transport layer while the BLE link
+        # still reports connected.
+        controller._async_write_frame = AsyncMock(
+            side_effect=TimeoutError("write timed out")
+        )
+
+        with pytest.raises(TimeoutError):
+            await controller._async_initialize_session()
+
+        assert controller._initialized is False
+
     async def test_read_response_correlates_by_function_code_only(
         self,
         sleep_number_mcr_coordinator,


### PR DESCRIPTION
## Problem

Sleep Number i8 FlexFit / 360 BAM beds (MCR protocol, firmware 0.4.x) **connect successfully** but then get stuck in a permanent reconnect loop. As of 2.9.4+ the runtime symptom is:

```
✗ CONNECTION TIMEOUT ... Timed out waiting for Sleep Number MCR response func=0
```

Reported in #322. The reporter (@JonGilmore) maintains a standalone integration ([JonGilmore/sleepnumber-ble](https://github.com/JonGilmore/sleepnumber-ble)) that works flawlessly on the **same** hardware and through the **same** ESPHome proxy, so the protocol bytes are correct — the divergence is purely in how the bed's **responses** are handled.

## Root cause

The init request frame is byte-identical to the working reference (`16 16 02 00 00 00 00 02 00 00 00 08 00…00 86`), so the bed receives a valid init and replies. But our `_handle_mcr_notification` runs every notification through a strict per-command correlation (`_frame_matches_request_key`) that required:

- the **response bit** (`byte 8 & 0x80`) to be set, **and**
- the **side nibble** to match the request.

Older BAM/MCR firmware replies **without the response bit set** and/or **with a different side nibble**. Such frames were discarded *before* reaching `_response_frames`, so the response event never fired, the 10 s wait timed out, and the connection looped forever. The reference avoids this entirely: it treats any notification as init success and parses all other replies by **function code only** (`hdr[8] & 0x7F`), never checking the response bit or side.

## Fix (mirrors the reference)

Two commits:

1. **Lenient init handshake.** Add an `accept_any_response` mode to `_async_send_frame`; during init, `_handle_mcr_notification` wakes the waiter on **any** notification, bypassing the strict matcher. If the firmware sends no echo at all but the BLE link is up, proceed anyway (the write primes the bed; follow-up commands are fire-and-forget). Only a dropped link fails the connect so the coordinator can reconnect — no more `RuntimeError`.

2. **Correlate all responses by function code only.** `_frame_matches_request_key` now matches purely on function code, exactly like the reference — no response-bit or side-nibble requirement. The bed is purely request/response with one outstanding request at a time, so the function code is sufficient. This also lets firmness / under-bed-light **state readback** populate, which the strict matcher would otherwise have blocked for the same reason init failed.

This was arrived at via a multi-agent root-cause investigation with adversarial verification: the verifiers confirmed the fix must act at the **notification-handler** level (not merely at the final init validation), because the rejection happened upstream in `_frame_matches_request_key`.

> Note: the test mock in `conftest.py` was self-fulfilling — it built replies with the response bit and matching side, exactly what the strict matcher wanted, so the unit tests passed while the real bed failed. The new tests below exercise *non-matching* echoes.

## Tests

- `test_init_handshake_accepts_non_matching_echo` — init succeeds on an echo with no response bit and a mismatched side (the #322 case).
- `test_init_handshake_proceeds_optimistically_without_echo` — no echo + live link → connection proceeds.
- `test_init_handshake_raises_when_link_dropped` — no echo + dropped link → fails so the coordinator reconnects.
- `test_read_response_correlates_by_function_code_only` — a read reply with no response bit and a mismatched side still correlates.

Full suite: **1821 passed** (before the matcher change; unaffected files). MCR + coordinator + entities re-run after both commits: **135 passed**. `ruff` clean.

## To verify on hardware

@JonGilmore — please test a build with this change and confirm the bed connects, presets/firmness/lights respond, and the firmness / under-bed-light values populate.

Ref #322