### PR TITLE
fix: stop OS-pairing Sleep Number Climate 360 (auth-82 / stale ESTABLISHED loop)

### DIFF
--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -1590,7 +1590,17 @@ ALL_PROTOCOL_VARIANTS: Final = [
 ]
 
 # Bed types that require BLE pairing before they can be controlled
-# These beds use encrypted connections and must be paired at the OS level
+# These beds use encrypted connections and must be paired at the OS level.
+#
+# NOTE: Sleep Number Climate 360 / FlexFit (Fuzion "bamkey") is deliberately
+# NOT listed here. The official SleepIQ app never creates an OS-level BLE bond
+# (there is no createBond/ensureBond call in the decompiled Fuzion BLE manager,
+# and the Auth characteristic is read-only). The bed "authenticates" purely at
+# the application layer by reading the Auth + TransferInfo characteristics after
+# every connect — handled by SleepNumberController._ensure_bed_presence_channel_primed().
+# Forcing OS-level pair=True made ESP-IDF/ESPHome Bluetooth proxies return
+# "auth fail reason=82" and leave the link wedged in the ESTABLISHED state, which
+# broke every subsequent reconnect until the proxy was factory reset (issue #318).
 BEDS_REQUIRING_PAIRING: Final[set[str]] = {
     BED_TYPE_OKIN_UUID,
     BED_TYPE_OKIN_CST,
@@ -1599,7 +1609,6 @@ BEDS_REQUIRING_PAIRING: Final[set[str]] = {
     BED_TYPE_OKIMAT,
     BED_TYPE_VIBRADORM,
     BED_TYPE_LOGICDATA,
-    BED_TYPE_SLEEP_NUMBER,
 }
 
 # Bed type + variant combinations that require BLE pairing

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -1097,7 +1097,12 @@ class AdjustableBedCoordinator:
                     # GATT discovery. Some devices expose different services depending
                     # on pairing state, and stale cached services from a previous
                     # non-paired connection will cause characteristic lookups to fail.
-                    disable_cache = use_pairing
+                    #
+                    # Sleep Number Climate 360 does not pair (see BEDS_REQUIRING_PAIRING)
+                    # but the SleepIQ app refreshes the GATT cache on every connect, so
+                    # force fresh discovery to keep parity and ensure the app-layer
+                    # priming reads always see the live characteristic handles.
+                    disable_cache = use_pairing or self._bed_type == BED_TYPE_SLEEP_NUMBER
                     try:
                         self._client = await establish_connection(
                             BleakClient,

--- a/docs/beds/sleep_number.md
+++ b/docs/beds/sleep_number.md
@@ -18,12 +18,14 @@
 
 ## Pairing
 
-Pairing depends on the Sleep Number BLE protocol family:
+Neither Sleep Number protocol family needs an OS-level BLE bond:
 
-- **Fuzion / Climate 360 / FlexFit (`Smart bed *`)**: BLE pairing is required before Home Assistant can connect.
-- **BAM / MCR (`ffffd1fd-...`, older i8 / 360 FlexFit 2)**: basic BLE control usually works without OS-level pairing.
+- **Fuzion / Climate 360 / FlexFit (`Smart bed *`)**: does **not** require OS-level BLE pairing/bonding. The bed authenticates at the application layer — the integration reads the Auth (`8d4675a5-…`) and TransferInfo (`e8d06e2a-…`) characteristics after every connect, exactly like the SleepIQ app (which never creates a BLE bond). Just make sure no phone app holds the connection; the bed allows only one BLE client at a time.
+- **BAM / MCR (`ffffd1fd-…`, older i8 / 360 FlexFit 2)**: basic BLE control works without OS-level pairing.
 
-For Fuzion bases, enter pairing mode by holding the side pairing button until the indicator flashes blue, then pair from Home Assistant or your system Bluetooth settings.
+> **Do not OS-pair a Fuzion base.** Earlier releases forced `pair=True`, which made ESP32 / ESPHome Bluetooth proxies report `auth fail reason=82` and leave the connection wedged in the `ESTABLISHED` state, breaking every reconnect until the proxy was factory-reset (issue #318). If your bed isn't discoverable, hold the side button until the indicator flashes blue to make it connectable — but do **not** complete an OS-level pairing.
+>
+> If you previously got stuck in this state, reboot the ESPHome Bluetooth proxy once after updating: the integration no longer re-pairs, so the proxy will reconnect cleanly instead of re-wedging on boot.
 
 ## Features
 
@@ -80,7 +82,7 @@ Older BAM/MCR bases use a different controller path. They expose both firmness s
 **Transfer Info UUID:** `e8d06e2a-c987-48f8-93a8-4d18d56b4337`  
 **Bulk Transfer Notify UUID:** `0ec9a5a3-8ac3-4582-92f3-1666421f323d`  
 **Format:** `fUzIoN` framed bamkey blobs with CRC validation  
-**Pairing Required:** Yes
+**Pairing Required:** No (application-layer auth via Auth/TransferInfo reads — no OS-level BLE bond)
 
 ## Detection
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -172,8 +172,8 @@ class TestPairingPersistence:
         flow.hass = hass
         flow._manual_data = {
             CONF_ADDRESS: "AA:BB:CC:DD:EE:01",
-            CONF_NAME: "Paired Sleep Number",
-            CONF_BED_TYPE: BED_TYPE_SLEEP_NUMBER,
+            CONF_NAME: "Paired Okimat",
+            CONF_BED_TYPE: BED_TYPE_OKIMAT,
             CONF_MOTOR_COUNT: 2,
             CONF_HAS_MASSAGE: False,
             CONF_DISABLE_ANGLE_SENSING: True,

--- a/tests/test_sleep_number.py
+++ b/tests/test_sleep_number.py
@@ -29,6 +29,7 @@ from custom_components.adjustable_bed.const import (
     SLEEP_NUMBER_VARIANT_LEFT,
     SLEEP_NUMBER_VARIANT_RIGHT,
     VARIANT_AUTO,
+    requires_pairing,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
 
@@ -77,6 +78,38 @@ def sleep_number_coordinator(hass: HomeAssistant, mock_coordinator_connected):
         return coordinator
 
     return _create
+
+
+class TestSleepNumberPairing:
+    """Regression coverage for issue #318 — the bed must never OS-pair.
+
+    The Fuzion / Climate 360 base authenticates at the application layer by
+    reading the Auth + TransferInfo characteristics after each connect (exactly
+    like the SleepIQ app, which never creates a BLE bond). Forcing OS-level
+    ``pair=True`` made ESP-IDF / ESPHome Bluetooth proxies return
+    ``auth fail reason=82`` and wedge the link in the ``ESTABLISHED`` state,
+    breaking every subsequent reconnect until the proxy was factory reset.
+    """
+
+    def test_sleep_number_is_not_a_pairing_required_bed(self) -> None:
+        """Sleep Number must not be classified as requiring OS-level pairing."""
+        assert requires_pairing(BED_TYPE_SLEEP_NUMBER) is False
+
+    async def test_connect_never_requests_ble_pairing(
+        self, sleep_number_coordinator, mock_establish_connection
+    ) -> None:
+        """The connect path must pass pair=False and force fresh GATT discovery."""
+        await sleep_number_coordinator(
+            address="AA:BB:CC:DD:EE:F0",
+            name="Smart bed 0074E7",
+            entry_id="sleep_number_no_pair",
+        )
+
+        kwargs = mock_establish_connection.await_args.kwargs
+        assert kwargs.get("pair") is False
+        # The SleepIQ app refreshes the GATT cache every connect; we mirror that
+        # so the priming reads always resolve live characteristic handles.
+        assert kwargs.get("use_services_cache") is False
 
 
 class TestSleepNumberController:


### PR DESCRIPTION
## Summary

Sleep Number **Climate 360 / FlexFit (Fuzion "bamkey")** bases get stuck in an unrecoverable connection loop via ESPHome/ESP32 Bluetooth proxies: the proxy reports `auth fail reason=82`, leaves the link wedged in `ESTABLISHED`, and every subsequent reconnect is ignored until the proxy is factory-reset. Ref #318.

## Root cause

This bed **does not use BLE SMP bonding.** Confirmed against the decompiled official SleepIQ app (`disassembly/output/com.selectcomfort.SleepIQ`): the Fuzion BLE manager (`com.fuzionble`) never calls `createBond`/`ensureBond`, and the Auth characteristic (`8d4675a5…`) is read-only. The bed "authenticates" purely at the application layer by **reading** the Auth + TransferInfo characteristics after each connect — which `SleepNumberController._ensure_bed_presence_channel_primed()` already does.

The integration wrongly listed it in `BEDS_REQUIRING_PAIRING`, so the coordinator passed `pair=True` to `establish_connection`. On ESP-IDF, SMP-pairing a non-bonding (or bond-asymmetric) device returns `auth fail reason=82` and wedges the link in `ESTABLISHED`. Worse, on every ESP reboot HA immediately retried connect-and-pair, re-wedging it — which is why power-cycling never helped and only a factory reset cleared it. This flaw was present in **every** version (2.9.3 also paired on every connect), so reverting didn't help either.

## Fix

- **`const.py`** — remove `BED_TYPE_SLEEP_NUMBER` from `BEDS_REQUIRING_PAIRING`. One change that disables `pair=True`, the config-flow pairing step, the pairing repair issue, and the auth-error clear-bond loop for this bed. App-layer priming is unchanged.
- **`coordinator.py`** — keep the GATT services cache disabled for `sleep_number` so it still does fresh discovery on every connect (parity with the SleepIQ app's `REFRESH_CACHE`, previously inherited as a side effect of pairing).
- **`docs/beds/sleep_number.md`** — correct the pairing guidance; add a proxy-reboot recovery note for already-stuck users.
- **Tests** — `TestSleepNumberPairing` asserts `requires_pairing(SLEEP_NUMBER)` is `False` and that the real connect path always passes `pair=False` with fresh discovery; one config-flow bond-persistence test retargeted off `sleep_number`.

## Recovery for already-stuck users

Software can't reliably un-wedge an ESP already in `ESTABLISHED` (that needed the factory reset). But with pairing gone the integration won't re-wedge it, so **one reboot of the ESPHome proxy after updating** lets it reconnect cleanly.

## Testing

Full suite: **1840 passed**. The existing bond/pairing coordinator tests use OKIMAT and still pass — other pairing-required beds (okin_uuid, okimat, leggett_okin, vibradorm, logicdata, okin_cst, okin_rf_eco_bt) are unaffected.

## Not included

No version bump (per request — bump at release time).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth connectivity for Sleep Number beds by preventing unnecessary OS-level pairing, resolving potential reconnection issues with Bluetooth proxies.

* **Documentation**
  * Updated Sleep Number protocol documentation with revised pairing guidance and troubleshooting steps for Bluetooth proxy reconnection wedge scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kristofferR/ha-adjustable-bed/pull/356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->