### PR TITLE
fix: don't create dead angle sensors for Sleep Number MCR beds

### DIFF
--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -1661,6 +1661,9 @@ BEDS_WITH_ANGLE_SENSING: Final = frozenset(
 # Includes all angle sensing beds plus beds that report percentage positions
 # Note: BED_TYPE_KEESON is NOT included here because only the ergomotion variant supports
 # position feedback - this is handled specially in number.py with variant checking
+# Note: BED_TYPE_SLEEP_NUMBER_MCR (BAM beds) is NOT included - the MCR controller only
+# reports sleep-number values and bed presence over BLE, never motor angle/position
+# feedback, so it must not get angle sensors or position-seeking number entities (#322).
 BEDS_WITH_POSITION_FEEDBACK: Final = frozenset(
     {
         BED_TYPE_LINAK,
@@ -1673,11 +1676,18 @@ BEDS_WITH_POSITION_FEEDBACK: Final = frozenset(
         BED_TYPE_JENSEN,
         BED_TYPE_LIMOSS,
         BED_TYPE_SLEEP_NUMBER,
-        BED_TYPE_SLEEP_NUMBER_MCR,
         BED_TYPE_VIBRADORM,
         BED_TYPE_SLEEPYS_BOX25,
     }
 )
+
+# Bed types that may have angle sensing enabled but report NO degree-angle data.
+# Sleep Number MCR/BAM beds only report sleep-number values and bed presence over BLE
+# (no motor angle feedback at all), so degree angle sensors would sit at "unknown"
+# forever. These are skipped during angle-sensor creation regardless of the
+# disable_angle_sensing option, which also fixes existing installs whose stored config
+# still has angle sensing enabled (#322).
+BEDS_WITHOUT_ANGLE_FEEDBACK: Final = frozenset({BED_TYPE_SLEEP_NUMBER_MCR})
 
 # Bed types that report positions as 0-100 percentages (not angle degrees)
 # These bed types return percentage values directly, so no angle-to-percent conversion is needed

--- a/custom_components/adjustable_bed/number.py
+++ b/custom_components/adjustable_bed/number.py
@@ -25,6 +25,7 @@ from .const import (
     BED_TYPE_SLEEP_NUMBER,
     BED_TYPE_SLEEPYS_BOX25,
     BEDS_WITH_POSITION_FEEDBACK,
+    BEDS_WITHOUT_ANGLE_FEEDBACK,
     CONF_BED_TYPE,
     CONF_HAS_MASSAGE,
     CONF_MOTOR_COUNT,
@@ -241,6 +242,12 @@ async def async_setup_entry(
     controller = coordinator.controller
 
     entities: list[NumberEntity] = []
+
+    # Beds with no angle/position feedback (e.g. Sleep Number MCR/BAM) were briefly
+    # in BEDS_WITH_POSITION_FEEDBACK and may have registered position number sliders;
+    # remove any so existing installs don't keep dead orphaned numbers (#322).
+    if bed_type in BEDS_WITHOUT_ANGLE_FEEDBACK:
+        _async_remove_stale_position_entities(hass, coordinator)
 
     # Set up position number entities (only for beds with position feedback)
     if not coordinator.disable_angle_sensing:
@@ -579,6 +586,26 @@ def _async_remove_stale_sleep_number_entity(
     )
     if entity_id is not None:
         registry.async_remove(entity_id)
+
+
+def _async_remove_stale_position_entities(
+    hass: HomeAssistant,
+    coordinator: AdjustableBedCoordinator,
+) -> None:
+    """Remove position number entities the integration no longer creates.
+
+    Beds in BEDS_WITHOUT_ANGLE_FEEDBACK (e.g. Sleep Number MCR/BAM) have no
+    position feedback, but were briefly in BEDS_WITH_POSITION_FEEDBACK and so
+    registered *_back_position/*_legs_position sliders that now linger as dead
+    orphaned numbers (#322).
+    """
+    registry = er.async_get(hass)
+    for description in NUMBER_DESCRIPTIONS:
+        entity_id = registry.async_get_entity_id(
+            "number", DOMAIN, f"{coordinator.address}_{description.key}"
+        )
+        if entity_id is not None:
+            registry.async_remove(entity_id)
 
 
 class AdjustableBedPositionNumber(AdjustableBedEntity, NumberEntity):

--- a/custom_components/adjustable_bed/sensor.py
+++ b/custom_components/adjustable_bed/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
@@ -140,6 +141,13 @@ async def async_setup_entry(
 
     entities: list[SensorEntity] = []
 
+    # Beds that never report degree angles (e.g. Sleep Number MCR/BAM) must not keep
+    # angle sensors. Remove any an earlier version registered (when angle sensing was
+    # enabled by default) so existing installs stop showing dead "unknown" entities
+    # after upgrading, regardless of the current disable_angle_sensing value (#322).
+    if bed_type in BEDS_WITHOUT_ANGLE_FEEDBACK:
+        _async_remove_stale_angle_entities(hass, coordinator)
+
     # Set up angle sensors (only for non-percentage beds with angle sensing enabled)
     if not coordinator.disable_angle_sensing:
         # Skip angle sensors for beds that report percentage instead of angles
@@ -184,6 +192,25 @@ async def async_setup_entry(
 
     if entities:
         async_add_entities(entities)
+
+
+def _async_remove_stale_angle_entities(
+    hass: HomeAssistant,
+    coordinator: AdjustableBedCoordinator,
+) -> None:
+    """Remove angle sensor entities the integration no longer creates.
+
+    Beds in BEDS_WITHOUT_ANGLE_FEEDBACK (e.g. Sleep Number MCR/BAM) report no
+    angles, but an earlier version registered back/legs/head/feet angle sensors
+    for them; those would otherwise linger as dead "unknown" entities (#322).
+    """
+    registry = er.async_get(hass)
+    for description in SENSOR_DESCRIPTIONS:
+        entity_id = registry.async_get_entity_id(
+            "sensor", DOMAIN, f"{coordinator.address}_{description.key}"
+        )
+        if entity_id is not None:
+            registry.async_remove(entity_id)
 
 
 class AdjustableBedAngleSensor(AdjustableBedEntity, SensorEntity):

--- a/custom_components/adjustable_bed/sensor.py
+++ b/custom_components/adjustable_bed/sensor.py
@@ -21,6 +21,7 @@ from .const import (
     BED_TYPE_KEESON,
     BED_TYPE_OKIN_CST,
     BEDS_WITH_PERCENTAGE_POSITIONS,
+    BEDS_WITHOUT_ANGLE_FEEDBACK,
     CONF_BED_TYPE,
     CONF_HAS_MASSAGE,
     CONF_MOTOR_COUNT,
@@ -143,7 +144,13 @@ async def async_setup_entry(
     if not coordinator.disable_angle_sensing:
         # Skip angle sensors for beds that report percentage instead of angles
         # (Keeson/Ergomotion/Serta report 0-100% position, not degrees)
-        if bed_type not in BEDS_WITH_PERCENTAGE_POSITIONS:
+        if bed_type in BEDS_WITH_PERCENTAGE_POSITIONS:
+            _LOGGER.debug("Skipping angle sensors for %s - reports percentage, not angle", bed_type)
+        # Skip beds that report no degree-angle data at all (e.g. Sleep Number MCR/BAM),
+        # which would otherwise create sensors stuck at "unknown" forever (#322).
+        elif bed_type in BEDS_WITHOUT_ANGLE_FEEDBACK:
+            _LOGGER.debug("Skipping angle sensors for %s - no angle feedback", bed_type)
+        else:
             sensor_descriptions = SENSOR_DESCRIPTIONS
             if bed_type == BED_TYPE_OKIN_CST:
                 sensor_descriptions = tuple(
@@ -154,8 +161,6 @@ async def async_setup_entry(
             for description in sensor_descriptions:
                 if motor_count >= description.min_motors:
                     entities.append(AdjustableBedAngleSensor(coordinator, description))
-        else:
-            _LOGGER.debug("Skipping angle sensors for %s - reports percentage, not angle", bed_type)
     else:
         _LOGGER.debug("Angle sensing disabled, skipping angle sensor creation")
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2449,6 +2449,62 @@ class TestSensorEntities:
                 is None
             )
 
+    async def test_sleep_number_mcr_removes_pre_existing_stale_angle_entities(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """Stale MCR angle entities from older versions must be removed on setup.
+
+        Regression test for #322 (Codex review): existing installs created the
+        *_back_angle/*_legs_angle entities before angle sensing was disabled for
+        MCR; setting up the entry should clean them out of the registry, not leave
+        them as dead "unknown" entities.
+        """
+        del mock_coordinator_connected, enable_custom_integrations
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Sleep Number MCR Stale Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:61",
+                CONF_NAME: "Sleep Number MCR Stale Bed",
+                CONF_BED_TYPE: BED_TYPE_SLEEP_NUMBER_MCR,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: False,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:61",
+            entry_id="sleep_number_mcr_stale_angle_entry",
+        )
+        entry.add_to_hass(hass)
+
+        # Simulate entities a previous version registered for this MCR bed.
+        for axis in ("back", "legs"):
+            registry.async_get_or_create(
+                "sensor",
+                DOMAIN,
+                f"AA:BB:CC:DD:EE:61_{axis}_angle",
+                config_entry=entry,
+            )
+        assert (
+            registry.async_get_entity_id("sensor", DOMAIN, "AA:BB:CC:DD:EE:61_back_angle")
+            is not None
+        )
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        for axis in ("back", "legs"):
+            assert (
+                registry.async_get_entity_id("sensor", DOMAIN, f"AA:BB:CC:DD:EE:61_{axis}_angle")
+                is None
+            )
+
 
 class TestEntityAvailability:
     """Test entity availability."""

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2397,6 +2397,58 @@ class TestSensorEntities:
             registry.async_get_entity_id("sensor", DOMAIN, "AA:BB:CC:DD:EE:29_feet_angle") is None
         )
 
+    async def test_sleep_number_mcr_creates_no_angle_sensors_even_when_enabled(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """MCR/BAM beds report no angles, so no degree angle sensors should be created.
+
+        Regression test for #322: even with angle sensing explicitly enabled (as stored
+        on existing installs), MCR must not get the back/legs/head/feet angle sensors
+        that would otherwise sit at "unknown" forever.
+        """
+        del mock_coordinator_connected, enable_custom_integrations
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Sleep Number MCR Angle Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:60",
+                CONF_NAME: "Sleep Number MCR Angle Bed",
+                CONF_BED_TYPE: BED_TYPE_SLEEP_NUMBER_MCR,
+                CONF_MOTOR_COUNT: 4,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: False,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:60",
+            entry_id="sleep_number_mcr_angle_entry",
+        )
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        for axis in ("back", "legs", "head", "feet"):
+            assert (
+                registry.async_get_entity_id(
+                    "sensor", DOMAIN, f"AA:BB:CC:DD:EE:60_{axis}_angle"
+                )
+                is None
+            )
+        # And no position-seeking number entities (MCR cannot read positions).
+        for axis in ("back", "legs", "head", "feet"):
+            assert (
+                registry.async_get_entity_id(
+                    "number", DOMAIN, f"AA:BB:CC:DD:EE:60_{axis}_position"
+                )
+                is None
+            )
+
 
 class TestEntityAvailability:
     """Test entity availability."""

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2483,7 +2483,9 @@ class TestSensorEntities:
         )
         entry.add_to_hass(hass)
 
-        # Simulate entities a previous version registered for this MCR bed.
+        # Simulate entities a previous version registered for this MCR bed:
+        # both the degree angle sensors and the position number sliders (MCR used
+        # to be in BEDS_WITH_POSITION_FEEDBACK).
         for axis in ("back", "legs"):
             registry.async_get_or_create(
                 "sensor",
@@ -2491,8 +2493,18 @@ class TestSensorEntities:
                 f"AA:BB:CC:DD:EE:61_{axis}_angle",
                 config_entry=entry,
             )
+            registry.async_get_or_create(
+                "number",
+                DOMAIN,
+                f"AA:BB:CC:DD:EE:61_{axis}_position",
+                config_entry=entry,
+            )
         assert (
             registry.async_get_entity_id("sensor", DOMAIN, "AA:BB:CC:DD:EE:61_back_angle")
+            is not None
+        )
+        assert (
+            registry.async_get_entity_id("number", DOMAIN, "AA:BB:CC:DD:EE:61_back_position")
             is not None
         )
 
@@ -2502,6 +2514,10 @@ class TestSensorEntities:
         for axis in ("back", "legs"):
             assert (
                 registry.async_get_entity_id("sensor", DOMAIN, f"AA:BB:CC:DD:EE:61_{axis}_angle")
+                is None
+            )
+            assert (
+                registry.async_get_entity_id("number", DOMAIN, f"AA:BB:CC:DD:EE:61_{axis}_position")
                 is None
             )
 


### PR DESCRIPTION
## Problem
Sleep Number MCR/BAM beds report no motor angle/position feedback over BLE (the controller only reports sleep-number values and bed presence), yet MCR was listed in `BEDS_WITH_POSITION_FEEDBACK`. That defaulted angle sensing on and created `back`/`legs` angle sensors stuck at `unknown` forever, plus non-functional position number entities.

## Fix
- Remove `BED_TYPE_SLEEP_NUMBER_MCR` from `BEDS_WITH_POSITION_FEEDBACK` — fixes the config-flow angle default and the phantom position number entities via the existing runtime checks.
- Add `BEDS_WITHOUT_ANGLE_FEEDBACK`, skipped during angle-sensor creation, so existing installs (stored `disable_angle_sensing=False`) also stop getting the dead sensors.

`supports_position_feedback` is deliberately not used as the gate — it is overloaded (True for percentage beds, False for real angle beds like Linak/CST). Limoss genuinely reports angles and is untouched.

## Tests
New `test_sleep_number_mcr_creates_no_angle_sensors_even_when_enabled`; full entity + config-flow suites pass.

Ref #322


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Sleep Number Climate 360/BAM beds incorrectly creating motor angle and position entities. These bed types now skip angle/position sensor and number creation, and any previously created stale “unknown” entities are removed during setup.
* **Tests**
  * Added regression coverage for Sleep Number MCR angle entity behavior with both fresh setups and pre-existing stale entity registry entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->