### PR TITLE
fix: make OKIN bed pairing self-healing and user-friendly

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -324,7 +324,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Adapter explicitly doesn't support pairing (e.g. old ESPHome proxy)
         if coordinator.pairing_supported is False:
             await create_pairing_required_issue(
-                hass, address or "Unknown", entry.data.get("name", entry.title)
+                hass,
+                address or "Unknown",
+                entry.data.get("name", entry.title),
+                entry.entry_id,
             )
             return
 

--- a/custom_components/adjustable_bed/ble_auth.py
+++ b/custom_components/adjustable_bed/ble_auth.py
@@ -1,0 +1,21 @@
+"""Helpers for detecting unauthenticated/unbonded BLE GATT links."""
+
+from __future__ import annotations
+
+import re
+
+_BLE_AUTHENTICATION_ERROR_MARKERS: tuple[str, ...] = (
+    "insufficient authentication",
+    "insufficient authorization",
+    "gatt error 5",
+)
+_BLE_AUTHENTICATION_ERROR_CODE_RE = re.compile(r"\berror=5\b")
+
+
+def is_ble_authentication_error(err: BaseException) -> bool:
+    """Return True if a Bleak error indicates an unauthenticated GATT link."""
+    message = str(err).lower()
+    return (
+        any(marker in message for marker in _BLE_AUTHENTICATION_ERROR_MARKERS)
+        or _BLE_AUTHENTICATION_ERROR_CODE_RE.search(message) is not None
+    )

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -225,8 +225,12 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         }:
             return await self._get_config_translation(
                 "step.bluetooth_pairing.data_description.pairing_instructions_okin",
-                "1. Put the OKIN receiver/control box in pairing mode (press or hold the receiver pairing button until the LED blinks)\n"
-                "2. Click 'Pair Now'",
+                "1. Put the OKIN base into Bluetooth pairing mode by power-cycling the control box: "
+                "unplug it for ~30 seconds, then plug it back in. The status light blinks blue, then turns "
+                "green after ~20 seconds. (Some models instead use the under-bed lamp/light button - hold it "
+                "until the light blinks blue.) There is no separate Bluetooth pairing button; any Pair/Learn "
+                "button on the box only syncs the RF remote.\n"
+                "2. While the light is active, click 'Pair Now'.",
             )
         return await self._get_config_translation(
             "step.bluetooth_pairing.data_description.pairing_instructions_generic",

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -7,7 +7,6 @@ import contextlib
 import inspect
 import logging
 import random
-import re
 import time
 import traceback
 from collections import deque
@@ -41,6 +40,7 @@ from .adapter import (
     read_ble_device_info,
     select_adapter,
 )
+from .ble_auth import is_ble_authentication_error
 from .const import (
     ADAPTER_AUTO,
     BED_MOTOR_PULSE_DEFAULTS,
@@ -151,24 +151,13 @@ _INITIAL_POSITION_READ_TIMEOUT = 10.0
 _INITIAL_POSITION_READ_RETRY_DELAY = 3.0
 _INITIAL_POSITION_READ_MAX_ATTEMPTS = 6
 _PASSIVE_POSITION_RECONCILIATION_IDLE_MARGIN = 15.0
-_BLE_AUTHENTICATION_ERROR_MARKERS: tuple[str, ...] = (
-    "insufficient authentication",
-    "insufficient authorization",
-    "gatt error 5",
-)
-_BLE_AUTHENTICATION_ERROR_CODE_RE = re.compile(r"\berror=5\b")
 
 MAX_COMMAND_TRACE_ENTRIES = 100
 MAX_CONNECTION_ATTEMPT_DETAILS = 25
 
-
-def _is_ble_authentication_error(err: BaseException) -> bool:
-    """Return True if a Bleak error indicates an unauthenticated GATT link."""
-    message = str(err).lower()
-    return (
-        any(marker in message for marker in _BLE_AUTHENTICATION_ERROR_MARKERS)
-        or _BLE_AUTHENTICATION_ERROR_CODE_RE.search(message) is not None
-    )
+# Backwards-compatible private alias; the implementation now lives in ble_auth
+# so the repairs flow can share it without importing the coordinator.
+_is_ble_authentication_error = is_ble_authentication_error
 
 
 class NotConnectedError(Exception):
@@ -608,13 +597,20 @@ class AdjustableBedCoordinator:
             },
         )
 
-    async def _async_handle_ble_authentication_error(self, err: BleakError) -> None:
-        """Handle a command failure caused by an unauthenticated BLE connection."""
+    async def _async_handle_ble_authentication_error(
+        self, err: BleakError, *, holding_lock: bool = False
+    ) -> None:
+        """Handle a failure caused by an unauthenticated BLE connection.
+
+        ``holding_lock`` must be True when called from a context that already
+        holds ``self._lock`` (e.g. bond verification inside the connect path),
+        so the disconnect uses the lock-free variant and does not deadlock.
+        """
         if not requires_pairing(self._bed_type, self._protocol_variant):
             return
 
         _LOGGER.warning(
-            "BLE command on %s failed because the GATT link is not authenticated: %s. "
+            "BLE link on %s is not authenticated: %s. "
             "Clearing the cached bond marker so the next connection can request pairing.",
             self._address,
             err,
@@ -633,7 +629,10 @@ class AdjustableBedCoordinator:
             )
 
         if self._client is not None and self._client.is_connected:
-            await self.async_disconnect(reason="authentication_failed")
+            if holding_lock:
+                await self._async_disconnect_locked(reason="authentication_failed")
+            else:
+                await self.async_disconnect(reason="authentication_failed")
 
     async def _async_verify_bonded(self) -> bool:
         """Probe an auth-gated characteristic to confirm the BLE bond is live.
@@ -659,7 +658,9 @@ class AdjustableBedCoordinator:
             await client.read_gatt_char(probe_uuid)
         except BleakError as err:
             if _is_ble_authentication_error(err):
-                await self._async_handle_ble_authentication_error(err)
+                # We run inside _async_connect_locked, which holds self._lock —
+                # disconnect via the lock-free path to avoid a deadlock.
+                await self._async_handle_ble_authentication_error(err, holding_lock=True)
                 return False
             _LOGGER.debug(
                 "Bond verification read for %s was inconclusive (%s); proceeding.",
@@ -2066,49 +2067,58 @@ class AdjustableBedCoordinator:
         """
         _LOGGER.debug("async_disconnect called for %s", self._address)
         async with self._lock:
-            self._cancel_disconnect_timer()
-            self._cancel_controller_state_refresh_retry()
-            if self._controller_state_refresh_task is not None:
-                self._controller_state_refresh_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await self._controller_state_refresh_task
-                self._controller_state_refresh_task = None
-            # Cancel any pending reconnect timer
-            if self._reconnect_timer is not None:
-                self._reconnect_timer.cancel()
-                self._reconnect_timer = None
-            if self._client is not None:
-                _LOGGER.info("Disconnecting from bed at %s", self._address)
-                # Mark as intentional so _on_disconnect doesn't trigger auto-reconnect
-                self._intentional_disconnect = True
-                # Track disconnect reason for diagnostics (issue #168)
-                self._last_disconnect_reason = reason
-                try:
-                    # Stop keep-alive and notifications before disconnecting
-                    if self._controller is not None:
-                        # Stop Octo keep-alive if running
-                        if hasattr(self._controller, "stop_keepalive"):
-                            try:
-                                # Cast to Any to avoid mypy error about BedController not having stop_keepalive
-                                await cast(Any, self._controller).stop_keepalive()
-                            except Exception as err:
-                                _LOGGER.debug("Error stopping keep-alive: %s", err)
+            await self._async_disconnect_locked(reason)
+
+    async def _async_disconnect_locked(self, reason: str = "intentional") -> None:
+        """Disconnect from the bed. The caller MUST already hold ``self._lock``.
+
+        Used by the bond-verification path, which runs inside
+        ``_async_connect_locked`` (lock already held) and would otherwise
+        deadlock on the public ``async_disconnect`` re-acquiring the lock.
+        """
+        self._cancel_disconnect_timer()
+        self._cancel_controller_state_refresh_retry()
+        if self._controller_state_refresh_task is not None:
+            self._controller_state_refresh_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._controller_state_refresh_task
+            self._controller_state_refresh_task = None
+        # Cancel any pending reconnect timer
+        if self._reconnect_timer is not None:
+            self._reconnect_timer.cancel()
+            self._reconnect_timer = None
+        if self._client is not None:
+            _LOGGER.info("Disconnecting from bed at %s", self._address)
+            # Mark as intentional so _on_disconnect doesn't trigger auto-reconnect
+            self._intentional_disconnect = True
+            # Track disconnect reason for diagnostics (issue #168)
+            self._last_disconnect_reason = reason
+            try:
+                # Stop keep-alive and notifications before disconnecting
+                if self._controller is not None:
+                    # Stop Octo keep-alive if running
+                    if hasattr(self._controller, "stop_keepalive"):
                         try:
