### PR TITLE
Fix Lucid L600 Malouf legacy protocol detection

### DIFF
--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -131,7 +131,7 @@ from .const import (
     resolve_richmat_remote_code,
 )
 from .controller_factory import create_controller
-from .detection import detect_richmat_remote_from_name
+from .detection import detect_richmat_remote_from_name, refine_malouf_protocol_from_gatt
 from .diagnostic_payloads import new_connection_attempt_details
 from .unsupported import create_pairing_required_issue
 
@@ -336,6 +336,35 @@ class AdjustableBedCoordinator:
             self._preferred_adapter,
             self._connection_profile,
         )
+
+    def _apply_runtime_bed_type_correction(self, corrected_bed_type: str) -> None:
+        """Apply a protocol correction discovered after BLE service discovery."""
+        previous_bed_type = self._bed_type
+        if corrected_bed_type == previous_bed_type:
+            return
+
+        _LOGGER.warning(
+            "Correcting bed protocol for %s from %s to %s based on connected GATT services",
+            self._address,
+            previous_bed_type,
+            corrected_bed_type,
+        )
+        previous_defaults = BED_MOTOR_PULSE_DEFAULTS.get(previous_bed_type)
+        corrected_defaults = BED_MOTOR_PULSE_DEFAULTS.get(corrected_bed_type)
+        if (
+            previous_defaults is not None
+            and corrected_defaults is not None
+            and (self._motor_pulse_count, self._motor_pulse_delay_ms) == previous_defaults
+        ):
+            self._motor_pulse_count, self._motor_pulse_delay_ms = corrected_defaults
+            _LOGGER.info(
+                "Updated motor pulse defaults for corrected %s protocol: count=%s, delay=%sms",
+                corrected_bed_type,
+                self._motor_pulse_count,
+                self._motor_pulse_delay_ms,
+            )
+
+        self._bed_type = corrected_bed_type
 
     @property
     def address(self) -> str:
@@ -1303,6 +1332,12 @@ class AdjustableBedCoordinator:
                     )
                     self._ble_manufacturer = ble_manufacturer
                     self._ble_model = ble_model
+
+                corrected_bed_type = refine_malouf_protocol_from_gatt(
+                    self._bed_type,
+                    self._client.services,
+                )
+                self._apply_runtime_bed_type_correction(corrected_bed_type)
 
                 # Post-connection protocol verification for DewertOkin Star devices.
                 # The adjustbed app (com.okin.bedding.adjustbed) reads BLE characteristic

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -351,9 +351,20 @@ class AdjustableBedCoordinator:
         )
         previous_defaults = BED_MOTOR_PULSE_DEFAULTS.get(previous_bed_type)
         corrected_defaults = BED_MOTOR_PULSE_DEFAULTS.get(corrected_bed_type)
