### PR TITLE
feat(config-flow): Auto-detect default in the full manual bed-type list

### DIFF
--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -149,6 +149,27 @@ CONFIGURED_RETRY_PREFIX = "configured_retry::"
 # the first alphabetical entry). Must not collide with any real bed type.
 BED_TYPE_AUTO_DETECT = "auto_detect"
 
+# Minimum confidence for the manual "Auto-detect" flow to commit to a concrete
+# bed type. Below this — or when the detection is ambiguous (shared-UUID guesses
+# such as OKIN receivers) — we keep "Auto-detect" selected and ask the user to
+# choose, rather than silently configuring a guessed protocol.
+_AUTO_DETECT_MIN_CONFIDENCE = 0.7
+
+
+def _confident_auto_detect(result: DetectionResult) -> str | None:
+    """Return the detected bed type only for a high-confidence, unambiguous match.
+
+    Used by the manual Auto-detect path so a low-confidence or ambiguous
+    detection does not become a silent default/auto-resolution.
+    """
+    if (
+        result.bed_type is not None
+        and result.confidence >= _AUTO_DETECT_MIN_CONFIDENCE
+        and not result.ambiguous_types
+    ):
+        return result.bed_type
+    return None
+
 CONNECTION_PROFILE_OPTIONS: dict[str, str] = {
     CONNECTION_PROFILE_BALANCED: "Balanced (recommended)",
     CONNECTION_PROFILE_RELIABLE: "Reliable (slower connect)",
@@ -1267,11 +1288,13 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             bed_type = user_input[CONF_BED_TYPE]
 
-            # "Auto-detect" resolves to the detected type if detection identifies
-            # the device, otherwise re-shows the form with a clear error instead
-            # of forcing a guess (issue #385).
+            # "Auto-detect" resolves only to a high-confidence, unambiguous match;
+            # otherwise it re-shows the form with a clear error instead of silently
+            # configuring a guessed protocol (issue #385).
             if bed_type == BED_TYPE_AUTO_DETECT:
-                resolved = detect_bed_type(self._discovery_info)
+                resolved = _confident_auto_detect(
+                    detect_bed_type_detailed(self._discovery_info)
+                )
                 if resolved:
                     _LOGGER.info(
                         "Auto-detect resolved bed type to %s for %s", resolved, address
@@ -1372,6 +1395,11 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         preselected_bed_type = self._selected_bed_type
         preselected_protocol_variant = self._selected_protocol_variant or VARIANT_AUTO
         detected_bed_type = detect_bed_type(self._discovery_info)
+        # Only a high-confidence, unambiguous detection becomes the Auto-detect
+        # default; ambiguous/low-confidence guesses keep "Auto-detect" selected.
+        confident_bed_type = _confident_auto_detect(
+            detect_bed_type_detailed(self._discovery_info)
+        )
 
         # Build base schema with bed type selector (alphabetically sorted)
         if preselected_bed_type:
@@ -1399,7 +1427,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             schema_dict = {
                 vol.Required(
-                    CONF_BED_TYPE, default=detected_bed_type or BED_TYPE_AUTO_DETECT
+                    CONF_BED_TYPE, default=confident_bed_type or BED_TYPE_AUTO_DETECT
                 ): SelectSelector(
                     SelectSelectorConfig(
                         options=[

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -143,6 +143,12 @@ _LOGGER = logging.getLogger(__name__)
 
 CONFIGURED_RETRY_PREFIX = "configured_retry::"
 
+# Sentinel value for the "Auto-detect" entry in the full manual bed-type list.
+# When chosen, the flow re-runs detection on the selected device instead of
+# forcing the user to guess a protocol (and instead of silently defaulting to
+# the first alphabetical entry). Must not collide with any real bed type.
+BED_TYPE_AUTO_DETECT = "auto_detect"
+
 CONNECTION_PROFILE_OPTIONS: dict[str, str] = {
     CONNECTION_PROFILE_BALANCED: "Balanced (recommended)",
     CONNECTION_PROFILE_RELIABLE: "Reliable (slower connect)",
@@ -602,6 +608,20 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             # Get user-selected bed type (may differ from auto-detected)
             selected_bed_type = user_input.get(CONF_BED_TYPE, bed_type)
+            # "Auto-detect" in the full manual list: resolve to the detected type
+            # if detection produced one, otherwise re-show the form with a clear
+            # error instead of guessing.
+            if selected_bed_type == BED_TYPE_AUTO_DETECT:
+                if detected_bed_type:
+                    _LOGGER.info(
+                        "Auto-detect resolved bed type to %s for %s",
+                        detected_bed_type,
+                        self._discovery_info.address,
+                    )
+                    selected_bed_type = detected_bed_type
+                else:
+                    errors["base"] = "auto_detect_failed"
+                    selected_bed_type = None
             octo_pin = normalize_octo_pin(user_input.get(CONF_OCTO_PIN, DEFAULT_OCTO_PIN))
             if (
                 selected_bed_type == BED_TYPE_OCTO
@@ -754,18 +774,30 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         # Build schema with optional variant selection
         # Use searchable dropdown when user asked for all bed types, otherwise simple dropdown
         bed_type_selector: Any
+        bed_type_default: Any = bed_type
         if self._show_full_bed_type_list:
+            # Prepend an "Auto-detect" option and default to it when detection
+            # didn't identify the device, so the user isn't silently dropped onto
+            # the first alphabetical protocol and forced to guess.
+            auto_label = await self._get_config_translation(
+                "step.bluetooth_confirm.data.auto_detect_option",
+                "Auto-detect (recommended)",
+            )
             bed_type_selector = SelectSelector(
                 SelectSelectorConfig(
-                    options=get_bed_type_options(),
+                    options=[
+                        SelectOptionDict(value=BED_TYPE_AUTO_DETECT, label=auto_label),
+                        *get_bed_type_options(),
+                    ],
                     mode=SelectSelectorMode.DROPDOWN,
                 )
             )
+            bed_type_default = bed_type or BED_TYPE_AUTO_DETECT
         else:
             bed_type_selector = vol.In(SUPPORTED_BED_TYPES)
 
         schema_dict: dict[vol.Marker, Any] = {
-            vol.Optional(CONF_BED_TYPE, default=bed_type): bed_type_selector,
+            vol.Optional(CONF_BED_TYPE, default=bed_type_default): bed_type_selector,
             vol.Optional(CONF_NAME, default=self._discovery_info.name or "Adjustable Bed"): str,
             vol.Optional(CONF_MOTOR_COUNT, default=default_motor_count): vol.All(
                 vol.Coerce(int), vol.In([2, 3, 4])

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -1267,11 +1267,26 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             bed_type = user_input[CONF_BED_TYPE]
 
+            # "Auto-detect" resolves to the detected type if detection identifies
+            # the device, otherwise re-shows the form with a clear error instead
+            # of forcing a guess (issue #385).
+            if bed_type == BED_TYPE_AUTO_DETECT:
+                resolved = detect_bed_type(self._discovery_info)
+                if resolved:
+                    _LOGGER.info(
+                        "Auto-detect resolved bed type to %s for %s", resolved, address
+                    )
+                    bed_type = resolved
+                else:
+                    errors["base"] = "auto_detect_failed"
+
             preferred_adapter = user_input.get(CONF_PREFERRED_ADAPTER, str(discovery_source))
             protocol_variant = user_input.get(CONF_PROTOCOL_VARIANT, DEFAULT_PROTOCOL_VARIANT)
 
             # Validate protocol variant is valid for bed type
-            if not is_valid_variant_for_bed_type(bed_type, protocol_variant):
+            if bed_type != BED_TYPE_AUTO_DETECT and not is_valid_variant_for_bed_type(
+                bed_type, protocol_variant
+            ):
                 errors[CONF_PROTOCOL_VARIANT] = "invalid_variant_for_bed_type"
 
             # Get bed-specific defaults for motor pulse settings
@@ -1375,10 +1390,22 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 ),
             }
         else:
+            # No pre-selected brand: offer "Auto-detect" first and default to it
+            # (or to the detected type) so the user isn't dropped onto the first
+            # alphabetical protocol and forced to guess (issue #385).
+            auto_label = await self._get_config_translation(
+                "step.bluetooth_confirm.data.auto_detect_option",
+                "Auto-detect (recommended)",
+            )
             schema_dict = {
-                vol.Required(CONF_BED_TYPE): SelectSelector(
+                vol.Required(
+                    CONF_BED_TYPE, default=detected_bed_type or BED_TYPE_AUTO_DETECT
+                ): SelectSelector(
                     SelectSelectorConfig(
-                        options=get_bed_type_options(),
+                        options=[
+                            SelectOptionDict(value=BED_TYPE_AUTO_DETECT, label=auto_label),
+                            *get_bed_type_options(),
+                        ],
                         mode=SelectSelectorMode.DROPDOWN,
                     )
                 ),

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -629,17 +629,21 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             # Get user-selected bed type (may differ from auto-detected)
             selected_bed_type = user_input.get(CONF_BED_TYPE, bed_type)
-            # "Auto-detect" in the full manual list: resolve to the detected type
-            # if detection produced one, otherwise re-show the form with a clear
-            # error instead of guessing.
+            # "Auto-detect" in the full manual list: resolve to an explicitly
+            # disambiguated choice or a high-confidence, unambiguous detection;
+            # otherwise re-show the form with a clear error instead of committing
+            # to a low-confidence/ambiguous guess.
             if selected_bed_type == BED_TYPE_AUTO_DETECT:
-                if detected_bed_type:
+                resolved = self._disambiguated_bed_type or _confident_auto_detect(
+                    detection_result
+                )
+                if resolved:
                     _LOGGER.info(
                         "Auto-detect resolved bed type to %s for %s",
-                        detected_bed_type,
+                        resolved,
                         self._discovery_info.address,
                     )
-                    selected_bed_type = detected_bed_type
+                    selected_bed_type = resolved
                 else:
                     errors["base"] = "auto_detect_failed"
                     selected_bed_type = None
@@ -813,7 +817,14 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                     mode=SelectSelectorMode.DROPDOWN,
                 )
             )
-            bed_type_default = bed_type or BED_TYPE_AUTO_DETECT
+            # Default to an explicit disambiguation choice or a high-confidence,
+            # unambiguous detection; otherwise keep "Auto-detect" selected so an
+            # ambiguous/low-confidence guess isn't silently accepted.
+            bed_type_default = (
+                self._disambiguated_bed_type
+                or _confident_auto_detect(detection_result)
+                or BED_TYPE_AUTO_DETECT
+            )
         else:
             bed_type_selector = vol.In(SUPPORTED_BED_TYPES)
 
@@ -1442,17 +1453,21 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 ),
             }
 
-        # Determine smart defaults based on preselected bed type and variant
-        if preselected_bed_type:
+        # Determine smart defaults based on the bed type the form will default to:
+        # a pre-selected brand, or the high-confidence detection that the
+        # Auto-detect default resolves to. Otherwise a one-click "accept the
+        # default" would persist generic timing/angle options for a known bed.
+        defaults_bed_type = preselected_bed_type or confident_bed_type
+        if defaults_bed_type:
             # Keeson with Ergomotion variant supports position feedback
-            has_position_feedback = preselected_bed_type in BEDS_WITH_POSITION_FEEDBACK or (
-                preselected_bed_type == BED_TYPE_KEESON
+            has_position_feedback = defaults_bed_type in BEDS_WITH_POSITION_FEEDBACK or (
+                defaults_bed_type == BED_TYPE_KEESON
                 and preselected_protocol_variant == KEESON_VARIANT_ERGOMOTION
             )
             default_disable_angle = not has_position_feedback
             # Use bed-specific motor pulse defaults if available
             pulse_defaults = BED_MOTOR_PULSE_DEFAULTS.get(
-                preselected_bed_type, (DEFAULT_MOTOR_PULSE_COUNT, DEFAULT_MOTOR_PULSE_DELAY_MS)
+                defaults_bed_type, (DEFAULT_MOTOR_PULSE_COUNT, DEFAULT_MOTOR_PULSE_DELAY_MS)
             )
             default_pulse_count, default_pulse_delay = pulse_defaults
         else:

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -56,7 +56,8 @@
           "disconnect_after_command": "Disconnect after each command",
           "idle_disconnect_seconds": "Idle disconnect timeout (seconds)",
           "octo_pin": "Octo PIN",
-          "jensen_pin": "Jensen PIN"
+          "jensen_pin": "Jensen PIN",
+          "auto_detect_option": "Auto-detect (recommended)"
         },
         "data_description": {
           "bed_type": "Auto-detected bed type. Change if detection was incorrect.",
@@ -249,7 +250,8 @@
       "invalid_variant_for_bed_type": "The selected protocol variant is not compatible with the selected bed type.",
       "pairing_not_confirmed": "Please confirm that you have paired the bed before continuing.",
       "pairing_failed": "Pairing failed. Make sure the bed is in pairing mode and try again.",
-      "pairing_not_supported": "Pairing not supported by this Bluetooth adapter. If using ESPHome proxy, update to ESPHome >= 2024.3.0."
+      "pairing_not_supported": "Pairing not supported by this Bluetooth adapter. If using ESPHome proxy, update to ESPHome >= 2024.3.0.",
+      "auto_detect_failed": "Couldn't identify this bed automatically. Pick a protocol from the list, or choose \"Diagnostic (unknown bed)\" to capture data for support."
     }
   },
   "options": {

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -56,7 +56,8 @@
           "disconnect_after_command": "Disconnect after each command",
           "idle_disconnect_seconds": "Idle disconnect timeout (seconds)",
           "octo_pin": "Octo PIN",
-          "jensen_pin": "Jensen PIN"
+          "jensen_pin": "Jensen PIN",
+          "auto_detect_option": "Auto-detect (recommended)"
         },
         "data_description": {
           "bed_type": "Auto-detected bed type. Change if detection was incorrect.",
@@ -249,7 +250,8 @@
       "invalid_variant_for_bed_type": "The selected protocol variant is not compatible with the selected bed type.",
       "pairing_not_confirmed": "Please confirm that you have paired the bed before continuing.",
       "pairing_failed": "Pairing failed. Make sure the bed is in pairing mode and try again.",
-      "pairing_not_supported": "Pairing not supported by this Bluetooth adapter. If using ESPHome proxy, update to ESPHome >= 2024.3.0."
+      "pairing_not_supported": "Pairing not supported by this Bluetooth adapter. If using ESPHome proxy, update to ESPHome >= 2024.3.0.",
+      "auto_detect_failed": "Couldn't identify this bed automatically. Pick a protocol from the list, or choose \"Diagnostic (unknown bed)\" to capture data for support."
     }
   },
   "options": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1019,6 +1019,79 @@ class TestBluetoothDiscoveryFlow:
         assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_BED_TYPE] == BED_TYPE_OKIN_64BIT
 
+    async def test_bluetooth_confirm_auto_detect_resolves_to_detected_type(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info_ambiguous_okin: MagicMock,
+        enable_custom_integrations,
+    ):
+        """'Auto-detect' in the full list resolves to the detected type, not an error."""
+        del enable_custom_integrations
+        from custom_components.adjustable_bed.config_flow import BED_TYPE_AUTO_DETECT
+        from custom_components.adjustable_bed.detection import detect_bed_type_detailed
+
+        expected = detect_bed_type_detailed(mock_bluetooth_service_info_ambiguous_okin).bed_type
+        assert expected  # fixture is detectable
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_BLUETOOTH},
+            data=mock_bluetooth_service_info_ambiguous_okin,
+        )
+        assert result["step_id"] == "bluetooth_disambiguate"
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"bed_type_choice": "show_all"},
+        )
+        assert result["step_id"] == "bluetooth_confirm"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_BED_TYPE: BED_TYPE_AUTO_DETECT,
+                CONF_NAME: "Auto Bed",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+        )
+
+        # Auto resolved to the detected type and progressed past the confirm form
+        # (to verify_connection or a pairing step) rather than erroring.
+        assert not (
+            result["type"] == FlowResultType.FORM
+            and result["step_id"] == "bluetooth_confirm"
+        )
+
+    async def test_bluetooth_confirm_auto_detect_failure_reprompts(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info_unknown: MagicMock,
+    ):
+        """'Auto-detect' on an unidentifiable device re-shows the form with an error."""
+        from custom_components.adjustable_bed.config_flow import BED_TYPE_AUTO_DETECT
+
+        flow = AdjustableBedConfigFlow()
+        flow.hass = hass
+        flow._discovery_info = mock_bluetooth_service_info_unknown
+        flow._show_full_bed_type_list = True
+
+        result = await flow.async_step_bluetooth_confirm(
+            user_input={
+                CONF_BED_TYPE: BED_TYPE_AUTO_DETECT,
+                CONF_NAME: "Mystery Bed",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "bluetooth_confirm"
+        assert result["errors"] == {"base": "auto_detect_failed"}
+
     async def test_bluetooth_disambiguate_okin_cst_requires_pairing(
         self,
         hass: HomeAssistant,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1151,6 +1151,38 @@ class TestBluetoothDiscoveryFlow:
             result["type"] == FlowResultType.FORM and result["step_id"] == "manual_config"
         )
 
+    async def test_manual_config_auto_detect_ambiguous_reprompts(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info_ambiguous_okin: MagicMock,
+    ):
+        """Auto-detect must not silently resolve an ambiguous (shared-UUID)
+        detection to a guessed protocol (issue #385, Codex round 2)."""
+        from custom_components.adjustable_bed.config_flow import BED_TYPE_AUTO_DETECT
+        from custom_components.adjustable_bed.detection import detect_bed_type_detailed
+
+        # Sanity: the fixture is an ambiguous detection.
+        assert detect_bed_type_detailed(mock_bluetooth_service_info_ambiguous_okin).ambiguous_types
+
+        flow = AdjustableBedConfigFlow()
+        flow.hass = hass
+        flow._discovery_info = mock_bluetooth_service_info_ambiguous_okin
+
+        result = await flow.async_step_manual_config(
+            user_input={
+                CONF_BED_TYPE: BED_TYPE_AUTO_DETECT,
+                CONF_NAME: "Ambiguous Bed",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "manual_config"
+        assert result["errors"] == {"base": "auto_detect_failed"}
+
     async def test_bluetooth_disambiguate_okin_cst_requires_pairing(
         self,
         hass: HomeAssistant,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1019,19 +1019,20 @@ class TestBluetoothDiscoveryFlow:
         assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_BED_TYPE] == BED_TYPE_OKIN_64BIT
 
-    async def test_bluetooth_confirm_auto_detect_resolves_to_detected_type(
+    async def test_bluetooth_confirm_auto_detect_ambiguous_reprompts(
         self,
         hass: HomeAssistant,
         mock_bluetooth_service_info_ambiguous_okin: MagicMock,
         enable_custom_integrations,
     ):
-        """'Auto-detect' in the full list resolves to the detected type, not an error."""
+        """In the disambiguate -> show-all -> confirm path, 'Auto-detect' must not
+        silently resolve an ambiguous detection (issue #385, Codex round 3)."""
         del enable_custom_integrations
         from custom_components.adjustable_bed.config_flow import BED_TYPE_AUTO_DETECT
         from custom_components.adjustable_bed.detection import detect_bed_type_detailed
 
-        expected = detect_bed_type_detailed(mock_bluetooth_service_info_ambiguous_okin).bed_type
-        assert expected  # fixture is detectable
+        # Sanity: the fixture is an ambiguous detection.
+        assert detect_bed_type_detailed(mock_bluetooth_service_info_ambiguous_okin).ambiguous_types
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -1057,12 +1058,10 @@ class TestBluetoothDiscoveryFlow:
             },
         )
 
-        # Auto resolved to the detected type and progressed past the confirm form
-        # (to verify_connection or a pairing step) rather than erroring.
-        assert not (
-            result["type"] == FlowResultType.FORM
-            and result["step_id"] == "bluetooth_confirm"
-        )
+        # Ambiguous → re-prompt on the confirm form rather than guessing.
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "bluetooth_confirm"
+        assert result["errors"] == {"base": "auto_detect_failed"}
 
     async def test_bluetooth_confirm_auto_detect_failure_reprompts(
         self,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1092,6 +1092,65 @@ class TestBluetoothDiscoveryFlow:
         assert result["step_id"] == "bluetooth_confirm"
         assert result["errors"] == {"base": "auto_detect_failed"}
 
+    async def test_manual_config_auto_detect_failure_reprompts(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info_unknown: MagicMock,
+    ):
+        """'Auto-detect' in the 'Show all BLE devices' manual path re-prompts on
+        failure rather than guessing (issue #385, Codex review)."""
+        from custom_components.adjustable_bed.config_flow import BED_TYPE_AUTO_DETECT
+
+        flow = AdjustableBedConfigFlow()
+        flow.hass = hass
+        flow._discovery_info = mock_bluetooth_service_info_unknown
+
+        result = await flow.async_step_manual_config(
+            user_input={
+                CONF_BED_TYPE: BED_TYPE_AUTO_DETECT,
+                CONF_NAME: "Mystery Bed",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "manual_config"
+        assert result["errors"] == {"base": "auto_detect_failed"}
+
+    async def test_manual_config_auto_detect_resolves(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info_leggett: MagicMock,
+    ):
+        """'Auto-detect' resolves to the detected type and leaves the manual form."""
+        from custom_components.adjustable_bed.config_flow import BED_TYPE_AUTO_DETECT
+        from custom_components.adjustable_bed.detection import detect_bed_type
+
+        assert detect_bed_type(mock_bluetooth_service_info_leggett)  # fixture is detectable
+
+        flow = AdjustableBedConfigFlow()
+        flow.hass = hass
+        flow._discovery_info = mock_bluetooth_service_info_leggett
+
+        result = await flow.async_step_manual_config(
+            user_input={
+                CONF_BED_TYPE: BED_TYPE_AUTO_DETECT,
+                CONF_NAME: "Leggett Bed",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+        )
+
+        # Resolved to a real type and progressed past manual_config (no error).
+        assert not (
+            result["type"] == FlowResultType.FORM and result["step_id"] == "manual_config"
+        )
+
     async def test_bluetooth_disambiguate_okin_cst_requires_pairing(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## Problem

When adding a bed via **"Show all BLE devices"**, the bed-type dropdown shows the full protocol list with **no auto option and no sensible default** — so it silently lands on the first alphabetical entry (**"1500 Tilt Base (Rondure)"**) and forces the user to *guess* a protocol.

This is exactly what happened in #385: a bed that auto-detection couldn't identify (no service UUIDs, unknown manufacturer ID) was set to a wrong type because the dropdown gave no guidance.

## Changes

- Prepend an **"Auto-detect (recommended)"** option to the full bed-type list, and default to it when detection didn't identify the device (instead of the first-alphabetical trap).
- On submit, "Auto-detect" re-resolves via `detect_bed_type_detailed()`:
  - type found → use it;
  - nothing found → re-show the form with an explicit **"Couldn't identify this bed automatically — pick a protocol, or choose Diagnostic (unknown bed)"** error, rather than proceeding with a wrong guess.
- `en` strings + 2 tests (auto resolves to detected type; auto re-prompts on failure).

Scoped to the full manual list (`_show_full_bed_type_list`); the discovered-bed path already defaults to its detected type.

## Tests

`pytest tests/test_config_flow.py` — 92 passed (ruff + pyright clean).

Ref #385

https://claude.ai/code/session_014FuCngQyFrUN7oWnYudZVw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Auto-detect (recommended)" option for Bluetooth bed-type selection
  * Enhanced auto-detection to resolve only high-confidence, unambiguous bed types

* **Bug Fixes**
  * Prevents silent commitment to uncertain bed-type detection
  * Displays explicit error message when automatic bed identification fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->