-                            await self._controller.stop_notify()
+                            # Cast to Any to avoid mypy error about BedController not having stop_keepalive
+                            await cast(Any, self._controller).stop_keepalive()
                         except Exception as err:
-                            _LOGGER.debug("Error stopping notifications: %s", err)
-                    await self._client.disconnect()
-                    _LOGGER.debug("Successfully disconnected from %s", self._address)
-                except BleakError as err:
-                    _LOGGER.debug("Error during disconnect from %s: %s", self._address, err)
-                finally:
-                    self._client = None
-                    self._controller = None
-                    # Update disconnect timestamp and notify state change
-                    # (don't rely on _on_disconnect callback which may not fire on clean disconnect)
-                    self._last_disconnected = datetime.now(UTC)
-                    self._notify_connection_state_change(False)
-                    self._intentional_disconnect = False
+                            _LOGGER.debug("Error stopping keep-alive: %s", err)
+                    try:
+                        await self._controller.stop_notify()
+                    except Exception as err:
+                        _LOGGER.debug("Error stopping notifications: %s", err)
+                await self._client.disconnect()
+                _LOGGER.debug("Successfully disconnected from %s", self._address)
+            except BleakError as err:
+                _LOGGER.debug("Error during disconnect from %s: %s", self._address, err)
+            finally:
+                self._client = None
+                self._controller = None
+                # Update disconnect timestamp and notify state change
+                # (don't rely on _on_disconnect callback which may not fire on clean disconnect)
+                self._last_disconnected = datetime.now(UTC)
+                self._notify_connection_state_change(False)
+                self._intentional_disconnect = False
 
     def _reset_disconnect_timer(self) -> None:
         """Reset the disconnect timer."""

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -113,6 +113,7 @@ from .const import (
     DEFAULT_OCTO_PIN,
     DEFAULT_POSITION_MODE,
     DEFAULT_PROTOCOL_VARIANT,
+    DEVICE_INFO_CHARS,
     DOMAIN,
     OKIMAT_SERVICE_UUID,
     POSITION_CHECK_INTERVAL,
@@ -133,7 +134,10 @@ from .const import (
 from .controller_factory import create_controller
 from .detection import detect_richmat_remote_from_name, refine_malouf_protocol_from_gatt
 from .diagnostic_payloads import new_connection_attempt_details
-from .unsupported import create_pairing_required_issue
+from .unsupported import (
+    create_pairing_required_issue,
+    delete_pairing_required_issue,
+)
 
 if TYPE_CHECKING:
     from .beds.base import BedController
@@ -302,6 +306,12 @@ class AdjustableBedCoordinator:
         self._ble_bond_established: bool = bool(
             entry.data.get(CONF_BLE_BOND_ESTABLISHED, False)
         )
+        # Transient (in-memory only) flag: a pairing attempt just failed, so the
+        # single next connection attempt should skip pair=True (some stacks fail
+        # to re-pair on top of an existing bond). Unlike the persisted bond
+        # marker, this never poisons the config entry, so a transient pairing
+        # failure cannot permanently prevent future pairing attempts.
+        self._skip_pair_next_attempt: bool = False
 
         # Connection history tracking for diagnostics (issue #168)
         self._connection_attempt_count: int = 0
@@ -612,7 +622,9 @@ class AdjustableBedCoordinator:
         self._clear_ble_bond_established()
 
         try:
-            await create_pairing_required_issue(self.hass, self._address, self._name)
+            await create_pairing_required_issue(
+                self.hass, self._address, self._name, self.entry.entry_id
+            )
         except Exception:
             _LOGGER.debug(
                 "Failed to create pairing required repair issue for %s",
@@ -622,6 +634,53 @@ class AdjustableBedCoordinator:
 
         if self._client is not None and self._client.is_connected:
             await self.async_disconnect(reason="authentication_failed")
+
+    async def _async_verify_bonded(self) -> bool:
+        """Probe an auth-gated characteristic to confirm the BLE bond is live.
+
+        For beds that require pairing, a connection — even one made with
+        ``pair=True`` — can succeed while the link is still unbonded; every
+        encrypted characteristic then fails with GATT error=5 "Insufficient
+        authentication". Reading one known auth-gated characteristic surfaces
+        this so we can clear a stale bond marker and re-pair instead of
+        silently staying unbonded.
+
+        Returns True if the link is bonded (or the check is inconclusive), and
+        False only when an authentication error is definitively observed — in
+        which case the bond marker is cleared, a repair issue is raised, and the
+        client is disconnected.
+        """
+        client = self._client
+        if client is None or not client.is_connected:
+            return True
+
+        probe_uuid = DEVICE_INFO_CHARS["model_number"]
+        try:
+            await client.read_gatt_char(probe_uuid)
+        except BleakError as err:
+            if _is_ble_authentication_error(err):
+                await self._async_handle_ble_authentication_error(err)
+                return False
+            _LOGGER.debug(
+                "Bond verification read for %s was inconclusive (%s); proceeding.",
+                self._address,
+                err,
+            )
+            return True
+        except (TimeoutError, OSError) as err:
+            _LOGGER.debug(
+                "Bond verification read for %s failed (%s); proceeding.",
+                self._address,
+                err,
+            )
+            return True
+
+        # Read succeeded → the encrypted link works → we are bonded.
+        self._skip_pair_next_attempt = False
+        self._mark_ble_bond_established()
+        await delete_pairing_required_issue(self.hass, self._address)
+        _LOGGER.debug("Bond verification succeeded for %s", self._address)
+        return True
 
     @property
     def cancel_command(self) -> asyncio.Event:
@@ -1115,8 +1174,13 @@ class AdjustableBedCoordinator:
                 use_pairing = (
                     bed_requires_pairing
                     and not self._ble_bond_established
+                    and not self._skip_pair_next_attempt
                     and self._pairing_supported is not False
                 )
+                # Consume the transient skip flag: it only suppresses pairing for
+                # the single attempt immediately following a failed pair, so we
+                # never get stuck skipping pairing forever.
+                self._skip_pair_next_attempt = False
                 keep_connecting_through_startup = self._uses_persistent_connection()
                 if use_pairing:
                     _LOGGER.info(
@@ -1188,22 +1252,26 @@ class AdjustableBedCoordinator:
                             raise
                     except (BleakError, TimeoutError, OSError) as pair_err:
                         # If pairing was requested and the connection failed,
-                        # the BLE bond may already exist from a previous
-                        # session.  Re-pairing on top of an existing bond
-                        # causes auth failures on some ESP-IDF stacks and
-                        # leaves the ESPHome proxy connection stuck.  Mark
-                        # pairing as complete and let the outer retry loop
-                        # reconnect without pair=True.
+                        # a BLE bond may already exist from a previous session;
+                        # re-pairing on top of an existing bond causes auth
+                        # failures on some ESP-IDF stacks and leaves the ESPHome
+                        # proxy connection stuck.  Skip pair=True on the *next*
+                        # attempt only (transient, in-memory) so the outer retry
+                        # loop can reconnect — but do NOT persist a bond marker,
+                        # since the failure may simply mean the base was not in
+                        # its pairing window.  The post-connect bond probe
+                        # (_async_verify_bonded) then confirms whether the link
+                        # is really bonded and re-pairs if not.
                         if use_pairing:
                             _LOGGER.warning(
                                 "Connection with pairing failed for %s: %s. "
-                                "Bond may already exist — next attempt will "
-                                "connect without re-pairing.",
+                                "Next attempt will connect without re-pairing; "
+                                "bond state will be verified after connecting.",
                                 self._name,
                                 pair_err,
                             )
                             self._pairing_supported = True
-                            self._mark_ble_bond_established()
+                            self._skip_pair_next_attempt = True
                             raise
                         raise
                 finally:
@@ -1320,6 +1388,36 @@ class AdjustableBedCoordinator:
                             self._name,
                             sorted(discovered_uuids),
                         )
+
+                # Actively verify the encrypted link is bonded for beds that
+                # require pairing. A connection — even establish_connection with
+                # pair=True — can succeed while the link is still unbonded: every
+                # encrypted characteristic then fails with GATT error=5. Skip the
+                # delay-sensitive bed types whose protocol handshake must run
+                # first (Sleep Number, Jensen).
+                if (
+                    bed_requires_pairing
+                    and self._client is not None
+                    and self._client.services
+                    and self._bed_type
+                    not in (
+                        BED_TYPE_SLEEP_NUMBER,
+                        BED_TYPE_SLEEP_NUMBER_MCR,
+                        BED_TYPE_JENSEN,
+                    )
+                    and not await self._async_verify_bonded()
+                ):
+                    # _async_verify_bonded cleared the bond marker, raised the
+                    # repair issue, and disconnected. Retry — the next attempt
+                    # requests pair=True again (the skip flag was consumed).
+                    _LOGGER.warning(
+                        "Bed %s connected but the BLE link is not bonded; "
+                        "retrying with pairing.",
+                        self._address,
+                    )
+                    self._connecting = False
+                    self._connection_attempt_details.append(attempt_details)
+                    continue
 
                 # Some beds (Sleep Number MCR/Fuzion, Jensen) disconnect if
                 # there is too much delay between the BLE connection and the

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -1199,16 +1199,22 @@ class AdjustableBedCoordinator:
                 self._notify_connection_state_change(False)
                 try:
                     # Use max_attempts=1 here since outer loop handles retries
-                    # When pairing is required, disable services cache to force fresh
-                    # GATT discovery. Some devices expose different services depending
-                    # on pairing state, and stale cached services from a previous
-                    # non-paired connection will cause characteristic lookups to fail.
+                    # Disable the services cache to force fresh GATT discovery for
+                    # every pairing-required bed, not just the pair=True attempt.
+                    # These devices expose different services/characteristics
+                    # depending on bond state, so a stale cache from a previous
+                    # non-paired connection would make characteristic lookups (and
+                    # the post-connect bond probe) fail. This also covers the
+                    # no-pair verify retry after a failed pair attempt, which must
+                    # see live services to confirm the bond instead of looping.
                     #
                     # Sleep Number Climate 360 does not pair (see BEDS_REQUIRING_PAIRING)
                     # but the SleepIQ app refreshes the GATT cache on every connect, so
                     # force fresh discovery to keep parity and ensure the app-layer
                     # priming reads always see the live characteristic handles.
-                    disable_cache = use_pairing or self._bed_type == BED_TYPE_SLEEP_NUMBER
+                    disable_cache = (
+                        bed_requires_pairing or self._bed_type == BED_TYPE_SLEEP_NUMBER
+                    )
                     try:
                         self._client = await establish_connection(
                             BleakClient,

--- a/custom_components/adjustable_bed/repairs.py
+++ b/custom_components/adjustable_bed/repairs.py
@@ -1,0 +1,134 @@
+"""Repair flows for the Adjustable Bed integration.
+
+Currently provides a guided fix for the ``pairing_required`` issue: it walks the
+user through putting an OKIN-style base into Bluetooth pairing mode (by
+power-cycling the control box), pairs with ``pair=True``, and verifies the bond
+by reading an auth-gated characteristic before resolving the issue.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.components import bluetooth
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import CONF_BLE_BOND_ESTABLISHED, DEVICE_INFO_CHARS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PairingRequiredRepairFlow(RepairsFlow):
+    """Guided flow to (re-)pair a bed that requires Bluetooth bonding."""
+
+    def __init__(self, address: str, name: str, entry_id: str | None) -> None:
+        """Store the target bed details from the issue data."""
+        self._address = address
+        self._name = name
+        self._entry_id = entry_id
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Entry point — show pairing instructions and a confirm button."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Pair with the bed when the user confirms."""
+        if user_input is not None:
+            if await self._async_try_pair():
+                return self.async_create_entry(title="", data={})
+            return self.async_abort(reason="pairing_failed")
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "name": self._name,
+                "address": self._address,
+            },
+        )
+
+    async def _async_try_pair(self) -> bool:
+        """Connect with pair=True and verify the encrypted link is bonded."""
+        from bleak import BleakClient
+        from bleak.exc import BleakError
+        from bleak_retry_connector import establish_connection
+
+        device = bluetooth.async_ble_device_from_address(
+            self.hass, self._address, connectable=True
+        )
+        if device is None:
+            _LOGGER.warning("Repair: bed %s not in range — cannot pair", self._address)
+            return False
+
+        try:
+            client = await establish_connection(
+                BleakClient, device, self._name, max_attempts=1, pair=True
+            )
+        except Exception as err:  # noqa: BLE001 - any failure means "not paired"
+            _LOGGER.warning("Repair: pairing failed for %s: %s", self._address, err)
+            return False
+
+        bonded = False
+        try:
+            # Verify the bond by reading a known auth-gated characteristic. A
+            # still-unbonded link fails here with GATT error=5.
+            await client.read_gatt_char(DEVICE_INFO_CHARS["model_number"])
+            bonded = True
+        except BleakError as err:
+            _LOGGER.warning(
+                "Repair: bond verification failed for %s: %s", self._address, err
+            )
+        except Exception as err:  # noqa: BLE001
+            # A non-auth error (e.g. characteristic absent) doesn't prove the
+            # bond failed — treat as success so we don't block the user.
+            _LOGGER.debug(
+                "Repair: bond verification inconclusive for %s: %s",
+                self._address,
+                err,
+            )
+            bonded = True
+        finally:
+            try:
+                await client.disconnect()
+            except Exception:  # noqa: BLE001
+                pass
+
+        if not bonded:
+            return False
+
+        # Persist the confirmed bond and reload so the coordinator reuses it
+        # (and does not try to re-pair on top of the existing bond).
+        if self._entry_id is not None:
+            entry = self.hass.config_entries.async_get_entry(self._entry_id)
+            if entry is not None:
+                if not entry.data.get(CONF_BLE_BOND_ESTABLISHED):
+                    self.hass.config_entries.async_update_entry(
+                        entry,
+                        data={**entry.data, CONF_BLE_BOND_ESTABLISHED: True},
+                    )
+                await self.hass.config_entries.async_reload(self._entry_id)
+
+        _LOGGER.info("Repair: pairing succeeded for %s", self._address)
+        return True
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, Any] | None,
+) -> RepairsFlow:
+    """Create the repair flow for a fixable issue."""
+    payload = data or {}
+    return PairingRequiredRepairFlow(
+        address=payload.get("address", ""),
+        name=payload.get("name", "your bed"),
+        entry_id=payload.get("entry_id"),
+    )

