### PR TITLE
fix(detection): name-guard Richmat W5 UUID to stop non-bed false positives

### DIFF
--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -315,13 +315,20 @@ BEDTECH_WRITE_CHAR_UUID: Final = "d44bc439-abfd-45a2-b575-925416129600"
 # The app supports 6 BLE variants (Nordic + W1-W5), we track the WiLinke ones here
 # W1 is the default fallback when no specific service is found
 RICHMAT_WILINKE_W1_SERVICE_UUID: Final = "0000fee9-0000-1000-8000-00805f9b34fb"
+# W5 uses a Telink-style custom 128-bit base (the "0xe0ff" is the little-endian
+# encoding of the generic 0xFFE0 short UUID). That base is shared by many non-bed
+# Telink-chip devices (e.g. a "Nokia-*" headset reported in issue #382), so this
+# UUID is NOT bed-unique: detection must require a corroborating Richmat name
+# signal before treating a W5 advertisement as a bed, and it is intentionally
+# left out of manifest.json's passive bluetooth discovery matchers.
+RICHMAT_WILINKE_W5_SERVICE_UUID: Final = "0000e0ff-3c17-d293-8e48-14fe2e4da212"
 RICHMAT_WILINKE_SERVICE_UUIDS: Final = [
     "8ebd4f76-da9d-4b5a-a96e-8ebfbeb622e7",  # Custom (legacy, index 0)
     "0000fee9-0000-1000-8000-00805f9b34fb",  # W1 (index 1) - default fallback
     "0000fee9-0000-1000-8000-00805f9b34bb",  # W2 (index 2) - note different base UUID suffix
     "0000ffe0-0000-1000-8000-00805f9b34fb",  # W3 (index 3)
     "0000fff0-0000-1000-8000-00805f9b34fb",  # W4 (index 4) - Germany Motions DHN-* beds
-    "0000e0ff-3c17-d293-8e48-14fe2e4da212",  # W5 (index 5) - custom base UUID
+    RICHMAT_WILINKE_W5_SERVICE_UUID,  # W5 (index 5) - shared Telink base, name-guarded
 ]
 RICHMAT_WILINKE_CHAR_UUIDS: Final = [
     # (write_char, notify_char) pairs matching service UUIDs above

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -134,6 +134,7 @@ from .const import (
     RICHMAT_NAME_PATTERNS,
     RICHMAT_NORDIC_SERVICE_UUID,
     RICHMAT_WILINKE_SERVICE_UUIDS,
+    RICHMAT_WILINKE_W5_SERVICE_UUID,
     SERTA_NAME_PATTERNS,
     SLEEP_NUMBER_MCR_SERVICE_UUID,
     SLEEP_NUMBER_SERVICE_UUID,
@@ -1423,6 +1424,21 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
     # Check for Richmat WiLinke variants (includes FEE9 which is also used by BedTech)
     for wilinke_uuid in RICHMAT_WILINKE_SERVICE_UUIDS:
         if wilinke_uuid.lower() in service_uuids:
+            # W5 (E0FF) uses a Telink-style custom base that non-bed devices also
+            # advertise (e.g. a "Nokia-*" headset, issue #382). It is not
+            # bed-unique, so only trust it when a Richmat name corroborates the
+            # match; otherwise keep scanning and let detection fall through.
+            if (
+                wilinke_uuid.lower() == RICHMAT_WILINKE_W5_SERVICE_UUID.lower()
+                and not is_richmat_named
+            ):
+                _LOGGER.debug(
+                    "Ignoring W5 WiLinke UUID for %s (name: %s): shared Telink "
+                    "base with no Richmat name to corroborate",
+                    service_info.address,
+                    service_info.name,
+                )
+                continue
             signals.append("uuid:wilinke")
             # FEE9 is ambiguous - could be Richmat or BedTech
             if wilinke_uuid.lower() == BEDTECH_SERVICE_UUID.lower():

--- a/custom_components/adjustable_bed/manifest.json
+++ b/custom_components/adjustable_bed/manifest.json
@@ -141,9 +141,6 @@
       "service_uuid": "6e403587-b5a3-f393-e0a9-e50e24dcca9e"
     },
     {
-      "service_uuid": "0000e0ff-3c17-d293-8e48-14fe2e4da212"
-    },
-    {
       "service_uuid": "0000fe60-0000-1000-8000-00805f9b34fb"
     },
     {

--- a/docs/beds/richmat.md
+++ b/docs/beds/richmat.md
@@ -252,6 +252,13 @@ The app tries BLE services in this order:
 4. **FFF0**: `0000FFF0-0000-1000-8000-00805F9B34FB`
 5. **FFE0**: `0000FFE0-0000-1000-8000-00805F9B34FB`
 
+> **W5 (`0000E0FF-3C17-D293-8E48-14FE2E4DA212`) caveat:** the Germany Motions app
+> also lists a sixth "W5" service on a Telink-style custom 128-bit base (`0xE0FF`
+> is just the little-endian form of the generic `0xFFE0`). That base is shared by
+> non-bed Telink-chip devices, so a "Nokia-*" headset was misdetected as a Richmat
+> bed (issue #382). W5 is therefore **not** used for passive discovery and only
+> detects as a bed when the device name also matches a Richmat pattern.
+
 ## Device Detection
 
 | Device Name Prefix | Features |

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -85,6 +85,7 @@ from custom_components.adjustable_bed.const import (
     REVERIE_SERVICE_UUID,
     RICHMAT_NORDIC_SERVICE_UUID,
     RICHMAT_WILINKE_SERVICE_UUIDS,
+    RICHMAT_WILINKE_W5_SERVICE_UUID,
     SLEEP_NUMBER_MCR_SERVICE_UUID,
     SLEEP_NUMBER_SERVICE_UUID,
     SOLACE_SERVICE_UUID,
@@ -1322,6 +1323,60 @@ class TestFEE9UUIDDisambiguation:
         assert result.bed_type == BED_TYPE_RICHMAT
         assert result.confidence == 0.5
         assert result.requires_characteristic_check is True
+
+
+class TestW5WiLinkeNameGuard:
+    """W5 (E0FF) uses a shared Telink base, so it needs a Richmat name (issue #382)."""
+
+    def test_w5_uuid_without_richmat_name_is_not_a_bed(self):
+        """A non-bed device advertising only the W5 UUID must not detect as Richmat.
+
+        Regression for #382: a "Nokia-*" headset advertised the W5 custom-base
+        UUID and was misidentified as a Richmat bed at 80% confidence.
+        """
+        service_info = _make_service_info(
+            name="Nokia-E4-F1",
+            address="E0:1F:2B:7A:E4:F1",
+            service_uuids=[RICHMAT_WILINKE_W5_SERVICE_UUID],
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type != BED_TYPE_RICHMAT
+        assert "uuid:wilinke" not in result.signals
+
+    def test_w5_uuid_with_richmat_name_still_detects(self):
+        """A genuine W5 bed with a Richmat name pattern still detects as Richmat."""
+        service_info = _make_service_info(
+            name="QRRM141291",
+            service_uuids=[RICHMAT_WILINKE_W5_SERVICE_UUID],
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type == BED_TYPE_RICHMAT
+        assert "uuid:wilinke" in result.signals
+
+    def test_w5_uuid_with_dhn_name_still_detects(self):
+        """Germany Motions DHN-* names corroborate a W5 advertisement."""
+        service_info = _make_service_info(
+            name="DHN-1234",
+            service_uuids=[RICHMAT_WILINKE_W5_SERVICE_UUID],
+        )
+        assert detect_bed_type(service_info) == BED_TYPE_RICHMAT
+
+    def test_w5_uuid_excluded_from_manifest_discovery(self):
+        """W5 must not be a passive bluetooth discovery matcher (avoids false flows)."""
+        import json
+        from pathlib import Path
+
+        manifest_path = (
+            Path(__file__).parents[1]
+            / "custom_components"
+            / "adjustable_bed"
+            / "manifest.json"
+        )
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        service_uuids = {
+            entry.get("service_uuid", "").lower() for entry in manifest["bluetooth"]
+        }
+        assert RICHMAT_WILINKE_W5_SERVICE_UUID.lower() not in service_uuids
 
 
 class TestNordicUARTDisambiguation:


### PR DESCRIPTION
## Problem

Ref #382 — a device named `Nokia-E4-F1` (a phone/headset) was auto-detected as a `richmat` bed at **80% confidence**, matching purely on the advertised service UUID `0000e0ff-3c17-d293-8e48-14fe2e4da212`.

That UUID is the Richmat **"W5"** WiLinke variant, added speculatively from the Germany Motions APK (#173). It uses a Telink-style custom 128-bit base where `0xE0FF` is just the little-endian form of the generic `0xFFE0` short UUID — that base is advertised by many non-bed Telink-chip devices, so **it is not bed-unique**. Detection trusted it on UUID alone, with no name guard (unlike the FEE9/BedTech ambiguity, which already requires a name match).

No real bed is confirmed to use W5; the only known Germany Motions beds (`DHN-*`) use W4 (FFF0).

## Changes

- **`detection.py`** — W5 advertisements only detect as Richmat when a Richmat name pattern corroborates them; otherwise detection keeps scanning and falls through. Mirrors the existing FEE9/BedTech precedent.
- **`const.py`** — extracted `RICHMAT_WILINKE_W5_SERVICE_UUID` with a comment explaining the shared-base hazard. W5 stays in the variant list so the controller can still drive a manually-added W5 bed post-connection.
- **`manifest.json`** — removed W5 from passive Bluetooth discovery, so these shared-base devices no longer trigger the config flow / repair-issue noise at all.
- **`docs/beds/richmat.md`** — documented the caveat.
- **`tests/test_detection.py`** — 4 regression tests (Nokia rejected; W5 + Richmat-name and W5 + DHN-name still detect; manifest exclusion).

## Testing

- Full detection + richmat + leggett_wilinke + manifest suites: **331 passed**.
- Config-flow / unsupported discovery subset: **25 passed**.
- `ruff` clean; `pyright` 0 errors on all touched files.

https://claude.ai/code/session_01XzfwMz4iRxPBDfMZTnqVq7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Richmat bed detection to prevent false positives by requiring device name corroboration when the W5 service variant is detected.

* **Documentation**
  * Added clarification about W5 service limitations: shared by non-bed devices and requires name pattern matching for proper identification.

* **Tests**
  * Added comprehensive tests for W5 variant detection behavior and passive discovery exclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->