### PR TITLE
chore: bump version to 3.0.0

### DIFF
--- a/custom_components/adjustable_bed/manifest.json
+++ b/custom_components/adjustable_bed/manifest.json
@@ -169,5 +169,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/kristofferR/ha-adjustable-bed/issues",
   "requirements": ["bleak>=1.0.0", "bleak-retry-connector>=3.5.0"],
-  "version": "2.9.14"
+  "version": "3.0.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-adjustable-bed"
-version = "2.9.14"
+version = "3.0.0"
 description = "Home Assistant integration for adjustable beds"
 requires-python = ">=3.14"
 


### PR DESCRIPTION
Bumps the integration to **3.0.0** for the release.

The next release is a major bump because of the new **native Lovelace card** (PR #375), alongside the merged bug-fix batch (Sleep Number MCR, Keeson reconnect storm, Okin CST / pairing / detection, BOX25 presets, verify-connection step).

- `manifest.json` → `3.0.0`
- `pyproject.toml` → `3.0.0`

Release notes drafted separately; tag `v3.0.0` after this merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 3.0.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->