--- a/custom_components/adjustable_bed/repairs.py
+++ b/custom_components/adjustable_bed/repairs.py
@@ -17,7 +17,14 @@ from homeassistant.components.repairs import RepairsFlow
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import CONF_BLE_BOND_ESTABLISHED, DEVICE_INFO_CHARS
+from .adapter import get_discovered_service_info
+from .ble_auth import is_ble_authentication_error
+from .const import (
+    ADAPTER_AUTO,
+    CONF_BLE_BOND_ESTABLISHED,
+    CONF_PREFERRED_ADAPTER,
+    DEVICE_INFO_CHARS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,22 +62,57 @@ class PairingRequiredRepairFlow(RepairsFlow):
             },
         )
 
+    def _find_device(self) -> object | None:
+        """Find the BLE device, honoring the entry's preferred adapter.
+
+        BLE bonds live on the adapter/proxy that performed pairing, so a repair
+        must pair on the same source the coordinator will use — otherwise it can
+        bond one source, mark the entry bonded, and leave the configured source
+        still unauthenticated.
+        """
+        preferred = ADAPTER_AUTO
+        if self._entry_id is not None:
+            entry = self.hass.config_entries.async_get_entry(self._entry_id)
+            if entry is not None:
+                preferred = entry.data.get(CONF_PREFERRED_ADAPTER, ADAPTER_AUTO)
+
+        if not preferred or preferred == ADAPTER_AUTO:
+            return bluetooth.async_ble_device_from_address(
+                self.hass, self._address, connectable=True
+            )
+
+        address_upper = self._address.upper()
+        for service_info in get_discovered_service_info(
+            self.hass, include_non_connectable=True
+        ):
+            if service_info.address.upper() != address_upper:
+                continue
+            if getattr(service_info, "source", None) == preferred:
+                return service_info.device
+        return None
+
     async def _async_try_pair(self) -> bool:
         """Connect with pair=True and verify the encrypted link is bonded."""
         from bleak import BleakClient
         from bleak.exc import BleakError
         from bleak_retry_connector import establish_connection
 
-        device = bluetooth.async_ble_device_from_address(
-            self.hass, self._address, connectable=True
-        )
+        device = self._find_device()
         if device is None:
-            _LOGGER.warning("Repair: bed %s not in range — cannot pair", self._address)
+            _LOGGER.warning(
+                "Repair: bed %s not reachable on the configured adapter — cannot pair",
+                self._address,
+            )
             return False
 
         try:
             client = await establish_connection(
-                BleakClient, device, self._name, max_attempts=1, pair=True
+                BleakClient,
+                device,
+                self._name,
+                max_attempts=1,
+                pair=True,
+                use_services_cache=False,
             )
         except Exception as err:  # noqa: BLE001 - any failure means "not paired"
             _LOGGER.warning("Repair: pairing failed for %s: %s", self._address, err)
