### PR TITLE
fix: recover from mid-capture disconnects during BLE diagnostics

### DIFF
--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -574,19 +574,21 @@ class BLEDiagnosticRunner:
 
     async def _reconnect(self) -> bool:
         """Re-establish a connection that dropped mid-diagnostics."""
-        if self._using_coordinator_connection:
-            # The coordinator owns its connection lifecycle; pick up its
-            # reconnected client if there is one, but never open a competing
-            # connection of our own.
-            if self.coordinator and self.coordinator.client and self.coordinator.is_connected:
-                self._client = self.coordinator.client
-                return True
-            message = "Coordinator connection lost during diagnostics"
-            if message not in self._errors:
-                self._errors.append(message)
-            return False
+        if (
+            self._using_coordinator_connection
+            and self.coordinator
+            and self.coordinator.client
+            and self.coordinator.is_connected
+        ):
+            # The coordinator already auto-reconnected on its own; adopt its client.
+            self._client = self.coordinator.client
+            return True
 
         if self._reconnect_count >= MAX_RECONNECT_ATTEMPTS:
+            _LOGGER.debug(
+                "Max reconnect attempts (%d) reached; not reconnecting",
+                MAX_RECONNECT_ATTEMPTS,
+            )
             return False
 
         self._reconnect_count += 1
@@ -597,12 +599,24 @@ class BLEDiagnosticRunner:
         _LOGGER.warning(message)
         self._errors.append(message)
 
-        if self._client is not None:
-            with contextlib.suppress(Exception):
-                await self._client.disconnect()
-            self._client = None
-
         try:
+            if self._using_coordinator_connection:
+                if self.coordinator is None:
+                    return False
+                # Reconnect through the coordinator so we never open a
+                # competing connection; leave its disconnect timer paused
+                # until the diagnostics run finishes.
+                if not await self.coordinator.async_ensure_connected(reset_timer=False):
+                    self._errors.append("Reconnect failed: coordinator could not reconnect")
+                    return False
+                self._client = self.coordinator.client
+                return self._client is not None and self._client.is_connected
+
+            if self._client is not None:
+                with contextlib.suppress(Exception):
+                    await self._client.disconnect()
+                self._client = None
+
             await self._connect()
         except asyncio.CancelledError:
             raise

--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -621,7 +621,7 @@ class BLEDiagnosticRunner:
         except asyncio.CancelledError:
             raise
         except Exception as err:
-            self._errors.append(f"Reconnect failed: {err}")
+            self._errors.append(f"Reconnect failed: {str(err) or type(err).__name__}")
             return False
 
         return self._client is not None and self._client.is_connected

--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -51,6 +51,9 @@ _LOGGER = logging.getLogger(__name__)
 CONNECTION_TIMEOUT = 30.0
 DEFAULT_CAPTURE_DURATION = 120  # 2 minutes
 MAX_CAPTURED_NOTIFICATIONS = 5000
+MAX_RECONNECT_ATTEMPTS = 2
+
+_SKIPPED_READ_ERROR = "Skipped: connection lost during service enumeration"
 
 # Timestamps above this value (approx. 2001-09-09) are treated as Unix epoch seconds
 _EPOCH_SECONDS_THRESHOLD = 1_000_000_000
@@ -198,6 +201,7 @@ class BLEDiagnosticRunner:
         self._selected_ble_device: BLEDevice | None = None
         self._using_non_connectable_fallback: bool = False
         self._background_tasks: set[asyncio.Task[None]] = set()
+        self._reconnect_count: int = 0
 
     async def run_diagnostics(self) -> DiagnosticReport:
         """Run full diagnostic capture on the device."""
@@ -223,6 +227,7 @@ class BLEDiagnosticRunner:
                 services_info = await self._enumerate_services()
                 device_information = await self._read_device_information()
 
+            if await self._ensure_connected():
                 try:
                     await self._subscribe_to_notifications(services_info)
 
@@ -234,6 +239,13 @@ class BLEDiagnosticRunner:
                     await asyncio.sleep(self.capture_duration)
                 finally:
                     await self._unsubscribe_from_notifications(services_info)
