### PR TITLE
fix: require OKIN/SmartBed name for bare manufacturer-ID-89 CB24 detection

### DIFF
--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -186,6 +186,12 @@ OKIN_SHARED_UUID_GATT_REFINABLE_TYPES: frozenset[str] = frozenset(
 
 NORA_CONTROLLER_NORMALIZED_NAMES: frozenset[str] = frozenset({"noracon"})
 
+# Manufacturer ID 89 is Nordic Semiconductor's company ID (0x0059), shared by many
+# non-bed devices. The bare-manufacturer-data CB24 fallback only applies when the
+# device also advertises a recognizable OKIN/SmartBed name, so a random Nordic
+# gadget (e.g. "ABXM2", #366) is not misidentified as a bed.
+OKIN_CB24_MANUFACTURER_NAME_HINTS: frozenset[str] = frozenset({"okin", "smartbed"})
+
 
 def detect_richmat_remote_from_name(device_name: str | None) -> str | None:
     """Extract Richmat remote code from device name.
@@ -1731,10 +1737,20 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
             requires_characteristic_check=True,
         )
 
-    # Fallback: Check for OKIN Automotive manufacturer ID 89 (CB24 protocol)
-    # This catches SmartBed devices that advertise only manufacturer data.
-    # Devices with both Nordic UART + mfr ID 89 are handled above.
-    if service_info.manufacturer_data and MANUFACTURER_ID_OKIN in service_info.manufacturer_data:
+    # Fallback: Check for manufacturer ID 89 (CB24 protocol)
+    # This catches OKIN SmartBed devices that advertise only manufacturer data
+    # (no service UUIDs); devices with Nordic UART + mfr ID 89 are handled above.
+    #
+    # Manufacturer ID 89 is Nordic Semiconductor's Bluetooth SIG company ID
+    # (0x0059), used by countless unrelated devices built on Nordic SoCs, so it is
+    # far too weak on its own to claim a CB24 bed. Require the device to also
+    # advertise an OKIN/SmartBed name; otherwise a bare mfr-89 advertisement from a
+    # random Nordic gadget gets misidentified as a bed (e.g. "ABXM2" in #366).
+    if (
+        service_info.manufacturer_data
+        and MANUFACTURER_ID_OKIN in service_info.manufacturer_data
+        and any(hint in device_name for hint in OKIN_CB24_MANUFACTURER_NAME_HINTS)
+    ):
         signals.append(f"manufacturer_id:{MANUFACTURER_ID_OKIN}")
         _LOGGER.info(
             "Detected Okin CB24 bed at %s (name: %s) by manufacturer ID %s (fallback)",

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -642,6 +642,20 @@ class TestDetectBedTypeByManufacturerData:
         assert result.confidence == 0.7  # Lower confidence as fallback
         assert result.manufacturer_id == MANUFACTURER_ID_OKIN
 
+    def test_bare_manufacturer_id_89_without_okin_name_is_not_a_bed(self):
+        """Manufacturer ID 89 alone (no OKIN/SmartBed name) must not match CB24.
+
+        Regression test for #366: the "ABXM2" device advertises only manufacturer
+        ID 89 (Nordic Semiconductor's generic company ID 0x0059) with no service
+        UUIDs and a non-OKIN name, and was wrongly auto-detected as okin_cb24.
+        """
+        service_info = _make_service_info(
+            name="ABXM2",
+            manufacturer_data={MANUFACTURER_ID_OKIN: bytes.fromhex("0800864100650400000270f90300")},
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type is None
+
     def test_detect_okin_cb24_nordic_uart_plus_manufacturer_id(self):
         """Test CB24 detection when device has both Nordic UART UUID and OKIN mfr ID.
 


### PR DESCRIPTION
## Problem
Manufacturer ID 89 is Nordic Semiconductor's Bluetooth SIG company ID (`0x0059`), shared by countless unrelated devices built on Nordic SoCs. The bare-manufacturer-data CB24 fallback matched on ID 89 alone, so random Nordic gadgets (e.g. the `ABXM2` device) were auto-detected as `okin_cb24`.

## Fix
Gate the fallback on a recognizable OKIN/SmartBed name. Genuine SmartBed-by-Okin devices that advertise only manufacturer data (e.g. `Smartbed209008942`, `OKIN - Receiver`) still detect; non-bed Nordic devices now return no match.

## Tests
New `test_bare_manufacturer_id_89_without_okin_name_is_not_a_bed`; existing CB24 / `OKIN - Receiver` / `Smartbed*` detection tests still pass.

Ref #366


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved OKIN SmartBed detection accuracy by implementing stricter identification criteria. Previously, devices sharing certain manufacturer information could be falsely identified as OKIN SmartBeds. The detection now validates device naming conventions alongside manufacturer data, significantly reducing false positives and ensuring only genuine OKIN SmartBeds are correctly identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->