@@ -79,16 +121,23 @@ class PairingRequiredRepairFlow(RepairsFlow):
         bonded = False
         try:
             # Verify the bond by reading a known auth-gated characteristic. A
-            # still-unbonded link fails here with GATT error=5.
+            # still-unbonded link fails with GATT error=5; non-auth errors
+            # (e.g. the characteristic is absent) are inconclusive, not failures.
             await client.read_gatt_char(DEVICE_INFO_CHARS["model_number"])
             bonded = True
         except BleakError as err:
-            _LOGGER.warning(
-                "Repair: bond verification failed for %s: %s", self._address, err
-            )
+            if is_ble_authentication_error(err):
+                _LOGGER.warning(
+                    "Repair: bond verification failed for %s: %s", self._address, err
+                )
+            else:
+                _LOGGER.debug(
+                    "Repair: bond verification inconclusive for %s: %s",
+                    self._address,
+                    err,
+                )
+                bonded = True
         except Exception as err:  # noqa: BLE001
-            # A non-auth error (e.g. characteristic absent) doesn't prove the
-            # bond failed — treat as success so we don't block the user.
             _LOGGER.debug(
                 "Repair: bond verification inconclusive for %s: %s",
                 self._address,

--- a/custom_components/adjustable_bed/repairs.py
+++ b/custom_components/adjustable_bed/repairs.py
@@ -9,7 +9,7 @@ by reading an auth-gated characteristic before resolving the issue.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 from homeassistant.components import bluetooth
@@ -25,6 +25,9 @@ from .const import (
     CONF_PREFERRED_ADAPTER,
     DEVICE_INFO_CHARS,
 )
+
+if TYPE_CHECKING:
+    from bleak.backends.device import BLEDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,7 +65,7 @@ class PairingRequiredRepairFlow(RepairsFlow):
             },
         )
 
-    def _find_device(self) -> object | None:
+    def _find_device(self) -> BLEDevice | None:
         """Find the BLE device, honoring the entry's preferred adapter.
 
         BLE bonds live on the adapter/proxy that performed pairing, so a repair

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -187,7 +187,7 @@
         },
         "data_description": {
           "pairing_instructions_generic": "1. Put your bed in pairing mode (hold lamp button until blue light blinks, or unplug for 30+ seconds)\n2. Click 'Pair Now'",
-          "pairing_instructions_okin": "1. Put the OKIN receiver/control box in pairing mode (press or hold the receiver pairing button until the LED blinks)\n2. Click 'Pair Now'",
+          "pairing_instructions_okin": "1. Put the OKIN base into Bluetooth pairing mode by power-cycling the control box: unplug it for ~30 seconds, then plug it back in. The status light blinks blue, then turns green after ~20 seconds. (Some models instead use the under-bed lamp/light button - hold it until the light blinks blue.) There is no separate Bluetooth pairing button; any Pair/Learn button on the box only syncs the RF remote.\n2. While the light is active, click 'Pair Now'.",
           "pairing_instructions_sleep_number": "1. Put your bed in pairing mode (hold the side pairing button until the blue light blinks)\n2. Click 'Pair Now'"
         }
       },
@@ -761,7 +761,18 @@
     },
     "pairing_required": {
       "title": "Bluetooth pairing required for {name}",
-      "description": "The bed at `{address}` requires Bluetooth pairing before it can be controlled.\n\n**To fix this:**\n\n1. Put your bed in pairing mode (usually by holding a button on the motor or remote for 5+ seconds until an LED blinks)\n2. On your Home Assistant host (or Bluetooth proxy device), go to Bluetooth settings\n3. Find and pair with the bed\n4. Return here and reload the integration\n\n**Note:** The pairing must be done on the device running Home Assistant's Bluetooth stack, not your phone."
+      "description": "The bed at `{address}` connected but its Bluetooth link is not bonded, so it cannot be controlled yet.\n\n**Click 'Fix' above** to be guided through pairing, or do it manually:\n\n1. Put the base into pairing mode by **power-cycling the control box** (unplug it for ~30 seconds, then plug it back in). The status light blinks blue, then turns green after ~20 seconds. OKIN bases have **no separate Bluetooth pairing button** — any Pair/Learn button only syncs the RF remote.\n2. Pair from the device running Home Assistant's Bluetooth stack (your HA host or a Bluetooth proxy), **not your phone**.\n\n**Note:** ESPHome Bluetooth proxies support pairing only on ESPHome 2024.3.0 or newer; if pairing keeps failing, try a local Bluetooth adapter near the bed.",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Pair your adjustable bed",
+            "description": "**{name}** ({address}) needs to finish Bluetooth pairing before it can be controlled.\n\n1. Put the base into pairing mode: **unplug the control box for ~30 seconds, then plug it back in**. The status light blinks blue, then turns green after ~20 seconds. (Some models use the under-bed lamp/light button — hold it until the light blinks blue.) There is no separate Bluetooth pairing button.\n2. While the light is active, press **Submit** to pair.\n\nPairing happens on your Home Assistant host or Bluetooth proxy — not your phone. ESPHome proxies must run ESPHome 2024.3.0 or newer."
+          }
+        },
+        "abort": {
+          "pairing_failed": "Pairing didn't complete. Make sure the base is in pairing mode (unplug the control box ~30s, then plug it back in) and in range of your Home Assistant adapter or an ESPHome proxy on 2024.3.0+, then run this repair again."
+        }
+      }
     }
   }
 }

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -761,16 +761,15 @@
     },
     "pairing_required": {
       "title": "Bluetooth pairing required for {name}",
-      "description": "The bed at `{address}` connected but its Bluetooth link is not bonded, so it cannot be controlled yet.\n\n**Click 'Fix' above** to be guided through pairing, or do it manually:\n\n1. Put the base into pairing mode by **power-cycling the control box** (unplug it for ~30 seconds, then plug it back in). The status light blinks blue, then turns green after ~20 seconds. OKIN bases have **no separate Bluetooth pairing button** — any Pair/Learn button only syncs the RF remote.\n2. Pair from the device running Home Assistant's Bluetooth stack (your HA host or a Bluetooth proxy), **not your phone**.\n\n**Note:** ESPHome Bluetooth proxies support pairing only on ESPHome 2024.3.0 or newer; if pairing keeps failing, try a local Bluetooth adapter near the bed.",
       "fix_flow": {
         "step": {
           "confirm": {
             "title": "Pair your adjustable bed",
-            "description": "**{name}** ({address}) needs to finish Bluetooth pairing before it can be controlled.\n\n1. Put the base into pairing mode: **unplug the control box for ~30 seconds, then plug it back in**. The status light blinks blue, then turns green after ~20 seconds. (Some models use the under-bed lamp/light button — hold it until the light blinks blue.) There is no separate Bluetooth pairing button.\n2. While the light is active, press **Submit** to pair.\n\nPairing happens on your Home Assistant host or Bluetooth proxy — not your phone. ESPHome proxies must run ESPHome 2024.3.0 or newer."
+            "description": "**{name}** ({address}) connected but its Bluetooth link is not bonded, so it cannot be controlled yet.\n\n1. Put the bed into pairing mode. **OKIN bases** (Okimat, Okin CST, Nectar OKIN-*, Mattress Firm 900-O): power-cycle the control box — unplug it for ~30 seconds, then plug it back in (the light blinks blue, then turns green); they have no Bluetooth pairing button. **Other beds**: hold the pairing button on the control box or remote until its light blinks.\n2. While the bed is discoverable, press **Submit** to pair.\n\nPairing happens on your Home Assistant host or Bluetooth proxy — not your phone. ESPHome proxies must run ESPHome 2024.3.0 or newer."
           }
         },
         "abort": {
-          "pairing_failed": "Pairing didn't complete. Make sure the base is in pairing mode (unplug the control box ~30s, then plug it back in) and in range of your Home Assistant adapter or an ESPHome proxy on 2024.3.0+, then run this repair again."
+          "pairing_failed": "Pairing didn't complete. Put the bed back into pairing mode (OKIN bases: unplug the control box ~30s, then plug it back in; other beds: hold the pairing button), make sure it is in range of your Home Assistant adapter or an ESPHome proxy on 2024.3.0+, then run this repair again."
         }
       }
     }

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -187,7 +187,7 @@
         },
         "data_description": {
           "pairing_instructions_generic": "1. Put your bed in pairing mode (hold lamp button until blue light blinks, or unplug for 30+ seconds)\n2. Click 'Pair Now'",
-          "pairing_instructions_okin": "1. Put the OKIN receiver/control box in pairing mode (press or hold the receiver pairing button until the LED blinks)\n2. Click 'Pair Now'",
+          "pairing_instructions_okin": "1. Put the OKIN base into Bluetooth pairing mode by power-cycling the control box: unplug it for ~30 seconds, then plug it back in. The status light blinks blue, then turns green after ~20 seconds. (Some models instead use the under-bed lamp/light button - hold it until the light blinks blue.) There is no separate Bluetooth pairing button; any Pair/Learn button on the box only syncs the RF remote.\n2. While the light is active, click 'Pair Now'.",
           "pairing_instructions_sleep_number": "1. Put your bed in pairing mode (hold the side pairing button until the blue light blinks)\n2. Click 'Pair Now'"
         }
       },
@@ -764,7 +764,18 @@
     },
     "pairing_required": {
       "title": "Bluetooth pairing required for {name}",
-      "description": "The bed at `{address}` requires Bluetooth pairing before it can be controlled.\n\n**To fix this:**\n\n1. Put your bed in pairing mode (usually by holding a button on the motor or remote for 5+ seconds until an LED blinks)\n2. On your Home Assistant host (or Bluetooth proxy device), go to Bluetooth settings\n3. Find and pair with the bed\n4. Return here and reload the integration\n\n**Note:** The pairing must be done on the device running Home Assistant's Bluetooth stack, not your phone."
+      "description": "The bed at `{address}` connected but its Bluetooth link is not bonded, so it cannot be controlled yet.\n\n**Click 'Fix' above** to be guided through pairing, or do it manually:\n\n1. Put the base into pairing mode by **power-cycling the control box** (unplug it for ~30 seconds, then plug it back in). The status light blinks blue, then turns green after ~20 seconds. OKIN bases have **no separate Bluetooth pairing button** — any Pair/Learn button only syncs the RF remote.\n2. Pair from the device running Home Assistant's Bluetooth stack (your HA host or a Bluetooth proxy), **not your phone**.\n\n**Note:** ESPHome Bluetooth proxies support pairing only on ESPHome 2024.3.0 or newer; if pairing keeps failing, try a local Bluetooth adapter near the bed.",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Pair your adjustable bed",
+            "description": "**{name}** ({address}) needs to finish Bluetooth pairing before it can be controlled.\n\n1. Put the base into pairing mode: **unplug the control box for ~30 seconds, then plug it back in**. The status light blinks blue, then turns green after ~20 seconds. (Some models use the under-bed lamp/light button — hold it until the light blinks blue.) There is no separate Bluetooth pairing button.\n2. While the light is active, press **Submit** to pair.\n\nPairing happens on your Home Assistant host or Bluetooth proxy — not your phone. ESPHome proxies must run ESPHome 2024.3.0 or newer."
+          }
+        },
+        "abort": {
+          "pairing_failed": "Pairing didn't complete. Make sure the base is in pairing mode (unplug the control box ~30s, then plug it back in) and in range of your Home Assistant adapter or an ESPHome proxy on 2024.3.0+, then run this repair again."
+        }
+      }
     }
   }
 }

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -764,16 +764,15 @@
     },
     "pairing_required": {
       "title": "Bluetooth pairing required for {name}",
-      "description": "The bed at `{address}` connected but its Bluetooth link is not bonded, so it cannot be controlled yet.\n\n**Click 'Fix' above** to be guided through pairing, or do it manually:\n\n1. Put the base into pairing mode by **power-cycling the control box** (unplug it for ~30 seconds, then plug it back in). The status light blinks blue, then turns green after ~20 seconds. OKIN bases have **no separate Bluetooth pairing button** — any Pair/Learn button only syncs the RF remote.\n2. Pair from the device running Home Assistant's Bluetooth stack (your HA host or a Bluetooth proxy), **not your phone**.\n\n**Note:** ESPHome Bluetooth proxies support pairing only on ESPHome 2024.3.0 or newer; if pairing keeps failing, try a local Bluetooth adapter near the bed.",
       "fix_flow": {
         "step": {
           "confirm": {
             "title": "Pair your adjustable bed",
-            "description": "**{name}** ({address}) needs to finish Bluetooth pairing before it can be controlled.\n\n1. Put the base into pairing mode: **unplug the control box for ~30 seconds, then plug it back in**. The status light blinks blue, then turns green after ~20 seconds. (Some models use the under-bed lamp/light button — hold it until the light blinks blue.) There is no separate Bluetooth pairing button.\n2. While the light is active, press **Submit** to pair.\n\nPairing happens on your Home Assistant host or Bluetooth proxy — not your phone. ESPHome proxies must run ESPHome 2024.3.0 or newer."
+            "description": "**{name}** ({address}) connected but its Bluetooth link is not bonded, so it cannot be controlled yet.\n\n1. Put the bed into pairing mode. **OKIN bases** (Okimat, Okin CST, Nectar OKIN-*, Mattress Firm 900-O): power-cycle the control box — unplug it for ~30 seconds, then plug it back in (the light blinks blue, then turns green); they have no Bluetooth pairing button. **Other beds**: hold the pairing button on the control box or remote until its light blinks.\n2. While the bed is discoverable, press **Submit** to pair.\n\nPairing happens on your Home Assistant host or Bluetooth proxy — not your phone. ESPHome proxies must run ESPHome 2024.3.0 or newer."
           }
         },
         "abort": {
-          "pairing_failed": "Pairing didn't complete. Make sure the base is in pairing mode (unplug the control box ~30s, then plug it back in) and in range of your Home Assistant adapter or an ESPHome proxy on 2024.3.0+, then run this repair again."
+          "pairing_failed": "Pairing didn't complete. Put the bed back into pairing mode (OKIN bases: unplug the control box ~30s, then plug it back in; other beds: hold the pairing button), make sure it is in range of your Home Assistant adapter or an ESPHome proxy on 2024.3.0+, then run this repair again."
         }
       }
     }

--- a/custom_components/adjustable_bed/unsupported.py
+++ b/custom_components/adjustable_bed/unsupported.py
@@ -12,6 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.issue_registry import (
     IssueSeverity,
     async_create_issue,
+    async_delete_issue,
 )
 from homeassistant.helpers.issue_registry import (
     async_get as async_get_issue_registry,
@@ -286,30 +287,43 @@ async def create_unsupported_device_issue(
     return True
 
 
+def _pairing_required_issue_id(address: str) -> str:
+    """Return the stable Repairs issue id for a pairing-required bed."""
+    return f"pairing_required_{address.replace(':', '_').lower()}"
+
+
 async def create_pairing_required_issue(
     hass: HomeAssistant,
     address: str,
     name: str,
+    entry_id: str | None = None,
 ) -> None:
-    """Create a persistent issue for beds that require Bluetooth pairing.
+    """Create a fixable issue for beds that require Bluetooth pairing.
 
-    This is shown when a bed requiring pairing fails to connect at runtime,
-    to guide users through the pairing process.
+    This is shown when a bed requiring pairing fails to bond at runtime, to
+    guide users through the pairing process. The issue is fixable: the repair
+    flow (see ``repairs.py``) walks the user through power-cycling the base and
+    re-pairs it. ``entry_id`` (when known) lets the repair flow clear a stale
+    bond marker and reload the entry on success.
     """
