### PR TITLE
fix: skip auto-reconnect for disconnect_after_command beds (reconnect storm)

### DIFF
--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -948,6 +948,15 @@ class AdjustableBedCoordinator:
 
     def _auto_reconnect_enabled(self) -> bool:
         """Return True when unexpected disconnects should schedule a reconnect timer."""
+        # disconnect_after_command beds intentionally drop the link after each command
+        # (and on idle), so an unexpected disconnect is expected behaviour, not a fault.
+        # Scheduling a reconnect there causes a storm: some receivers (e.g. Keeson
+        # BT40SA) require GATT activity within ~12s or they drop the link, and after a
+        # few reconnect cycles enter a protection mode where they stop advertising
+        # entirely until power-cycled (#369). The next user command reconnects on
+        # demand, so no reconnect timer is needed for these beds.
+        if self._disconnect_after_operation_enabled():
+            return False
         return not self._uses_persistent_connection()
 
     async def _async_connect_locked(self, reset_timer: bool = True) -> bool:
@@ -1921,7 +1930,8 @@ class AdjustableBedCoordinator:
 
         if not self._auto_reconnect_enabled():
             _LOGGER.debug(
-                "Skipping auto-reconnect timer for persistent connection bed type %s",
+                "Skipping auto-reconnect timer for %s (persistent connection or "
+                "disconnect_after_command); next command reconnects on demand",
                 self._bed_type,
             )
             if self._reconnect_timer is not None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1539,6 +1539,47 @@ class TestSleepNumberMcrCoordinatorLifecycle:
         assert coordinator.client is None
         assert coordinator.controller is None
 
+    async def test_disconnect_after_command_skips_auto_reconnect(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """disconnect_after_command beds must not schedule timer-based auto-reconnect.
+
+        Regression test for #369: a Keeson BT40SA with disconnect_after_command +
+        disable_angle_sensing drops the link on idle; auto-reconnecting on that
+        expected disconnect causes a reconnect storm that pushes the receiver into a
+        protection mode. The next user command should reconnect on demand instead.
+        """
+        del mock_coordinator_connected
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Keeson BT40SA Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:69",
+                CONF_NAME: "Keeson BT40SA Bed",
+                CONF_BED_TYPE: BED_TYPE_KEESON,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_DISCONNECT_AFTER_COMMAND: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:69",
+            entry_id="keeson_disconnect_after_command_reconnect_test",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        assert coordinator._auto_reconnect_enabled() is False
+        await coordinator.async_connect()
+        mock_bleak_client.is_connected = False
+
+        coordinator._on_disconnect(mock_bleak_client)
+
+        assert coordinator._reconnect_timer is None
+
     async def test_sleep_number_mcr_keeps_connecting_guard_through_startup_disconnect(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## Problem
With `disconnect_after_command` + `disable_angle_sensing`, the bed intentionally drops the BLE link on idle. `_auto_reconnect_enabled()` returned `True` (it only excluded Sleep Number MCR), so the integration reconnected on every expected disconnect. Receivers like the Keeson BT40SA require GATT activity within ~12s or they drop the link, and after a few reconnect cycles enter a protection mode where they **stop advertising entirely** until power-cycled.

## Fix
`_auto_reconnect_enabled()` now returns `False` for `disconnect_after_command` beds (via the existing `_disconnect_after_operation_enabled()` helper). The next user command reconnects on demand.

> [!WARNING]
> This is global to **all** `disconnect_after_command` beds, not just Keeson.

## Tests
New `test_disconnect_after_command_skips_auto_reconnect`; reconnect suite passes.

Ref #369


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved connection handling for adjustable beds configured to disconnect after commands. These devices will no longer attempt unnecessary automatic reconnections, preventing potential device protection mode triggers. Reconnection will occur on demand when the next command is issued.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->