+            else:
+                message = (
+                    "Skipped notification capture: connection lost and "
+                    "could not be re-established"
+                )
+                _LOGGER.warning(message)
+                self._errors.append(message)
 
         except asyncio.CancelledError:
             raise
@@ -434,12 +446,15 @@ class BLEDiagnosticRunner:
 
     async def _enumerate_services(self) -> list[ServiceInfo]:
         """Enumerate all GATT services and characteristics."""
-        if not self._client or not self._client.services:
+        services_collection = self._safe_services()
+        if services_collection is None:
             return []
 
+        enumeration_client = self._client
         services: list[ServiceInfo] = []
+        reads_aborted = False
 
-        for service in self._client.services:
+        for service in services_collection:
             service_info = ServiceInfo(
                 uuid=service.uuid,
                 handle=getattr(service, "handle", None),
@@ -466,15 +481,13 @@ class BLEDiagnosticRunner:
                 )
 
                 if "read" in char.properties:
-                    try:
-                        value = await self._client.read_gatt_char(char)
-                        char_info.read_result = format_payload(value)
-                    except Exception as err:
-                        char_info.read_error = str(err)
-                        _LOGGER.debug(
-                            "Could not read characteristic %s: %s",
-                            char.uuid,
-                            err,
+                    if reads_aborted:
+                        char_info.read_error = _SKIPPED_READ_ERROR
+                    else:
+                        reads_aborted = not await self._read_characteristic(
+                            char,
+                            char_info,
+                            enumeration_client,
                         )
 
                 service_info.characteristics.append(char_info)
@@ -484,15 +497,134 @@ class BLEDiagnosticRunner:
         _LOGGER.info("Enumerated %d GATT services", len(services))
         return services
 
+    async def _read_characteristic(
+        self,
+        char: Any,
+        char_info: CharacteristicInfo,
+        enumeration_client: BleakClient | None,
+    ) -> bool:
+        """Read one characteristic value into char_info.
+
+        Returns False when the connection is lost and cannot be restored, so
+        the caller can skip the remaining reads.
+        """
+        if not await self._ensure_connected() or self._client is None:
+            char_info.read_error = _SKIPPED_READ_ERROR
+            return False
+
+        # After a reconnect the enumerated characteristic objects are stale;
+        # re-resolve against the new client's service collection.
+        target: Any = char
+        if self._client is not enumeration_client:
+            target = self._find_current_characteristic(char_info)
+            if target is None:
+                char_info.read_error = "Characteristic not found after reconnect"
+                return True
+
+        try:
+            value = await self._client.read_gatt_char(target)
+            char_info.read_result = format_payload(value)
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            char_info.read_error = str(err) or type(err).__name__
+            _LOGGER.debug(
+                "Could not read characteristic %s: %s",
+                char_info.uuid,
+                err,
+            )
+        return True
+
+    def _find_current_characteristic(self, char_info: CharacteristicInfo) -> Any | None:
+        """Look up a characteristic in the current client's service collection."""
+        services_collection = self._safe_services()
+        if services_collection is None:
+            return None
+
+        if char_info.handle is not None:
+            characteristic = services_collection.get_characteristic(char_info.handle)
+            if characteristic is not None:
+                return characteristic
+
+        for service in services_collection:
+            for characteristic in service.characteristics:
+                if characteristic.uuid == char_info.uuid:
+                    return characteristic
+        return None
+
+    def _safe_services(self) -> Any | None:
+        """Return the client's GATT service collection, or None if unavailable.
+
+        Accessing BleakClient.services raises BleakError once a disconnect
+        clears the backend's discovered services.
+        """
+        if self._client is None:
+            return None
+        try:
+            services = self._client.services
+        except BleakError:
+            return None
+        return services or None
+
+    async def _ensure_connected(self) -> bool:
+        """Return True if the client is connected, reconnecting when possible."""
+        if self._client is not None and self._client.is_connected:
+            return True
+        return await self._reconnect()
+
+    async def _reconnect(self) -> bool:
+        """Re-establish a connection that dropped mid-diagnostics."""
+        if self._using_coordinator_connection:
+            # The coordinator owns its connection lifecycle; pick up its
+            # reconnected client if there is one, but never open a competing
+            # connection of our own.
+            if self.coordinator and self.coordinator.client and self.coordinator.is_connected:
+                self._client = self.coordinator.client
+                return True
+            message = "Coordinator connection lost during diagnostics"
+            if message not in self._errors:
+                self._errors.append(message)
+            return False
+
+        if self._reconnect_count >= MAX_RECONNECT_ATTEMPTS:
+            return False
+
+        self._reconnect_count += 1
+        message = (
+            f"Device disconnected during diagnostics; reconnecting "
+            f"(attempt {self._reconnect_count}/{MAX_RECONNECT_ATTEMPTS})"
+        )
+        _LOGGER.warning(message)
+        self._errors.append(message)
+
+        if self._client is not None:
+            with contextlib.suppress(Exception):
+                await self._client.disconnect()
+            self._client = None
+
+        try:
+            await self._connect()
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            self._errors.append(f"Reconnect failed: {err}")
+            return False
+
+        return self._client is not None and self._client.is_connected
+
     async def _read_device_information(self) -> dict[str, str | None]:
         """Read standard Device Information Service if available."""
-        if not self._client or not self._client.services:
+        if not await self._ensure_connected():
+            return {}
+
+        services_collection = self._safe_services()
+        if not self._client or services_collection is None:
             return {}
 
         info: dict[str, str | None] = {}
 
         has_device_info = any(
-            service.uuid.lower() == DEVICE_INFO_SERVICE_UUID for service in self._client.services
+            service.uuid.lower() == DEVICE_INFO_SERVICE_UUID for service in services_collection
         )
         if not has_device_info:
             _LOGGER.debug("Device Information Service not found")
@@ -549,8 +681,13 @@ class BLEDiagnosticRunner:
                         )
             return
 