-    # Use address as unique identifier (normalized to avoid duplicates)
-    issue_id = f"pairing_required_{address.replace(':', '_').lower()}"
+    issue_id = _pairing_required_issue_id(address)
 
     async_create_issue(
         hass,
         DOMAIN,
         issue_id,
-        is_fixable=False,
+        is_fixable=True,
         is_persistent=True,
         severity=IssueSeverity.ERROR,
         translation_key="pairing_required",
         translation_placeholders={
             "name": name,
             "address": address,
+        },
+        data={
+            "address": address,
+            "name": name,
+            "entry_id": entry_id,
         },
     )
 
@@ -318,3 +332,8 @@ async def create_pairing_required_issue(
         name,
         address,
     )
+
+
+async def delete_pairing_required_issue(hass: HomeAssistant, address: str) -> None:
+    """Remove the pairing-required Repairs issue once the bed is bonded."""
+    async_delete_issue(hass, DOMAIN, _pairing_required_issue_id(address))

--- a/docs/CONNECTION_GUIDE.md
+++ b/docs/CONNECTION_GUIDE.md
@@ -30,6 +30,7 @@ Some beds require OS-level Bluetooth pairing before the integration can communic
 | Bed Type | Pairing Required |
 |----------|-----------------|
 | Okimat/Okin | ✅ Yes |
+| Okin CST (incl. OKIN-* Nectar Motion / Mattress Firm 900-O / Rize MF900) | ✅ Yes |
 | Leggett & Platt Okin variant | ✅ Yes |
 | Logicdata SimplicityFrame | ✅ Yes |
 | Vibradorm | ✅ Yes |
@@ -37,22 +38,22 @@ Some beds require OS-level Bluetooth pairing before the integration can communic
 | Sleep Number i8 / 360 FlexFit 2 (BAM/MCR) | ❌ No |
 | Leggett & Platt Gen2 | ❌ No |
 | Leggett & Platt MlRM | ❌ No |
