### PR TITLE
fix(box25): resend preset frames at 100ms so presets actually move the bed

### DIFF
--- a/custom_components/adjustable_bed/beds/sleepys_box25.py
+++ b/custom_components/adjustable_bed/beds/sleepys_box25.py
@@ -116,6 +116,20 @@ class Box25Commands:
 _WAKE_DELAY = 0.15
 _INIT_DELAY = 0.08
 
+# Preset/memory frames must be *resent*, not fired once. The decompiled OKIN app
+# (com.okin.bedding.sleepy) drives presets via ControlManager._writeContinueData,
+# which writes the same frame on a Timer.periodic at a 100 ms cadence — exactly
+# like a motor move — for the on-screen (button) source. This firmware (252201 /
+# 25_22_01, Ashley/Nectar M1X1232) latches the preset target on the first frame
+# but only begins its autonomous drive once a follow-up motor frame arrives
+# >=100 ms later. That is why a single fire-and-forget write never moved the bed,
+# while a human-delayed STOP press or a BLE disconnect "executed" it, and why the
+# old 50 ms preset->STOP was too fast to latch (#372). Resend the frame a handful
+# of times at the app's cadence to reliably latch + trigger; no trailing STOP
+# (the app never sends one after a preset and the bed completes the drive itself).
+_PRESET_REPEAT_COUNT = 15
+_PRESET_REPEAT_DELAY_MS = 100
+
 
 class SleepysBox25Controller(BedController):
     """Controller for Sleepy's Elite BOX25 Star beds.
@@ -124,8 +138,10 @@ class SleepysBox25Controller(BedController):
     motor commands require 0xD0 init, massage/light commands require 0xB0 init.
     Both tracks need a wake command (5A 0B 00 A5) sent first.
 
-    Presets are fire-and-forget (the decompiled OKIN app marks them
-    needConfirm=0); a trailing MOTOR_STOP cancels the preset on some firmware.
+    Presets/memory recalls are resent at a 100 ms cadence (matching the OKIN
+    app's periodic-resend timer) rather than fired once: the bed latches the
+    target on the first frame but needs a follow-up frame to start its
+    autonomous drive. No trailing STOP is sent (it would cancel the move).
     """
 
     # Position feedback: head/feet/lumbar at 0-100 percentage
@@ -557,15 +573,21 @@ class SleepysBox25Controller(BedController):
     # ─── Presets ─────────────────────────────────────────────────────────
 
     async def _send_preset(self, preset_cmd: bytes) -> None:
-        """Send a BOX25 preset/memory command (fire-and-forget).
+        """Send a BOX25 preset/memory recall by resending the frame at 100 ms.
 