+        services_collection = self._safe_services()
         for service in services:
-            bleak_service = self._client.services.get_service(service.uuid)
+            bleak_service = (
+                services_collection.get_service(service.uuid)
+                if services_collection is not None
+                else None
+            )
             for char in service.characteristics:
                 if "notify" not in char.properties and "indicate" not in char.properties:
                     continue
@@ -602,8 +739,13 @@ class BLEDiagnosticRunner:
         if not self._client or not self._client.is_connected:
             return
 
+        services_collection = self._safe_services()
         for service in services:
-            bleak_service = self._client.services.get_service(service.uuid)
+            bleak_service = (
+                services_collection.get_service(service.uuid)
+                if services_collection is not None
+                else None
+            )
             for char in service.characteristics:
                 if "notify" not in char.properties and "indicate" not in char.properties:
                     continue

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -485,6 +485,94 @@ class TestBleDiagnosticsRunner:
         assert any(error.startswith("Reconnect failed") for error in report.errors)
         assert any("Skipped notification capture" in error for error in report.errors)
 
+    async def test_run_diagnostics_reconnects_via_coordinator_when_shared_connection_drops(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,
+    ):
+        """Diagnostics reusing the coordinator connection should reconnect through it."""
+        connectable_info = _build_unknown_service_info(
+            source="proxy_1",
+            connectable=True,
+            rssi=-55,
+        )
+
+        service1 = _build_reconnect_test_service()
+        char_ok1, char_kill1, _char_after1 = service1.characteristics
+        client1 = _build_diagnostic_client(_FakeServices([service1]))
+
+        service2 = _build_reconnect_test_service()
+        char_after2 = service2.characteristics[2]
+        client2 = _build_diagnostic_client(_FakeServices([service2]))
+
+        coordinator = MagicMock()
+        coordinator.client = client1
+        coordinator.is_connected = True
+        coordinator.connection_source = "proxy_1"
+        coordinator.connection_rssi = -55
+        coordinator.disable_angle_sensing = False
+        coordinator.adapter_details = {}
+        coordinator.connection_history = {}
+        coordinator.connection_attempt_details = []
+        coordinator.command_trace = []
+
+        async def _read_gatt_char_1(target):
+            target_uuid = getattr(target, "uuid", target)
+            if target_uuid == char_ok1.uuid:
+                return b"\x01"
+            if target_uuid == char_kill1.uuid:
+                # The drop clears the coordinator's client; auto-reconnect has
+                # not fired yet when the next read comes around.
+                client1.is_connected = False
+                coordinator.client = None
+                coordinator.is_connected = False
+                raise BleakError("")
+            raise BleakError(f"unexpected read on client1: {target_uuid}")
+
+        async def _read_gatt_char_2(target):
+            target_uuid = getattr(target, "uuid", target)
+            if target_uuid == char_after2.uuid:
+                return b"\x02"
+            raise BleakError(f"unexpected read on client2: {target_uuid}")
+
+        client1.read_gatt_char = AsyncMock(side_effect=_read_gatt_char_1)
+        client2.read_gatt_char = AsyncMock(side_effect=_read_gatt_char_2)
+
+        async def _coordinator_reconnect(reset_timer=True):
+            coordinator.client = client2
+            coordinator.is_connected = True
+            return True
+
+        coordinator.async_ensure_connected = AsyncMock(side_effect=_coordinator_reconnect)
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.get_service_info_snapshots_by_address",
+                return_value=[(connectable_info, True)],
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.bluetooth.async_scanner_count",
+                return_value=1,
+            ),
+        ):
+            report = await BLEDiagnosticRunner(
+                hass,
+                "AA:BB:CC:DD:EE:FF",
+                capture_duration=0,
+                coordinator=coordinator,
+            ).run_diagnostics()
+
+        coordinator.async_ensure_connected.assert_awaited_once_with(reset_timer=False)
+        chars = report.gatt_services[0]["characteristics"]
+        assert chars[0]["read_result"]["hex"] == "01"
+        assert chars[1]["read_error"] == "BleakError"
+        assert chars[2]["read_result"]["hex"] == "02"
+        assert any("reconnecting" in error for error in report.errors)
+        coordinator.pause_disconnect_timer.assert_called_once()
+        coordinator.resume_disconnect_timer.assert_called_once()
+        coordinator.set_raw_notify_callback.assert_called_with(None)
+        client2.disconnect.assert_not_awaited()
+
 
 class TestSupportBundle:
     """Test support bundle orchestration."""

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from bleak.exc import BleakError
 from homeassistant.core import HomeAssistant
 
 from custom_components.adjustable_bed.adapter import AdapterSelectionResult