-| Nectar | ❌ No |
+| Nectar (DewertOkin protocol) | ❌ No |
 | DewertOkin | ❌ No |
 | Most other beds | ❌ No |
 
 *Note: the two Sleep Number entries are separate bed types, not variants of the same one — Sleep Number Fuzion always requires pairing, Sleep Number BAM/MCR never does. Leggett & Platt only requires pairing on its Okin variant.*
 
-**How to pair (if required):**
-1. Put your bed in pairing mode (usually hold a button on the remote for 3-5 seconds)
-2. On your Home Assistant host or phone, open Bluetooth settings
-3. Pair with the bed (may appear as `OKIN`, `OKIN-Receiver`, `OKIN - Receiver`, `Okimat`, `Smart bed 123456`, or similar)
-4. Then add the integration in Home Assistant
+> **Nectar is split across two rows on purpose.** "Nectar" branding covers more than one protocol. Bases that advertise as `OKIN-XXXXXX` are detected as **Okin CST** and **do** require pairing; older Nectar bases that use the DewertOkin protocol do **not**. The integration picks the right one by GATT signature — the brand on the bed is only a hint.
 
-For Sleep Number Climate 360 / FlexFit Fuzion bases, hold the side pairing button until the blue light blinks.
+**How to pair (if required):**
+1. Put your bed in pairing mode. For **OKIN** bases (Okimat, Okin CST, Nectar OKIN-*, Mattress Firm 900-O, Rize MF900), **power-cycle the control box** — unplug it ~30 seconds, then plug it back in; the light blinks blue then turns green after ~20 s. There is **no Bluetooth pairing button**; any Pair/Learn button only syncs the RF remote. For **Sleep Number Climate 360 / FlexFit Fuzion**, hold the side pairing button until the blue light blinks.
+2. On the device running Home Assistant's Bluetooth stack (HA host or proxy), let the integration pair, or pair manually in Bluetooth settings.
+3. The bed may appear as `OKIN`, `OKIN-XXXXXX`, `OKIN-Receiver`, `Okimat`, `Smart bed 123456`, or similar.
+
 Older Sleep Number BAM/MCR bases connect without OS-level pairing.
 
-**Note:** If you're using an ESPHome Bluetooth Proxy, you may need to pair on the device running Home Assistant, not on your phone.
+**Note:** Pair on the device running Home Assistant's Bluetooth stack, **not your phone**. ESPHome Bluetooth proxies support pairing only on **ESPHome 2024.3.0+**; if pairing keeps failing, use a local adapter near the bed. If a bed connects but stays unbonded, Home Assistant raises a **"Bluetooth pairing required"** repair with a **Fix** button that walks you through it.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -222,35 +222,27 @@ See [Motor Pulse Settings](CONFIGURATION.md#motor-pulse-settings) for default va
 
 ## Pairing Required Beds
 
-Some beds require Bluetooth pairing before they can be controlled.
+Some beds (Okimat / OKIN, Okin CST, Leggett & Platt Okin variant, Logicdata, Vibradorm, Sleep Number Climate 360 / FlexFit Fuzion) require an OS-level Bluetooth **bond** before they can be controlled. The integration requests pairing automatically; the steps below are for putting the bed into pairing mode and recovering when a bond fails.
 
-### How to Pair
+### Putting the bed in pairing mode
 
-1. **On Linux/Raspberry Pi:**
-   ```bash
-   bluetoothctl
-   scan on
-   # Find your bed's MAC address
-   pair XX:XX:XX:XX:XX:XX
-   trust XX:XX:XX:XX:XX:XX
-   ```
+- **OKIN bases (Okimat, Okin CST, Nectar / Mattress Firm 900-O / Rize MF900, etc.):** Power-cycle the control box — **unplug it for ~30 seconds, then plug it back in**. The status light blinks blue, then turns green after ~20 seconds. That window is when the base accepts a new Bluetooth bond. Some models instead use the under-bed **lamp/light button** (hold until it blinks blue). There is **no dedicated Bluetooth pairing button** — any "Pair"/"Learn" button on the control box only syncs the RF remote, not Bluetooth.
+- **Sleep Number Climate 360 / FlexFit Fuzion:** hold the side pairing button until the blue light blinks. (Older Sleep Number BAM/MCR i8 / 360 FlexFit 2 beds do **not** need OS-level pairing.)
 
-2. **On Home Assistant OS:**
-   - SSH into your Home Assistant OS and use `bluetoothctl` (same as Linux)
-   - Note: ESPHome Bluetooth proxies don't support OS-level pairing - use a local Bluetooth adapter for beds that require pairing
+### How the integration pairs
 
-3. **On Windows/macOS (for testing):**
-   - Go to Bluetooth settings
-   - Find the bed and click "Pair"
+The integration connects with pairing enabled and, for OKIN-style beds, verifies the bond afterward by reading an encrypted characteristic. If the link connected but never bonded, it clears its cached bond state and re-pairs on the next attempt, and raises a **"Bluetooth pairing required"** repair with a **Fix** button that walks you through the power-cycle + pair.
 