+        # Only swap in the corrected protocol's defaults if the user never set
+        # their own pulse values. Comparing against ``previous_defaults`` alone is
+        # not enough: an explicit override can coincidentally equal the previous
+        # bed type's defaults (e.g. NEW_OKIN's (10, 100)), and we must not silently
+        # overwrite it. Pulse values are read from ``entry.data`` in __init__, so
+        # presence of these keys there is the authoritative override boundary.
+        has_custom_pulse_override = (
+            CONF_MOTOR_PULSE_COUNT in self.entry.data
+            or CONF_MOTOR_PULSE_DELAY_MS in self.entry.data
+        )
         if (
             previous_defaults is not None
             and corrected_defaults is not None
+            and not has_custom_pulse_override
             and (self._motor_pulse_count, self._motor_pulse_delay_ms) == previous_defaults
         ):
             self._motor_pulse_count, self._motor_pulse_delay_ms = corrected_defaults

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -105,8 +105,10 @@ from .const import (
     LINAK_POSITION_SERVICE_UUID,
     LOGICDATA_SERVICE_UUID,
     MALOUF_LEGACY_OKIN_SERVICE_UUID,
+    MALOUF_LEGACY_OKIN_WRITE_CHAR_UUID,
     MALOUF_NAME_PATTERNS,
     MALOUF_NEW_OKIN_ADVERTISED_SERVICE_UUID,
+    MALOUF_NEW_OKIN_WRITE_CHAR_UUID,
     MANUFACTURER_ID_DEWERTOKIN,
     MANUFACTURER_ID_LOGICDATA,
     MANUFACTURER_ID_OKIN,
@@ -241,6 +243,21 @@ def _check_manufacturer_data(
     # a fallback after UUID-based detection. See detect_bed_type_detailed().
 
     return None, 0.0, None
+
+
+def _manufacturer_data_contains_ascii(
+    manufacturer_data: dict[int, bytes] | None,
+    marker: str,
+) -> bool:
+    """Return True if any manufacturer payload contains an ASCII marker."""
+    if not manufacturer_data:
+        return False
+
+    marker_lower = marker.lower()
+    return any(
+        marker_lower in payload.decode("ascii", errors="ignore").lower()
+        for payload in manufacturer_data.values()
+    )
 
 
 # Solace naming convention pattern (e.g., S4-Y-192-461000AD)
@@ -462,6 +479,28 @@ def detect_bed_type_from_gatt_services(gatt_services: Any) -> DetectionResult:
         )
 
     return DetectionResult(bed_type=None, confidence=0.0, signals=[])
+
+
+def refine_malouf_protocol_from_gatt(bed_type: str, gatt_services: Any) -> str:
+    """Correct Malouf/Lucid family protocol once connected GATT services are known."""
+    if bed_type not in {BED_TYPE_MALOUF_NEW_OKIN, BED_TYPE_MALOUF_LEGACY_OKIN}:
+        return bed_type
+
+    characteristic_uuids: set[str] = set()
+    for service in gatt_services or []:
+        for char in _characteristics_from_gatt_service(service):
+            if char_uuid := _uuid_from_gatt_object(char):
+                characteristic_uuids.add(char_uuid)
+
+    has_new_okin_write = MALOUF_NEW_OKIN_WRITE_CHAR_UUID.lower() in characteristic_uuids
+    has_legacy_okin_write = MALOUF_LEGACY_OKIN_WRITE_CHAR_UUID.lower() in characteristic_uuids
+
+    if bed_type == BED_TYPE_MALOUF_NEW_OKIN and has_legacy_okin_write and not has_new_okin_write:
+        return BED_TYPE_MALOUF_LEGACY_OKIN
+    if bed_type == BED_TYPE_MALOUF_LEGACY_OKIN and has_new_okin_write and not has_legacy_okin_write:
+        return BED_TYPE_MALOUF_NEW_OKIN
+
+    return bed_type
 
 
 def detect_bed_type(service_info: BluetoothServiceInfoBleak) -> str | None:
@@ -898,8 +937,30 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
             signals=signals,
         )
 
-    # Check for Malouf NEW_OKIN - unique advertised service UUID (most specific first)
+    # Check for Malouf/Lucid app family. Most devices advertising this UUID use
+    # NEW_OKIN over Nordic UART, but Lucid L600 / OKIN-BLE BTCB controllers have
+    # been observed advertising the same UUID while exposing the FFE5/FFE9 command
+    # path after connection.
     if MALOUF_NEW_OKIN_ADVERTISED_SERVICE_UUID.lower() in service_uuids:
+        if device_name.startswith("okin-ble") and _manufacturer_data_contains_ascii(
+            service_info.manufacturer_data,
+            "btcb",
+        ):
+            signals.append("uuid:malouf_family")
+            signals.append("name:okin_ble")
+            signals.append("manufacturer_payload:btcb")
+            _LOGGER.info(
+                "Detected Malouf/Lucid FFE5 bed at %s (name: %s, BTCB payload)",
+                service_info.address,
+                service_info.name,
+            )
+            return DetectionResult(
+                bed_type=BED_TYPE_MALOUF_LEGACY_OKIN,
+                confidence=0.9,
+                signals=signals,
+                ambiguous_types=[BED_TYPE_MALOUF_NEW_OKIN],
+            )
+
         signals.append("uuid:malouf_new_okin")
         _LOGGER.info(
             "Detected Malouf NEW_OKIN bed at %s (name: %s)",

--- a/docs/SUPPORTED_ACTUATORS.md
+++ b/docs/SUPPORTED_ACTUATORS.md
@@ -149,7 +149,7 @@ These beds have their own dedicated integrations:
    - Service `62741523-...` plus CSS service `90311623-...` and write characteristic `90311625-...` → [OKIN Smart Remote / RF ECO BT](beds/okin-rf-eco-bt.md)
    - Service `45e25100-...` → Leggett & Platt Gen2
    - Service `0000aa5c-...` → Octo Star2 variant
-   - Service `01000001-...` → Malouf (New OKIN)
+   - Service `01000001-...` → Malouf/Lucid family (usually New OKIN; `OKIN-BLE` + `BTCB` uses Legacy OKIN)
    - Service `0000ffe5-...` → Malouf (Legacy OKIN) or Keeson OKIN variant
    - Service `0000fff0-...` + name `SUTA-*` → SUTA Smart Home
    - Service `6e400001-...` + name `AHF*` → TiMOTION AHF

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -285,7 +285,7 @@ Use these to identify your bed type in a BLE scanner:
 | `0000ffe0-0000-1000-8000-00805f9b34fb` | Solace, MotoSleep, Octo (standard), Limoss/Stawett (name-based) |
 | `0000ffe5-0000-1000-8000-00805f9b34fb` | Keeson Base, Ergomotion, Malouf LEGACY_OKIN, OKIN FFE, Serta |
 | `0000fff0-0000-1000-8000-00805f9b34fb` | Keeson Base (fallback), Richmat WiLinke (variant) |
-| `01000001-0000-1000-8000-00805f9b34fb` | Malouf NEW_OKIN |
+| `01000001-0000-1000-8000-00805f9b34fb` | Malouf/Lucid family (usually NEW_OKIN; `OKIN-BLE` + `BTCB` uses LEGACY_OKIN/FFE5) |
 | `1b1d9641-b942-4da8-89cc-98e6a58fbd93` | Reverie |
 | `45e25100-3171-4cfc-ae89-1d83cf8d8071` | Leggett & Platt Gen2 |
 | `09d23fae-90e6-44c2-95b6-0b3d0f1abf25` | Sleep Number Climate 360 / FlexFit |

--- a/docs/beds/malouf.md
+++ b/docs/beds/malouf.md
@@ -63,6 +63,11 @@ Malouf beds use two distinct protocols. The integration auto-detects which one y
 **Format:** 9 bytes `[0xE6, 0xFE, 0x16, cmd&0xFF, (cmd>>8)&0xFF, (cmd>>16)&0xFF, (cmd>>24)&0xFF, 0x00, checksum]`
 **Checksum:** `(~sum(bytes[0:8])) & 0xFF`
 
+Some Lucid L600 / DewertOKIN `OKIN-BLE` controllers advertise the Malouf/Lucid
+family UUID (`01000001-...`) but expose only the FFE5/FFE9 command service after
+connection. Their advertising manufacturer payload commonly contains `BTCB`.
+Those devices are treated as the LEGACY_OKIN/FFE5 protocol.
+
 ## Commands
 
 Both protocols use the same command values (32-bit integers):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -15,6 +15,8 @@ from custom_components.adjustable_bed.const import (
     BED_MOTOR_PULSE_DEFAULTS,
     BED_TYPE_KEESON,
     BED_TYPE_LINAK,
+    BED_TYPE_MALOUF_LEGACY_OKIN,
+    BED_TYPE_MALOUF_NEW_OKIN,
     BED_TYPE_OKIMAT,
     BED_TYPE_RICHMAT,
     BED_TYPE_SLEEP_NUMBER_MCR,
@@ -1859,6 +1861,69 @@ class TestMotorPulseConfiguration:
         # Custom values should override bed-type defaults
         assert coordinator.motor_pulse_count == 15
         assert coordinator.motor_pulse_delay_ms == 75
+
+
+class TestRuntimeBedTypeCorrection:
+    """Test runtime Malouf protocol correction after GATT discovery."""
+
+    def _make_coordinator(self, hass, mock_config_entry_data, extra):
+        mock_config_entry_data[CONF_BED_TYPE] = BED_TYPE_MALOUF_NEW_OKIN
+        mock_config_entry_data.update(extra)
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=TEST_NAME,
+            data=mock_config_entry_data,
+            unique_id="AA:BB:CC:DD:EE:FF",
+            entry_id="test_entry_runtime_correction",
+        )
+        return AdjustableBedCoordinator(hass, entry)
+
+    async def test_correction_updates_unconfigured_pulse_defaults(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_data: dict,
+    ):
+        """Without a user override, correction swaps in the new protocol's defaults."""
+        coordinator = self._make_coordinator(hass, mock_config_entry_data, {})
+        # Starts at NEW_OKIN defaults.
+        assert (coordinator.motor_pulse_count, coordinator.motor_pulse_delay_ms) == (
+            BED_MOTOR_PULSE_DEFAULTS[BED_TYPE_MALOUF_NEW_OKIN]
+        )
+
+        coordinator._apply_runtime_bed_type_correction(BED_TYPE_MALOUF_LEGACY_OKIN)
+
+        assert coordinator.bed_type == BED_TYPE_MALOUF_LEGACY_OKIN
+        assert (coordinator.motor_pulse_count, coordinator.motor_pulse_delay_ms) == (
+            BED_MOTOR_PULSE_DEFAULTS[BED_TYPE_MALOUF_LEGACY_OKIN]
+        )
+
+    async def test_correction_preserves_explicit_pulse_override(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_data: dict,
+    ):
+        """Regression: an explicit override equal to the old defaults must survive.
+
+        The user configured pulse values that happen to equal NEW_OKIN's defaults
+        (10, 100). A correction to LEGACY_OKIN must update the bed type but must not
+        silently rewrite the user's values to LEGACY_OKIN's (7, 150).
+        """
+        new_okin_defaults = BED_MOTOR_PULSE_DEFAULTS[BED_TYPE_MALOUF_NEW_OKIN]
+        coordinator = self._make_coordinator(
+            hass,
+            mock_config_entry_data,
+            {
+                CONF_MOTOR_PULSE_COUNT: new_okin_defaults[0],
+                CONF_MOTOR_PULSE_DELAY_MS: new_okin_defaults[1],
+            },
+        )
+
+        coordinator._apply_runtime_bed_type_correction(BED_TYPE_MALOUF_LEGACY_OKIN)
+
+        # Bed type is still corrected...
+        assert coordinator.bed_type == BED_TYPE_MALOUF_LEGACY_OKIN
+        # ...but the explicit override is preserved, not overwritten.
+        assert (coordinator.motor_pulse_count, coordinator.motor_pulse_delay_ms) == new_okin_defaults
 
 
 class TestMultiMotorConfiguration:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1866,7 +1866,12 @@ class TestMotorPulseConfiguration:
 class TestRuntimeBedTypeCorrection:
     """Test runtime Malouf protocol correction after GATT discovery."""
 
-    def _make_coordinator(self, hass, mock_config_entry_data, extra):
+    def _make_coordinator(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_data: dict,
+        extra: dict,
+    ) -> AdjustableBedCoordinator:
         mock_config_entry_data[CONF_BED_TYPE] = BED_TYPE_MALOUF_NEW_OKIN
         mock_config_entry_data.update(extra)
         entry = MockConfigEntry(

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -61,7 +61,9 @@ from custom_components.adjustable_bed.const import (
     LEGGETT_GEN2_SERVICE_UUID,
     LIMOSS_SERVICE_UUID,
     LINAK_CONTROL_SERVICE_UUID,
+    MALOUF_LEGACY_OKIN_WRITE_CHAR_UUID,
     MALOUF_NEW_OKIN_ADVERTISED_SERVICE_UUID,
+    MALOUF_NEW_OKIN_WRITE_CHAR_UUID,
     MANUFACTURER_ID_DEWERTOKIN,
     MANUFACTURER_ID_OKIN,
     MANUFACTURER_ID_VIBRADORM,
@@ -91,6 +93,7 @@ from custom_components.adjustable_bed.detection import (
     detect_bed_type_detailed,
     detect_bed_type_from_gatt_services,
     detect_richmat_remote_from_name,
+    refine_malouf_protocol_from_gatt,
 )
 
 
@@ -268,6 +271,22 @@ class TestDetectBedTypeByServiceUUID:
             service_uuids=[MALOUF_NEW_OKIN_ADVERTISED_SERVICE_UUID],
         )
         assert detect_bed_type(service_info) == BED_TYPE_MALOUF_NEW_OKIN
+
+    def test_detect_lucid_l600_btcb_as_malouf_legacy(self):
+        """Lucid L600 OKIN-BLE/BTCB beacons use the FFE5 Malouf protocol."""
+        service_info = _make_service_info(
+            name="OKIN-BLE00017786",
+            service_uuids=[MALOUF_NEW_OKIN_ADVERTISED_SERVICE_UUID],
+            manufacturer_data={3: b"BTCB.03"},
+        )
+
+        result = detect_bed_type_detailed(service_info)
+
+        assert result.bed_type == BED_TYPE_MALOUF_LEGACY_OKIN
+        assert result.confidence == 0.9
+        assert "name:okin_ble" in result.signals
+        assert "manufacturer_payload:btcb" in result.signals
+        assert result.ambiguous_types == [BED_TYPE_MALOUF_NEW_OKIN]
 
     def test_detect_leggett_gen2_by_uuid(self):
         """Test Leggett Gen2 detection by unique service UUID."""
@@ -766,6 +785,45 @@ class TestOkinUUIDDisambiguation:
         assert result.bed_type == BED_TYPE_OKIN_RF_ECO_BT
         assert result.confidence == 0.9
         assert "gatt_char:okin_smart_remote_css_write" in result.signals
+
+    def test_malouf_new_refines_to_legacy_when_gatt_has_ffe9_only(self):
+        """A saved Malouf Nordic entry should use FFE5 when connected GATT proves it."""
+        gatt_services = [
+            SimpleNamespace(
+                uuid=KEESON_BASE_SERVICE_UUID,
+                characteristics=[SimpleNamespace(uuid=MALOUF_LEGACY_OKIN_WRITE_CHAR_UUID)],
+            )
+        ]
+
+        assert (
+            refine_malouf_protocol_from_gatt(BED_TYPE_MALOUF_NEW_OKIN, gatt_services)
+            == BED_TYPE_MALOUF_LEGACY_OKIN
+        )
+
+    def test_malouf_legacy_refines_to_new_when_gatt_has_nordic_write_only(self):
+        """The Malouf family correction should work in both protocol directions."""
+        gatt_services = [
+            SimpleNamespace(
+                uuid=NORDIC_UART_SERVICE_UUID,
+                characteristics=[SimpleNamespace(uuid=MALOUF_NEW_OKIN_WRITE_CHAR_UUID)],
+            )
+        ]
+
+        assert (
+            refine_malouf_protocol_from_gatt(BED_TYPE_MALOUF_LEGACY_OKIN, gatt_services)
+            == BED_TYPE_MALOUF_NEW_OKIN
+        )
+
+    def test_malouf_gatt_refinement_leaves_non_malouf_types_unchanged(self):
+        """GATT refinement is scoped to Malouf/Lucid entries because FFE5 is shared."""
+        gatt_services = [
+            SimpleNamespace(
+                uuid=KEESON_BASE_SERVICE_UUID,
+                characteristics=[SimpleNamespace(uuid=MALOUF_LEGACY_OKIN_WRITE_CHAR_UUID)],
+            )
+        ]
+
+        assert refine_malouf_protocol_from_gatt(BED_TYPE_KEESON, gatt_services) == BED_TYPE_KEESON
 
     def test_okin_uuid_defaults_to_okimat(self):
         """Test OKIN UUID defaults to Okimat with low confidence for unknown name."""


### PR DESCRIPTION
## Summary
- detect Lucid L600 OKIN-BLE/BTCB Malouf-family advertisements as the FFE5/FFE9 Legacy OKIN protocol
- correct existing Malouf/Lucid entries at connection time when GATT write characteristics prove the other Malouf protocol
- document the Lucid L600/BTCB exception and add regression tests

Ref #358

## Tests
- uv run pytest -n 0 tests/test_detection.py tests/test_controller_contract.py
- uv run ruff check custom_components/adjustable_bed/detection.py custom_components/adjustable_bed/coordinator.py tests/test_detection.py docs/beds/malouf.md docs/SUPPORTED_ACTUATORS.md docs/TROUBLESHOOTING.md
- uv run mypy --python-version 3.14 custom_components/adjustable_bed/detection.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved detection for Malouf/Lucid bed variants using additional manufacturer-payload checks.
  * Runtime protocol refinement after connection that corrects detected bed type and, when appropriate, adjusts motor pulse defaults without overwriting explicit user settings.

* **Documentation**
  * Clarified Malouf/Lucid family UUID mapping and documented legacy OKIN variant handling.

* **Tests**
  * Added tests covering detection paths and runtime protocol refinement behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->