### PR TITLE
fix: coerce string values for integer config-flow dropdowns

### DIFF
--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -730,7 +730,9 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         schema_dict: dict[vol.Marker, Any] = {
             vol.Optional(CONF_BED_TYPE, default=bed_type): bed_type_selector,
             vol.Optional(CONF_NAME, default=self._discovery_info.name or "Adjustable Bed"): str,
-            vol.Optional(CONF_MOTOR_COUNT, default=default_motor_count): vol.In([2, 3, 4]),
+            vol.Optional(CONF_MOTOR_COUNT, default=default_motor_count): vol.All(
+                vol.Coerce(int), vol.In([2, 3, 4])
+            ),
             vol.Optional(CONF_HAS_MASSAGE, default=DEFAULT_HAS_MASSAGE): bool,
             vol.Optional(CONF_DISABLE_ANGLE_SENSING, default=default_disable_angle): bool,
             vol.Optional(CONF_PREFERRED_ADAPTER, default=ADAPTER_AUTO): vol.In(adapters),
@@ -1346,7 +1348,9 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 vol.Optional(
                     CONF_NAME, default=device_name if device_name != "Unknown" else "Adjustable Bed"
                 ): str,
-                vol.Optional(CONF_MOTOR_COUNT, default=DEFAULT_MOTOR_COUNT): vol.In([2, 3, 4]),
+                vol.Optional(CONF_MOTOR_COUNT, default=DEFAULT_MOTOR_COUNT): vol.All(
+                    vol.Coerce(int), vol.In([2, 3, 4])
+                ),
                 vol.Optional(CONF_HAS_MASSAGE, default=DEFAULT_HAS_MASSAGE): bool,
                 vol.Optional(CONF_DISABLE_ANGLE_SENSING, default=default_disable_angle): bool,
                 vol.Optional(CONF_PREFERRED_ADAPTER, default=discovery_source): vol.In(adapters),
@@ -1361,7 +1365,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 ): bool,
                 vol.Optional(
                     CONF_IDLE_DISCONNECT_SECONDS, default=DEFAULT_IDLE_DISCONNECT_SECONDS
-                ): vol.In(range(10, 301)),
+                ): vol.All(vol.Coerce(int), vol.Range(min=10, max=300)),
             }
         )
 
@@ -1533,7 +1537,9 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         schema_dict.update(
             {
                 vol.Optional(CONF_NAME, default="Adjustable Bed"): str,
-                vol.Optional(CONF_MOTOR_COUNT, default=DEFAULT_MOTOR_COUNT): vol.In([2, 3, 4]),
+                vol.Optional(CONF_MOTOR_COUNT, default=DEFAULT_MOTOR_COUNT): vol.All(
+                    vol.Coerce(int), vol.In([2, 3, 4])
+                ),
                 vol.Optional(CONF_HAS_MASSAGE, default=DEFAULT_HAS_MASSAGE): bool,
                 vol.Optional(CONF_DISABLE_ANGLE_SENSING, default=default_disable_angle): bool,
                 vol.Optional(CONF_PREFERRED_ADAPTER, default=ADAPTER_AUTO): vol.In(adapters),
@@ -1548,7 +1554,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 ): bool,
                 vol.Optional(
                     CONF_IDLE_DISCONNECT_SECONDS, default=DEFAULT_IDLE_DISCONNECT_SECONDS
-                ): vol.In(range(10, 301)),
+                ): vol.All(vol.Coerce(int), vol.Range(min=10, max=300)),
             }
         )
 
@@ -2023,7 +2029,7 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
             vol.Optional(
                 CONF_MOTOR_COUNT,
                 default=current_data.get(CONF_MOTOR_COUNT, DEFAULT_MOTOR_COUNT),
-            ): vol.In([2, 3, 4]),
+            ): vol.All(vol.Coerce(int), vol.In([2, 3, 4])),
             vol.Optional(
                 CONF_HAS_MASSAGE,
                 default=current_data.get(CONF_HAS_MASSAGE, DEFAULT_HAS_MASSAGE),
@@ -2057,7 +2063,7 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
                 default=current_data.get(
                     CONF_IDLE_DISCONNECT_SECONDS, DEFAULT_IDLE_DISCONNECT_SECONDS
                 ),
-            ): vol.In(range(10, 301)),
+            ): vol.All(vol.Coerce(int), vol.Range(min=10, max=300)),
             vol.Optional(
                 CONF_DISABLE_ANGLE_SENSING,
                 default=current_data.get(CONF_DISABLE_ANGLE_SENSING, DEFAULT_DISABLE_ANGLE_SENSING),

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -636,6 +636,38 @@ class TestBluetoothDiscoveryFlow:
         assert result["data"][CONF_HAS_MASSAGE] is True
         assert result["data"][CONF_DISABLE_ANGLE_SENSING] is False
 
+    async def test_bluetooth_discovery_confirm_coerces_string_motor_count(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info: BluetoothServiceInfoBleak,
+        enable_custom_integrations,
+    ):
+        """Regression for #361: HA frontend submits the dropdown value as a string.
+
+        ``vol.In([2, 3, 4])`` rejected ``"3"`` with "value must be one of [2, 3, 4]",
+        blocking the config flow. The schema must coerce the string to an int.
+        """
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_BLUETOOTH},
+            data=mock_bluetooth_service_info,
+        )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_NAME: "My Bed",
+                # Frontend sends select-dropdown values as strings, not ints.
+                CONF_MOTOR_COUNT: "3",
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: False,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_MOTOR_COUNT] == 3
+
     async def test_bluetooth_discovery_duplicate_octo_names_warn_about_split_setup(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## Problem

Adding a bed via the config flow fails with **`value must be one of [2, 3, 4]`** as soon as the motor count is submitted — blocking setup entirely (discovery *and* manual). Reported in #361 (Rize MF900, and a Leggett & Platt Okin box in the comments — it's not bed-specific).

## Root cause

The HA frontend renders `vol.In([2, 3, 4])` as a `<select>` dropdown and now hands the chosen option back as a **string** (`"3"`), not an int. `vol.In([2, 3, 4])` then rejects `"3"` with exactly that voluptuous error. The schemas were written expecting int input; a frontend behavior change surfaced the mismatch.

## Fix

Wrap every integer-valued `vol.In` with `vol.Coerce(int)` so it accepts both the string the frontend sends and a raw int. The serialized schema is byte-identical, so the dropdown UI is unchanged.

- **`motor_count`** (×4: discovery-confirm, manual-config, manual-entry, options) → `vol.All(vol.Coerce(int), vol.In([2, 3, 4]))`
- **`idle_disconnect_seconds`** (×3) → `vol.All(vol.Coerce(int), vol.Range(min=10, max=300))`, matching the pattern already used in the bluetooth-confirm step. Same latent string-coercion bug, and it also replaces an unintended 291-item dropdown with a number box.

These were the only integer-valued `vol.In` fields; string-valued ones (adapters, bed type, variants, remotes) are unaffected.

## Testing

- Added `test_bluetooth_discovery_confirm_coerces_string_motor_count`, which submits `motor_count: "3"` (the exact frontend behavior) and asserts the entry is created with int `3`.
- `pytest tests/test_config_flow.py` → **84 passed**; `ruff check` clean.

Ref #361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation for numeric configuration fields in the adjustable bed setup flow. The system now more reliably processes and validates motor count and idle timeout settings, ensuring only valid values are accepted during initial configuration and adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->