-        BOX25 presets do not need a confirm: the decompiled OKIN app marks these
-        commands needConfirm=0. Sending a trailing MOTOR_STOP actually *cancels*
-        the just-issued preset on some firmware (e.g. 25_22_01, Ashley/Nectar
-        M1X1232), so the bed never moves (#372). The bed drives itself to the
-        target position and stops on its own.
+        The OKIN app drives presets with a periodic resend (one frame every
+        100 ms), not a single write. On firmware 252201 (Ashley/Nectar M1X1232)
+        a lone frame latches the target but never starts moving; a follow-up
+        frame >=100 ms later triggers the bed's autonomous drive to the preset
+        (#372). Resend the frame ``_PRESET_REPEAT_COUNT`` times at the app's
+        cadence; no trailing STOP — the bed completes the drive on its own and a
+        STOP would cancel it.
         """
-        await self._write_motor_command(preset_cmd)
+        await self.write_command(
+            preset_cmd,
+            repeat_count=_PRESET_REPEAT_COUNT,
+            repeat_delay_ms=_PRESET_REPEAT_DELAY_MS,
+        )
 
     async def preset_flat(self) -> None:
         await self._send_preset(Box25Commands.PRESET_FLAT)
@@ -590,8 +612,13 @@ class SleepysBox25Controller(BedController):
         if memory_num < 1 or memory_num > len(Box25Commands.MEMORY_STORE):
             _LOGGER.warning("Invalid memory slot %d (valid: 1-4)", memory_num)
             return
-        # Fire-and-forget (needConfirm=0); see _send_preset for why no STOP follows.
-        await self._write_motor_command(Box25Commands.MEMORY_STORE[memory_num - 1])
+        # Resend the store frame at the app's cadence so the bed registers the
+        # save (see _send_preset); re-saving the same position is idempotent.
+        await self.write_command(
+            Box25Commands.MEMORY_STORE[memory_num - 1],
+            repeat_count=_PRESET_REPEAT_COUNT,
+            repeat_delay_ms=_PRESET_REPEAT_DELAY_MS,
+        )
 
     # ─── Lights ──────────────────────────────────────────────────────────
 

--- a/tests/test_sleepys.py
+++ b/tests/test_sleepys.py
@@ -1246,49 +1246,71 @@ class TestSleepysBox25Controller:
         assert controller._motor_initialized is False
         mock_client.write_gatt_char.assert_not_called()
 
-    async def test_preset_is_fire_and_forget_no_stop(
+    async def test_preset_resends_frame_no_stop(
         self,
         hass: HomeAssistant,
         mock_sleepys_box25_config_entry,
         mock_coordinator_connected,
     ):
-        """BOX25 presets are fire-and-forget (needConfirm=0): no trailing STOP.
+        """BOX25 presets resend the frame at 100 ms with no trailing STOP.
 
-        Regression test for #372: a trailing MOTOR_STOP cancels the just-issued
-        preset on some firmware (e.g. 25_22_01 / Ashley/Nectar M1X1232), so the
-        bed never moves. The preset command alone must be sent.
+        Regression test for #372: a single fire-and-forget write never moves
+        firmware 252201 (Ashley/Nectar M1X1232) — the bed latches the target on
+        the first frame but only starts driving when a follow-up frame arrives
+        >=100 ms later (the OKIN app drives presets via a 100 ms periodic
+        resend). The frame must be resent, and no STOP may follow (it would
+        cancel the move).
         """
+        from custom_components.adjustable_bed.beds.sleepys_box25 import (
+            _PRESET_REPEAT_COUNT,
+            _PRESET_REPEAT_DELAY_MS,
+        )
+
         coordinator = AdjustableBedCoordinator(hass, mock_sleepys_box25_config_entry)
         await coordinator.async_connect()
         controller = coordinator.controller
 
         with (
-            patch.object(controller, "_write_motor_command", AsyncMock()) as mock_write,
+            patch.object(controller, "write_command", AsyncMock()) as mock_write,
             patch.object(controller, "_send_stop", AsyncMock()) as mock_stop,
         ):
             await controller.preset_flat()
 
-        mock_write.assert_awaited_once_with(Box25Commands.PRESET_FLAT)
+        mock_write.assert_awaited_once_with(
+            Box25Commands.PRESET_FLAT,
+            repeat_count=_PRESET_REPEAT_COUNT,
+            repeat_delay_ms=_PRESET_REPEAT_DELAY_MS,
+        )
+        assert _PRESET_REPEAT_COUNT > 1  # must resend, not fire once
         mock_stop.assert_not_called()
 
-    async def test_program_memory_is_fire_and_forget_no_stop(
+    async def test_program_memory_resends_frame_no_stop(
         self,
         hass: HomeAssistant,
         mock_sleepys_box25_config_entry,
         mock_coordinator_connected,
     ):
-        """BOX25 memory store is fire-and-forget too: no trailing STOP (#372)."""
+        """BOX25 memory store resends the frame too, with no trailing STOP (#372)."""
+        from custom_components.adjustable_bed.beds.sleepys_box25 import (
+            _PRESET_REPEAT_COUNT,
+            _PRESET_REPEAT_DELAY_MS,
+        )
+
         coordinator = AdjustableBedCoordinator(hass, mock_sleepys_box25_config_entry)
         await coordinator.async_connect()
         controller = coordinator.controller
 
         with (
-            patch.object(controller, "_write_motor_command", AsyncMock()) as mock_write,
+            patch.object(controller, "write_command", AsyncMock()) as mock_write,
             patch.object(controller, "_send_stop", AsyncMock()) as mock_stop,
         ):
             await controller.program_memory(1)
 
-        mock_write.assert_awaited_once_with(Box25Commands.MEMORY_STORE[0])
+        mock_write.assert_awaited_once_with(
+            Box25Commands.MEMORY_STORE[0],
+            repeat_count=_PRESET_REPEAT_COUNT,
+            repeat_delay_ms=_PRESET_REPEAT_DELAY_MS,
+        )
         mock_stop.assert_not_called()
 
     async def test_set_motor_position_supports_lumbar(


### PR DESCRIPTION
## Problem (#372)

On the Ashley/Nectar **M1X1232** (detected as `sleepys_box25`, firmware **252201** / `25_22_01`), the preset buttons — Flat, Zero-G, Anti-Snore, Lounge, Memory 1–4 — don't move the bed. The reporter found the preset only executes if, right after pressing it, they **press Stop-All** or **hit BLE disconnect**.

The 3.0 attempt (drop the trailing STOP, send the preset fire-and-forget) didn't fix it — the reporter confirms presets still need a follow-up Stop press to execute.

## Root cause

The single fire-and-forget write was the wrong model. This firmware **latches** the preset target on the first frame but only starts its **autonomous drive** once a follow-up motor frame arrives **≥100 ms later**. That explains every observation:

- lone preset write → bed latches but never triggers → no movement
- preset → *human-delayed* STOP / disconnect → the follow-up frame triggers the drive ✅
- the old **50 ms** preset→STOP → too fast to latch → nothing

This is confirmed in the decompiled OKIN app (`com.okin.bedding.sleepy`): on-screen preset buttons drive `ControlManager._writeContinueData`, which resends the **same frame** on a `Timer.periodic` at a **100 ms cadence** — exactly like a motor move. Only the voice (`"speak"`) source writes a preset once. (The sibling `docs/beds/dewertokin.md` notes the same family timing: *100 ms repeat interval, continuous while held.*)

## Fix

Resend the preset/memory frame **15× at the app's 100 ms cadence** so it reliably latches **and** triggers. No trailing STOP — the app never sends one after a preset, the bed completes the drive on its own, and a STOP would cancel it. Memory store is resent the same way (re-saving the same position is idempotent).

Only `sleepys_box25.py` is touched; other Sleepy's/DewertOkin controllers (BOX15/BOX24, handle-based DewertOkin) are unaffected.

## Tests

- Updated the two `#372` regression tests to assert the resend cadence (`repeat_count`/`repeat_delay_ms`) with no STOP.
- `tests/test_sleepys.py` (76) + BOX25 entity tests pass; ruff + pyright clean.

## Testing on hardware

This is a hardware-specific protocol behavior I can't verify locally. @scroberts72 offered to test betas — once this is in a build, the ask is: do **Flat / Zero-G / Anti-Snore / Lounge / Memory** now drive the bed **without** a follow-up Stop press? If they start but stall partway, the resend count likely needs raising (the bed may need frames for the whole travel rather than just a kick).

Ref #372

https://claude.ai/code/session_015GbNPdd2ssUZhpuA3gkfTG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of memory preset recalls on adjustable beds by adjusting how preset commands are transmitted, ensuring consistent autonomous bed movement.

* **Tests**
  * Updated test coverage for memory preset and storage functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->