### PR TITLE
Fix Nectar Motion CST detection

### DIFF
--- a/custom_components/adjustable_bed/actuator_groups.py
+++ b/custom_components/adjustable_bed/actuator_groups.py
@@ -27,6 +27,7 @@ from .const import (
     BED_TYPE_OCTO,
     BED_TYPE_OKIN_7BYTE,
     BED_TYPE_OKIN_64BIT,
+    BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_FFE,
     BED_TYPE_OKIN_HANDLE,
     BED_TYPE_OKIN_NORDIC,
@@ -218,6 +219,12 @@ ACTUATOR_GROUPS: Final[dict[str, ActuatorGroup]] = {
                 "label": "Nectar beds",
                 "description": "Nectar Move and similar models",
                 "hint": "Device name contains 'Nectar'",
+            },
+            {
+                "type": BED_TYPE_OKIN_CST,
+                "label": "CST / Nectar Motion",
+                "description": "Rize MF900, newer Nectar Motion, and some OKIN-* bases",
+                "hint": "Try this for OKIN-* beds with 62741525 plus 90311625/00001530 GATT services",
             },
             {
                 "type": BED_TYPE_OKIN_NORDIC,

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -477,6 +477,11 @@ OKIN_SMART_REMOTE_CSS_SERVICE_UUID: Final = "90311623-25fa-3346-12ef-3cfb7a2556a
 OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID: Final = "90311625-25fa-3346-12ef-3cfb7a2556ac"
 OKIN_SMART_REMOTE_CSS_NOTIFY_CHAR_UUID: Final = "90311725-25fa-3346-12ef-3cfb7a2556ac"
 
+# Nordic DFU service observed on some newer OKIN dual-stack controllers. It is
+# not a control surface, but helps distinguish full bed controllers from the
+# RF ECO BT single-actuator profile when both expose OKIN Smart Remote CSS.
+NORDIC_DFU_SERVICE_UUID: Final = "00001530-1212-efde-1523-785feabcd123"
+
 # OKIN position feedback UUIDs (used by Lucid, some Okimat beds)
 # Reference: https://github.com/richardhopton/smartbed-mqtt/issues/53
 OKIN_POSITION_SERVICE_UUID: Final = "0000ffe0-0000-1000-8000-00805f9b34fb"

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -113,6 +113,7 @@ from .const import (
     MANUFACTURER_ID_LOGICDATA,
     MANUFACTURER_ID_OKIN,
     MANUFACTURER_ID_VIBRADORM,
+    NORDIC_DFU_SERVICE_UUID,
     OCTO_NAME_PATTERNS,
     OCTO_STAR2_SERVICE_UUID,
     OKIMAT_NAME_ONLY_PATTERNS,
@@ -465,17 +466,27 @@ def detect_bed_type_from_gatt_services(gatt_services: Any) -> DetectionResult:
         OKIN_SMART_REMOTE_CSS_SERVICE_UUID.lower() in service_uuids
         and OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID.lower() in characteristic_uuids
     )
+    has_nordic_dfu = NORDIC_DFU_SERVICE_UUID.lower() in service_uuids
 
     if has_okin_uuid_write and has_smart_remote_css:
+        signals = [
+            "gatt_service:okin_uuid",
+            "gatt_char:okin_write",
+            "gatt_service:okin_smart_remote_css",
+            "gatt_char:okin_smart_remote_css_write",
+        ]
+        if has_nordic_dfu:
+            return DetectionResult(
+                bed_type=BED_TYPE_OKIN_CST,
+                confidence=0.8,
+                signals=[*signals, "gatt_service:nordic_dfu"],
+                ambiguous_types=[BED_TYPE_NECTAR, BED_TYPE_OKIN_RF_ECO_BT],
+            )
+
         return DetectionResult(
             bed_type=BED_TYPE_OKIN_RF_ECO_BT,
             confidence=0.9,
-            signals=[
-                "gatt_service:okin_uuid",
-                "gatt_char:okin_write",
-                "gatt_service:okin_smart_remote_css",
-                "gatt_char:okin_smart_remote_css_write",
-            ],
+            signals=signals,
         )
 
     return DetectionResult(bed_type=None, confidence=0.0, signals=[])
@@ -1646,6 +1657,11 @@ async def detect_bed_type_by_characteristics(
         if gatt_detection.bed_type == BED_TYPE_OKIN_RF_ECO_BT:
             _LOGGER.info("Refined detection: OKIN Smart Remote CSS signature found")
             return BED_TYPE_OKIN_RF_ECO_BT
+        if gatt_detection.bed_type == BED_TYPE_OKIN_CST:
+            _LOGGER.info(
+                "Refined detection: OKIN CST dual-stack GATT signature found"
+            )
+            return BED_TYPE_OKIN_CST
 
         # Build a set of all characteristic UUIDs for easy lookup
         all_chars: set[str] = set()

--- a/docs/SUPPORTED_ACTUATORS.md
+++ b/docs/SUPPORTED_ACTUATORS.md
@@ -62,11 +62,11 @@ Several bed brands use Okin-based BLE controllers. While they share common roots
 | [Malouf](beds/malouf.md) | 8-byte (32-bit cmd) | Nordic UART or FFE5 | ❌ No | Service UUID detection |
 | [Keeson/Ergomotion](beds/keeson.md) | 8-byte (32-bit cmd) | Nordic UART | ❌ No | Name patterns |
 | [Okin CB35](beds/okin-cb35.md) | 7-byte (1-byte cmd) | Nordic UART | ❌ No | Name starts with "Star35" |
-| [Okin CST](beds/okin-cst.md) | 14-byte (dual 32-bit) | UUID `62741525-...` | ✅ Yes | Name patterns |
+| [Okin CST](beds/okin-cst.md) | 14-byte (dual 32-bit) | UUID `62741525-...` | ✅ Yes | Name patterns; some Nectar Motion `OKIN-*` bases |
 | [OKIN Smart Remote / RF ECO BT](beds/okin-rf-eco-bt.md) | 6-byte (32-bit cmd) | UUID `62741525-...` | Unknown | Manual selection; diagnostics can match CSS GATT signature |
 
 **Key differences:**
-- **6-byte vs 7-byte vs 8-byte vs 10-byte**: Different command structures - not interchangeable
+- **6-byte vs 7-byte vs 8-byte vs 10-byte vs 14-byte**: Different command structures - not interchangeable
 - **32-bit vs 64-bit commands**: Okin 64-bit uses 8-byte command values instead of 4-byte
 - **UUID vs Handle**: DewertOkin writes to a BLE handle instead of a characteristic UUID
 - **Nordic UART**: Many newer beds use the Nordic UART service
@@ -79,8 +79,9 @@ Several bed brands use Okin-based BLE controllers. While they share common roots
 3. Name contains "okimat", "okin rf", or "okin ble" → Okimat
 4. Name starts with `OKIN-` → prompt for Okin-family protocol (confirmed Nectar bases can advertise this way)
 5. Name is `OKIN-Receiver` / `OKIN - Receiver` → prompt for Okin-family protocol
-6. Connected GATT has `62741525-...` plus CSS `90311625-...` → OKIN Smart Remote / RF ECO BT
-7. Fallback → Okimat (with warning logged)
+6. Connected GATT has `62741525-...` plus CSS `90311625-...` and Nordic DFU `00001530-...` → Okin CST
+7. Connected GATT has `62741525-...` plus CSS `90311625-...` without Nordic DFU → OKIN Smart Remote / RF ECO BT
+8. Fallback → Okimat (with warning logged)
 
 ---
 
@@ -142,11 +143,12 @@ These beds have their own dedicated integrations:
    - `Simmons*`, `Glory*`, `Symphony*` → See [DewertOkin](beds/dewertokin.md)
    - `Star35*` → [Okin CB35](beds/okin-cb35.md) (Sealy Posturematic)
    - `SILVERmotion*` or Logicdata manufacturer ID → [Logicdata](beds/logicdata.md)
-   - `OKIN-*` with no advertised service UUIDs → manual setup; use diagnostics to check for [OKIN Smart Remote / RF ECO BT](beds/okin-rf-eco-bt.md)
+   - `OKIN-*` with no advertised service UUIDs → manual setup; use diagnostics to check for [Okin CST](beds/okin-cst.md) or [OKIN Smart Remote / RF ECO BT](beds/okin-rf-eco-bt.md)
 
 4. **Use the support bundle to find service UUIDs**: If unsure, use **Browse unsupported BLE devices** to find the MAC address, then run `adjustable_bed.generate_support_bundle` with `target_address`. The output includes service UUIDs:
    - Service `62741523-...` → Okin family (see [Okin Protocol Family](#okin-protocol-family))
-   - Service `62741523-...` plus CSS service `90311623-...` and write characteristic `90311625-...` → [OKIN Smart Remote / RF ECO BT](beds/okin-rf-eco-bt.md)
+   - Service `62741523-...` plus CSS service `90311623-...`, write characteristic `90311625-...`, and Nordic DFU service `00001530-...` → [Okin CST](beds/okin-cst.md)
+   - Service `62741523-...` plus CSS service `90311623-...` and write characteristic `90311625-...` without Nordic DFU → [OKIN Smart Remote / RF ECO BT](beds/okin-rf-eco-bt.md)
    - Service `45e25100-...` → Leggett & Platt Gen2
    - Service `0000aa5c-...` → Octo Star2 variant
    - Service `01000001-...` → Malouf/Lucid family (usually New OKIN; `OKIN-BLE` + `BTCB` uses Legacy OKIN)

--- a/docs/beds/nectar.md
+++ b/docs/beds/nectar.md
@@ -10,11 +10,18 @@
 - Nectar adjustable bases
 - Other beds using Okin controllers with 7-byte command format
 
+Some newer Nectar Motion bases advertise only as `OKIN-XXXXXX` and use the
+[Okin CST](okin-cst.md) 14-byte protocol instead of this 7-byte protocol.
+If diagnostics show the `62741523-...` OKIN service, `90311623-...` CSS service,
+and Nordic DFU service `00001530-...`, choose **Okin CST / Nectar Motion** in
+manual setup.
+
 ## Apps
 
 | Analyzed | App | Package ID |
 |----------|-----|------------|
 | ⬜ | Nectar Adjustable | (no longer available) |
+| ✅ | Nectar Motion | `com.okin.bedding.nectarmotion` (uses Okin CST) |
 
 ## Features
 
@@ -77,8 +84,10 @@
 Detected by device name containing: `nectar` (case-insensitive) AND Okin service UUID present.
 
 Some Nectar bases advertise only as `OKIN-XXXXXX`. Those names are ambiguous
-with classic Okimat controllers, so setup prompts for the Okin-family protocol.
-Choose `Nectar` for the 7-byte protocol.
+with classic Okimat, 7-byte Nectar, and newer CST controllers, so setup prompts
+for the Okin-family protocol. Choose `Nectar` only for the 7-byte protocol.
+Choose `Okin CST / Nectar Motion` when diagnostics show the CSS service
+`90311623-...` plus Nordic DFU service `00001530-...`.
 
 Or manually configured with bed type: `nectar`
 
@@ -94,5 +103,6 @@ Nectar is part of the [Okin Protocol Family](../SUPPORTED_ACTUATORS.md#okin-prot
 
 - Nectar beds share the Okin service UUID with Okimat beds but use a different command protocol
 - Generic `OKIN-XXXXXX` names require user confirmation because several Okin protocols share the same advertised UUID
+- Newer Nectar Motion `OKIN-XXXXXX` bases may use [Okin CST](okin-cst.md) instead
 - Massage control is global (no separate head/foot control)
 - Lights have separate on/off commands (no toggle)

--- a/docs/beds/okin-cst.md
+++ b/docs/beds/okin-cst.md
@@ -6,16 +6,20 @@
 ## Known Brands
 
 - Rize MF900
+- Nectar Motion / some `OKIN-*` Nectar bases
 
 ## Detection
 
 | Signal | Value |
 |--------|-------|
 | Service UUID | `62741523-52f9-8864-b1ab-3b3a8d65950b` (standard OKIN) |
-| Name patterns | Varies (shared UUID requires disambiguation) |
+| Name patterns | Varies (shared UUID requires disambiguation; some report as `OKIN-XXXXXX`) |
+| Connected GATT hint | CSS `90311623-...` plus Nordic DFU `00001530-...` |
 | BLE Pairing | Required |
 
 Manual selection may be needed since the service UUID is shared with other Okin protocols.
+Choose this profile for Nectar Motion style `OKIN-*` bases when diagnostics show
+both the CSS service and Nordic DFU service.
 
 ## Protocol
 
@@ -82,7 +86,9 @@ Command values are identical to Okimat/Okin UUID values. The difference is the p
 ## App
 
 - **Android:** `com.okin.bedding.rizemf900`
+- **Android:** `com.okin.bedding.nectarmotion`
 
 ## Source
 
-Protocol reverse-engineered from `CSTProtocol.java` in the Rize MF900 APK.
+Protocol reverse-engineered from `CSTProtocol.java` in the Rize MF900 and
+Nectar Motion APKs.

--- a/docs/beds/okin-rf-eco-bt.md
+++ b/docs/beds/okin-rf-eco-bt.md
@@ -37,6 +37,10 @@ can identify it after connecting when this GATT signature is present:
 - CSS service `90311623-25fa-3346-12ef-3cfb7a2556ac`
 - CSS write characteristic `90311625-25fa-3346-12ef-3cfb7a2556ac`
 
+If the same device also exposes Nordic DFU service
+`00001530-1212-efde-1523-785feabcd123`, it may be a full bed controller using
+[Okin CST](okin-cst.md), not this single-actuator stair profile.
+
 Generic `OKIN-*` devices remain ambiguous because multiple unrelated OKIN
 protocols use that naming pattern.
 

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -67,6 +67,7 @@ from custom_components.adjustable_bed.const import (
     MANUFACTURER_ID_DEWERTOKIN,
     MANUFACTURER_ID_OKIN,
     MANUFACTURER_ID_VIBRADORM,
+    NORDIC_DFU_SERVICE_UUID,
     NORDIC_UART_SERVICE_UUID,
     OCTO_STAR2_SERVICE_UUID,
     OKIMAT_SERVICE_UUID,
@@ -785,6 +786,34 @@ class TestOkinUUIDDisambiguation:
         assert result.bed_type == BED_TYPE_OKIN_RF_ECO_BT
         assert result.confidence == 0.9
         assert "gatt_char:okin_smart_remote_css_write" in result.signals
+
+    def test_okin_cst_dual_stack_gatt_signature_wins_over_rf_eco_bt(self):
+        """Newer OKIN full-bed controllers can expose CSS plus Nordic DFU."""
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=NORDIC_DFU_SERVICE_UUID,
+                characteristics=[],
+            ),
+        ]
+
+        result = detect_bed_type_from_gatt_services(gatt_services)
+
+        assert result.bed_type == BED_TYPE_OKIN_CST
+        assert result.confidence == 0.8
+        assert "gatt_service:nordic_dfu" in result.signals
+        assert BED_TYPE_OKIN_RF_ECO_BT in result.ambiguous_types
 
     def test_malouf_new_refines_to_legacy_when_gatt_has_ffe9_only(self):
         """A saved Malouf Nordic entry should use FFE5 when connected GATT proves it."""

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -13,9 +13,11 @@ from custom_components.adjustable_bed.ble_diagnostics import (
     DiagnosticReport,
 )
 from custom_components.adjustable_bed.const import (
+    BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_RF_ECO_BT,
     DEVICE_INFO_CHARS,
     LINAK_CONTROL_SERVICE_UUID,
+    NORDIC_DFU_SERVICE_UUID,
     OKIMAT_SERVICE_UUID,
     OKIMAT_WRITE_CHAR_UUID,
     OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
@@ -325,6 +327,108 @@ class TestBleDiagnosticsRunner:
         assert report.detection["bed_type"] == BED_TYPE_OKIN_RF_ECO_BT
         assert report.detection["supported_match"] is True
         assert "gatt_char:okin_smart_remote_css_write" in report.detection["signals"]
+
+    async def test_run_diagnostics_detects_okin_cst_dual_stack_signature(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,
+    ):
+        """Diagnostics should not classify full OKIN CST beds as RF ECO BT."""
+        service_info = MagicMock()
+        service_info.name = "OKIN-441954"
+        service_info.address = "AA:BB:CC:DD:EE:55"
+        service_info.rssi = -59
+        service_info.manufacturer_data = {}
+        service_info.service_data = {}
+        service_info.service_uuids = [OKIMAT_SERVICE_UUID]
+        service_info.source = "proxy_1"
+        service_info.device = MagicMock(
+            address="AA:BB:CC:DD:EE:55",
+            name="OKIN-441954",
+            details={"source": "proxy_1", "props": {"Paired": True}},
+        )
+        service_info.connectable = True
+        service_info.time = 1_700_000_000
+
+        okin_write = MagicMock(
+            uuid=OKIMAT_WRITE_CHAR_UUID,
+            handle=19,
+            properties=["read", "write"],
+            descriptors=[],
+        )
+        css_write = MagicMock(
+            uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID,
+            handle=42,
+            properties=["read", "write"],
+            descriptors=[],
+        )
+        services = _FakeServices(
+            [
+                MagicMock(
+                    uuid=OKIMAT_SERVICE_UUID,
+                    handle=12,
+                    characteristics=[okin_write],
+                ),
+                MagicMock(
+                    uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                    handle=33,
+                    characteristics=[css_write],
+                ),
+                MagicMock(
+                    uuid=NORDIC_DFU_SERVICE_UUID,
+                    handle=43,
+                    characteristics=[],
+                ),
+            ]
+        )
+
+        client = MagicMock()
+        client.is_connected = True
+        client.services = services
+        client._backend = MagicMock(
+            _device=MagicMock(details={"source": "proxy_1", "props": {"Paired": True}})
+        )
+        client.get_services = AsyncMock()
+        client.read_gatt_char = AsyncMock()
+        client.start_notify = AsyncMock()
+        client.stop_notify = AsyncMock()
+        client.disconnect = AsyncMock()
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.get_service_info_snapshots_by_address",
+                return_value=[(service_info, True)],
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.select_adapter",
+                new=AsyncMock(
+                    return_value=AdapterSelectionResult(
+                        device=service_info.device,
+                        source="proxy_1",
+                        rssi=-59,
+                        connectable=True,
+                        available_sources=["proxy_1 (RSSI: -59)"],
+                    )
+                ),
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.establish_connection",
+                new=AsyncMock(return_value=client),
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.bluetooth.async_scanner_count",
+                return_value=1,
+            ),
+        ):
+            report = await BLEDiagnosticRunner(
+                hass,
+                "AA:BB:CC:DD:EE:55",
+                capture_duration=0,
+            ).run_diagnostics()
+
+        assert report.detection["bed_type"] == BED_TYPE_OKIN_CST
+        assert report.detection["supported_match"] is True
+        assert "gatt_service:nordic_dfu" in report.detection["signals"]
 
     async def test_run_diagnostics_reconnects_after_mid_enumeration_disconnect(
         self,


### PR DESCRIPTION
## Summary

- classify OKIN dual-stack GATT devices with CSS plus Nordic DFU as `okin_cst` instead of RF ECO BT
- add the CST / Nectar Motion option to the Okin manual setup group
- update Nectar, Okin CST, RF ECO BT, and supported-actuator docs with the new guidance
- add detection and support-bundle regression coverage for the CST vs RF ECO BT split

## Root Cause

The support bundle from discussion #346 showed a Nectar Motion style `OKIN-*` device exposing the OKIN service, CSS service, and Nordic DFU service. The previous GATT detector treated OKIN + CSS as definitive RF ECO BT, but RF ECO BT is a single-actuator stair profile. The Nordic DFU service distinguishes these full bed controllers and maps them to the existing Okin CST 14-byte controller.

## Validation

- `uv run pytest tests/test_detection.py tests/test_support_bundle.py`
- `uv run ruff check custom_components/adjustable_bed/actuator_groups.py custom_components/adjustable_bed/const.py custom_components/adjustable_bed/detection.py tests/test_detection.py tests/test_support_bundle.py`
- `uv run pyright custom_components/adjustable_bed/actuator_groups.py custom_components/adjustable_bed/const.py custom_components/adjustable_bed/detection.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for OKIN CST / Nectar Motion actuator variants with automatic device detection.

* **Documentation**
  * Updated bed type identification guides to clarify OKIN CST support and help distinguish newer Nectar Motion bases from existing variants.

* **Tests**
  * Added test coverage for OKIN CST detection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->