-Sleep Number Climate 360 / FlexFit Fuzion bases enter pairing mode by holding the side pairing button until the blue light blinks. Older Sleep Number BAM/MCR bases such as some i8 / 360 FlexFit 2 beds do not need OS-level pairing.
+**Bluetooth adapter notes:**
+- ESPHome Bluetooth proxies **do** support OS-level pairing, but only on **ESPHome 2024.3.0 or newer**. Pairing over a proxy can be unreliable; if it keeps failing, put the bed in range of a **local Bluetooth adapter** (or the HA host's own adapter) for the initial bond.
+- You can also pair manually from the device running HA's Bluetooth stack — **not your phone**:
+  - **Linux / Raspberry Pi / HA OS (SSH):** `bluetoothctl` → `scan on` → `pair XX:XX:XX:XX:XX:XX` → `trust XX:XX:XX:XX:XX:XX`
+  - **Windows / macOS (for testing):** Bluetooth settings → find the bed → "Pair"
 
 ### Signs Pairing is Needed
 - Connection succeeds but no commands work
-- Bed specifically requires PIN entry or pairing confirmation
-- "Pairing required" error message
-
-**Note:** If discovery works but connection fails, first try the [pairing mode procedure](#bed-is-discovered-but-wont-connect) above. OS-level Bluetooth pairing is only needed for specific beds such as Okimat, Leggett Okin, and newer Sleep Number Climate 360 / FlexFit Fuzion bases.
+- Device info (manufacturer/model) is blank and reads fail with "insufficient authentication"
+- "Bluetooth pairing required" repair / error message
 
 ---
 

--- a/docs/beds/okin-cst.md
+++ b/docs/beds/okin-cst.md
@@ -24,6 +24,28 @@ both the CSS service and Nordic DFU service.
 This also applies to Mattress Firm 900-O / MFirm 900-O bases advertising as
 `OKIN-XXXXXX` with the same connected GATT signature.
 
+## Pairing
+
+These bases require an OS-level Bluetooth **bond** before commands are accepted.
+Pairing is "Just Works" — **no PIN** and **no dedicated Bluetooth pairing button**.
+The bond is negotiated automatically by the OS when a client accesses one of the
+firmware's encrypted characteristics; on a real device every read/notify and
+Device Information characteristic returns GATT `error=5` "Insufficient
+authentication" until the link is bonded, while the command write characteristic
+(`62741525-…`) is reachable unbonded.
+
+**To enter pairing mode, power-cycle the control box:** unplug it for ~30 seconds,
+then plug it back in. The status light blinks blue, then turns green after ~20 s —
+that window is when the base accepts a new bond. Some models instead use the
+under-bed lamp/light button (hold until it blinks blue). The physical "Pair"/"Learn"
+button found on some OKIN control boxes only syncs the **RF remote**, not Bluetooth.
+
+The integration requests `pair=True` automatically and verifies the bond after
+connecting; if the link connected but did not bond it clears its cached bond state,
+re-pairs on the next attempt, and surfaces a **"Bluetooth pairing required"** repair
+with a guided **Fix** button. ESPHome Bluetooth proxies can pair only on ESPHome
+≥ 2024.3.0; a local adapter near the bed is the most reliable for the first bond.
+
 ## Protocol
 
 Uses a 14-byte command format with two separate 32-bit fields:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1773,6 +1773,7 @@ class TestCoordinatorWriteCommand:
         coordinator = AdjustableBedCoordinator(hass, entry)
         client = MagicMock()
         client.is_connected = True
+        client.disconnect = AsyncMock()
         client.read_gatt_char = AsyncMock(
             side_effect=BleakError(
                 "Bluetooth GATT Error address=AA:BB:CC:DD:EE:FF "
@@ -1781,16 +1782,16 @@ class TestCoordinatorWriteCommand:
         )
         coordinator._client = client
 
-        with (
-            patch(
-                "custom_components.adjustable_bed.coordinator.create_pairing_required_issue",
-                new_callable=AsyncMock,
-            ) as mock_create_issue,
-            patch.object(
-                coordinator, "async_disconnect", new_callable=AsyncMock
-            ) as mock_disconnect,
-        ):
-            bonded = await coordinator._async_verify_bonded()
+        with patch(
+            "custom_components.adjustable_bed.coordinator.create_pairing_required_issue",
+            new_callable=AsyncMock,
+        ) as mock_create_issue:
+            # Reproduce the real call context: the connect path holds self._lock
+            # while verifying. If the disconnect re-acquired the lock this would
+            # deadlock, so guard with a timeout to fail fast instead of hanging.
+            async with coordinator._lock:
+                async with asyncio.timeout(5):
+                    bonded = await coordinator._async_verify_bonded()
 
         assert bonded is False
         assert coordinator._ble_bond_established is False
@@ -1798,7 +1799,9 @@ class TestCoordinatorWriteCommand:
         mock_create_issue.assert_awaited_once_with(
             hass, TEST_ADDRESS, TEST_NAME, "okimat_verify_bonded_test"
         )
-        mock_disconnect.assert_awaited_once_with(reason="authentication_failed")
+        # Disconnect ran via the lock-free path and cleared the client.
+        client.disconnect.assert_awaited_once()
+        assert coordinator._client is None
 
     async def test_verify_bonded_confirms_and_clears_repair_when_readable(
         self,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1674,8 +1674,172 @@ class TestCoordinatorWriteCommand:
 
         assert coordinator._ble_bond_established is False
         assert entry.data[CONF_BLE_BOND_ESTABLISHED] is False
-        mock_create_issue.assert_awaited_once_with(hass, TEST_ADDRESS, TEST_NAME)
+        mock_create_issue.assert_awaited_once_with(
+            hass, TEST_ADDRESS, TEST_NAME, "okimat_auth_failure_test"
+        )
         mock_disconnect.assert_awaited_once_with(reason="authentication_failed")
+
+    async def test_failed_pairing_does_not_persist_bond_marker(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_adapters,
+    ):
+        """A failed pairing attempt must not poison the persisted bond marker.
+
+        Regression: previously a BleakError during a pair=True connect was
+        assumed to mean "already bonded" and persisted CONF_BLE_BOND_ESTABLISHED,
+        which permanently prevented future pairing attempts on a still-unbonded
+        bed. Now it only sets a transient in-memory skip flag.
+        """
+        del mock_bluetooth_adapters
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Unpaired OKIN Bed",
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: TEST_NAME,
+                CONF_BED_TYPE: BED_TYPE_OKIMAT,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id="okimat_failed_pairing_test",
+        )
+        entry.add_to_hass(hass)
+
+        adapter_result = MagicMock()
+        adapter_result.device = MagicMock()
+        adapter_result.device.address = TEST_ADDRESS
+        adapter_result.device.name = TEST_NAME
+        adapter_result.device.details = {"source": "local"}
+        adapter_result.source = "local"
+        adapter_result.rssi = -60
+        adapter_result.connectable = True
+        adapter_result.available_sources = ["local"]
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.coordinator.select_adapter",
+                new_callable=AsyncMock,
+                return_value=adapter_result,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.establish_connection",
+                new_callable=AsyncMock,
+                side_effect=BleakError("pairing failed"),
+            ) as mock_establish_connection,
+        ):
+            coordinator = AdjustableBedCoordinator(hass, entry)
+            result = await coordinator.async_connect()
+
+        assert result is False
+        # The failed pairing attempt must NOT have persisted a bond marker.
+        assert coordinator._ble_bond_established is False
+        assert entry.data.get(CONF_BLE_BOND_ESTABLISHED) is not True
+        # The transient skip flag should have produced both a pairing attempt
+        # and a no-pair retry across the retry loop.
+        pair_kwargs = [
+            call.kwargs.get("pair") for call in mock_establish_connection.await_args_list
+        ]
+        assert True in pair_kwargs
+        assert False in pair_kwargs
+
+    async def test_verify_bonded_detects_unbonded_link_and_repairs(
+        self,
+        hass: HomeAssistant,
+    ):
+        """An auth error while probing an encrypted char clears the marker + repairs."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=TEST_NAME,
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: TEST_NAME,
+                CONF_BED_TYPE: BED_TYPE_OKIMAT,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+                CONF_BLE_BOND_ESTABLISHED: True,
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id="okimat_verify_bonded_test",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        client = MagicMock()
+        client.is_connected = True
+        client.read_gatt_char = AsyncMock(
+            side_effect=BleakError(
+                "Bluetooth GATT Error address=AA:BB:CC:DD:EE:FF "
+                "handle=24 error=5 description=Insufficient authentication"
+            )
+        )
+        coordinator._client = client
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.coordinator.create_pairing_required_issue",
+                new_callable=AsyncMock,
+            ) as mock_create_issue,
+            patch.object(
+                coordinator, "async_disconnect", new_callable=AsyncMock
+            ) as mock_disconnect,
+        ):
+            bonded = await coordinator._async_verify_bonded()
+
+        assert bonded is False
+        assert coordinator._ble_bond_established is False
+        assert entry.data[CONF_BLE_BOND_ESTABLISHED] is False
+        mock_create_issue.assert_awaited_once_with(
+            hass, TEST_ADDRESS, TEST_NAME, "okimat_verify_bonded_test"
+        )
+        mock_disconnect.assert_awaited_once_with(reason="authentication_failed")
+
+    async def test_verify_bonded_confirms_and_clears_repair_when_readable(
+        self,
+        hass: HomeAssistant,
+    ):
+        """A successful auth-gated read confirms the bond and clears the repair."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=TEST_NAME,
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: TEST_NAME,
+                CONF_BED_TYPE: BED_TYPE_OKIMAT,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id="okimat_verify_bonded_ok_test",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        coordinator._skip_pair_next_attempt = True
+        client = MagicMock()
+        client.is_connected = True
+        client.read_gatt_char = AsyncMock(return_value=b"Model X")
+        coordinator._client = client
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator.delete_pairing_required_issue",
+            new_callable=AsyncMock,
+        ) as mock_delete_issue:
+            bonded = await coordinator._async_verify_bonded()
+
+        assert bonded is True
+        assert coordinator._ble_bond_established is True
+        assert entry.data[CONF_BLE_BOND_ESTABLISHED] is True
+        assert coordinator._skip_pair_next_attempt is False
+        mock_delete_issue.assert_awaited_once_with(hass, TEST_ADDRESS)
 
 
 class TestCoordinatorNotifications:

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -122,8 +122,26 @@ async def test_try_pair_succeeds_and_clears_marker(hass: HomeAssistant) -> None:
 
 
 async def test_try_pair_treats_non_auth_read_error_as_success(hass: HomeAssistant) -> None:
