### PR TITLE
Refine Okin protocol detection for CST and NORA controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The names below refer to motor/actuator manufacturers. Your bed might use one of
 | ✅ [Leggett & Platt](docs/beds/leggett-platt.md) | Leggett & Platt |
 | ✅ [Reverie](docs/beds/reverie.md) | Reverie |
 | ✅ [Okimat/Okin](docs/beds/okimat.md) | Lucid, CVB, Smartbed |
+| ✅ [Okin 64-Bit](docs/beds/okin-64bit.md) | NORA_CON / NORACON Mattress Firm controllers |
 | ✅ [Jiecang](docs/beds/jiecang.md) | Glideaway, Dream Motion, LOGICDATA |
 | ✅ [Kaidi](docs/beds/kaidi.md) | Rize Remedy III / newer Mouselet-based Rize beds, Floyd Home, ISleep |
 | ✅ [Limoss](docs/beds/limoss.md) | Limoss, Stawett |
@@ -99,7 +100,7 @@ The names below refer to motor/actuator manufacturers. Your bed might use one of
 | ✅ [SBI/Q-Plus](docs/beds/sbi.md) | Q-Plus (Costco) |
 | ✅ [Logicdata](docs/beds/logicdata.md) | SILVERmotion, SimplicityFrame |
 | ✅ [Okin CB35](docs/beds/okin-cb35.md) | Sealy Posturematic |