@@ -43,6 +44,13 @@ class _FakeServices:
                 return service
         return None
 
+    def get_characteristic(self, specifier: int | str) -> MagicMock | None:
+        for service in self._services:
+            for characteristic in service.characteristics:
+                if specifier in (characteristic.handle, characteristic.uuid):
+                    return characteristic
+        return None
+
 
 def _build_unknown_service_info(*, source: str, connectable: bool, rssi: int) -> MagicMock:
     """Create a mock BLE advertisement snapshot."""
@@ -62,6 +70,49 @@ def _build_unknown_service_info(*, source: str, connectable: bool, rssi: int) ->
     service_info.connectable = connectable
     service_info.time = 1_700_000_000
     return service_info
+
+
+def _build_reconnect_test_service() -> MagicMock:
+    """Create a service whose second characteristic read drops the connection."""
+    char_ok = MagicMock(
+        uuid="0000ffe1-0000-1000-8000-00805f9b34fb",
+        handle=33,
+        properties=["read", "notify"],
+        descriptors=[],
+    )
+    char_kill = MagicMock(
+        uuid="0000ffe2-0000-1000-8000-00805f9b34fb",
+        handle=35,
+        properties=["read"],
+        descriptors=[],
+    )
+    char_after = MagicMock(
+        uuid="0000ffe3-0000-1000-8000-00805f9b34fb",
+        handle=37,
+        properties=["read"],
+        descriptors=[],
+    )
+    return MagicMock(
+        uuid="0000ffe0-0000-1000-8000-00805f9b34fb",
+        handle=32,
+        characteristics=[char_ok, char_kill, char_after],
+    )
+
+
+def _build_diagnostic_client(services: _FakeServices) -> MagicMock:
+    """Create a mock BleakClient backed by the given service collection."""
+    client = MagicMock()
+    client.is_connected = True
+    client.services = services
+    client._backend = MagicMock(
+        _device=MagicMock(details={"source": "proxy_1", "props": {"Paired": False}})
+    )
+    client.get_services = AsyncMock()
+    client.read_gatt_char = AsyncMock()
+    client.start_notify = AsyncMock()
+    client.stop_notify = AsyncMock()
+    client.disconnect = AsyncMock()
+    return client
 
 
 class TestBleDiagnosticsRunner:
@@ -274,6 +325,165 @@ class TestBleDiagnosticsRunner:
         assert report.detection["bed_type"] == BED_TYPE_OKIN_RF_ECO_BT
         assert report.detection["supported_match"] is True
         assert "gatt_char:okin_smart_remote_css_write" in report.detection["signals"]
+
+    async def test_run_diagnostics_reconnects_after_mid_enumeration_disconnect(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,
+    ):
+        """A disconnect during enumeration should reconnect and continue the capture."""
+        connectable_info = _build_unknown_service_info(
+            source="proxy_1",
+            connectable=True,
+            rssi=-55,
+        )
+
+        service1 = _build_reconnect_test_service()
+        char_ok1, char_kill1, _char_after1 = service1.characteristics
+        client1 = _build_diagnostic_client(_FakeServices([service1]))
+
+        service2 = _build_reconnect_test_service()
+        char_after2 = service2.characteristics[2]
+        client2 = _build_diagnostic_client(_FakeServices([service2]))
+
+        async def _read_gatt_char_1(target):
+            target_uuid = getattr(target, "uuid", target)
+            if target_uuid == char_ok1.uuid:
+                return b"\x01"
+            if target_uuid == char_kill1.uuid:
+                client1.is_connected = False
+                raise BleakError("")
+            raise BleakError(f"unexpected read on client1: {target_uuid}")
+
+        async def _read_gatt_char_2(target):
+            target_uuid = getattr(target, "uuid", target)
+            if target_uuid == char_after2.uuid:
+                return b"\x02"
+            raise BleakError(f"unexpected read on client2: {target_uuid}")
+
+        async def _start_notify_2(target, handler):
+            handler(MagicMock(), bytearray(b"OK"))
+
+        client1.read_gatt_char = AsyncMock(side_effect=_read_gatt_char_1)
+        client2.read_gatt_char = AsyncMock(side_effect=_read_gatt_char_2)
+        client2.start_notify = AsyncMock(side_effect=_start_notify_2)
+
+        establish_mock = AsyncMock(side_effect=[client1, client2])
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.get_service_info_snapshots_by_address",
+                return_value=[(connectable_info, True)],
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.select_adapter",
+                new=AsyncMock(
+                    return_value=AdapterSelectionResult(
+                        device=connectable_info.device,
+                        source="proxy_1",
+                        rssi=-55,
+                        connectable=True,
+                        available_sources=["proxy_1 (RSSI: -55)"],
+                    )
+                ),
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.establish_connection",
+                new=establish_mock,
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.bluetooth.async_scanner_count",
+                return_value=1,
+            ),
+        ):
+            report = await BLEDiagnosticRunner(
+                hass,
+                "AA:BB:CC:DD:EE:FF",
+                capture_duration=0,
+            ).run_diagnostics()
+
+        assert establish_mock.await_count == 2
+        chars = report.gatt_services[0]["characteristics"]
+        assert chars[0]["read_result"]["hex"] == "01"
+        assert chars[1]["read_error"] == "BleakError"
+        assert chars[2]["read_result"]["hex"] == "02"
+        assert any("reconnecting" in error for error in report.errors)
+        assert chars[0]["notify_subscription"]["success"] is True
+        assert report.notifications[0]["data_hex"] == "4f4b"
+        client2.stop_notify.assert_awaited()
+        client2.disconnect.assert_awaited()
+
+    async def test_run_diagnostics_degrades_gracefully_when_reconnect_fails(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,
+    ):
+        """If the device cannot be reconnected, remaining steps are skipped with clear errors."""
+        connectable_info = _build_unknown_service_info(
+            source="proxy_1",
+            connectable=True,
+            rssi=-55,
+        )
+
+        service = _build_reconnect_test_service()
+        char_ok, char_kill, _char_after = service.characteristics
+        client = _build_diagnostic_client(_FakeServices([service]))
+
+        async def _read_gatt_char(target):
+            target_uuid = getattr(target, "uuid", target)
+            if target_uuid == char_ok.uuid:
+                return b"\x01"
+            if target_uuid == char_kill.uuid:
+                client.is_connected = False
+                raise BleakError("")
+            raise BleakError(f"unexpected read: {target_uuid}")
+
+        client.read_gatt_char = AsyncMock(side_effect=_read_gatt_char)
+
+        establish_mock = AsyncMock(
+            side_effect=[client] + [BleakError("boom")] * 4,
+        )
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.get_service_info_snapshots_by_address",
+                return_value=[(connectable_info, True)],
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.select_adapter",
+                new=AsyncMock(
+                    return_value=AdapterSelectionResult(
+                        device=connectable_info.device,
+                        source="proxy_1",
+                        rssi=-55,
+                        connectable=True,
+                        available_sources=["proxy_1 (RSSI: -55)"],
+                    )
+                ),
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.establish_connection",
+                new=establish_mock,
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.bluetooth.async_scanner_count",
+                return_value=1,
+            ),
+        ):
+            report = await BLEDiagnosticRunner(
+                hass,
+                "AA:BB:CC:DD:EE:FF",
+                capture_duration=0,
+            ).run_diagnostics()
+
+        chars = report.gatt_services[0]["characteristics"]
+        assert chars[0]["read_result"]["hex"] == "01"
+        assert chars[1]["read_error"] == "BleakError"
+        assert chars[2]["read_error"] == "Skipped: connection lost during service enumeration"
+        assert chars[0]["notify_subscription"]["attempted"] is False
+        assert report.notifications == []
+        assert any(error.startswith("Reconnect failed") for error in report.errors)
+        assert any("Skipped notification capture" in error for error in report.errors)
 
 
 class TestSupportBundle:


### PR DESCRIPTION
## Problem

The support bundle in #344 revealed a bug in the diagnostics runner itself. When a device drops the BLE connection while `run_diagnostics` enumerates its characteristics (common on OKIN units that disconnect when a protected characteristic is read without pairing — also seen in #338), the whole diagnostic run was ruined:

1. Every remaining characteristic read failed with bleak's confusing `Service Discovery has not been performed yet` (the dead client's services are cleared on disconnect), but the loop kept hammering the dead client.
2. `_read_device_information()` then accessed `client.services`, which **raises** on a disconnected client. The exception escaped to the catch-all in `run_diagnostics()`, silently skipping the entire 120-second notification capture — the most valuable part of the bundle.

#344's report confirms it: zero notifications, empty device info, `notify_subscription.attempted: false` everywhere, and a single cryptic error.

## Fix

- Detect the dropped connection, reconnect (capped at 2 attempts per run), re-resolve characteristics from the fresh service collection by handle, and resume both the reads and the notification capture. The characteristic that triggered the disconnect is not retried, so it can't loop.
- For coordinator-owned connections, pick up the coordinator's reconnected client but never open a competing connection.
- If reconnection fails, skip remaining reads and the capture phase with explicit messages in the report (`Skipped: connection lost during service enumeration`, `Skipped notification capture: ...`) instead of misleading bleak internals.
- Guard all `client.services` accesses (the property raises `BleakError` after disconnect).
- Empty exception strings now fall back to the exception class name (the bundle contained a bare `""` read error).

## Testing

Two new tests in `tests/test_support_bundle.py` replay the #344 scenario: one where reconnect succeeds (read resumes on the new client, notifications captured), one where it fails (graceful degradation with clear errors). Full suite passes: 1849 tests.

Ref #344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BLE diagnostics to handle mid-connection drops during service/characteristic enumeration, with bounded reconnect attempts, graceful marking of skipped reads, safer service discovery handling, and conditional notification capture when reconnection succeeds.
  * Robustified subscription/unsubscription to tolerate transient connection loss.

* **Tests**
  * Added tests for mid-enumeration disconnects, failed-reconnect degradation, and coordinator-mediated reconnection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->