-    """A non-auth read failure (e.g. char absent) is inconclusive, not a failure."""
-    flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, None)
+    """A non-auth read failure (e.g. char absent) is inconclusive, not a failure.
+
+    It must still persist the bond marker and reload the entry so the repair
+    closes for good rather than re-triggering on the next connection.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=TEST_NAME,
+        data={
+            CONF_ADDRESS: TEST_ADDRESS,
+            CONF_NAME: TEST_NAME,
+            CONF_BED_TYPE: "okimat",
+            CONF_BLE_BOND_ESTABLISHED: False,
+        },
+        unique_id=TEST_ADDRESS,
+        entry_id="repair_inconclusive_entry",
+    )
+    entry.add_to_hass(hass)
+
+    flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, entry.entry_id)
     flow.hass = hass
 
     client = MagicMock()
@@ -133,9 +151,12 @@ async def test_try_pair_treats_non_auth_read_error_as_success(hass: HomeAssistan
     with (
         patch(BLEAK_DEVICE, return_value=MagicMock()),
         patch(ESTABLISH, new=AsyncMock(return_value=client)),
+        patch.object(hass.config_entries, "async_reload", new=AsyncMock()) as mock_reload,
     ):
         assert await flow._async_try_pair() is True
 
+    assert entry.data[CONF_BLE_BOND_ESTABLISHED] is True
+    mock_reload.assert_awaited_once_with(entry.entry_id)
     client.disconnect.assert_awaited_once()
 
 

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1,0 +1,141 @@
+"""Tests for the Adjustable Bed repair flows."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bleak.exc import BleakError
+from homeassistant.const import CONF_ADDRESS, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adjustable_bed.const import (
+    CONF_BED_TYPE,
+    CONF_BLE_BOND_ESTABLISHED,
+    DOMAIN,
+)
+from custom_components.adjustable_bed.repairs import (
+    PairingRequiredRepairFlow,
+    async_create_fix_flow,
+)
+
+from .conftest import TEST_ADDRESS, TEST_NAME
+
+BLEAK_DEVICE = "custom_components.adjustable_bed.repairs.bluetooth.async_ble_device_from_address"
+ESTABLISH = "bleak_retry_connector.establish_connection"
+
+
+async def test_async_create_fix_flow_builds_pairing_flow(hass: HomeAssistant) -> None:
+    """The factory wires issue data into the pairing repair flow."""
+    flow = await async_create_fix_flow(
+        hass,
+        f"pairing_required_{TEST_ADDRESS.replace(':', '_').lower()}",
+        {"address": TEST_ADDRESS, "name": TEST_NAME, "entry_id": "abc123"},
+    )
+    assert isinstance(flow, PairingRequiredRepairFlow)
+    assert flow._address == TEST_ADDRESS
+    assert flow._name == TEST_NAME
+    assert flow._entry_id == "abc123"
+
+
+async def test_confirm_step_shows_form_first(hass: HomeAssistant) -> None:
+    """The first step presents the pairing instructions form."""
+    flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, None)
+    flow.hass = hass
+
+    result = await flow.async_step_init()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+    assert result["description_placeholders"]["address"] == TEST_ADDRESS
+
+
+async def test_confirm_step_resolves_on_successful_pair(hass: HomeAssistant) -> None:
+    """Submitting the form resolves the issue when pairing succeeds."""
+    flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, None)
+    flow.hass = hass
+
+    with patch.object(flow, "_async_try_pair", new=AsyncMock(return_value=True)):
+        result = await flow.async_step_confirm({})
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_confirm_step_aborts_on_failed_pair(hass: HomeAssistant) -> None:
+    """Submitting the form aborts (issue stays) when pairing fails."""
+    flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, None)
+    flow.hass = hass
+
+    with patch.object(flow, "_async_try_pair", new=AsyncMock(return_value=False)):
+        result = await flow.async_step_confirm({})
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "pairing_failed"
+
+
+async def test_try_pair_returns_false_when_device_not_in_range(hass: HomeAssistant) -> None:
+    """No reachable device means pairing cannot proceed."""
+    flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, None)
+    flow.hass = hass
+
+    with patch(BLEAK_DEVICE, return_value=None):
+        assert await flow._async_try_pair() is False
+
+
+async def test_try_pair_succeeds_and_clears_marker(hass: HomeAssistant) -> None:
+    """A successful pair + verified read persists the bond and reloads the entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=TEST_NAME,
+        data={
+            CONF_ADDRESS: TEST_ADDRESS,
+            CONF_NAME: TEST_NAME,
+            CONF_BED_TYPE: "okimat",
+            CONF_BLE_BOND_ESTABLISHED: False,
+        },
+        unique_id=TEST_ADDRESS,
+        entry_id="repair_ok_entry",
+    )
+    entry.add_to_hass(hass)
+
+    flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, entry.entry_id)
+    flow.hass = hass
+
+    client = MagicMock()
+    client.read_gatt_char = AsyncMock(return_value=b"Model X")
+    client.disconnect = AsyncMock()
+
+    with (
+        patch(BLEAK_DEVICE, return_value=MagicMock()),
+        patch(ESTABLISH, new=AsyncMock(return_value=client)),
+        patch.object(
+            hass.config_entries, "async_reload", new=AsyncMock()
+        ) as mock_reload,
+    ):
+        result = await flow._async_try_pair()
+
+    assert result is True
+    assert entry.data[CONF_BLE_BOND_ESTABLISHED] is True
+    mock_reload.assert_awaited_once_with(entry.entry_id)
+    client.disconnect.assert_awaited_once()
+
+
+async def test_try_pair_returns_false_on_auth_error(hass: HomeAssistant) -> None:
+    """Pairing that connects but fails the encrypted read is treated as not paired."""
+    flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, None)
+    flow.hass = hass
+
+    client = MagicMock()
+    client.read_gatt_char = AsyncMock(
+        side_effect=BleakError("handle=24 error=5 description=Insufficient authentication")
+    )
+    client.disconnect = AsyncMock()
+
+    with (
+        patch(BLEAK_DEVICE, return_value=MagicMock()),
+        patch(ESTABLISH, new=AsyncMock(return_value=client)),
+    ):
+        assert await flow._async_try_pair() is False
+
+    client.disconnect.assert_awaited_once()

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -121,6 +121,24 @@ async def test_try_pair_succeeds_and_clears_marker(hass: HomeAssistant) -> None:
     client.disconnect.assert_awaited_once()
 
 
+async def test_try_pair_treats_non_auth_read_error_as_success(hass: HomeAssistant) -> None:
+    """A non-auth read failure (e.g. char absent) is inconclusive, not a failure."""
+    flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, None)
+    flow.hass = hass
+
+    client = MagicMock()
+    client.read_gatt_char = AsyncMock(side_effect=BleakError("Characteristic not found"))
+    client.disconnect = AsyncMock()
+
+    with (
+        patch(BLEAK_DEVICE, return_value=MagicMock()),
+        patch(ESTABLISH, new=AsyncMock(return_value=client)),
+    ):
+        assert await flow._async_try_pair() is True
+
+    client.disconnect.assert_awaited_once()
+
+
 async def test_try_pair_returns_false_on_auth_error(hass: HomeAssistant) -> None:
     """Pairing that connects but fails the encrypted read is treated as not paired."""
     flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, None)


### PR DESCRIPTION
## Problem

OKIN-style bases (Okimat, Okin CST, Nectar `OKIN-*`, Mattress Firm 900-O / Rize MF900) have **no Bluetooth pairing button** — they enter pairing mode via a **power-cycle** of the control box. The integration's instructions told users to "press the receiver pairing button," which doesn't exist on these bases.

Worse, a failed `pair=True` connection was assumed to mean "already bonded" and **persisted** `ble_bond_established=True`, so the integration never requested pairing again. A base that wasn't in its pairing window during the first attempt got permanently stuck: it connects fine, every encrypted characteristic returns `error=5` "insufficient authentication", device info is blank, and no commands work. (See discussion #346.)

## Changes

**Accurate instructions** (`config_flow.py`, `strings.json`, `translations/en.json`): describe the power-cycle method (unplug ~30 s → blue→green LED) and state plainly there is no Bluetooth pairing button — any Pair/Learn button only syncs the RF remote.

**Self-healing bond recovery** (`coordinator.py`):
- A failed pairing attempt no longer persists a bond marker — it sets a transient, in-memory `_skip_pair_next_attempt` flag for the single next retry only.
- New `_async_verify_bonded()` probes an auth-gated characteristic (`0x2A24`) after connecting. On an authentication error it clears the marker, raises the repair issue, disconnects, and the retry loop **re-pairs automatically**. On success it confirms the bond and clears the repair. This now also covers `OKIN_CST`, which previously had no post-connect verification.

**Guided fixable repair** (new `repairs.py`, `unsupported.py`): the *Bluetooth pairing required* issue is now fixable — a **Fix** button walks the user through power-cycling, pairs with `pair=True`, verifies the bond, persists it, reloads the entry, and dismisses the issue.

**Docs** (`TROUBLESHOOTING.md`, `CONNECTION_GUIDE.md`, `docs/beds/okin-cst.md`): correct the outdated "ESPHome proxies can't pair" note (supported on ESPHome ≥ 2024.3.0, just unreliable), document the power-cycle procedure, and clarify Nectar vs Okin CST pairing.

## Tests

- `test_coordinator.py`: stuck-marker regression (a failed pair must not persist the marker) + both bond-probe outcomes (unbonded → repair, readable → confirm/clear).
- New `test_repairs.py`: the guided fix flow (form, resolve-on-success, abort-on-failure, device-not-in-range, auth-error).
- Full suite green: **1862 passed**.

## Notes

- No version bump in this PR.
- Out of scope, flagged for follow-up: `beds/okin_cst.py` subscribes notifications to `0xFFE4` rather than this device's `62741625` notify char — a position-feedback bug unrelated to pairing/control.

Ref #346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided “Bluetooth Pairing Required” repair flow that verifies bonding and updates the device’s bonding state.
* **Improvements**
  * Enhanced OKIN pairing guidance with clearer, step-by-step power-cycle instructions and updated light timing.
  * Improved bonding/auth verification and retry behavior after a failed pairing attempt to reduce unnecessary re-pairing.
* **Bug Fixes**
  * Improved recovery from unauthenticated Bluetooth failures by clearing stale bond state and better associating the repair issue.
* **Documentation**
  * Updated connection and troubleshooting materials with revised, device-specific pairing procedures and proxy/host guidance.
* **Tests**
  * Added and expanded tests covering coordinator behavior and the full repair flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->