-| ✅ [Okin CST](docs/beds/okin-cst.md) | Mattress Firm 900-O / MFirm 900-O, Rize MF900, Nectar Motion |
+| ✅ [Okin CST](docs/beds/okin-cst.md) | Mattress Firm 900-O / MFirm 900-O, Rize MF900, Nectar Motion, LP Prodigy CE |
 | ✅ [OKIN Smart Remote / RF ECO BT](docs/beds/okin-rf-eco-bt.md) | Elda BTH / MEGAMAT staircase actuator |
 
 **Have one of these?** [Let us know](https://github.com/kristofferR/ha-adjustable-bed/issues) how well it works!

--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -26,6 +26,7 @@ from .const import (
     BED_TYPE_ERGOMOTION,
     BED_TYPE_KAIDI,
     BED_TYPE_KEESON,
+    BED_TYPE_OKIN_CST,
     BED_TYPE_RICHMAT,
     BED_TYPE_SLEEPYS_BOX25,
     BED_TYPE_VIBRADORM,
@@ -47,6 +48,7 @@ from .const import (
     DEFAULT_MOTOR_COUNT,
     DOMAIN,
     KEESON_VARIANT_ERGOMOTION,
+    OKIN_CST_POSITION_AXES,
     RICHMAT_REMOTE_AUTO,
     VARIANT_AUTO,
     requires_pairing,
@@ -726,6 +728,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
             # Define motor configurations.
             # For Keeson/Ergomotion: only head and feet are valid, they map to back/legs keys.
             # For BOX25: only head and feet are valid, using direct percentage positions.
+            # For CST: only back and legs publish position feedback.
             # For Kaidi: direct position writes expose back/legs percentage targets.
             # For standard beds: based on motor_count (2=back/legs, 3=+head, 4=+feet).
             uses_percentage_positions = bed_type in (
@@ -787,6 +790,24 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                         "move_down_fn": lambda ctrl: ctrl.move_feet_down(),
                         "move_stop_fn": lambda ctrl: ctrl.move_feet_stop(),
                         "max_value": 100.0,
+                    },
+                }
+            elif bed_type == BED_TYPE_OKIN_CST:
+                valid_motors = set(OKIN_CST_POSITION_AXES)
+                motor_configs = {
+                    "back": {
+                        "position_key": "back",
+                        "move_up_fn": lambda ctrl: ctrl.move_back_up(),
+                        "move_down_fn": lambda ctrl: ctrl.move_back_down(),
+                        "move_stop_fn": lambda ctrl: ctrl.move_back_stop(),
+                        "max_value": coordinator.get_max_angle("back"),  # Degrees
+                    },
+                    "legs": {
+                        "position_key": "legs",
+                        "move_up_fn": lambda ctrl: ctrl.move_legs_up(),
+                        "move_down_fn": lambda ctrl: ctrl.move_legs_down(),
+                        "move_stop_fn": lambda ctrl: ctrl.move_legs_stop(),
+                        "max_value": coordinator.get_max_angle("legs"),  # Degrees
                     },
                 }
             else:

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -1648,6 +1648,7 @@ BEDS_WITH_ANGLE_SENSING: Final = frozenset(
     {
         BED_TYPE_LINAK,
         BED_TYPE_OKIMAT,
+        BED_TYPE_OKIN_CST,
         BED_TYPE_OKIN_UUID,  # Same protocol as Okimat
         BED_TYPE_REVERIE,
         BED_TYPE_REVERIE_NIGHTSTAND,
@@ -1662,6 +1663,7 @@ BEDS_WITH_POSITION_FEEDBACK: Final = frozenset(
     {
         BED_TYPE_LINAK,
         BED_TYPE_OKIMAT,
+        BED_TYPE_OKIN_CST,
         BED_TYPE_OKIN_UUID,  # Same protocol as Okimat
         BED_TYPE_REVERIE,
         BED_TYPE_REVERIE_NIGHTSTAND,

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -109,6 +109,8 @@ BED_TYPE_LEGGETT_GEN2: Final = "leggett_gen2"  # Leggett Gen2 ASCII protocol
 BED_TYPE_LEGGETT_OKIN: Final = "leggett_okin"  # Leggett Okin binary protocol
 BED_TYPE_LEGGETT_WILINKE: Final = "leggett_wilinke"  # Leggett WiLinke 5-byte
 
+OKIN_CST_POSITION_AXES: Final = frozenset({"back", "legs"})
+
 # Bed types - Legacy naming (backwards compatibility)
 # These map to the protocol-based types above
 BED_TYPE_LINAK: Final = "linak"

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -1461,6 +1461,7 @@ class AdjustableBedCoordinator:
                 corrected_bed_type = refine_okin_shared_uuid_protocol_from_gatt(
                     corrected_bed_type,
                     self._client.services,
+                    self._protocol_variant,
                 )
                 corrected_bed_type = refine_nordic_uart_protocol_from_device_info(
                     corrected_bed_type,

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -79,6 +79,7 @@ from .const import (
     BED_TYPE_SLEEPYS_BOX25,
     BED_TYPE_SOLACE,
     BED_TYPE_VIBRADORM,
+    BEDS_WITH_ANGLE_SENSING,
     CONF_BACK_MAX_ANGLE,
     CONF_BED_TYPE,
     CONF_BLE_BOND_ESTABLISHED,
@@ -380,10 +381,23 @@ class AdjustableBedCoordinator:
             )
 
         self._bed_type = corrected_bed_type
-        if self.entry.data.get(CONF_BED_TYPE) != corrected_bed_type:
+
+        entry_data = dict(self.entry.data)
+        entry_data[CONF_BED_TYPE] = corrected_bed_type
+        if corrected_bed_type not in BEDS_WITH_ANGLE_SENSING and not self._disable_angle_sensing:
+            self._disable_angle_sensing = True
+            entry_data[CONF_DISABLE_ANGLE_SENSING] = True
+            _LOGGER.info(
+                "Disabled angle sensing for corrected %s protocol on %s: "
+                "the corrected profile does not support position feedback",
+                corrected_bed_type,
+                self._address,
+            )
+
+        if entry_data != self.entry.data:
             self.hass.config_entries.async_update_entry(
                 self.entry,
-                data={**self.entry.data, CONF_BED_TYPE: corrected_bed_type},
+                data=entry_data,
             )
 
         return True

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -384,7 +384,21 @@ class AdjustableBedCoordinator:
 
         entry_data = dict(self.entry.data)
         entry_data[CONF_BED_TYPE] = corrected_bed_type
-        if corrected_bed_type not in BEDS_WITH_ANGLE_SENSING and not self._disable_angle_sensing:
+        angle_sensing_defaulted = CONF_DISABLE_ANGLE_SENSING not in self.entry.data
+        if (
+            corrected_bed_type in BEDS_WITH_ANGLE_SENSING
+            and angle_sensing_defaulted
+            and self._disable_angle_sensing
+        ):
+            self._disable_angle_sensing = False
+            entry_data[CONF_DISABLE_ANGLE_SENSING] = False
+            _LOGGER.info(
+                "Enabled angle sensing for corrected %s protocol on %s: "
+                "the previous entry used the legacy default",
+                corrected_bed_type,
+                self._address,
+            )
+        elif corrected_bed_type not in BEDS_WITH_ANGLE_SENSING and not self._disable_angle_sensing:
             self._disable_angle_sensing = True
             entry_data[CONF_DISABLE_ANGLE_SENSING] = True
             _LOGGER.info(

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -120,6 +120,8 @@ from .const import (
     DOMAIN,
     OKIMAT_SERVICE_UUID,
     OKIN_CST_POSITION_AXES,
+    OKIN_FOOT_MAX_ANGLE,
+    OKIN_HEAD_MAX_ANGLE,
     POSITION_CHECK_INTERVAL,
     POSITION_MODE_ACCURACY,
     POSITION_OVERSHOOT_TOLERANCE,
@@ -348,15 +350,15 @@ class AdjustableBedCoordinator:
     def _apply_runtime_bed_type_correction(self, corrected_bed_type: str) -> bool:
         """Apply a protocol correction discovered after BLE service discovery."""
         previous_bed_type = self._bed_type
-        if corrected_bed_type == previous_bed_type:
-            return False
 
-        _LOGGER.warning(
-            "Correcting bed protocol for %s from %s to %s based on connected GATT services",
-            self._address,
-            previous_bed_type,
-            corrected_bed_type,
-        )
+        bed_type_changed = corrected_bed_type != previous_bed_type
+        if bed_type_changed:
+            _LOGGER.warning(
+                "Correcting bed protocol for %s from %s to %s based on connected GATT services",
+                self._address,
+                previous_bed_type,
+                corrected_bed_type,
+            )
         previous_defaults = BED_MOTOR_PULSE_DEFAULTS.get(previous_bed_type)
         corrected_defaults = BED_MOTOR_PULSE_DEFAULTS.get(corrected_bed_type)
         # Only swap in the corrected protocol's defaults if the user never set
@@ -372,6 +374,7 @@ class AdjustableBedCoordinator:
         if (
             previous_defaults is not None
             and corrected_defaults is not None
+            and bed_type_changed
             and not has_custom_pulse_override
             and (self._motor_pulse_count, self._motor_pulse_delay_ms) == previous_defaults
         ):
@@ -389,7 +392,10 @@ class AdjustableBedCoordinator:
         entry_data[CONF_BED_TYPE] = corrected_bed_type
         angle_sensing_defaulted = CONF_DISABLE_ANGLE_SENSING not in self.entry.data or (
             self.entry.data.get(CONF_DISABLE_ANGLE_SENSING) is True
-            and previous_bed_type not in BEDS_WITH_POSITION_FEEDBACK
+            and (
+                previous_bed_type not in BEDS_WITH_POSITION_FEEDBACK
+                or previous_bed_type == BED_TYPE_OKIN_CST
+            )
         )
         if (
             corrected_bed_type in BEDS_WITH_ANGLE_SENSING
@@ -404,7 +410,11 @@ class AdjustableBedCoordinator:
                 corrected_bed_type,
                 self._address,
             )
-        elif corrected_bed_type not in BEDS_WITH_ANGLE_SENSING and not self._disable_angle_sensing:
+        elif (
+            bed_type_changed
+            and corrected_bed_type not in BEDS_WITH_ANGLE_SENSING
+            and not self._disable_angle_sensing
+        ):
             self._disable_angle_sensing = True
             entry_data[CONF_DISABLE_ANGLE_SENSING] = True
             _LOGGER.info(
@@ -414,13 +424,14 @@ class AdjustableBedCoordinator:
                 self._address,
             )
 
-        if entry_data != self.entry.data:
+        entry_data_changed = entry_data != self.entry.data
+        if entry_data_changed:
             self.hass.config_entries.async_update_entry(
                 self.entry,
                 data=entry_data,
             )
 
-        return True
+        return bed_type_changed or entry_data_changed
 
     @property
     def address(self) -> str:
@@ -492,10 +503,14 @@ class AdjustableBedCoordinator:
             Maximum angle in degrees for the specified motor.
         """
         if position_key in ("back", "head"):
+            if self._bed_type == BED_TYPE_OKIN_CST:
+                return OKIN_HEAD_MAX_ANGLE
             if self._bed_type in (BED_TYPE_REVERIE, BED_TYPE_REVERIE_NIGHTSTAND):
                 return REVERIE_BACK_MAX_ANGLE
             return self.back_max_angle
         if position_key in ("legs", "feet"):
+            if self._bed_type == BED_TYPE_OKIN_CST:
+                return OKIN_FOOT_MAX_ANGLE
             return self.legs_max_angle
         # Unknown motor, return back max as default
         return self.back_max_angle

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -2544,7 +2544,7 @@ class AdjustableBedCoordinator:
                 if _is_ble_authentication_error(err):
                     await self._async_handle_ble_authentication_error(err)
                 raise
-            except ConnectionError, RuntimeError:
+            except (ConnectionError, RuntimeError):
                 if (
                     self._client is not None
                     and self._client.is_connected

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -66,6 +66,7 @@ from .const import (
     BED_TYPE_OKIMAT,
     BED_TYPE_OKIN_7BYTE,
     BED_TYPE_OKIN_CB35,
+    BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_FFE,
     BED_TYPE_OKIN_HANDLE,
     BED_TYPE_OKIN_NORDIC,
@@ -118,6 +119,7 @@ from .const import (
     DEVICE_INFO_CHARS,
     DOMAIN,
     OKIMAT_SERVICE_UUID,
+    OKIN_CST_POSITION_AXES,
     POSITION_CHECK_INTERVAL,
     POSITION_MODE_ACCURACY,
     POSITION_OVERSHOOT_TOLERANCE,
@@ -2026,6 +2028,8 @@ class AdjustableBedCoordinator:
         """Return the logical position axes that startup hydration should populate."""
         if self._motor_count <= 0:
             return set()
+        if self._bed_type == BED_TYPE_OKIN_CST:
+            return set(OKIN_CST_POSITION_AXES)
 
         expected_axes = {"back", "legs"}
         if self._motor_count > 2:

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -957,23 +957,31 @@ class AdjustableBedCoordinator:
         exhausted_adapters: set[str] = set()
         adapter_result: AdapterSelectionResult | None = None
 
-        for attempt in range(self._max_retries):
+        attempt = 0
+        attempt_limit = self._max_retries
+        protocol_correction_pairing_retry_reserved = False
+        while attempt < attempt_limit:
+            attempt_index = attempt
+            attempt += 1
+            attempt_number = attempt_index + 1
             attempt_start = time.monotonic()
-            attempt_details = new_connection_attempt_details(attempt + 1, self._preferred_adapter)
+            attempt_details = new_connection_attempt_details(
+                attempt_number, self._preferred_adapter
+            )
             # Track connection attempt for diagnostics (issue #168)
             self._connection_attempt_count += 1
             self._last_connection_attempt = datetime.now(UTC)
 
             # On retries, add a delay before attempting to give the Bluetooth stack time to reset
-            if attempt > 0:
-                base_delay = self._retry_base_delay * (2 ** (attempt - 1))
+            if attempt_index > 0:
+                base_delay = self._retry_base_delay * (2 ** (attempt_index - 1))
                 jitter = random.uniform(1 - self._retry_jitter, 1 + self._retry_jitter)
                 pre_retry_delay = base_delay * jitter
                 _LOGGER.info(
                     "Waiting %.1fs before connection retry %d/%d to %s...",
                     pre_retry_delay,
-                    attempt + 1,
-                    self._max_retries,
+                    attempt_number,
+                    attempt_limit,
                     self._address,
                 )
                 await asyncio.sleep(pre_retry_delay)
@@ -981,8 +989,8 @@ class AdjustableBedCoordinator:
             try:
                 _LOGGER.debug(
                     "Connection attempt %d/%d: Looking up device %s via HA Bluetooth (preferred adapter: %s)",
-                    attempt + 1,
-                    self._max_retries,
+                    attempt_number,
+                    attempt_limit,
                     self._address,
                     self._preferred_adapter,
                 )
@@ -1035,8 +1043,8 @@ class AdjustableBedCoordinator:
                         "Bed may be powered off, out of range, or connected to another device.",
                         self._address,
                         lookup_elapsed,
-                        attempt + 1,
-                        self._max_retries,
+                        attempt_number,
+                        attempt_limit,
                     )
                     # Log what devices ARE visible
                     try:
@@ -1525,6 +1533,9 @@ class AdjustableBedCoordinator:
                     await self._async_disconnect_locked(
                         reason="protocol_correction_requires_pairing"
                     )
+                    if not protocol_correction_pairing_retry_reserved:
+                        protocol_correction_pairing_retry_reserved = True
+                        attempt_limit += 1
                     continue
 
                 # Post-connection protocol verification for DewertOkin Star devices.
@@ -1744,8 +1755,8 @@ class AdjustableBedCoordinator:
                     error_category,
                     self._address,
                     attempt_elapsed,
-                    attempt + 1,
-                    self._max_retries,
+                    attempt_number,
+                    attempt_limit,
                     err,
                 )
                 _LOGGER.debug(
@@ -1784,8 +1795,8 @@ class AdjustableBedCoordinator:
                 _LOGGER.warning(
                     "Unexpected error connecting to %s (attempt %d/%d): %s",
                     self._address,
-                    attempt + 1,
-                    self._max_retries,
+                    attempt_number,
+                    attempt_limit,
                     err,
                 )
                 _LOGGER.debug(

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -149,6 +149,7 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 _LOGGER = logging.getLogger(__name__)
+_CONTROLLER_OPERATION_RECOVERY_EXCEPTIONS = (ConnectionError, RuntimeError)
 _READABLE_LIGHT_STATE_TIMEOUT = 2.0
 _READABLE_LIGHT_STATE_RETRY_DELAY = 1.0
 _READABLE_LIGHT_STATE_MAX_RETRIES = 3
@@ -340,11 +341,11 @@ class AdjustableBedCoordinator:
             self._connection_profile,
         )
 
-    def _apply_runtime_bed_type_correction(self, corrected_bed_type: str) -> None:
+    def _apply_runtime_bed_type_correction(self, corrected_bed_type: str) -> bool:
         """Apply a protocol correction discovered after BLE service discovery."""
         previous_bed_type = self._bed_type
         if corrected_bed_type == previous_bed_type:
-            return
+            return False
 
         _LOGGER.warning(
             "Correcting bed protocol for %s from %s to %s based on connected GATT services",
@@ -379,6 +380,13 @@ class AdjustableBedCoordinator:
             )
 
         self._bed_type = corrected_bed_type
+        if self.entry.data.get(CONF_BED_TYPE) != corrected_bed_type:
+            self.hass.config_entries.async_update_entry(
+                self.entry,
+                data={**self.entry.data, CONF_BED_TYPE: corrected_bed_type},
+            )
+
+        return True
 
     @property
     def address(self) -> str:
@@ -1445,6 +1453,7 @@ class AdjustableBedCoordinator:
                     self._ble_manufacturer = ble_manufacturer
                     self._ble_model = ble_model
 
+                previous_bed_type = self._bed_type
                 corrected_bed_type = refine_malouf_protocol_from_gatt(
                     self._bed_type,
                     self._client.services,
@@ -1459,7 +1468,29 @@ class AdjustableBedCoordinator:
                     ble_manufacturer,
                     ble_model,
                 )
-                self._apply_runtime_bed_type_correction(corrected_bed_type)
+                bed_type_corrected = self._apply_runtime_bed_type_correction(corrected_bed_type)
+                if (
+                    bed_type_corrected
+                    and not bed_requires_pairing
+                    and requires_pairing(self._bed_type, self._protocol_variant)
+                ):
+                    _LOGGER.info(
+                        "Runtime protocol correction for %s changed %s to pairing-required "
+                        "%s; reconnecting so BLE pairing and bond verification run before "
+                        "controller startup",
+                        self._address,
+                        previous_bed_type,
+                        self._bed_type,
+                    )
+                    attempt_details["total_elapsed_seconds"] = round(
+                        time.monotonic() - attempt_start, 3
+                    )
+                    attempt_details["result"] = "retry_with_pairing_after_protocol_correction"
+                    self._connection_attempt_details.append(attempt_details)
+                    await self._async_disconnect_locked(
+                        reason="protocol_correction_requires_pairing"
+                    )
+                    continue
 
                 # Post-connection protocol verification for DewertOkin Star devices.
                 # The adjustbed app (com.okin.bedding.adjustbed) reads BLE characteristic
@@ -2544,7 +2575,7 @@ class AdjustableBedCoordinator:
                 if _is_ble_authentication_error(err):
                     await self._async_handle_ble_authentication_error(err)
                 raise
-            except (ConnectionError, RuntimeError):
+            except _CONTROLLER_OPERATION_RECOVERY_EXCEPTIONS:
                 if (
                     self._client is not None
                     and self._client.is_connected

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -80,6 +80,7 @@ from .const import (
     BED_TYPE_SOLACE,
     BED_TYPE_VIBRADORM,
     BEDS_WITH_ANGLE_SENSING,
+    BEDS_WITH_POSITION_FEEDBACK,
     CONF_BACK_MAX_ANGLE,
     CONF_BED_TYPE,
     CONF_BLE_BOND_ESTABLISHED,
@@ -384,7 +385,10 @@ class AdjustableBedCoordinator:
 
         entry_data = dict(self.entry.data)
         entry_data[CONF_BED_TYPE] = corrected_bed_type
-        angle_sensing_defaulted = CONF_DISABLE_ANGLE_SENSING not in self.entry.data
+        angle_sensing_defaulted = CONF_DISABLE_ANGLE_SENSING not in self.entry.data or (
+            self.entry.data.get(CONF_DISABLE_ANGLE_SENSING) is True
+            and previous_bed_type not in BEDS_WITH_POSITION_FEEDBACK
+        )
         if (
             corrected_bed_type in BEDS_WITH_ANGLE_SENSING
             and angle_sensing_defaulted

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -132,7 +132,12 @@ from .const import (
     resolve_richmat_remote_code,
 )
 from .controller_factory import create_controller
-from .detection import detect_richmat_remote_from_name, refine_malouf_protocol_from_gatt
+from .detection import (
+    detect_richmat_remote_from_name,
+    refine_malouf_protocol_from_gatt,
+    refine_nordic_uart_protocol_from_device_info,
+    refine_okin_shared_uuid_protocol_from_gatt,
+)
 from .diagnostic_payloads import new_connection_attempt_details
 from .unsupported import (
     create_pairing_required_issue,
@@ -292,9 +297,7 @@ class AdjustableBedCoordinator:
 
         # Track if pairing is supported by the Bluetooth adapter (None = unknown)
         self._pairing_supported: bool | None = None
-        self._ble_bond_established: bool = bool(
-            entry.data.get(CONF_BLE_BOND_ESTABLISHED, False)
-        )
+        self._ble_bond_established: bool = bool(entry.data.get(CONF_BLE_BOND_ESTABLISHED, False))
         # Transient (in-memory only) flag: a pairing attempt just failed, so the
         # single next connection attempt should skip pair=True (some stacks fail
         # to re-pair on top of an existing bond). Unlike the persisted bond
@@ -580,9 +583,7 @@ class AdjustableBedCoordinator:
 
     def _clear_ble_bond_established(self) -> None:
         """Clear the persisted bond marker after an authentication failure."""
-        if not self._ble_bond_established and not self.entry.data.get(
-            CONF_BLE_BOND_ESTABLISHED
-        ):
+        if not self._ble_bond_established and not self.entry.data.get(CONF_BLE_BOND_ESTABLISHED):
             return
 
         self._ble_bond_established = False
@@ -1212,9 +1213,7 @@ class AdjustableBedCoordinator:
                     # but the SleepIQ app refreshes the GATT cache on every connect, so
                     # force fresh discovery to keep parity and ensure the app-layer
                     # priming reads always see the live characteristic handles.
-                    disable_cache = (
-                        bed_requires_pairing or self._bed_type == BED_TYPE_SLEEP_NUMBER
-                    )
+                    disable_cache = bed_requires_pairing or self._bed_type == BED_TYPE_SLEEP_NUMBER
                     try:
                         self._client = await establish_connection(
                             BleakClient,
@@ -1418,8 +1417,7 @@ class AdjustableBedCoordinator:
                     # repair issue, and disconnected. Retry — the next attempt
                     # requests pair=True again (the skip flag was consumed).
                     _LOGGER.warning(
-                        "Bed %s connected but the BLE link is not bonded; "
-                        "retrying with pairing.",
+                        "Bed %s connected but the BLE link is not bonded; retrying with pairing.",
                         self._address,
                     )
                     self._connecting = False
@@ -1450,6 +1448,16 @@ class AdjustableBedCoordinator:
                 corrected_bed_type = refine_malouf_protocol_from_gatt(
                     self._bed_type,
                     self._client.services,
+                )
+                corrected_bed_type = refine_okin_shared_uuid_protocol_from_gatt(
+                    corrected_bed_type,
+                    self._client.services,
+                )
+                corrected_bed_type = refine_nordic_uart_protocol_from_device_info(
+                    corrected_bed_type,
+                    device.name,
+                    ble_manufacturer,
+                    ble_model,
                 )
                 self._apply_runtime_bed_type_correction(corrected_bed_type)
 
@@ -1904,7 +1912,11 @@ class AdjustableBedCoordinator:
                     # Use command lock to prevent concurrent GATT operations
                     async with self._command_lock:
                         controller = self._controller
-                        if controller is None or self._client is None or not self._client.is_connected:
+                        if (
+                            controller is None
+                            or self._client is None
+                            or not self._client.is_connected
+                        ):
                             return
                         await controller.prepare_for_position_read()
                         await self._async_read_positions()
@@ -2052,9 +2064,7 @@ class AdjustableBedCoordinator:
                 err,
             )
 
-    async def _async_execute_position_reconciliation_query(
-        self, controller: BedController
-    ) -> None:
+    async def _async_execute_position_reconciliation_query(self, controller: BedController) -> None:
         """Run a serialized passive position reconciliation read."""
         await controller.prepare_for_position_read()
         await controller.read_positions(self._motor_count)
@@ -2534,7 +2544,7 @@ class AdjustableBedCoordinator:
                 if _is_ble_authentication_error(err):
                     await self._async_handle_ble_authentication_error(err)
                 raise
-            except (ConnectionError, RuntimeError):
+            except ConnectionError, RuntimeError:
                 if (
                     self._client is not None
                     and self._client.is_connected
@@ -3354,8 +3364,7 @@ class AdjustableBedCoordinator:
                         if (
                             chain_seek_steps
                             and movement >= position_stall_threshold
-                            and remaining_distance
-                            >= position_seek_chain_min_remaining_distance
+                            and remaining_distance >= position_seek_chain_min_remaining_distance
                         ):
                             _LOGGER.debug(
                                 "Position %s still moving at %.1f with %.1f remaining, chaining seek step",

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -174,6 +174,7 @@ OKIN_SHARED_UUID_GATT_REFINABLE_TYPES: frozenset[str] = frozenset(
         BED_TYPE_LEGGETT_OKIN,
         BED_TYPE_NECTAR,
         BED_TYPE_OKIMAT,
+        BED_TYPE_OKIN_7BYTE,
         BED_TYPE_OKIN_64BIT,
         BED_TYPE_OKIN_CST,
         BED_TYPE_OKIN_RF_ECO_BT,
@@ -564,7 +565,12 @@ def refine_nordic_uart_protocol_from_device_info(
     ble_model: str | None,
 ) -> str:
     """Correct Nordic UART profiles when Device Info identifies a NORA controller."""
-    if bed_type not in {BED_TYPE_RICHMAT, BED_TYPE_MATTRESSFIRM, BED_TYPE_OKIN_64BIT}:
+    if bed_type not in {
+        BED_TYPE_RICHMAT,
+        BED_TYPE_MATTRESSFIRM,
+        BED_TYPE_OKIN_NORDIC,
+        BED_TYPE_OKIN_64BIT,
+    }:
         return bed_type
 
     has_nora_name = _is_nora_controller_identifier(device_name)

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -169,6 +169,20 @@ KEESON_FALLBACK_SERVICE_UUIDS: frozenset[str] = frozenset(
     service_uuid.lower() for service_uuid, _ in KEESON_FALLBACK_GATT_PAIRS
 )
 
+OKIN_SHARED_UUID_GATT_REFINABLE_TYPES: frozenset[str] = frozenset(
+    {
+        BED_TYPE_LEGGETT_OKIN,
+        BED_TYPE_NECTAR,
+        BED_TYPE_OKIMAT,
+        BED_TYPE_OKIN_64BIT,
+        BED_TYPE_OKIN_CST,
+        BED_TYPE_OKIN_RF_ECO_BT,
+        BED_TYPE_OKIN_UUID,
+    }
+)
+
+NORA_CONTROLLER_NORMALIZED_NAMES: frozenset[str] = frozenset({"noracon"})
+
 
 def detect_richmat_remote_from_name(device_name: str | None) -> str | None:
     """Extract Richmat remote code from device name.
@@ -259,6 +273,16 @@ def _manufacturer_data_contains_ascii(
         marker_lower in payload.decode("ascii", errors="ignore").lower()
         for payload in manufacturer_data.values()
     )
+
+
+def _normalize_compact_identifier(value: str | None) -> str:
+    """Normalize BLE names/model IDs for exact identifier comparisons."""
+    return re.sub(r"[\s_-]+", "", (value or "").strip().lower())
+
+
+def _is_nora_controller_identifier(value: str | None) -> bool:
+    """Return True for NORA_CON / NORACON controller identifiers."""
+    return _normalize_compact_identifier(value) in NORA_CONTROLLER_NORMALIZED_NAMES
 
 
 # Solace naming convention pattern (e.g., S4-Y-192-461000AD)
@@ -514,6 +538,54 @@ def refine_malouf_protocol_from_gatt(bed_type: str, gatt_services: Any) -> str:
     return bed_type
 
 
+def refine_okin_shared_uuid_protocol_from_gatt(bed_type: str, gatt_services: Any) -> str:
+    """Correct shared OKIN UUID profiles once connected GATT services are known."""
+    if bed_type not in OKIN_SHARED_UUID_GATT_REFINABLE_TYPES:
+        return bed_type
+
+    gatt_detection = detect_bed_type_from_gatt_services(gatt_services)
+    if gatt_detection.bed_type in {BED_TYPE_OKIN_CST, BED_TYPE_OKIN_RF_ECO_BT}:
+        if gatt_detection.bed_type != bed_type:
+            _LOGGER.info(
+                "Refined shared OKIN protocol from %s to %s using GATT signals: %s",
+                bed_type,
+                gatt_detection.bed_type,
+                ", ".join(gatt_detection.signals),
+            )
+        return gatt_detection.bed_type
+
+    return bed_type
+
+
+def refine_nordic_uart_protocol_from_device_info(
+    bed_type: str,
+    device_name: str | None,
+    ble_manufacturer: str | None,
+    ble_model: str | None,
+) -> str:
+    """Correct Nordic UART profiles when Device Info identifies a NORA controller."""
+    if bed_type not in {BED_TYPE_RICHMAT, BED_TYPE_MATTRESSFIRM, BED_TYPE_OKIN_64BIT}:
+        return bed_type
+
+    has_nora_name = _is_nora_controller_identifier(device_name)
+    has_nora_model = _is_nora_controller_identifier(ble_model)
+    has_idt_manufacturer = (ble_manufacturer or "").strip().lower() == "idt"
+    if not (has_nora_model or (has_nora_name and has_idt_manufacturer)):
+        return bed_type
+
+    if bed_type != BED_TYPE_OKIN_64BIT:
+        _LOGGER.info(
+            "Refined Nordic UART protocol from %s to %s using Device Info "
+            "(name=%s, manufacturer=%s, model=%s)",
+            bed_type,
+            BED_TYPE_OKIN_64BIT,
+            device_name,
+            ble_manufacturer,
+            ble_model,
+        )
+    return BED_TYPE_OKIN_64BIT
+
+
 def detect_bed_type(service_info: BluetoothServiceInfoBleak) -> str | None:
     """Detect bed type from service info.
 
@@ -573,7 +645,9 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
                     service_info.name,
                     pattern,
                 )
-                return DetectionResult(bed_type=None, confidence=0.0, signals=["excluded:" + pattern])
+                return DetectionResult(
+                    bed_type=None, confidence=0.0, signals=["excluded:" + pattern]
+                )
 
     # Priority 1: Check manufacturer data (highest confidence, unique signal)
     mfr_bed_type, mfr_confidence, mfr_id = _check_manufacturer_data(service_info.manufacturer_data)
@@ -604,8 +678,7 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
     )
     has_kaidi_name = any(device_name.startswith(pattern) for pattern in KAIDI_NAME_PATTERNS)
     has_kaidi_mac = any(
-        service_info.address.upper().startswith(prefix)
-        for prefix in KAIDI_MAC_PREFIXES
+        service_info.address.upper().startswith(prefix) for prefix in KAIDI_MAC_PREFIXES
     )
     if kaidi_adv:
         signals.append(f"manufacturer_payload:kaidi_type_{kaidi_adv.adv_type}")
@@ -1056,7 +1129,9 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
             service_info.address,
             service_info.name,
         )
-        return DetectionResult(bed_type=BED_TYPE_REVERIE_NIGHTSTAND, confidence=1.0, signals=signals)
+        return DetectionResult(
+            bed_type=BED_TYPE_REVERIE_NIGHTSTAND, confidence=1.0, signals=signals
+        )
 
     # Check for Logicdata SimplicityFrame (unique LogicLink UUID)
     if LOGICDATA_SERVICE_UUID.lower() in service_uuids:
@@ -1091,9 +1166,7 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
             service_info.address,
             service_info.name,
         )
-        return DetectionResult(
-            bed_type=BED_TYPE_SLEEPYS_BOX24, confidence=0.9, signals=signals
-        )
+        return DetectionResult(bed_type=BED_TYPE_SLEEPYS_BOX24, confidence=0.9, signals=signals)
 
     # Check for Nectar - name-based detection (before Okimat since same UUID)
     # Nectar beds use OKIN service UUID but different command protocol
@@ -1408,9 +1481,7 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
             service_info.address,
             service_info.name,
         )
-        return DetectionResult(
-            bed_type=BED_TYPE_SLEEPYS_BOX15, confidence=0.9, signals=signals
-        )
+        return DetectionResult(bed_type=BED_TYPE_SLEEPYS_BOX15, confidence=0.9, signals=signals)
 
     # Check for Cool Base - name pattern detection (before Keeson since same UUID)
     # Cool Base is a Keeson BaseI5 variant with additional fan control
@@ -1489,7 +1560,8 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
 
     # Check for Jiecang - name-based detection (Glide beds, Dream Motion app)
     if any(
-        x in device_name for x in ["jiecang", "jc-", "dream motion", "glide", "comfort motion", "lierda"]
+        x in device_name
+        for x in ["jiecang", "jc-", "dream motion", "glide", "comfort motion", "lierda"]
     ):
         signals.append("name:jiecang")
         _LOGGER.info(
@@ -1567,6 +1639,27 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
         )
         return DetectionResult(bed_type=BED_TYPE_MATTRESSFIRM, confidence=0.9, signals=signals)
 
+    # NORA_CON / NORACON Mattress Firm controllers use OKIN's 64-bit Nordic UART
+    # profile. Without this name-specific check, the shared Nordic UART service
+    # falls through to Richmat's incompatible single-byte Nordic profile.
+    if (
+        _is_nora_controller_identifier(service_info.name)
+        and RICHMAT_NORDIC_SERVICE_UUID.lower() in service_uuids
+    ):
+        signals.append("name:nora_con")
+        signals.append("uuid:nordic_uart")
+        _LOGGER.info(
+            "Detected NORA_CON OKIN 64-bit bed at %s (name: %s)",
+            service_info.address,
+            service_info.name,
+        )
+        return DetectionResult(
+            bed_type=BED_TYPE_OKIN_64BIT,
+            confidence=0.85,
+            signals=signals,
+            ambiguous_types=[BED_TYPE_MATTRESSFIRM, BED_TYPE_RICHMAT],
+        )
+
     # Check for Extended Nordic UART (Ergomotion/SFD beds) - maps to Keeson
     if KEESON_EXTENDED_NORDIC_SERVICE_UUID.lower() in service_uuids:
         signals.append("uuid:extended_nordic_uart")
@@ -1584,7 +1677,10 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
 
         # If OKIN manufacturer ID is also present, this is likely a CB24 device
         # (e.g., SmartBed by Okin / Lucid L600) that also advertises Nordic UART.
-        if service_info.manufacturer_data and MANUFACTURER_ID_OKIN in service_info.manufacturer_data:
+        if (
+            service_info.manufacturer_data
+            and MANUFACTURER_ID_OKIN in service_info.manufacturer_data
+        ):
             signals.append(f"manufacturer_id:{MANUFACTURER_ID_OKIN}")
             _LOGGER.info(
                 "Detected Okin CB24 bed at %s (name: %s) - Nordic UART + OKIN manufacturer ID",
@@ -1595,7 +1691,12 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
                 bed_type=BED_TYPE_OKIN_CB24,
                 confidence=0.7,
                 signals=signals,
-                ambiguous_types=[BED_TYPE_RICHMAT, BED_TYPE_KEESON, BED_TYPE_MATTRESSFIRM, BED_TYPE_OKIN_64BIT],
+                ambiguous_types=[
+                    BED_TYPE_RICHMAT,
+                    BED_TYPE_KEESON,
+                    BED_TYPE_MATTRESSFIRM,
+                    BED_TYPE_OKIN_64BIT,
+                ],
                 manufacturer_id=MANUFACTURER_ID_OKIN,
             )
 
@@ -1658,9 +1759,7 @@ async def detect_bed_type_by_characteristics(
             _LOGGER.info("Refined detection: OKIN Smart Remote CSS signature found")
             return BED_TYPE_OKIN_RF_ECO_BT
         if gatt_detection.bed_type == BED_TYPE_OKIN_CST:
-            _LOGGER.info(
-                "Refined detection: OKIN CST dual-stack GATT signature found"
-            )
+            _LOGGER.info("Refined detection: OKIN CST dual-stack GATT signature found")
             return BED_TYPE_OKIN_CST
 
         # Build a set of all characteristic UUIDs for easy lookup
@@ -1673,9 +1772,7 @@ async def detect_bed_type_by_characteristics(
         if initial_detection == BED_TYPE_RICHMAT:
             # BedTech has a specific write characteristic
             if BEDTECH_WRITE_CHAR_UUID.lower() in all_chars:
-                _LOGGER.info(
-                    "Refined detection: BedTech characteristic found (was Richmat)"
-                )
+                _LOGGER.info("Refined detection: BedTech characteristic found (was Richmat)")
                 return BED_TYPE_BEDTECH
 
         # For OKIN service (62741523): Check for 64-bit read characteristic
@@ -1684,9 +1781,7 @@ async def detect_bed_type_by_characteristics(
             if OKIMAT_NOTIFY_CHAR_UUID.lower() in all_chars:
                 # The presence of 62741625 doesn't definitively mean 64-bit
                 # (Okimat also has this), but we can note it for logging
-                _LOGGER.debug(
-                    "OKIN notify characteristic found - could be Okimat or OKIN 64-bit"
-                )
+                _LOGGER.debug("OKIN notify characteristic found - could be Okimat or OKIN 64-bit")
                 # To truly distinguish, we'd need to try sending a command
                 # and check the response format (6-byte vs 10-byte)
                 # For now, keep as Okimat since it's more common

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -32,6 +32,7 @@ from .const import (
     BED_TYPE_KEESON,
     BED_TYPE_LEGGETT_GEN2,
     BED_TYPE_LEGGETT_OKIN,
+    BED_TYPE_LEGGETT_PLATT,
     BED_TYPE_LEGGETT_WILINKE,
     BED_TYPE_LIMOSS,
     BED_TYPE_LINAK,
@@ -99,6 +100,7 @@ from .const import (
     LEGGETT_GEN2_SERVICE_UUID,
     LEGGETT_OKIN_NAME_PATTERNS,
     LEGGETT_RICHMAT_NAME_PATTERNS,
+    LEGGETT_VARIANT_OKIN,
     LIMOSS_NAME_PATTERNS,
     LINAK_CONTROL_SERVICE_UUID,
     LINAK_NAME_PATTERNS,
@@ -539,9 +541,16 @@ def refine_malouf_protocol_from_gatt(bed_type: str, gatt_services: Any) -> str:
     return bed_type
 
 
-def refine_okin_shared_uuid_protocol_from_gatt(bed_type: str, gatt_services: Any) -> str:
+def refine_okin_shared_uuid_protocol_from_gatt(
+    bed_type: str,
+    gatt_services: Any,
+    protocol_variant: str | None = None,
+) -> str:
     """Correct shared OKIN UUID profiles once connected GATT services are known."""
-    if bed_type not in OKIN_SHARED_UUID_GATT_REFINABLE_TYPES:
+    is_leggett_okin_variant = (
+        bed_type == BED_TYPE_LEGGETT_PLATT and protocol_variant == LEGGETT_VARIANT_OKIN
+    )
+    if bed_type not in OKIN_SHARED_UUID_GATT_REFINABLE_TYPES and not is_leggett_okin_variant:
         return bed_type
 
     gatt_detection = detect_bed_type_from_gatt_services(gatt_services)

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -555,6 +555,8 @@ def refine_okin_shared_uuid_protocol_from_gatt(
 
     gatt_detection = detect_bed_type_from_gatt_services(gatt_services)
     if gatt_detection.bed_type in {BED_TYPE_OKIN_CST, BED_TYPE_OKIN_RF_ECO_BT}:
+        if bed_type == BED_TYPE_OKIN_CST and gatt_detection.bed_type == BED_TYPE_OKIN_RF_ECO_BT:
+            return bed_type
         if gatt_detection.bed_type != bed_type:
             _LOGGER.info(
                 "Refined shared OKIN protocol from %s to %s using GATT signals: %s",

--- a/custom_components/adjustable_bed/number.py
+++ b/custom_components/adjustable_bed/number.py
@@ -21,6 +21,7 @@ from .const import (
     BED_TYPE_ERGOMOTION,
     BED_TYPE_KAIDI,
     BED_TYPE_KEESON,
+    BED_TYPE_OKIN_CST,
     BED_TYPE_SLEEP_NUMBER,
     BED_TYPE_SLEEPYS_BOX25,
     BEDS_WITH_POSITION_FEEDBACK,
@@ -334,6 +335,31 @@ async def async_setup_entry(
                         min_motors=2,
                     )
                     entities.append(AdjustableBedPositionNumber(coordinator, box25_desc))
+            elif bed_type == BED_TYPE_OKIN_CST:
+                _LOGGER.debug(
+                    "Setting up CST position numbers for %s",
+                    coordinator.name,
+                )
+
+                for description in NUMBER_DESCRIPTIONS[:2]:
+                    max_angle = coordinator.get_max_angle(description.position_key)
+                    cst_desc = AdjustableBedNumberEntityDescription(
+                        key=description.key,
+                        translation_key=description.translation_key,
+                        icon=description.icon,
+                        native_min_value=description.native_min_value,
+                        native_max_value=max_angle,
+                        native_step=description.native_step,
+                        native_unit_of_measurement=description.native_unit_of_measurement,
+                        mode=description.mode,
+                        position_key=description.position_key,
+                        move_up_fn=description.move_up_fn,
+                        move_down_fn=description.move_down_fn,
+                        move_stop_fn=description.move_stop_fn,
+                        max_angle=max_angle,
+                        min_motors=description.min_motors,
+                    )
+                    entities.append(AdjustableBedPositionNumber(coordinator, cst_desc))
             elif bed_type == BED_TYPE_KAIDI and controller is not None:
                 _LOGGER.debug(
                     "Setting up Kaidi direct-position numbers for %s",

--- a/custom_components/adjustable_bed/number.py
+++ b/custom_components/adjustable_bed/number.py
@@ -32,6 +32,7 @@ from .const import (
     DEFAULT_MOTOR_COUNT,
     DOMAIN,
     KEESON_VARIANT_ERGOMOTION,
+    OKIN_CST_POSITION_AXES,
 )
 from .coordinator import AdjustableBedCoordinator
 from .entity import AdjustableBedEntity
@@ -341,7 +342,10 @@ async def async_setup_entry(
                     coordinator.name,
                 )
 
-                for description in NUMBER_DESCRIPTIONS[:2]:
+                for key in ("back_position", "legs_position"):
+                    description = descriptions_by_key[key]
+                    if description.position_key not in OKIN_CST_POSITION_AXES:
+                        continue
                     max_angle = coordinator.get_max_angle(description.position_key)
                     cst_desc = AdjustableBedNumberEntityDescription(
                         key=description.key,

--- a/custom_components/adjustable_bed/sensor.py
+++ b/custom_components/adjustable_bed/sensor.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import (
     BED_TYPE_ERGOMOTION,
     BED_TYPE_KEESON,
+    BED_TYPE_OKIN_CST,
     BEDS_WITH_PERCENTAGE_POSITIONS,
     CONF_BED_TYPE,
     CONF_HAS_MASSAGE,
@@ -27,6 +28,7 @@ from .const import (
     DEFAULT_MOTOR_COUNT,
     DOMAIN,
     KEESON_VARIANT_ERGOMOTION,
+    OKIN_CST_POSITION_AXES,
 )
 from .coordinator import AdjustableBedCoordinator
 from .entity import AdjustableBedEntity
@@ -142,7 +144,14 @@ async def async_setup_entry(
         # Skip angle sensors for beds that report percentage instead of angles
         # (Keeson/Ergomotion/Serta report 0-100% position, not degrees)
         if bed_type not in BEDS_WITH_PERCENTAGE_POSITIONS:
-            for description in SENSOR_DESCRIPTIONS:
+            sensor_descriptions = SENSOR_DESCRIPTIONS
+            if bed_type == BED_TYPE_OKIN_CST:
+                sensor_descriptions = tuple(
+                    description
+                    for description in SENSOR_DESCRIPTIONS
+                    if description.position_key in OKIN_CST_POSITION_AXES
+                )
+            for description in sensor_descriptions:
                 if motor_count >= description.min_motors:
                     entities.append(AdjustableBedAngleSensor(coordinator, description))
         else:

--- a/docs/SUPPORTED_ACTUATORS.md
+++ b/docs/SUPPORTED_ACTUATORS.md
@@ -13,6 +13,7 @@ This document provides an overview of supported bed brands. Click on a brand nam
 | [Leggett & Platt](beds/leggett-platt.md) | ✅ Supported | Gen2: motor control + RGB lighting; Okin: tilt/lumbar, massage |
 | [Reverie](beds/reverie.md) | ✅ Supported | Position control (0-100%), 4 presets, wave massage |
 | [Okimat/Okin](beds/okimat.md) | ✅ Supported | 4 memory presets, massage, lights (requires pairing) |
+| [Okin 64-Bit](beds/okin-64bit.md) | 🧪 Needs Testing | 10-byte Nordic/custom OKIN protocol, lumbar, lights, massage |
 | [Jiecang](beds/jiecang.md) | ✅ Supported | Motor control, 3 memory slots, massage, split bed support |
 | [Kaidi](beds/kaidi.md) | 🧪 Needs Testing | Mouselet-based beds, Flat/Zero-G/Anti-Snore, 4 memory slots |
 | [Jensen](beds/jensen.md) | ✅ Supported | Go-to-position, variable massage (0-10), dynamic feature detection |
@@ -54,7 +55,7 @@ Several bed brands use Okin-based BLE controllers. While they share common roots
 | Bed Type | Command Format | Write Method | Pairing Required | Detection |
 |----------|---------------|--------------|------------------|-----------|
 | [Okimat](beds/okimat.md) | 6-byte (32-bit cmd) | UUID `62741525-...` | ✅ Yes | Name patterns or fallback |
-| [Okin 64-bit](beds/sleepys.md#box24-protocol-7-byte-packets) | 10-byte (64-bit cmd) | Nordic UART or UUID | ❌ No | Manual selection |
+| [Okin 64-bit](beds/okin-64bit.md) | 10-byte (64-bit cmd) | Nordic UART or UUID | ❌ No | `NORA_CON` / `NORACON`, manual selection |
 | [Leggett & Platt Okin](beds/leggett-platt.md) | 6-byte (32-bit cmd) | UUID `62741525-...` | ✅ Yes | Name patterns |
 | [Nectar](beds/nectar.md) | 7-byte (32-bit cmd) | UUID `62741525-...` without response | ❌ No | Name contains "nectar" or generic `OKIN-*` disambiguation |
 | [DewertOkin](beds/dewertokin.md) | 6-byte (32-bit cmd) | Handle `0x0013` | ❌ No | Name patterns |

--- a/docs/beds/okimat.md
+++ b/docs/beds/okimat.md
@@ -14,14 +14,13 @@
 
 ## Apps
 
-19 apps use this protocol:
+Several apps use this protocol:
 
 | Analyzed | App | Package ID |
 |----------|-----|------------|
 | ✅ | [OKIN ComfortBed II-N](https://play.google.com/store/apps/details?id=com.ore.jalon.neworebeding) | `com.ore.jalon.neworebeding` |
 | ✅ | [OKIN Comfort Bed](https://play.google.com/store/apps/details?id=com.ore.okincomfortbed) | `com.ore.okincomfortbed` |
 | ✅ | [OKIN Smart Bed](https://play.google.com/store/apps/details?id=com.okin.bedding.smartbedwifi) | `com.okin.bedding.smartbedwifi` |
-| ✅ | [Adjustable bed](https://play.google.com/store/apps/details?id=com.okin.bedding.adjustbed) | `com.okin.bedding.adjustbed` |
 | ✅ | Rize II | `com.okin.bedding.rizeii` |
 | ✅ | Rize Resident | `com.okin.bedding.rizeResident` |
 | ✅ | Customatic Clarity | `com.okin.bedding.customaticclarity` |
@@ -55,7 +54,7 @@
 > | [DewertOkin](dewertokin.md) | 6-byte | Handle-based writes (not UUID) |
 > | [Mattress Firm 900](mattressfirm.md) | 7-byte | Uses Nordic UART service |
 > | [Okin CST](okin-cst.md) | 14-byte | MFirm 900-O / Rize MF900-style OKIN service devices |
-> | **Okin 64-Bit** | 10-byte | 64-bit commands, `0x08 0x02` header |
+> | [Okin 64-Bit](okin-64bit.md) | 10-byte | 64-bit commands, `0x08 0x02` header |
 >
 > See [Okin Protocol Family](../SUPPORTED_ACTUATORS.md#okin-protocol-family) for detection priority and troubleshooting.
 
@@ -180,58 +179,9 @@ The app supports multiple protocol versions based on device name:
 
 ---
 
-## Okin 64-Bit Protocol
+## Related Okin 64-Bit Protocol
 
-Some newer Okin beds use a different 64-bit command protocol. This was discovered in the `com.okin.bedding.adjustbed` app (Flutter/Dart).
-
-**Select "Okin 64-Bit" as bed type if your bed uses this protocol.**
-
-### Protocol Variants
-
-| Variant | Service UUID | Write Characteristic | Mode |
-|---------|--------------|---------------------|------|
-| Nordic (25_42_02) | `6e400001-b5a3-f393-e0a9-e50e24dcca9e` | `6e400002-...` | Fire-and-forget |
-| Custom (36_33_04a) | `62741523-52f9-8864-b1ab-3b3a8d65950b` | `62741525-...` | Wait-for-response |
-
-### Packet Format
-
-**Format:** `[0x08, 0x02, cmd[0], cmd[1], cmd[2], cmd[3], cmd[4], cmd[5], cmd[6], cmd[7]]`
-
-- Header: `0x08 0x02` (distinguishes from 32-bit Keeson `0x04 0x02` and Malouf `0x05 0x02`)
-- Command: 8 bytes (64-bit bitmask value)
-- No checksum
-
-### Commands (64-bit Values)
-
-| Command | Bytes | Description |
-|---------|-------|-------------|
-| Stop | `00 00 00 00 00 00 00 00` | Stop all motors |
-| Head Up | `00 00 00 01 00 00 00 00` | Raise head |
-| Head Down | `00 00 00 02 00 00 00 00` | Lower head |
-| Foot Up | `00 00 00 04 00 00 00 00` | Raise foot |
-| Foot Down | `00 00 00 08 00 00 00 00` | Lower foot |
-| Lumbar Up | `00 00 00 10 00 00 00 00` | Raise lumbar |
-| Lumbar Down | `00 00 00 20 00 00 00 00` | Lower lumbar |
-| Flat | `08 00 00 00 00 00 00 00` | Flat preset |
-| Zero-G | `00 00 10 00 00 00 00 00` | Zero gravity |
-| Lounge | `00 00 20 00 00 00 00 00` | Lounge preset |
-| TV/PC | `00 00 40 00 00 00 00 00` | TV position |
-| Anti-Snore | `00 00 80 00 00 00 00 00` | Anti-snore |
-| Memory 1 | `00 01 00 00 00 00 00 00` | Go to memory 1 |
-| Memory 2 | `00 04 00 00 00 00 00 00` | Go to memory 2 |
-| Light Toggle | `00 02 00 00 00 00 00 00` | Toggle lights |
-| Light On | `00 00 00 00 00 00 00 40` | Turn light on |
-| Light Off | `00 00 00 00 00 00 00 80` | Turn light off |
-| Massage Switch | `00 00 01 00 00 00 00 00` | Switch massage mode |
-| Massage Stop | `02 00 00 00 00 00 00 00` | Stop massage |
-
-### Features
-
-| Feature | Supported |
-|---------|-----------|
-| Motor Control | ✅ Head, Foot, Lumbar |
-| Position Feedback | ❌ |
-| Memory Presets | ✅ (2 slots) |
-| Massage | ✅ (with timer, wave modes) |
-| Under-bed Lights | ✅ |
-| Zero-G / Anti-Snore / TV / Lounge | ✅ |
+Some newer Okin controllers use the separate [Okin 64-Bit](okin-64bit.md)
+protocol with 10-byte `0x08 0x02` frames. Select **Okin 64-Bit** instead of
+Okimat if diagnostics show a `NORA_CON` / `NORACON` controller or the 64-bit
+packet format from the `com.okin.bedding.adjustbed` app.

--- a/docs/beds/okin-64bit.md
+++ b/docs/beds/okin-64bit.md
@@ -1,0 +1,97 @@
+# Okin 64-Bit
+
+**Status:** Needs testing
+**Ref:** Reverse-engineered from the `com.okin.bedding.adjustbed` APK
+
+## Known Controllers
+
+- `NORA_CON` / `NORACON` Mattress Firm controllers
+- Other newer Okin controllers using the 10-byte `0x08 0x02` command frame
+
+Reported `NORA_CON` / `NORACON` controllers use the Nordic variant. Their connected
+Device Information Service reports manufacturer `IDT` and model `NORACON`.
+
+## Apps
+
+| Analyzed | App | Package ID |
+|----------|-----|------------|
+| ✅ | Adjustable bed | `com.okin.bedding.adjustbed` |
+
+## Detection
+
+| Signal | Value |
+|--------|-------|
+| Nordic service UUID | `6e400001-b5a3-f393-e0a9-e50e24dcca9e` |
+| Nordic write characteristic | `6e400002-b5a3-f393-e0a9-e50e24dcca9e` |
+| Custom OKIN service UUID | `62741523-52f9-8864-b1ab-3b3a8d65950b` |
+| Custom OKIN write characteristic | `62741525-52f9-8864-b1ab-3b3a8d65950b` |
+| Name hint | `NORA_CON` |
+| Device Information hint | Manufacturer `IDT`, model `NORACON` |
+
+The Nordic UART service is shared by several bed protocols. Generic Nordic UART
+devices still need disambiguation; `NORA_CON` / `NORACON` is the known
+high-confidence signal for this 64-bit profile.
+
+## Protocol Variants
+
+| Variant | Service UUID | Write Characteristic | Mode |
+|---------|--------------|----------------------|------|
+| Nordic (`25_42_02`) | `6e400001-b5a3-f393-e0a9-e50e24dcca9e` | `6e400002-...` | Fire-and-forget |
+| Custom OKIN (`36_33_04a`) | `62741523-52f9-8864-b1ab-3b3a8d65950b` | `62741525-...` | Wait-for-response |
+
+## Packet Format
+
+```text
+[0x08, 0x02, cmd[0], cmd[1], cmd[2], cmd[3], cmd[4], cmd[5], cmd[6], cmd[7]]
+```
+
+- Header: `0x08 0x02`
+- Command: 8-byte 64-bit bitmask value
+- Checksum: none
+
+The `0x08 0x02` header distinguishes this from 32-bit Okin/Keeson-style frames
+such as `0x04 0x02` and `0x05 0x02`. Do not reuse 6-byte Okimat or 7-byte
+Mattress Firm Nordic packets with this protocol.
+
+## Commands
+
+| Command | Bytes | Description |
+|---------|-------|-------------|
+| Stop | `00 00 00 00 00 00 00 00` | Stop all motors |
+| Head Up | `00 00 00 01 00 00 00 00` | Raise head |
+| Head Down | `00 00 00 02 00 00 00 00` | Lower head |
+| Foot Up | `00 00 00 04 00 00 00 00` | Raise foot |
+| Foot Down | `00 00 00 08 00 00 00 00` | Lower foot |
+| Lumbar Up | `00 00 00 10 00 00 00 00` | Raise lumbar |
+| Lumbar Down | `00 00 00 20 00 00 00 00` | Lower lumbar |
+| Flat | `08 00 00 00 00 00 00 00` | Flat preset |
+| Zero-G | `00 00 10 00 00 00 00 00` | Zero gravity |
+| Lounge | `00 00 20 00 00 00 00 00` | Lounge preset |
+| TV/PC | `00 00 40 00 00 00 00 00` | TV position |
+| Anti-Snore | `00 00 80 00 00 00 00 00` | Anti-snore |
+| Memory 1 | `00 01 00 00 00 00 00 00` | Go to memory 1 |
+| Memory 2 | `00 04 00 00 00 00 00 00` | Go to memory 2 |
+| Light Toggle | `00 02 00 00 00 00 00 00` | Toggle lights |
+| Light On | `00 00 00 00 00 00 00 40` | Turn light on |
+| Light Off | `00 00 00 00 00 00 00 80` | Turn light off |
+| Massage Switch | `00 00 01 00 00 00 00 00` | Switch massage mode |
+| Massage Stop | `02 00 00 00 00 00 00 00` | Stop massage |
+
+## Features
+
+| Feature | Supported |
+|---------|-----------|
+| Motor Control | ✅ Head, Foot, Lumbar |
+| Position Feedback | ❌ |
+| Memory Presets | ✅ (2 slots) |
+| Massage | ✅ (timer, wave modes) |
+| Under-bed Lights | ✅ |
+| Zero-G / Anti-Snore / TV / Lounge | ✅ |
+
+## Related Protocols
+
+- [Okimat/Okin](okimat.md) uses the same custom OKIN service UUID on some models,
+  but sends 6-byte `0x04 0x02` frames.
+- [Mattress Firm 900](mattressfirm.md) also uses Nordic UART, but sends 7-byte
+  `5A 01 ... A5` frames.
+- [Okin CB35](okin-cb35.md) uses Nordic UART with a related 7-byte Star protocol.

--- a/docs/beds/okin-cst.md
+++ b/docs/beds/okin-cst.md
@@ -8,6 +8,8 @@
 - Mattress Firm 900-O / MFirm 900-O
 - Rize MF900
 - Nectar Motion / some `OKIN-*` Nectar bases
+- Leggett & Platt Prodigy Comfort Elite / `LP BED CONTROL` when diagnostics
+  show the CST connected GATT signature
 
 ## Detection
 

--- a/docs/beds/sleepys.md
+++ b/docs/beds/sleepys.md
@@ -307,5 +307,5 @@ Sleepy's Elite beds are auto-detected by name plus BLE services:
 ## Related Protocols
 
 - **[DewertOkin](dewertokin.md)** - Different command format, uses handle writes
-- **[Okin 64-bit](okimat.md#okin-64-bit-protocol)** - Similar service UUID but different packet format
+- **[Okin 64-bit](okin-64bit.md)** - Similar service UUID but different packet format
 - **[Keeson](keeson.md)** - Same FFE5 service but different command encoding

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -39,6 +39,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_SUTA,
     BED_TYPE_TIMOTION_AHF,
     BED_TYPE_VIBRADORM,
+    BEDS_WITH_POSITION_FEEDBACK,
     CONF_BED_TYPE,
     CONF_BLE_BOND_ESTABLISHED,
     CONF_DISABLE_ANGLE_SENSING,
@@ -159,6 +160,10 @@ class TestPairingInstructions:
     async def test_okin_rf_eco_bt_requires_pairing(self) -> None:
         """RF ECO BT should request BLE pairing before authenticated OKIN writes."""
         assert requires_pairing(BED_TYPE_OKIN_RF_ECO_BT)
+
+    async def test_okin_cst_supports_position_feedback(self) -> None:
+        """CST should keep position sliders available after runtime correction."""
+        assert BED_TYPE_OKIN_CST in BEDS_WITH_POSITION_FEEDBACK
 
 
 class TestPairingPersistence:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -164,9 +164,7 @@ class TestPairingInstructions:
 class TestPairingPersistence:
     """Test that successful pairing is persisted on the created entry."""
 
-    async def test_bluetooth_pairing_marks_bond_as_established(
-        self, hass: HomeAssistant
-    ) -> None:
+    async def test_bluetooth_pairing_marks_bond_as_established(self, hass: HomeAssistant) -> None:
         """Pair Now should persist that the bed is already bonded."""
         flow = AdjustableBedConfigFlow()
         flow.hass = hass
@@ -869,6 +867,37 @@ class TestBluetoothDiscoveryFlow:
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "bluetooth_disambiguate"
 
+    async def test_bluetooth_discovery_name_only_okin_receiver_shows_disambiguation(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,
+    ):
+        """A pre-pairing OKIN receiver advertisement should not be dropped as unknown."""
+        del enable_custom_integrations
+
+        service_info = MagicMock()
+        service_info.name = "OKIN - Receiver"
+        service_info.address = "F1:8A:7F:61:EE:8B"
+        service_info.rssi = -75
+        service_info.manufacturer_data = {}
+        service_info.service_data = {}
+        service_info.service_uuids = []
+        service_info.source = "local"
+        service_info.device = MagicMock()
+        service_info.advertisement = MagicMock()
+        service_info.connectable = True
+        service_info.time = 0
+        service_info.tx_power = None
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_BLUETOOTH},
+            data=service_info,
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "bluetooth_disambiguate"
+
     async def test_bluetooth_disambiguate_selects_type(
         self,
         hass: HomeAssistant,
@@ -1513,9 +1542,7 @@ class TestUserFlow:
                 DOMAIN,
                 context={"source": SOURCE_USER},
             )
-            retrying_option = (
-                f"configured_retry::{mock_bluetooth_service_info.address.upper()}"
-            )
+            retrying_option = f"configured_retry::{mock_bluetooth_service_info.address.upper()}"
             assert result["type"] == FlowResultType.FORM
             selector_options = next(iter(result["data_schema"].schema.values())).container
             assert retrying_option in selector_options
@@ -1528,7 +1555,10 @@ class TestUserFlow:
 
         assert result["type"] == FlowResultType.ABORT
         assert result["reason"] == "configured_retrying"
-        assert result["description_placeholders"]["address"] == mock_bluetooth_service_info.address.upper()
+        assert (
+            result["description_placeholders"]["address"]
+            == mock_bluetooth_service_info.address.upper()
+        )
         assert result["description_placeholders"]["name"] == "Retrying Bed"
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -41,6 +41,8 @@ from custom_components.adjustable_bed.const import (
     NORDIC_DFU_SERVICE_UUID,
     OKIMAT_SERVICE_UUID,
     OKIMAT_WRITE_CHAR_UUID,
+    OKIN_FOOT_MAX_ANGLE,
+    OKIN_HEAD_MAX_ANGLE,
     OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
     OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID,
     RICHMAT_REMOTE_AUTO,
@@ -358,6 +360,29 @@ class TestCoordinatorConnection:
         )
 
         assert coordinator._expected_initial_position_axes() == {"back", "legs"}
+
+    async def test_cst_max_angles_use_reported_position_ranges(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_data: dict,
+    ) -> None:
+        """CST seek limits should match the angles reported by notifications."""
+        mock_config_entry_data[CONF_BED_TYPE] = BED_TYPE_OKIN_CST
+        coordinator = AdjustableBedCoordinator(
+            hass,
+            MockConfigEntry(
+                domain=DOMAIN,
+                title=TEST_NAME,
+                data=mock_config_entry_data,
+                unique_id=TEST_ADDRESS,
+                entry_id="cst_max_angles",
+            ),
+        )
+
+        assert coordinator.get_max_angle("back") == OKIN_HEAD_MAX_ANGLE
+        assert coordinator.get_max_angle("head") == OKIN_HEAD_MAX_ANGLE
+        assert coordinator.get_max_angle("legs") == OKIN_FOOT_MAX_ANGLE
+        assert coordinator.get_max_angle("feet") == OKIN_FOOT_MAX_ANGLE
 
     async def test_passive_position_reconciliation_reads_positions_when_idle(
         self,
@@ -2226,6 +2251,28 @@ class TestRuntimeBedTypeCorrection:
 
         coordinator._apply_runtime_bed_type_correction(BED_TYPE_OKIN_CST)
 
+        assert coordinator.bed_type == BED_TYPE_OKIN_CST
+        assert coordinator.disable_angle_sensing is False
+        assert coordinator.entry.data[CONF_DISABLE_ANGLE_SENSING] is False
+
+    async def test_correction_to_cst_repairs_same_type_stored_default_angle_sensing(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_data: dict,
+    ):
+        """Saved CST entries with the old no-feedback default should be repaired."""
+        coordinator = self._make_coordinator(
+            hass,
+            mock_config_entry_data,
+            {CONF_DISABLE_ANGLE_SENSING: True},
+            bed_type=BED_TYPE_OKIN_CST,
+        )
+
+        assert coordinator.disable_angle_sensing is True
+
+        changed = coordinator._apply_runtime_bed_type_correction(BED_TYPE_OKIN_CST)
+
+        assert changed is True
         assert coordinator.bed_type == BED_TYPE_OKIN_CST
         assert coordinator.disable_angle_sensing is False
         assert coordinator.entry.data[CONF_DISABLE_ANGLE_SENSING] is False

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2378,6 +2378,7 @@ class TestRuntimeBedTypeCorrection:
             ),
         ):
             coordinator = AdjustableBedCoordinator(hass, entry)
+            coordinator._max_retries = 1
             result = await coordinator.async_connect()
 
         assert result is True

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -14,10 +14,13 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.adjustable_bed.const import (
     BED_MOTOR_PULSE_DEFAULTS,
     BED_TYPE_KEESON,
+    BED_TYPE_LEGGETT_OKIN,
     BED_TYPE_LINAK,
     BED_TYPE_MALOUF_LEGACY_OKIN,
     BED_TYPE_MALOUF_NEW_OKIN,
     BED_TYPE_OKIMAT,
+    BED_TYPE_OKIN_64BIT,
+    BED_TYPE_OKIN_CST,
     BED_TYPE_RICHMAT,
     BED_TYPE_SLEEP_NUMBER_MCR,
     CONF_BED_TYPE,
@@ -558,9 +561,7 @@ class TestCoordinatorPositionSeek:
         move_stop = AsyncMock()
         readings = iter([7.0, 10.0])
         read_positions = AsyncMock(
-            side_effect=lambda: coordinator._position_data.__setitem__(
-                "legs", next(readings, 10.0)
-            )
+            side_effect=lambda: coordinator._position_data.__setitem__("legs", next(readings, 10.0))
         )
 
         with (
@@ -2031,15 +2032,16 @@ class TestMotorPulseConfiguration:
 
 
 class TestRuntimeBedTypeCorrection:
-    """Test runtime Malouf protocol correction after GATT discovery."""
+    """Test runtime protocol correction after GATT discovery."""
 
     def _make_coordinator(
         self,
         hass: HomeAssistant,
         mock_config_entry_data: dict,
         extra: dict,
+        bed_type: str = BED_TYPE_MALOUF_NEW_OKIN,
     ) -> AdjustableBedCoordinator:
-        mock_config_entry_data[CONF_BED_TYPE] = BED_TYPE_MALOUF_NEW_OKIN
+        mock_config_entry_data[CONF_BED_TYPE] = bed_type
         mock_config_entry_data.update(extra)
         entry = MockConfigEntry(
             domain=DOMAIN,
@@ -2095,7 +2097,44 @@ class TestRuntimeBedTypeCorrection:
         # Bed type is still corrected...
         assert coordinator.bed_type == BED_TYPE_MALOUF_LEGACY_OKIN
         # ...but the explicit override is preserved, not overwritten.
-        assert (coordinator.motor_pulse_count, coordinator.motor_pulse_delay_ms) == new_okin_defaults
+        assert (
+            coordinator.motor_pulse_count,
+            coordinator.motor_pulse_delay_ms,
+        ) == new_okin_defaults
+
+    async def test_correction_updates_shared_okin_bed_type(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_data: dict,
+    ):
+        """Connected GATT correction can move an existing Leggett/Okin entry to CST."""
+        coordinator = self._make_coordinator(
+            hass,
+            mock_config_entry_data,
+            {},
+            bed_type=BED_TYPE_LEGGETT_OKIN,
+        )
+
+        coordinator._apply_runtime_bed_type_correction(BED_TYPE_OKIN_CST)
+
+        assert coordinator.bed_type == BED_TYPE_OKIN_CST
+
+    async def test_correction_updates_richmat_to_okin_64bit(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_data: dict,
+    ):
+        """Connected Device Info correction can move a Richmat fallback to OKIN 64-bit."""
+        coordinator = self._make_coordinator(
+            hass,
+            mock_config_entry_data,
+            {},
+            bed_type=BED_TYPE_RICHMAT,
+        )
+
+        coordinator._apply_runtime_bed_type_correction(BED_TYPE_OKIN_64BIT)
+
+        assert coordinator.bed_type == BED_TYPE_OKIN_64BIT
 
 
 class TestMultiMotorConfiguration:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -23,6 +23,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_OKIMAT,
     BED_TYPE_OKIN_64BIT,
     BED_TYPE_OKIN_CST,
+    BED_TYPE_OKIN_RF_ECO_BT,
     BED_TYPE_RICHMAT,
     BED_TYPE_SLEEP_NUMBER_MCR,
     CONF_BED_TYPE,
@@ -2144,6 +2145,44 @@ class TestRuntimeBedTypeCorrection:
 
         assert coordinator.bed_type == BED_TYPE_OKIN_CST
         assert coordinator.entry.data[CONF_BED_TYPE] == BED_TYPE_OKIN_CST
+
+    async def test_correction_to_cst_preserves_enabled_angle_sensing(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_data: dict,
+    ):
+        """CST corrections should keep position sensors and position controls enabled."""
+        coordinator = self._make_coordinator(
+            hass,
+            mock_config_entry_data,
+            {CONF_DISABLE_ANGLE_SENSING: False},
+            bed_type=BED_TYPE_OKIMAT,
+        )
+
+        coordinator._apply_runtime_bed_type_correction(BED_TYPE_OKIN_CST)
+
+        assert coordinator.bed_type == BED_TYPE_OKIN_CST
+        assert coordinator.disable_angle_sensing is False
+        assert coordinator.entry.data[CONF_DISABLE_ANGLE_SENSING] is False
+
+    async def test_correction_to_rf_eco_bt_disables_angle_sensing(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_data: dict,
+    ):
+        """Single-actuator RF ECO BT corrections should not expose position sensors."""
+        coordinator = self._make_coordinator(
+            hass,
+            mock_config_entry_data,
+            {CONF_DISABLE_ANGLE_SENSING: False},
+            bed_type=BED_TYPE_OKIMAT,
+        )
+
+        coordinator._apply_runtime_bed_type_correction(BED_TYPE_OKIN_RF_ECO_BT)
+
+        assert coordinator.bed_type == BED_TYPE_OKIN_RF_ECO_BT
+        assert coordinator.disable_angle_sensing is True
+        assert coordinator.entry.data[CONF_DISABLE_ANGLE_SENSING] is True
 
     async def test_correction_updates_richmat_to_okin_64bit(
         self,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -338,6 +338,27 @@ class TestCoordinatorConnection:
         assert controller.prepare_for_position_read.await_count == 2
         mock_sleep.assert_awaited_once()
 
+    async def test_cst_initial_position_axes_ignore_unreported_extra_motors(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_data: dict,
+    ) -> None:
+        """CST startup hydration should not wait for head/feet axes."""
+        mock_config_entry_data[CONF_BED_TYPE] = BED_TYPE_OKIN_CST
+        mock_config_entry_data[CONF_MOTOR_COUNT] = 4
+        coordinator = AdjustableBedCoordinator(
+            hass,
+            MockConfigEntry(
+                domain=DOMAIN,
+                title=TEST_NAME,
+                data=mock_config_entry_data,
+                unique_id=TEST_ADDRESS,
+                entry_id="cst_expected_axes",
+            ),
+        )
+
+        assert coordinator._expected_initial_position_axes() == {"back", "legs"}
+
     async def test_passive_position_reconciliation_reads_positions_when_idle(
         self,
         hass: HomeAssistant,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2188,6 +2188,27 @@ class TestRuntimeBedTypeCorrection:
         assert coordinator.disable_angle_sensing is False
         assert coordinator.entry.data[CONF_DISABLE_ANGLE_SENSING] is False
 
+    async def test_correction_to_cst_enables_stored_no_feedback_default_angle_sensing(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_data: dict,
+    ):
+        """Saved no-feedback defaults should not suppress corrected CST position features."""
+        coordinator = self._make_coordinator(
+            hass,
+            mock_config_entry_data,
+            {CONF_DISABLE_ANGLE_SENSING: True},
+            bed_type=BED_TYPE_NECTAR,
+        )
+
+        assert coordinator.disable_angle_sensing is True
+
+        coordinator._apply_runtime_bed_type_correction(BED_TYPE_OKIN_CST)
+
+        assert coordinator.bed_type == BED_TYPE_OKIN_CST
+        assert coordinator.disable_angle_sensing is False
+        assert coordinator.entry.data[CONF_DISABLE_ANGLE_SENSING] is False
+
     async def test_correction_to_cst_preserves_explicit_disabled_angle_sensing(
         self,
         hass: HomeAssistant,
@@ -2295,6 +2316,9 @@ class TestRuntimeBedTypeCorrection:
         adapter_result.connectable = True
         adapter_result.available_sources = ["local"]
 
+        mock_controller = MagicMock()
+        mock_controller.start_notify = AsyncMock()
+
         with (
             patch(
                 "custom_components.adjustable_bed.coordinator.select_adapter",
@@ -2325,7 +2349,7 @@ class TestRuntimeBedTypeCorrection:
             patch(
                 "custom_components.adjustable_bed.coordinator.create_controller",
                 new_callable=AsyncMock,
-                return_value=MagicMock(),
+                return_value=mock_controller,
             ) as mock_create_controller,
             patch(
                 "custom_components.adjustable_bed.coordinator.asyncio.sleep",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2165,6 +2165,48 @@ class TestRuntimeBedTypeCorrection:
         assert coordinator.disable_angle_sensing is False
         assert coordinator.entry.data[CONF_DISABLE_ANGLE_SENSING] is False
 
+    async def test_correction_to_cst_enables_defaulted_angle_sensing(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_data: dict,
+    ):
+        """Legacy entries missing the angle key should gain CST position features."""
+        legacy_data = dict(mock_config_entry_data)
+        legacy_data.pop(CONF_DISABLE_ANGLE_SENSING, None)
+        coordinator = self._make_coordinator(
+            hass,
+            legacy_data,
+            {},
+            bed_type=BED_TYPE_OKIMAT,
+        )
+
+        assert coordinator.disable_angle_sensing is True
+
+        coordinator._apply_runtime_bed_type_correction(BED_TYPE_OKIN_CST)
+
+        assert coordinator.bed_type == BED_TYPE_OKIN_CST
+        assert coordinator.disable_angle_sensing is False
+        assert coordinator.entry.data[CONF_DISABLE_ANGLE_SENSING] is False
+
+    async def test_correction_to_cst_preserves_explicit_disabled_angle_sensing(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_data: dict,
+    ):
+        """An explicit user choice to disable angle sensing should survive CST correction."""
+        coordinator = self._make_coordinator(
+            hass,
+            mock_config_entry_data,
+            {CONF_DISABLE_ANGLE_SENSING: True},
+            bed_type=BED_TYPE_OKIMAT,
+        )
+
+        coordinator._apply_runtime_bed_type_correction(BED_TYPE_OKIN_CST)
+
+        assert coordinator.bed_type == BED_TYPE_OKIN_CST
+        assert coordinator.disable_angle_sensing is True
+        assert coordinator.entry.data[CONF_DISABLE_ANGLE_SENSING] is True
+
     async def test_correction_to_rf_eco_bt_disables_angle_sensing(
         self,
         hass: HomeAssistant,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
@@ -18,6 +19,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_LINAK,
     BED_TYPE_MALOUF_LEGACY_OKIN,
     BED_TYPE_MALOUF_NEW_OKIN,
+    BED_TYPE_NECTAR,
     BED_TYPE_OKIMAT,
     BED_TYPE_OKIN_64BIT,
     BED_TYPE_OKIN_CST,
@@ -35,6 +37,11 @@ from custom_components.adjustable_bed.const import (
     CONF_PREFERRED_ADAPTER,
     CONF_RICHMAT_REMOTE,
     DOMAIN,
+    NORDIC_DFU_SERVICE_UUID,
+    OKIMAT_SERVICE_UUID,
+    OKIMAT_WRITE_CHAR_UUID,
+    OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+    OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID,
     RICHMAT_REMOTE_AUTO,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
@@ -2050,6 +2057,7 @@ class TestRuntimeBedTypeCorrection:
             unique_id="AA:BB:CC:DD:EE:FF",
             entry_id="test_entry_runtime_correction",
         )
+        entry.add_to_hass(hass)
         return AdjustableBedCoordinator(hass, entry)
 
     async def test_correction_updates_unconfigured_pulse_defaults(
@@ -2119,6 +2127,24 @@ class TestRuntimeBedTypeCorrection:
 
         assert coordinator.bed_type == BED_TYPE_OKIN_CST
 
+    async def test_correction_persists_bed_type_to_entry(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_data: dict,
+    ):
+        """Runtime corrections must update entry data before platform setup."""
+        coordinator = self._make_coordinator(
+            hass,
+            mock_config_entry_data,
+            {},
+            bed_type=BED_TYPE_OKIMAT,
+        )
+
+        coordinator._apply_runtime_bed_type_correction(BED_TYPE_OKIN_CST)
+
+        assert coordinator.bed_type == BED_TYPE_OKIN_CST
+        assert coordinator.entry.data[CONF_BED_TYPE] == BED_TYPE_OKIN_CST
+
     async def test_correction_updates_richmat_to_okin_64bit(
         self,
         hass: HomeAssistant,
@@ -2135,6 +2161,113 @@ class TestRuntimeBedTypeCorrection:
         coordinator._apply_runtime_bed_type_correction(BED_TYPE_OKIN_64BIT)
 
         assert coordinator.bed_type == BED_TYPE_OKIN_64BIT
+
+    async def test_correction_to_pairing_required_type_reconnects_before_controller_startup(
+        self,
+        hass: HomeAssistant,
+        mock_bleak_client: MagicMock,
+        mock_bluetooth_adapters,
+    ):
+        """A corrected pairing-required profile should reconnect with pair=True first."""
+        del mock_bluetooth_adapters
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=TEST_NAME,
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: TEST_NAME,
+                CONF_BED_TYPE: BED_TYPE_NECTAR,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id="test_entry_runtime_correction_pairing",
+        )
+        entry.add_to_hass(hass)
+
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID)],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID)],
+            ),
+            SimpleNamespace(uuid=NORDIC_DFU_SERVICE_UUID, characteristics=[]),
+        ]
+        mock_bleak_client.services = MagicMock()
+        mock_bleak_client.services.__iter__ = lambda self: iter(gatt_services)
+        mock_bleak_client.services.__len__ = lambda self: len(gatt_services)
+        mock_bleak_client.services.get_service = MagicMock(return_value=None)
+
+        adapter_result = MagicMock()
+        adapter_result.device = MagicMock()
+        adapter_result.device.address = TEST_ADDRESS
+        adapter_result.device.name = TEST_NAME
+        adapter_result.device.details = {"source": "local"}
+        adapter_result.source = "local"
+        adapter_result.rssi = -60
+        adapter_result.connectable = True
+        adapter_result.available_sources = ["local"]
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.coordinator.select_adapter",
+                new_callable=AsyncMock,
+                return_value=adapter_result,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.establish_connection",
+                new_callable=AsyncMock,
+                return_value=mock_bleak_client,
+            ) as mock_establish_connection,
+            patch(
+                "custom_components.adjustable_bed.coordinator.discover_services",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.read_ble_device_info",
+                new_callable=AsyncMock,
+                return_value=(None, None),
+            ),
+            patch.object(
+                AdjustableBedCoordinator,
+                "_async_verify_bonded",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.create_controller",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ) as mock_create_controller,
+            patch(
+                "custom_components.adjustable_bed.coordinator.asyncio.sleep",
+                new=AsyncMock(),
+            ),
+        ):
+            coordinator = AdjustableBedCoordinator(hass, entry)
+            result = await coordinator.async_connect()
+
+        assert result is True
+        assert entry.data[CONF_BED_TYPE] == BED_TYPE_OKIN_CST
+        assert coordinator.bed_type == BED_TYPE_OKIN_CST
+        assert mock_create_controller.await_count == 1
+        assert mock_create_controller.await_args.kwargs["bed_type"] == BED_TYPE_OKIN_CST
+        assert mock_bleak_client.disconnect.await_count == 1
+        assert [call.kwargs.get("pair") for call in mock_establish_connection.await_args_list] == [
+            False,
+            True,
+        ]
+        assert (
+            coordinator._connection_attempt_details[0]["result"]
+            == "retry_with_pairing_after_protocol_correction"
+        )
 
 
 class TestMultiMotorConfiguration:

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -18,6 +18,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_KEESON,
     BED_TYPE_LEGGETT_GEN2,
     BED_TYPE_LEGGETT_OKIN,
+    BED_TYPE_LEGGETT_PLATT,
     BED_TYPE_LEGGETT_WILINKE,
     BED_TYPE_LIMOSS,
     BED_TYPE_LINAK,
@@ -62,6 +63,8 @@ from custom_components.adjustable_bed.const import (
     KEESON_FALLBACK_GATT_PAIRS,
     KEESON_JSON_SERVICE_UUID,
     LEGGETT_GEN2_SERVICE_UUID,
+    LEGGETT_VARIANT_GEN2,
+    LEGGETT_VARIANT_OKIN,
     LIMOSS_SERVICE_UUID,
     LINAK_CONTROL_SERVICE_UUID,
     MALOUF_LEGACY_OKIN_WRITE_CHAR_UUID,
@@ -856,6 +859,66 @@ class TestOkinUUIDDisambiguation:
         assert (
             refine_okin_shared_uuid_protocol_from_gatt(BED_TYPE_LEGGETT_OKIN, gatt_services)
             == BED_TYPE_OKIN_CST
+        )
+
+    def test_shared_okin_gatt_refinement_corrects_legacy_leggett_okin_variant_to_cst(self):
+        """A legacy Leggett entry using the OKIN variant should be GATT-refinable."""
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=NORDIC_DFU_SERVICE_UUID,
+                characteristics=[],
+            ),
+        ]
+
+        assert (
+            refine_okin_shared_uuid_protocol_from_gatt(
+                BED_TYPE_LEGGETT_PLATT,
+                gatt_services,
+                LEGGETT_VARIANT_OKIN,
+            )
+            == BED_TYPE_OKIN_CST
+        )
+
+    def test_shared_okin_gatt_refinement_ignores_legacy_leggett_gen2_variant(self):
+        """Only the legacy Leggett OKIN variant should enter the OKIN GATT refiner."""
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=NORDIC_DFU_SERVICE_UUID,
+                characteristics=[],
+            ),
+        ]
+
+        assert (
+            refine_okin_shared_uuid_protocol_from_gatt(
+                BED_TYPE_LEGGETT_PLATT,
+                gatt_services,
+                LEGGETT_VARIANT_GEN2,
+            )
+            == BED_TYPE_LEGGETT_PLATT
         )
 
     def test_shared_okin_gatt_refinement_corrects_canonical_7byte_to_cst(self):

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -28,6 +28,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_NECTAR,
     BED_TYPE_OCTO,
     BED_TYPE_OKIMAT,
+    BED_TYPE_OKIN_64BIT,
     BED_TYPE_OKIN_CB24,
     BED_TYPE_OKIN_CB35,
     BED_TYPE_OKIN_CST,
@@ -95,6 +96,8 @@ from custom_components.adjustable_bed.detection import (
     detect_bed_type_from_gatt_services,
     detect_richmat_remote_from_name,
     refine_malouf_protocol_from_gatt,
+    refine_nordic_uart_protocol_from_device_info,
+    refine_okin_shared_uuid_protocol_from_gatt,
 )
 
 
@@ -386,6 +389,7 @@ class TestDetectBedTypeByServiceUUID:
         assert result.bed_type == BED_TYPE_LIMOSS
         assert result.confidence == 0.9
 
+
 class TestDetectBedTypeByNamePattern:
     """Test detection by device name patterns."""
 
@@ -432,9 +436,7 @@ class TestDetectBedTypeByNamePattern:
             ("OKIN - Receiver", [DEVICE_INFO_SERVICE_UUID]),
         ],
     )
-    def test_detect_okin_receiver_before_pairing(
-        self, name: str, service_uuids: list[str]
-    ):
+    def test_detect_okin_receiver_before_pairing(self, name: str, service_uuids: list[str]):
         """OKIN receiver modules can require pairing before bed service UUIDs are visible."""
         service_info = _make_service_info(name=name, service_uuids=service_uuids)
         result = detect_bed_type_detailed(service_info)
@@ -663,6 +665,19 @@ class TestDetectBedTypeByManufacturerData:
         assert result.bed_type == BED_TYPE_RICHMAT
         assert result.confidence == 0.5
 
+    def test_nora_con_nordic_uart_detects_okin_64bit(self):
+        """NORA_CON Mattress Firm controllers should not default to Richmat Nordic."""
+        service_info = _make_service_info(
+            name="NORA_CON",
+            service_uuids=[RICHMAT_NORDIC_SERVICE_UUID],
+        )
+        result = detect_bed_type_detailed(service_info)
+
+        assert result.bed_type == BED_TYPE_OKIN_64BIT
+        assert result.confidence == 0.85
+        assert "name:nora_con" in result.signals
+        assert "uuid:nordic_uart" in result.signals
+
 
 class TestOkinUUIDDisambiguation:
     """Test disambiguation of beds sharing OKIN service UUID (62741523)."""
@@ -814,6 +829,116 @@ class TestOkinUUIDDisambiguation:
         assert result.confidence == 0.8
         assert "gatt_service:nordic_dfu" in result.signals
         assert BED_TYPE_OKIN_RF_ECO_BT in result.ambiguous_types
+
+    def test_shared_okin_gatt_refinement_corrects_leggett_okin_to_cst(self):
+        """A saved Leggett/Okin entry should use CST when connected GATT proves it."""
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=NORDIC_DFU_SERVICE_UUID,
+                characteristics=[],
+            ),
+        ]
+
+        assert (
+            refine_okin_shared_uuid_protocol_from_gatt(BED_TYPE_LEGGETT_OKIN, gatt_services)
+            == BED_TYPE_OKIN_CST
+        )
+
+    def test_shared_okin_gatt_refinement_corrects_okimat_to_rf_eco_bt(self):
+        """Connected CSS without DFU identifies the RF ECO BT profile."""
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
+                ],
+            ),
+        ]
+
+        assert (
+            refine_okin_shared_uuid_protocol_from_gatt(BED_TYPE_OKIMAT, gatt_services)
+            == BED_TYPE_OKIN_RF_ECO_BT
+        )
+
+    def test_shared_okin_gatt_refinement_leaves_unrelated_types_unchanged(self):
+        """The OKIN correction is scoped away from other shared UUID families."""
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=NORDIC_DFU_SERVICE_UUID,
+                characteristics=[],
+            ),
+        ]
+
+        assert (
+            refine_okin_shared_uuid_protocol_from_gatt(BED_TYPE_KEESON, gatt_services)
+            == BED_TYPE_KEESON
+        )
+
+    def test_nordic_uart_device_info_refinement_corrects_richmat_to_okin_64bit(self):
+        """A saved Richmat entry should use OKIN 64-bit when Device Info proves NORA."""
+        assert (
+            refine_nordic_uart_protocol_from_device_info(
+                BED_TYPE_RICHMAT,
+                "NORA_CON",
+                "IDT",
+                "NORACON",
+            )
+            == BED_TYPE_OKIN_64BIT
+        )
+
+    def test_nordic_uart_device_info_refinement_accepts_noracon_model(self):
+        """The model number alone is enough when Device Info reports NORACON."""
+        assert (
+            refine_nordic_uart_protocol_from_device_info(
+                BED_TYPE_MATTRESSFIRM,
+                "Unknown Nordic",
+                None,
+                "NORACON",
+            )
+            == BED_TYPE_OKIN_64BIT
+        )
+
+    def test_nordic_uart_device_info_refinement_leaves_generic_richmat_unchanged(self):
+        """Generic Nordic UART devices must keep the existing low-confidence fallback."""
+        assert (
+            refine_nordic_uart_protocol_from_device_info(
+                BED_TYPE_RICHMAT,
+                "Unknown Nordic",
+                "Unknown",
+                "Unknown",
+            )
+            == BED_TYPE_RICHMAT
+        )
 
     def test_malouf_new_refines_to_legacy_when_gatt_has_ffe9_only(self):
         """A saved Malouf Nordic entry should use FFE5 when connected GATT proves it."""

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -28,11 +28,13 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_NECTAR,
     BED_TYPE_OCTO,
     BED_TYPE_OKIMAT,
+    BED_TYPE_OKIN_7BYTE,
     BED_TYPE_OKIN_64BIT,
     BED_TYPE_OKIN_CB24,
     BED_TYPE_OKIN_CB35,
     BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_FFE,
+    BED_TYPE_OKIN_NORDIC,
     BED_TYPE_OKIN_RF_ECO_BT,
     BED_TYPE_OKIN_UUID,
     BED_TYPE_REMACRO,
@@ -856,6 +858,32 @@ class TestOkinUUIDDisambiguation:
             == BED_TYPE_OKIN_CST
         )
 
+    def test_shared_okin_gatt_refinement_corrects_canonical_7byte_to_cst(self):
+        """A saved canonical OKIN 7-byte entry should still be GATT-refinable."""
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=NORDIC_DFU_SERVICE_UUID,
+                characteristics=[],
+            ),
+        ]
+
+        assert (
+            refine_okin_shared_uuid_protocol_from_gatt(BED_TYPE_OKIN_7BYTE, gatt_services)
+            == BED_TYPE_OKIN_CST
+        )
+
     def test_shared_okin_gatt_refinement_corrects_okimat_to_rf_eco_bt(self):
         """Connected CSS without DFU identifies the RF ECO BT profile."""
         gatt_services = [
@@ -923,6 +951,18 @@ class TestOkinUUIDDisambiguation:
                 BED_TYPE_MATTRESSFIRM,
                 "Unknown Nordic",
                 None,
+                "NORACON",
+            )
+            == BED_TYPE_OKIN_64BIT
+        )
+
+    def test_nordic_uart_device_info_refinement_corrects_canonical_okin_nordic(self):
+        """A saved canonical OKIN Nordic entry should still be Device Info-refinable."""
+        assert (
+            refine_nordic_uart_protocol_from_device_info(
+                BED_TYPE_OKIN_NORDIC,
+                "NORA_CON",
+                "IDT",
                 "NORACON",
             )
             == BED_TYPE_OKIN_64BIT

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -969,6 +969,28 @@ class TestOkinUUIDDisambiguation:
             == BED_TYPE_OKIN_RF_ECO_BT
         )
 
+    def test_shared_okin_gatt_refinement_preserves_explicit_cst_without_dfu(self):
+        """A manually selected CST entry should not require DFU to remain CST."""
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
+                ],
+            ),
+        ]
+
+        assert (
+            refine_okin_shared_uuid_protocol_from_gatt(BED_TYPE_OKIN_CST, gatt_services)
+            == BED_TYPE_OKIN_CST
+        )
+
     def test_shared_okin_gatt_refinement_leaves_unrelated_types_unchanged(self):
         """The OKIN correction is scoped away from other shared UUID families."""
         gatt_services = [

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -36,6 +36,8 @@ from custom_components.adjustable_bed.const import (
     DOMAIN,
     KAIDI_VARIANT_SEAT_1,
     LEGGETT_GEN2_WRITE_CHAR_UUID,
+    OKIN_FOOT_MAX_ANGLE,
+    OKIN_HEAD_MAX_ANGLE,
     SLEEP_NUMBER_VARIANT_LEFT,
 )
 
@@ -503,6 +505,8 @@ class TestNumberEntities:
         assert legs_state is not None
         assert back_state.attributes["max"] == pytest.approx(coordinator.get_max_angle("back"))
         assert legs_state.attributes["max"] == pytest.approx(coordinator.get_max_angle("legs"))
+        assert back_state.attributes["max"] == pytest.approx(OKIN_HEAD_MAX_ANGLE)
+        assert legs_state.attributes["max"] == pytest.approx(OKIN_FOOT_MAX_ANGLE)
         assert (
             registry.async_get_entity_id("number", DOMAIN, "AA:BB:CC:DD:EE:28_head_position")
             is None

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -19,6 +19,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_LEGGETT_GEN2,
     BED_TYPE_MALOUF_LEGACY_OKIN,
     BED_TYPE_MALOUF_NEW_OKIN,
+    BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_RF_ECO_BT,
     BED_TYPE_RICHMAT,
     BED_TYPE_SLEEP_NUMBER,
@@ -454,6 +455,53 @@ class TestNumberEntities:
         )
         assert (
             registry.async_get_entity_id("number", DOMAIN, "AA:BB:CC:DD:EE:27_legs_position")
+            is None
+        )
+
+    async def test_okin_cst_number_entities_only_include_back_and_legs_position(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """CST should expose only the axes reported by its position payload."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="OKIN CST Numbers",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:28",
+                CONF_NAME: "OKIN CST Numbers",
+                CONF_BED_TYPE: BED_TYPE_OKIN_CST,
+                CONF_MOTOR_COUNT: 4,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: False,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:28",
+            entry_id="okin_cst_number_entry",
+        )
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        assert (
+            registry.async_get_entity_id("number", DOMAIN, "AA:BB:CC:DD:EE:28_back_position")
+            is not None
+        )
+        assert (
+            registry.async_get_entity_id("number", DOMAIN, "AA:BB:CC:DD:EE:28_legs_position")
+            is not None
+        )
+        assert (
+            registry.async_get_entity_id("number", DOMAIN, "AA:BB:CC:DD:EE:28_head_position")
+            is None
+        )
+        assert (
+            registry.async_get_entity_id("number", DOMAIN, "AA:BB:CC:DD:EE:28_feet_position")
             is None
         )
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -488,14 +488,21 @@ class TestNumberEntities:
         from homeassistant.helpers import entity_registry as er
 
         registry = er.async_get(hass)
-        assert (
-            registry.async_get_entity_id("number", DOMAIN, "AA:BB:CC:DD:EE:28_back_position")
-            is not None
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        back_entity_id = registry.async_get_entity_id(
+            "number", DOMAIN, "AA:BB:CC:DD:EE:28_back_position"
         )
-        assert (
-            registry.async_get_entity_id("number", DOMAIN, "AA:BB:CC:DD:EE:28_legs_position")
-            is not None
+        legs_entity_id = registry.async_get_entity_id(
+            "number", DOMAIN, "AA:BB:CC:DD:EE:28_legs_position"
         )
+        assert back_entity_id is not None
+        assert legs_entity_id is not None
+        back_state = hass.states.get(back_entity_id)
+        legs_state = hass.states.get(legs_entity_id)
+        assert back_state is not None
+        assert legs_state is not None
+        assert back_state.attributes["max"] == pytest.approx(coordinator.get_max_angle("back"))
+        assert legs_state.attributes["max"] == pytest.approx(coordinator.get_max_angle("legs"))
         assert (
             registry.async_get_entity_id("number", DOMAIN, "AA:BB:CC:DD:EE:28_head_position")
             is None
@@ -2340,6 +2347,51 @@ class TestSensorEntities:
 
         # With 2 motors, should have back_angle and legs_angle sensors
         assert len(sensor_states) == 2
+
+    async def test_okin_cst_angle_sensors_only_include_back_and_legs(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """CST should only create angle sensors for axes reported by notifications."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="OKIN CST Sensor Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:29",
+                CONF_NAME: "OKIN CST Sensor Bed",
+                CONF_BED_TYPE: BED_TYPE_OKIN_CST,
+                CONF_MOTOR_COUNT: 4,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: False,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:29",
+            entry_id="okin_cst_sensor_entry",
+        )
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        assert (
+            registry.async_get_entity_id("sensor", DOMAIN, "AA:BB:CC:DD:EE:29_back_angle")
+            is not None
+        )
+        assert (
+            registry.async_get_entity_id("sensor", DOMAIN, "AA:BB:CC:DD:EE:29_legs_angle")
+            is not None
+        )
+        assert (
+            registry.async_get_entity_id("sensor", DOMAIN, "AA:BB:CC:DD:EE:29_head_angle") is None
+        )
+        assert (
+            registry.async_get_entity_id("sensor", DOMAIN, "AA:BB:CC:DD:EE:29_feet_angle") is None
+        )
 
 
 class TestEntityAvailability:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -46,6 +46,7 @@ from custom_components.adjustable_bed.const import (
     CONF_RICHMAT_REMOTE,
     DOMAIN,
     KAIDI_VARIANT_SEAT_1,
+    OKIN_HEAD_MAX_ANGLE,
 )
 
 
@@ -1155,6 +1156,63 @@ class TestServices:
                     },
                     blocking=True,
                 )
+
+    async def test_set_position_service_rejects_okin_cst_back_above_reported_range(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """CST back targets above reported feedback range should be rejected."""
+        import pytest
+        from homeassistant.exceptions import ServiceValidationError
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="OKIN CST Range Service Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:37",
+                CONF_NAME: "OKIN CST Range Service Bed",
+                CONF_BED_TYPE: BED_TYPE_OKIN_CST,
+                CONF_MOTOR_COUNT: 4,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: False,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:37",
+            entry_id="okin_cst_range_service_entry",
+        )
+        entry.add_to_hass(hass)
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator."
+            "AdjustableBedCoordinator.async_read_initial_positions",
+            new=AsyncMock(),
+        ):
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        from homeassistant.helpers import device_registry as dr
+
+        device_registry = dr.async_get(hass)
+        devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+        assert len(devices) == 1
+        device_id = devices[0].id
+
+        with pytest.raises(
+            ServiceValidationError,
+            match=rf"Valid range: 0-{OKIN_HEAD_MAX_ANGLE}°",
+        ):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_SET_POSITION,
+                {
+                    "device_id": [device_id],
+                    "motor": "back",
+                    "position": OKIN_HEAD_MAX_ANGLE + 1,
+                },
+                blocking=True,
+            )
 
     async def test_set_position_service_accepts_kaidi_back_and_legs_percentages(
         self,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -26,6 +26,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_KAIDI,
     BED_TYPE_LINAK,
     BED_TYPE_MALOUF_LEGACY_OKIN,
+    BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_RF_ECO_BT,
     BED_TYPE_REVERIE,
     BED_TYPE_RICHMAT,
@@ -1032,6 +1033,128 @@ class TestServices:
                 },
                 blocking=True,
             )
+
+    async def test_set_position_service_accepts_okin_cst_back_and_legs(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """CST set_position should accept only axes reported by position feedback."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="OKIN CST Service Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:35",
+                CONF_NAME: "OKIN CST Service Bed",
+                CONF_BED_TYPE: BED_TYPE_OKIN_CST,
+                CONF_MOTOR_COUNT: 4,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: False,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:35",
+            entry_id="okin_cst_service_entry",
+        )
+        entry.add_to_hass(hass)
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator."
+            "AdjustableBedCoordinator.async_read_initial_positions",
+            new=AsyncMock(),
+        ):
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        from homeassistant.helpers import device_registry as dr
+
+        device_registry = dr.async_get(hass)
+        devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+        assert len(devices) == 1
+        device_id = devices[0].id
+
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        coordinator.async_seek_position = AsyncMock()
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_POSITION,
+            {
+                "device_id": [device_id],
+                "motor": "back",
+                "position": 50,
+            },
+            blocking=True,
+        )
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_POSITION,
+            {
+                "device_id": [device_id],
+                "motor": "legs",
+                "position": 40,
+            },
+            blocking=True,
+        )
+
+        assert [
+            call.kwargs["position_key"] for call in coordinator.async_seek_position.await_args_list
+        ] == ["back", "legs"]
+
+    async def test_set_position_service_rejects_okin_cst_head_and_feet(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """CST set_position should reject axes without position data."""
+        import pytest
+        from homeassistant.exceptions import ServiceValidationError
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="OKIN CST Invalid Service Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:36",
+                CONF_NAME: "OKIN CST Invalid Service Bed",
+                CONF_BED_TYPE: BED_TYPE_OKIN_CST,
+                CONF_MOTOR_COUNT: 4,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: False,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:36",
+            entry_id="okin_cst_invalid_service_entry",
+        )
+        entry.add_to_hass(hass)
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator."
+            "AdjustableBedCoordinator.async_read_initial_positions",
+            new=AsyncMock(),
+        ):
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        from homeassistant.helpers import device_registry as dr
+
+        device_registry = dr.async_get(hass)
+        devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+        assert len(devices) == 1
+        device_id = devices[0].id
+
+        for motor in ("head", "feet"):
+            with pytest.raises(ServiceValidationError, match="Valid motors: back, legs"):
+                await hass.services.async_call(
+                    DOMAIN,
+                    SERVICE_SET_POSITION,
+                    {
+                        "device_id": [device_id],
+                        "motor": motor,
+                        "position": 20,
+                    },
+                    blocking=True,
+                )
 
     async def test_set_position_service_accepts_kaidi_back_and_legs_percentages(
         self,


### PR DESCRIPTION
## Summary

This refines several Okin-family detection paths using the APK/GATT evidence from the recent support bundles.

- Ref #368: runtime-correct shared OKIN UUID entries, including existing `leggett_okin` configs, to `okin_cst` when connected GATT exposes the CST CSS + Nordic DFU signature.
- Ref #338: adds regression coverage for `OKIN - Receiver` advertisements with no service UUIDs so they reach the focused Okin-family disambiguation flow instead of being treated as unknown.
- Ref #370: detects `NORA_CON` / `NORACON` Mattress Firm controllers as `okin_64bit`, and runtime-corrects existing saved Richmat Nordic fallback entries when Device Info reports `IDT` / `NORACON`.
- Adds a dedicated Okin 64-bit protocol doc and updates protocol matrix / README links so it is no longer hidden under Okimat.

## Root Cause

Several bed families share either the standard OKIN UUID or Nordic UART UUID. Advertisement-only detection was falling back to a plausible but wrong controller in two cases:

- CST-capable controllers could remain configured as 6-byte Leggett/Okin even after GATT proved the 14-byte CST profile.
- NORA controllers advertised generic Nordic UART and were saved as Richmat Nordic, which uses incompatible single-byte commands.

## Validation

- `uv run ruff format --check custom_components/adjustable_bed/detection.py custom_components/adjustable_bed/coordinator.py tests/test_detection.py tests/test_coordinator.py tests/test_config_flow.py`
- `uv run ruff check custom_components/adjustable_bed/detection.py custom_components/adjustable_bed/coordinator.py tests/test_detection.py tests/test_coordinator.py tests/test_config_flow.py`
- `uv run pytest -q tests/test_detection.py tests/test_coordinator.py tests/test_config_flow.py` -> 374 passed
- Baseline before edits: `uv run pytest -q` -> 1863 passed
- Full suite after edits: `uv run pytest -q` -> 1872 passed, 1 failed in untouched `tests/test_sleep_number_mcr.py::TestSleepNumberMcrController::test_async_send_frame_ignores_late_optional_response_for_next_same_key_request`; direct reruns of that test also fail, so it appears to be an unrelated existing timing-sensitive failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved bed/controller detection with additional OKIN refinements (including **Okin 64-Bit**) and enhanced **NORA-CON / Mattress Firm** handling.
  * Added/expanded **OKIN CST** support, including CST-specific back/legs number entities, angle sensors, and `set_position` validation.
  * If runtime protocol correction changes whether pairing is required, the integration now retries the BLE flow before controller startup.
* **Documentation**
  * Updated supported bed/controller references and added the new **Okin 64-Bit** documentation, with related doc link/cleanup updates.
* **Tests / Quality**
  * Expanded detection, config flow, coordinator runtime correction, entity creation, and `set_position` service test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->