### PR TITLE
feat(leggett): LP Comfort Connect (Gen2 / 209-M001) support

### DIFF
--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -160,6 +160,18 @@ class BedController(ABC):
         return False
 
     @property
+    def manual_disconnect_strands_connection(self) -> bool:
+        """Return True if a manual disconnect would leave the bed unrecoverable.
+
+        Distinct from ``requires_persistent_connection``: persistent beds that can
+        still reconnect on demand (e.g. Sleep Number MCR) keep the Disconnect
+        control as a way to release the single BLE connection. Beds that can only
+        reconnect in pairing mode (LP Comfort Connect) override this to True so the
+        Disconnect button is hidden — pressing it would strand the integration.
+        """
+        return False
+
+    @property
     def reverses_position_seek_on_overshoot(self) -> bool:
         """Return True if position seeking should reverse after overshooting.
 

--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -147,6 +147,19 @@ class BedController(ABC):
         return False
 
     @property
+    def requires_persistent_connection(self) -> bool:
+        """Return True if the BLE link must be held open for the entry's lifetime.
+
+        Controllers whose hardware refuses reconnection once disconnected (e.g.
+        Leggett & Platt Gen2 / LP Comfort Connect, which only accepts a connection
+        while in pairing mode) override this to return True so the coordinator
+        never idle-disconnects them. Because this is a property of the resolved
+        controller, it is authoritative even when the bed type/variant resolves to
+        different protocols at connect time.
+        """
+        return False
+
+    @property
     def reverses_position_seek_on_overshoot(self) -> bool:
         """Return True if position seeking should reverse after overshooting.
 

--- a/custom_components/adjustable_bed/beds/leggett_gen2.py
+++ b/custom_components/adjustable_bed/beds/leggett_gen2.py
@@ -270,6 +270,48 @@ class LeggettGen2Controller(BedController):
         """Return True when the model exposes memory positions (per profile)."""
         return self._caps.memory_slots > 0
 
+    # The base capability helpers detect overridden methods, so they would report
+    # massage/light controls for every Gen2 bed. Gate them on the profile so models
+    # without massage or an under-bed light don't get phantom entities.
+    @property
+    def supports_under_bed_lights(self) -> bool:
+        return self._caps.light != "none"
+
+    @property
+    def supports_light_toggle_control(self) -> bool:
+        return self._caps.light != "none"
+
+    @property
+    def supports_massage_off_control(self) -> bool:
+        return self._caps.has_massage
+
+    @property
+    def supports_massage_toggle_control(self) -> bool:
+        return self._caps.has_massage
+
+    @property
+    def supports_massage_intensity_step_control(self) -> bool:
+        return self._caps.has_massage
+
+    @property
+    def supports_massage_mode_step_control(self) -> bool:
+        return self._caps.has_massage
+
+    @property
+    def motor_control_specs(self) -> tuple:
+        """Expose only the primary actuators the model actually has (per profile)."""
+        present = {
+            "back": self._caps.has_head,
+            "legs": self._caps.has_foot,
+            "pillow": self._caps.has_pillow,
+            "lumbar": self._caps.has_lumbar,
+        }
+        return tuple(
+            spec
+            for spec in super().motor_control_specs
+            if present.get(spec.key, True)
+        )
+
     # Motor control methods - Gen2 re-sends the move command every 200 ms while
     # held and sends an explicit per-actuator stop on release (matching the app).
     async def _move_with_stop(
@@ -457,16 +499,20 @@ class LeggettGen2Controller(BedController):
         await self.write_command(LeggettGen2Commands.LIGHT_TOGGLE)
 
     async def lights_on(self) -> None:
-        """Turn on the under-bed light (white at full brightness)."""
-        await self.write_command(LeggettGen2Commands.rgb_set(255, 255, 255))
+        """Turn on the under-bed light (idempotent against the live state).
+
+        The only on/off primitive is the toggle, so we toggle only when the
+        bed-reported state (from STATE notifications) says the light is not already
+        on, to avoid inverting it on stale assumed state.
+        """
+        if self._light_on is True:
+            return
+        await self.write_command(LeggettGen2Commands.LIGHT_TOGGLE)
 
     async def lights_off(self) -> None:
-        """Turn off the under-bed light.
-
-        The app's only on/off primitive is the toggle. Home Assistant tracks the
-        live on/off state from STATE notifications and only issues "off" when it
-        believes the light is on, so the toggle resolves to the intended state.
-        """
+        """Turn off the under-bed light (idempotent against the live state)."""
+        if self._light_on is False:
+            return
         await self.write_command(LeggettGen2Commands.LIGHT_TOGGLE)
 
     async def set_light_color(self, rgb_color: tuple[int, int, int]) -> None:

--- a/custom_components/adjustable_bed/beds/leggett_gen2.py
+++ b/custom_components/adjustable_bed/beds/leggett_gen2.py
@@ -561,16 +561,22 @@ class LeggettGen2Controller(BedController):
         if len(data) <= 10:
             return
         mode = data[6]
+        updates: dict[str, Any] = {}
         if mode == 0x01:
             light_on = True
-            self._light_rgb = (data[7], data[8], data[9])
+            rgb = (data[7], data[8], data[9])
+            if rgb != self._light_rgb:
+                self._light_rgb = rgb
+                updates["under_bed_lights_rgb"] = rgb
         elif mode == 0x04:
             light_on = False
         else:
             return
         if light_on != self._light_on:
             self._light_on = light_on
-            self.forward_controller_state_update("under_bed_lights_on", light_on)
+            updates["under_bed_lights_on"] = light_on
+        if updates:
+            self.forward_controller_state_updates(updates)
 
     # Massage methods. Gen2 intensity is relative (VII raise/lower), so no level is
     # tracked locally. "Off" sets all four channels to 0 (matching the app's

--- a/custom_components/adjustable_bed/beds/leggett_gen2.py
+++ b/custom_components/adjustable_bed/beds/leggett_gen2.py
@@ -204,6 +204,11 @@ class LeggettGen2Controller(BedController):
         return True
 
     @property
+    def manual_disconnect_strands_connection(self) -> bool:
+        """A manual disconnect can't be recovered without re-entering pairing mode."""
+        return True
+
+    @property
     def requires_notification_channel(self) -> bool:
         """Subscribe to STATE notifications even with angle sensing disabled, so we
         receive live under-bed light on/off + colour state from the bed."""
@@ -291,6 +296,14 @@ class LeggettGen2Controller(BedController):
         return self._caps.light != "none"
 
     @property
+    def supports_head_massage_intensity_step_control(self) -> bool:
+        return self._caps.has_massage
+
+    @property
+    def supports_foot_massage_intensity_step_control(self) -> bool:
+        return self._caps.has_massage
+
+    @property
     def supports_massage_off_control(self) -> bool:
         return self._caps.has_massage
 
@@ -308,35 +321,42 @@ class LeggettGen2Controller(BedController):
     def supports_massage_mode_step_control(self) -> bool:
         return self._caps.has_massage
 
-    @property
-    def motor_control_specs(self) -> tuple:
-        """Expose only the primary actuators the model actually has (per profile)."""
-        present = {
+    # Gen2 models head/foot as the primary "back"/"legs" controls; the base's
+    # extra "head"/"feet" specs (added at higher motor_count) would be duplicates.
+    _PRESENT_SPEC_KEYS = ("back", "legs", "pillow", "lumbar")
+
+    def _present_specs(self) -> dict[str, bool]:
+        return {
             "back": self._caps.has_head,
             "legs": self._caps.has_foot,
             "pillow": self._caps.has_pillow,
             "lumbar": self._caps.has_lumbar,
         }
+
+    @property
+    def motor_control_specs(self) -> tuple:
+        """Expose only the primary actuators the model has (per profile).
+
+        Only the four profile keys are ever exposed; any other base spec (e.g. the
+        duplicate ``head``/``feet`` added for high motor counts) is dropped.
+        """
+        present = self._present_specs()
         return tuple(
-            spec
-            for spec in super().motor_control_specs
-            if present.get(spec.key, True)
+            spec for spec in super().motor_control_specs if present.get(spec.key, False)
         )
 
     @property
     def stale_motor_entity_keys(self) -> frozenset[str]:
-        """Remove covers for actuators the profile says are absent.
+        """Remove covers for actuators not in this profile.
 
-        Lets cover.py clean up covers left over from the old always-full feature
-        set when an existing entry resolves to a profile that hides actuators.
+        Covers absent profile actuators plus the duplicate ``head``/``feet`` keys,
+        so cover.py cleans up covers left over from the old always-full feature set
+        (including no-actuator profiles).
         """
-        present = {
-            "back": self._caps.has_head,
-            "legs": self._caps.has_foot,
-            "pillow": self._caps.has_pillow,
-            "lumbar": self._caps.has_lumbar,
-        }
-        return frozenset(key for key, is_present in present.items() if not is_present)
+        present = self._present_specs()
+        stale = {key for key, is_present in present.items() if not is_present}
+        stale.update({"head", "feet"})
+        return frozenset(stale)
 
     # Motor control methods - Gen2 re-sends the move command every 200 ms while
     # held and sends an explicit per-actuator stop on release (matching the app).

--- a/custom_components/adjustable_bed/beds/leggett_gen2.py
+++ b/custom_components/adjustable_bed/beds/leggett_gen2.py
@@ -21,13 +21,14 @@ Connection note:
     persistent connection (it is never idle-disconnected). See
     coordinator._uses_persistent_connection().
 
-Features:
-    - Motor control (head/back, feet, pillow, lumbar) via the ASCII "M" command
+Features (gated per model by the bundled capability profile — see
+leggett_gen2_profiles; the bed does not report its feature set over BLE):
+    - Motor control (head/back, feet, and pillow/lumbar where present) via "M"
     - Position presets (Flat, Unwind, Sleep, Wake Up, Relax, Anti-Snore)
-    - Memory position programming
-    - RGB under-bed lighting control
+    - Memory position programming (slot count per model, typically 3)
+    - Under-bed lighting: none / on-off toggle / single-colour / RGB per model,
+      with live on/off + colour state from 45e25103 notifications
     - Massage control with adjustable strength
-    - No position feedback
 """
 
 from __future__ import annotations
@@ -38,8 +39,15 @@ from typing import TYPE_CHECKING
 
 from ..const import LEGGETT_GEN2_WRITE_CHAR_UUID
 from .base import BedController
+from .leggett_gen2_profiles import (
+    Gen2Capabilities,
+    capabilities_for_product,
+    compute_product_id,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from ..coordinator import AdjustableBedCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -61,34 +69,57 @@ class LeggettGen2Commands:
     PROGRAM_SLEEP = b"SMEM 2"
     PROGRAM_WAKE_UP = b"SMEM 3"
     PROGRAM_RELAX = b"SMEM 4"
-    PROGRAM_ANTI_SNORE = b"SNPOS 0"
+    # (Gen2 has no anti-snore *program* command; SNPOS is not a Gen2 command.)
 
     # Control
     STOP = b"STOP"
     GET_STATE = b"GET STATE"
 
-    # Lighting
-    RGB_OFF = b"RGBENABLE 0:0"
+    # Lighting (under-bed light, LightID 0). The LP Control app has NO "RGBENABLE"
+    # command (the previous off/toggle command was invalid). The confirmed GEN2
+    # light commands are:
+    #   UBL TOGGLE            - toggle the under-bed light on/off (the only on/off
+    #                           primitive; the app has no separate on/off command)
+    #   RGBSET 0:RRGGBBAA     - set colour (8 hex: red, green, blue, alpha/brightness)
+    #   RGBBRT 0:AA           - set brightness (2 hex)
+    # Source: com.leggett.android.universal Gen2BedControlBoxInterface.
+    # NOTE: reliable explicit on/off needs the live light state (mode byte) from the
+    # 45e25103 STATE frame (StateChangeParser); that state layer is a follow-up, so
+    # for now on/off is best-effort via the toggle.
+    LIGHT_TOGGLE = b"UBL TOGGLE"
 
     @staticmethod
-    def rgb_set(red: int, green: int, blue: int, brightness: int) -> bytes:
-        """Create RGB color command."""
-        hex_str = f"{red:02X}{green:02X}{blue:02X}{brightness:02X}"
+    def rgb_set(red: int, green: int, blue: int, alpha: int = 0xFF) -> bytes:
+        """Create an RGBSET colour command (``RGBSET 0:RRGGBBAA``)."""
+        hex_str = f"{red:02X}{green:02X}{blue:02X}{alpha:02X}"
         return f"RGBSET 0:{hex_str}".encode()
 
-    # Massage
     @staticmethod
-    def massage_head_strength(strength: int) -> bytes:
-        """Set head massage strength (0-10)."""
-        return f"MVI 0:{strength}".encode()
+    def brightness_set(level: int) -> bytes:
+        """Create an RGBBRT brightness command (``RGBBRT 0:AA``, level 0-255)."""
+        return f"RGBBRT 0:{max(0, min(255, level)):02X}".encode()
+
+    # Massage. Gen2 intensity is RELATIVE: "VII :<ch>" raises and "VII <ch>::"
+    # lowers the given channel (0=primary head, 1=primary foot). Absolute set uses
+    # "MVI <ch>:<level>" with level 0=off, 1=low, 2=med, 3=high (used for "off").
+    # Mode is "MMODE <group>:<mode>" (group 0=primary; mode 0=wave, 1=pulse,
+    # 2=always-on); wave speed is "WSP <group>:<speed>" (0=slow, 1=med, 2=fast);
+    # "WVE TOGGLE" toggles wave. Source: Gen2BedControlBoxInterface/Gen2CommandFormatter.
+    MASSAGE_HEAD_UP = b"VII :0"
+    MASSAGE_HEAD_DOWN = b"VII 0::"
+    MASSAGE_FOOT_UP = b"VII :1"
+    MASSAGE_FOOT_DOWN = b"VII 1::"
+    WAVE_TOGGLE = b"WVE TOGGLE"
 
     @staticmethod
-    def massage_foot_strength(strength: int) -> bytes:
-        """Set foot massage strength (0-10)."""
-        return f"MVI 1:{strength}".encode()
+    def massage_set(channel: int, level: int) -> bytes:
+        """Set absolute massage intensity (``MVI <channel>:<level>``, level 0-3)."""
+        return f"MVI {channel}:{max(0, min(3, level))}".encode()
 
-    MASSAGE_WAVE_ON = b"MMODE 0:0"
-    MASSAGE_WAVE_OFF = b"MMODE 0:2"
+    @staticmethod
+    def wave_speed(speed: int) -> bytes:
+        """Set primary wave speed (``WSP 0:<speed>``, 0=slow, 1=med, 2=fast)."""
+        return f"WSP 0:{max(0, min(2, speed))}".encode()
 
     # Motor control: the LP Control app formats motor commands as
     #   M {down_codes}:{up_codes}:{stop_codes}
@@ -119,11 +150,6 @@ class LeggettGen2Commands:
     # The app uses the plain "STOP" string to halt all actuators.
     MOTOR_STOP_ALL = b"STOP"
 
-    @staticmethod
-    def massage_wave_level(level: int) -> bytes:
-        """Set wave massage level."""
-        return f"WSP 0:{level}".encode()
-
 
 class LeggettGen2Controller(BedController):
     """Controller for Leggett & Platt Gen2 beds.
@@ -132,12 +158,28 @@ class LeggettGen2Controller(BedController):
     They do not support direct motor control (uses position-based control instead).
     """
 
-    def __init__(self, coordinator: AdjustableBedCoordinator) -> None:
-        """Initialize the Leggett & Platt Gen2 controller."""
+    def __init__(
+        self,
+        coordinator: AdjustableBedCoordinator,
+        manufacturer_data: Mapping[int, bytes] | None = None,
+    ) -> None:
+        """Initialize the Leggett & Platt Gen2 controller.
+
+        The bed's feature set is not reported over BLE; it is looked up from the
+        bundled per-model profile keyed by a productId derived from the
+        advertisement manufacturer data (see leggett_gen2_profiles).
+        """
         super().__init__(coordinator)
-        self._massage_head_level = 0
-        self._massage_foot_level = 0
-        _LOGGER.debug("LeggettGen2Controller initialized")
+        product_id = compute_product_id(manufacturer_data)
+        self._caps: Gen2Capabilities = capabilities_for_product(product_id)
+        # Live under-bed light on/off, populated from 45e25103 STATE notifications.
+        self._light_on: bool | None = None
+        self._light_rgb: tuple[int, int, int] | None = None
+        _LOGGER.debug(
+            "LeggettGen2Controller initialized (product_id=%s, caps=%s)",
+            product_id,
+            self._caps,
+        )
 
     @property
     def control_characteristic_uuid(self) -> str:
@@ -161,58 +203,64 @@ class LeggettGen2Controller(BedController):
 
     @property
     def supports_lights(self) -> bool:
-        """Return True - Gen2 beds support RGB lighting."""
-        return True
+        """Return True when this model has an under-bed light (per profile)."""
+        return self._caps.light != "none"
 
     @property
     def supports_discrete_light_control(self) -> bool:
-        """Return True - Gen2 has RGB control with discrete on/off."""
-        return True
+        """Return True for any model with a light (on/off via RGBSET/UBL)."""
+        return self._caps.light != "none"
 
     @property
     def supports_light_color_control(self) -> bool:
-        """Return True - Gen2 beds support RGB light color control."""
-        return True
+        """Return True only for RGB (multi-colour) under-bed lights."""
+        return self._caps.light == "rgb"
 
     @property
     def supports_explicit_light_on_control(self) -> bool:
-        """Return True - RGBSET command turns the light on."""
-        return True
+        """Return False - the only confirmed on/off primitive is UBL TOGGLE, so we
+        don't issue a separate explicit "on"; setting a colour turns RGB lights on."""
+        return False
 
     @property
     def default_light_rgb_color(self) -> tuple[int, int, int] | None:
-        """Return default white color."""
-        return (255, 255, 255)
+        """Return default white color for RGB lights."""
+        return (255, 255, 255) if self._caps.light == "rgb" else None
 
     @property
     def supports_memory_presets(self) -> bool:
-        """Return True - Gen2 beds support memory presets 1-4."""
-        return True
+        """Return True when the model exposes memory positions (per profile)."""
+        return self._caps.memory_slots > 0
 
     @property
     def supports_motor_control(self) -> bool:
-        """Return True - Gen2 supports motor control via ASCII M command."""
-        return True
+        """Return True when the model has at least one actuator."""
+        return (
+            self._caps.has_head
+            or self._caps.has_foot
+            or self._caps.has_pillow
+            or self._caps.has_lumbar
+        )
 
     @property
     def has_pillow_support(self) -> bool:
-        """Return True - Gen2 beds support pillow motor."""
-        return True
+        """Return True when the model has a pillow actuator (per profile)."""
+        return self._caps.has_pillow
 
     @property
     def has_lumbar_support(self) -> bool:
-        """Return True - Gen2 beds support lumbar motor."""
-        return True
+        """Return True when the model has a lumbar actuator (per profile)."""
+        return self._caps.has_lumbar
 
     @property
     def memory_slot_count(self) -> int:
-        """Return 4 - Gen2 beds support memory slots 1-4."""
-        return 4
+        """Return the model's memory slot count (per profile; typically 3)."""
+        return self._caps.memory_slots
 
     @property
     def supports_memory_programming(self) -> bool:
-        """Return True - Gen2 beds support programming memory positions."""
-        return True
+        """Return True when the model exposes memory positions (per profile)."""
+        return self._caps.memory_slots > 0
 
     # Motor control methods - Gen2 re-sends the move command every 200 ms while
     # held and sends an explicit per-actuator stop on release (matching the app).
@@ -394,62 +442,56 @@ class LeggettGen2Controller(BedController):
             except Exception:
                 _LOGGER.debug("Failed to send STOP command during preset_anti_snore cleanup")
 
-    # Light methods
+    # Light methods. The app toggles with "UBL TOGGLE" and turns the light off by
+    # setting the colour to 0 (RGBSET 0:00000000); a non-zero colour turns it on.
     async def lights_toggle(self) -> None:
-        """Toggle lights."""
-        await self.write_command(LeggettGen2Commands.RGB_OFF)
+        """Toggle the under-bed light."""
+        await self.write_command(LeggettGen2Commands.LIGHT_TOGGLE)
 
     async def lights_on(self) -> None:
-        """Turn on lights (white at full brightness)."""
-        await self.write_command(LeggettGen2Commands.rgb_set(255, 255, 255, 255))
+        """Turn on the under-bed light (white at full brightness)."""
+        await self.write_command(LeggettGen2Commands.rgb_set(255, 255, 255))
 
     async def lights_off(self) -> None:
-        """Turn off lights."""
-        await self.write_command(LeggettGen2Commands.RGB_OFF)
+        """Turn off the under-bed light.
+
+        The app's only on/off primitive is the toggle, so this is best-effort
+        until the live light-state layer lands. Home Assistant only issues "off"
+        when it believes the light is on, so a toggle is a reasonable proxy.
+        """
+        await self.write_command(LeggettGen2Commands.LIGHT_TOGGLE)
 
     async def set_light_color(self, rgb_color: tuple[int, int, int]) -> None:
-        """Set light RGB color using RGBSET command."""
+        """Set the under-bed light colour using the RGBSET command."""
         r, g, b = rgb_color
         if not all(0 <= v <= 255 for v in (r, g, b)):
             raise ValueError(f"RGB values must be 0-255, got {rgb_color}")
-        await self.write_command(LeggettGen2Commands.rgb_set(r, g, b, 255))
+        await self.write_command(LeggettGen2Commands.rgb_set(r, g, b))
 
-    # Massage methods
+    # Massage methods. Gen2 intensity is relative (VII raise/lower), so no level is
+    # tracked locally. "Off" sets all four channels to 0 (matching the app's
+    # stopMassage(ALL)).
     async def massage_off(self) -> None:
-        """Turn off massage."""
-        self._massage_head_level = 0
-        self._massage_foot_level = 0
-        await self.write_command(LeggettGen2Commands.massage_head_strength(0))
-        await self.write_command(LeggettGen2Commands.massage_foot_strength(0))
+        """Turn off massage (set every channel's intensity to 0)."""
+        for channel in (0, 1, 2, 3):
+            await self.write_command(LeggettGen2Commands.massage_set(channel, 0))
 
     async def massage_head_up(self) -> None:
-        """Increase head massage intensity."""
-        self._massage_head_level = min(10, self._massage_head_level + 1)
-        await self.write_command(
-            LeggettGen2Commands.massage_head_strength(self._massage_head_level)
-        )
+        """Increase head massage intensity (relative)."""
+        await self.write_command(LeggettGen2Commands.MASSAGE_HEAD_UP)
 
     async def massage_head_down(self) -> None:
-        """Decrease head massage intensity."""
-        self._massage_head_level = max(0, self._massage_head_level - 1)
-        await self.write_command(
-            LeggettGen2Commands.massage_head_strength(self._massage_head_level)
-        )
+        """Decrease head massage intensity (relative)."""
+        await self.write_command(LeggettGen2Commands.MASSAGE_HEAD_DOWN)
 
     async def massage_foot_up(self) -> None:
-        """Increase foot massage intensity."""
-        self._massage_foot_level = min(10, self._massage_foot_level + 1)
-        await self.write_command(
-            LeggettGen2Commands.massage_foot_strength(self._massage_foot_level)
-        )
+        """Increase foot massage intensity (relative)."""
+        await self.write_command(LeggettGen2Commands.MASSAGE_FOOT_UP)
 
     async def massage_foot_down(self) -> None:
-        """Decrease foot massage intensity."""
-        self._massage_foot_level = max(0, self._massage_foot_level - 1)
-        await self.write_command(
-            LeggettGen2Commands.massage_foot_strength(self._massage_foot_level)
-        )
+        """Decrease foot massage intensity (relative)."""
+        await self.write_command(LeggettGen2Commands.MASSAGE_FOOT_DOWN)
 
     async def massage_toggle(self) -> None:
-        """Toggle massage."""
-        await self.write_command(LeggettGen2Commands.MASSAGE_WAVE_ON)
+        """Toggle the wave massage mode (the only Gen2 massage toggle)."""
+        await self.write_command(LeggettGen2Commands.WAVE_TOGGLE)

--- a/custom_components/adjustable_bed/beds/leggett_gen2.py
+++ b/custom_components/adjustable_bed/beds/leggett_gen2.py
@@ -101,16 +101,23 @@ class LeggettGen2Commands:
         return f"RGBBRT 0:{max(0, min(255, level)):02X}".encode()
 
     # Massage. Gen2 intensity is RELATIVE: "VII :<ch>" raises and "VII <ch>::"
-    # lowers the given channel (0=primary head, 1=primary foot). Absolute set uses
+    # lowers a channel (0=head, 1=foot; "0123" = all channels). Absolute set uses
     # "MVI <ch>:<level>" with level 0=off, 1=low, 2=med, 3=high (used for "off").
     # Mode is "MMODE <group>:<mode>" (group 0=primary; mode 0=wave, 1=pulse,
-    # 2=always-on); wave speed is "WSP <group>:<speed>" (0=slow, 1=med, 2=fast);
-    # "WVE TOGGLE" toggles wave. Source: Gen2BedControlBoxInterface/Gen2CommandFormatter.
+    # 2=always-on); "WVE TOGGLE" toggles wave.
+    # Source: Gen2BedControlBoxInterface/Gen2CommandFormatter.
     MASSAGE_HEAD_UP = b"VII :0"
     MASSAGE_HEAD_DOWN = b"VII 0::"
     MASSAGE_FOOT_UP = b"VII :1"
     MASSAGE_FOOT_DOWN = b"VII 1::"
+    MASSAGE_ALL_UP = b"VII :0123"
+    MASSAGE_ALL_DOWN = b"VII 0123::"
     WAVE_TOGGLE = b"WVE TOGGLE"
+
+    # MMODE mode codes (primary group).
+    MODE_WAVE = 0
+    MODE_PULSE = 1
+    MODE_ALWAYS_ON = 2
 
     @staticmethod
     def massage_set(channel: int, level: int) -> bytes:
@@ -118,9 +125,9 @@ class LeggettGen2Commands:
         return f"MVI {channel}:{max(0, min(3, level))}".encode()
 
     @staticmethod
-    def wave_speed(speed: int) -> bytes:
-        """Set primary wave speed (``WSP 0:<speed>``, 0=slow, 1=med, 2=fast)."""
-        return f"WSP 0:{max(0, min(2, speed))}".encode()
+    def massage_mode(mode: int) -> bytes:
+        """Set the primary massage mode (``MMODE 0:<mode>``)."""
+        return f"MMODE 0:{mode}".encode()
 
     # Motor control: the LP Control app formats motor commands as
     #   M {down_codes}:{up_codes}:{stop_codes}
@@ -177,6 +184,8 @@ class LeggettGen2Controller(BedController):
         self._light_on: bool | None = None
         self._light_rgb: tuple[int, int, int] | None = None
         self._notify_started = False
+        # Index into the model's massage-mode cycle for massage_mode_step().
+        self._massage_mode_idx = 0
         _LOGGER.debug(
             "LeggettGen2Controller initialized (product_id=%s, caps=%s)",
             product_id,
@@ -287,7 +296,9 @@ class LeggettGen2Controller(BedController):
 
     @property
     def supports_massage_toggle_control(self) -> bool:
-        return self._caps.has_massage
+        # The only massage toggle is the wave toggle (WVE TOGGLE), so only expose
+        # it on models that actually have wave massage.
+        return self._caps.has_massage and self._caps.has_massage_wave
 
     @property
     def supports_massage_intensity_step_control(self) -> bool:
@@ -492,28 +503,28 @@ class LeggettGen2Controller(BedController):
             except Exception:
                 _LOGGER.debug("Failed to send STOP command during preset_anti_snore cleanup")
 
-    # Light methods. The app toggles with "UBL TOGGLE" and turns the light off by
-    # setting the colour to 0 (RGBSET 0:00000000); a non-zero colour turns it on.
+    # Light methods. The only on/off primitive is "UBL TOGGLE", so on/off are
+    # toggles guarded by the cached state (updated optimistically here and
+    # corrected by STATE notifications) to stay idempotent.
     async def lights_toggle(self) -> None:
         """Toggle the under-bed light."""
         await self.write_command(LeggettGen2Commands.LIGHT_TOGGLE)
+        if self._light_on is not None:
+            self._light_on = not self._light_on
 
     async def lights_on(self) -> None:
-        """Turn on the under-bed light (idempotent against the live state).
-
-        The only on/off primitive is the toggle, so we toggle only when the
-        bed-reported state (from STATE notifications) says the light is not already
-        on, to avoid inverting it on stale assumed state.
-        """
+        """Turn on the under-bed light (idempotent against the cached state)."""
         if self._light_on is True:
             return
         await self.write_command(LeggettGen2Commands.LIGHT_TOGGLE)
+        self._light_on = True
 
     async def lights_off(self) -> None:
-        """Turn off the under-bed light (idempotent against the live state)."""
+        """Turn off the under-bed light (idempotent against the cached state)."""
         if self._light_on is False:
             return
         await self.write_command(LeggettGen2Commands.LIGHT_TOGGLE)
+        self._light_on = False
 
     async def set_light_color(self, rgb_color: tuple[int, int, int]) -> None:
         """Set the under-bed light colour using the RGBSET command."""
@@ -605,3 +616,25 @@ class LeggettGen2Controller(BedController):
     async def massage_toggle(self) -> None:
         """Toggle the wave massage mode (the only Gen2 massage toggle)."""
         await self.write_command(LeggettGen2Commands.WAVE_TOGGLE)
+
+    async def massage_intensity_up(self) -> None:
+        """Raise overall (all-channel) massage intensity."""
+        await self.write_command(LeggettGen2Commands.MASSAGE_ALL_UP)
+
+    async def massage_intensity_down(self) -> None:
+        """Lower overall (all-channel) massage intensity."""
+        await self.write_command(LeggettGen2Commands.MASSAGE_ALL_DOWN)
+
+    def _massage_modes(self) -> tuple[int, ...]:
+        """Massage modes to cycle for this model (wave only if supported)."""
+        modes: list[int] = []
+        if self._caps.has_massage_wave:
+            modes.append(LeggettGen2Commands.MODE_WAVE)
+        modes += [LeggettGen2Commands.MODE_PULSE, LeggettGen2Commands.MODE_ALWAYS_ON]
+        return tuple(modes)
+
+    async def massage_mode_step(self) -> None:
+        """Step to the next massage mode (MMODE), cycling the model's modes."""
+        modes = self._massage_modes()
+        self._massage_mode_idx = (self._massage_mode_idx + 1) % len(modes)
+        await self.write_command(LeggettGen2Commands.massage_mode(modes[self._massage_mode_idx]))

--- a/custom_components/adjustable_bed/beds/leggett_gen2.py
+++ b/custom_components/adjustable_bed/beds/leggett_gen2.py
@@ -1,6 +1,10 @@
 """Leggett & Platt Gen2 bed controller implementation.
 
-Reverse engineering by MarcusW and Richard Hopton (smartbed-mqtt).
+Also known as the Leggett & Platt "LP Comfort Connect" controller (control box
+209-M001, an ESP32-WROOM-32D board). Originally reverse-engineered by MarcusW
+and Richard Hopton (smartbed-mqtt); the motor command format and detection here
+were corrected from a decompile of the LP Control app
+(com.leggett.android.universal) — see docs/beds/leggett-platt.md.
 
 This controller handles Leggett & Platt beds using the Gen2 (Richmat-based) ASCII protocol.
 
@@ -8,14 +12,21 @@ Protocol details:
     Service UUID: 45e25100-3171-4cfc-ae89-1d83cf8d8071
     Write characteristic: 45e25101-3171-4cfc-ae89-1d83cf8d8071
     Read characteristic: 45e25103-3171-4cfc-ae89-1d83cf8d8071
-    Command format: ASCII text (e.g., b"MEM 0" for flat preset)
+    Command format: ASCII text (e.g., b"MEM 0" for flat preset; motor moves use
+        "M {down}:{up}:{stop}").
+
+Connection note:
+    The ESP32 controller only accepts a BLE connection while the bed is in
+    pairing mode and refuses reconnection afterwards, so this bed type uses a
+    persistent connection (it is never idle-disconnected). See
+    coordinator._uses_persistent_connection().
 
 Features:
+    - Motor control (head/back, feet, pillow, lumbar) via the ASCII "M" command
     - Position presets (Flat, Unwind, Sleep, Wake Up, Relax, Anti-Snore)
     - Memory position programming
     - RGB under-bed lighting control
     - Massage control with adjustable strength
-    - No motor control (position-based control only)
     - No position feedback
 """
 
@@ -79,22 +90,34 @@ class LeggettGen2Commands:
     MASSAGE_WAVE_ON = b"MMODE 0:0"
     MASSAGE_WAVE_OFF = b"MMODE 0:2"
 
-    # Motor control: M {up_motors}:{down_motors}:{stop_motors}
-    # Motor numbers: 0=head, 1=feet, 2=pillow, 3=lumbar
+    # Motor control: the LP Control app formats motor commands as
+    #   M {down_codes}:{up_codes}:{stop_codes}
+    # with the actuator code in exactly ONE of the three colon-separated fields
+    # (the others empty), and no trailing stop list. Actuator codes:
+    #   0=head, 1=feet, 2=pillow, 3=lumbar.
+    # Examples (from com.leggett.android.universal Gen2CommandFormatter):
+    #   head up = "M :0:", head down = "M 0::", stop head = "M ::0".
+    # Source: APK reverse engineering (replaces the earlier smartbed-mqtt guess,
+    # which had up/down swapped and appended a stop list).
     @staticmethod
-    def motor_move(up: str = "", down: str = "", stop: str = "") -> bytes:
-        """Build motor move command."""
-        return f"M {up}:{down}:{stop}".encode()
+    def motor_move(down: str = "", up: str = "", stop: str = "") -> bytes:
+        """Build a motor move/stop command (``M {down}:{up}:{stop}``)."""
+        return f"M {down}:{up}:{stop}".encode()
 
-    MOTOR_HEAD_UP = b"M 0::123"
-    MOTOR_HEAD_DOWN = b"M :0:123"
-    MOTOR_FEET_UP = b"M 1::023"
-    MOTOR_FEET_DOWN = b"M :1:023"
-    MOTOR_PILLOW_UP = b"M 2::013"
-    MOTOR_PILLOW_DOWN = b"M :2:013"
-    MOTOR_LUMBAR_UP = b"M 3::012"
-    MOTOR_LUMBAR_DOWN = b"M :3:012"
-    MOTOR_STOP_ALL = b"M ::0123"
+    MOTOR_HEAD_UP = b"M :0:"
+    MOTOR_HEAD_DOWN = b"M 0::"
+    MOTOR_HEAD_STOP = b"M ::0"
+    MOTOR_FEET_UP = b"M :1:"
+    MOTOR_FEET_DOWN = b"M 1::"
+    MOTOR_FEET_STOP = b"M ::1"
+    MOTOR_PILLOW_UP = b"M :2:"
+    MOTOR_PILLOW_DOWN = b"M 2::"
+    MOTOR_PILLOW_STOP = b"M ::2"
+    MOTOR_LUMBAR_UP = b"M :3:"
+    MOTOR_LUMBAR_DOWN = b"M 3::"
+    MOTOR_LUMBAR_STOP = b"M ::3"
+    # The app uses the plain "STOP" string to halt all actuators.
+    MOTOR_STOP_ALL = b"STOP"
 
     @staticmethod
     def massage_wave_level(level: int) -> bytes:
@@ -185,34 +208,39 @@ class LeggettGen2Controller(BedController):
         """Return True - Gen2 beds support programming memory positions."""
         return True
 
-    # Motor control methods - Gen2 uses ASCII "M up:down:stop" format
-    async def _move_with_stop(self, command: bytes) -> None:
-        """Execute a movement command and always send STOP at the end."""
+    # Motor control methods - Gen2 re-sends the move command every 200 ms while
+    # held and sends an explicit per-actuator stop on release (matching the app).
+    async def _move_with_stop(
+        self, command: bytes, stop_command: bytes = LeggettGen2Commands.MOTOR_STOP_ALL
+    ) -> None:
+        """Execute a movement command and always send a stop at the end."""
         try:
             await self.write_command(command, repeat_count=25, repeat_delay_ms=200)
         finally:
             try:
-                await self.write_command(
-                    LeggettGen2Commands.MOTOR_STOP_ALL,
-                    cancel_event=asyncio.Event(),
-                )
+                await self.write_command(stop_command, cancel_event=asyncio.Event())
             except Exception:
                 _LOGGER.debug("Failed to send stop during motor cleanup")
 
+    async def _stop(self, stop_command: bytes) -> None:
+        """Send a stop command (per-actuator or stop-all)."""
+        await self.write_command(stop_command, cancel_event=asyncio.Event())
+
     async def move_head_up(self) -> None:
         """Move head up."""
-        await self._move_with_stop(LeggettGen2Commands.MOTOR_HEAD_UP)
+        await self._move_with_stop(
+            LeggettGen2Commands.MOTOR_HEAD_UP, LeggettGen2Commands.MOTOR_HEAD_STOP
+        )
 
     async def move_head_down(self) -> None:
         """Move head down."""
-        await self._move_with_stop(LeggettGen2Commands.MOTOR_HEAD_DOWN)
+        await self._move_with_stop(
+            LeggettGen2Commands.MOTOR_HEAD_DOWN, LeggettGen2Commands.MOTOR_HEAD_STOP
+        )
 
     async def move_head_stop(self) -> None:
         """Stop head motor."""
-        await self.write_command(
-            LeggettGen2Commands.MOTOR_STOP_ALL,
-            cancel_event=asyncio.Event(),
-        )
+        await self._stop(LeggettGen2Commands.MOTOR_HEAD_STOP)
 
     async def move_back_up(self) -> None:
         """Move back up (same as head)."""
@@ -228,15 +256,19 @@ class LeggettGen2Controller(BedController):
 
     async def move_legs_up(self) -> None:
         """Move legs up."""
-        await self._move_with_stop(LeggettGen2Commands.MOTOR_FEET_UP)
+        await self._move_with_stop(
+            LeggettGen2Commands.MOTOR_FEET_UP, LeggettGen2Commands.MOTOR_FEET_STOP
+        )
 
     async def move_legs_down(self) -> None:
         """Move legs down."""
-        await self._move_with_stop(LeggettGen2Commands.MOTOR_FEET_DOWN)
+        await self._move_with_stop(
+            LeggettGen2Commands.MOTOR_FEET_DOWN, LeggettGen2Commands.MOTOR_FEET_STOP
+        )
 
     async def move_legs_stop(self) -> None:
         """Stop legs motor."""
-        await self.move_head_stop()
+        await self._stop(LeggettGen2Commands.MOTOR_FEET_STOP)
 
     async def move_feet_up(self) -> None:
         """Move feet up."""
@@ -252,34 +284,39 @@ class LeggettGen2Controller(BedController):
 
     async def move_pillow_up(self) -> None:
         """Move pillow up."""
-        await self._move_with_stop(LeggettGen2Commands.MOTOR_PILLOW_UP)
+        await self._move_with_stop(
+            LeggettGen2Commands.MOTOR_PILLOW_UP, LeggettGen2Commands.MOTOR_PILLOW_STOP
+        )
 
     async def move_pillow_down(self) -> None:
         """Move pillow down."""
-        await self._move_with_stop(LeggettGen2Commands.MOTOR_PILLOW_DOWN)
+        await self._move_with_stop(
+            LeggettGen2Commands.MOTOR_PILLOW_DOWN, LeggettGen2Commands.MOTOR_PILLOW_STOP
+        )
 
     async def move_pillow_stop(self) -> None:
         """Stop pillow motor."""
-        await self.move_head_stop()
+        await self._stop(LeggettGen2Commands.MOTOR_PILLOW_STOP)
 
     async def move_lumbar_up(self) -> None:
         """Move lumbar up."""
-        await self._move_with_stop(LeggettGen2Commands.MOTOR_LUMBAR_UP)
+        await self._move_with_stop(
+            LeggettGen2Commands.MOTOR_LUMBAR_UP, LeggettGen2Commands.MOTOR_LUMBAR_STOP
+        )
 
     async def move_lumbar_down(self) -> None:
         """Move lumbar down."""
-        await self._move_with_stop(LeggettGen2Commands.MOTOR_LUMBAR_DOWN)
+        await self._move_with_stop(
+            LeggettGen2Commands.MOTOR_LUMBAR_DOWN, LeggettGen2Commands.MOTOR_LUMBAR_STOP
+        )
 
     async def move_lumbar_stop(self) -> None:
         """Stop lumbar motor."""
-        await self.move_head_stop()
+        await self._stop(LeggettGen2Commands.MOTOR_LUMBAR_STOP)
 
     async def stop_all(self) -> None:
         """Stop all motors."""
-        await self.write_command(
-            LeggettGen2Commands.MOTOR_STOP_ALL,
-            cancel_event=asyncio.Event(),
-        )
+        await self._stop(LeggettGen2Commands.MOTOR_STOP_ALL)
 
     # Preset methods
     async def preset_flat(self) -> None:

--- a/custom_components/adjustable_bed/beds/leggett_gen2.py
+++ b/custom_components/adjustable_bed/beds/leggett_gen2.py
@@ -144,6 +144,12 @@ class LeggettGen2Controller(BedController):
         """Return the UUID of the control characteristic."""
         return LEGGETT_GEN2_WRITE_CHAR_UUID
 
+    @property
+    def requires_persistent_connection(self) -> bool:
+        """LP Comfort Connect's ESP32 only accepts a connection while in pairing
+        mode and refuses reconnection afterwards, so the link must be held open."""
+        return True
+
     # Capability properties
     @property
     def supports_preset_zero_g(self) -> bool:

--- a/custom_components/adjustable_bed/beds/leggett_gen2.py
+++ b/custom_components/adjustable_bed/beds/leggett_gen2.py
@@ -323,6 +323,21 @@ class LeggettGen2Controller(BedController):
             if present.get(spec.key, True)
         )
 
+    @property
+    def stale_motor_entity_keys(self) -> frozenset[str]:
+        """Remove covers for actuators the profile says are absent.
+
+        Lets cover.py clean up covers left over from the old always-full feature
+        set when an existing entry resolves to a profile that hides actuators.
+        """
+        present = {
+            "back": self._caps.has_head,
+            "legs": self._caps.has_foot,
+            "pillow": self._caps.has_pillow,
+            "lumbar": self._caps.has_lumbar,
+        }
+        return frozenset(key for key, is_present in present.items() if not is_present)
+
     # Motor control methods - Gen2 re-sends the move command every 200 ms while
     # held and sends an explicit per-actuator stop on release (matching the app).
     async def _move_with_stop(
@@ -527,11 +542,17 @@ class LeggettGen2Controller(BedController):
         self._light_on = False
 
     async def set_light_color(self, rgb_color: tuple[int, int, int]) -> None:
-        """Set the under-bed light colour using the RGBSET command."""
+        """Set the under-bed light colour using the RGBSET command.
+
+        This is also the RGB turn-on path (the light entity calls it without a
+        separate lights_on), so reflect that the light is now on in the cache —
+        otherwise a following lights_off() would hit the off-guard and no-op.
+        """
         r, g, b = rgb_color
         if not all(0 <= v <= 255 for v in (r, g, b)):
             raise ValueError(f"RGB values must be 0-255, got {rgb_color}")
         await self.write_command(LeggettGen2Commands.rgb_set(r, g, b))
+        self._light_on = any(rgb_color)
 
     # ---- Live light state from 45e25103 STATE notifications -----------------
     async def start_notify(self, callback: Callable[[str, float], None] | None = None) -> None:

--- a/custom_components/adjustable_bed/beds/leggett_gen2.py
+++ b/custom_components/adjustable_bed/beds/leggett_gen2.py
@@ -550,6 +550,11 @@ class LeggettGen2Controller(BedController):
                 )
             self._notify_started = True
             _LOGGER.debug("Started Gen2 STATE notifications for %s", self._coordinator.address)
+            # Proactively request current state so light on/off is resolved before
+            # any user action — otherwise a toggle issued while state is unknown
+            # could invert the light (issue #385 review). Best-effort.
+            with contextlib.suppress(Exception):
+                await self.write_command(LeggettGen2Commands.GET_STATE)
 
     async def stop_notify(self) -> None:
         """Unsubscribe from the STATE characteristic."""

--- a/custom_components/adjustable_bed/beds/leggett_gen2.py
+++ b/custom_components/adjustable_bed/beds/leggett_gen2.py
@@ -34,10 +34,11 @@ leggett_gen2_profiles; the bed does not report its feature set over BLE):
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from ..const import LEGGETT_GEN2_WRITE_CHAR_UUID
+from ..const import LEGGETT_GEN2_READ_CHAR_UUID, LEGGETT_GEN2_WRITE_CHAR_UUID
 from .base import BedController
 from .leggett_gen2_profiles import (
     Gen2Capabilities,
@@ -46,7 +47,7 @@ from .leggett_gen2_profiles import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
 
     from ..coordinator import AdjustableBedCoordinator
 
@@ -83,9 +84,9 @@ class LeggettGen2Commands:
     #   RGBSET 0:RRGGBBAA     - set colour (8 hex: red, green, blue, alpha/brightness)
     #   RGBBRT 0:AA           - set brightness (2 hex)
     # Source: com.leggett.android.universal Gen2BedControlBoxInterface.
-    # NOTE: reliable explicit on/off needs the live light state (mode byte) from the
-    # 45e25103 STATE frame (StateChangeParser); that state layer is a follow-up, so
-    # for now on/off is best-effort via the toggle.
+    # On/off is the toggle; the live light state (on/off + colour) is read back from
+    # the 45e25103 STATE frame (see _handle_state_notification), so Home Assistant
+    # knows the current state and the toggle resolves to the intended on/off.
     LIGHT_TOGGLE = b"UBL TOGGLE"
 
     @staticmethod
@@ -175,6 +176,7 @@ class LeggettGen2Controller(BedController):
         # Live under-bed light on/off, populated from 45e25103 STATE notifications.
         self._light_on: bool | None = None
         self._light_rgb: tuple[int, int, int] | None = None
+        self._notify_started = False
         _LOGGER.debug(
             "LeggettGen2Controller initialized (product_id=%s, caps=%s)",
             product_id,
@@ -191,6 +193,12 @@ class LeggettGen2Controller(BedController):
         """LP Comfort Connect's ESP32 only accepts a connection while in pairing
         mode and refuses reconnection afterwards, so the link must be held open."""
         return True
+
+    @property
+    def requires_notification_channel(self) -> bool:
+        """Subscribe to STATE notifications even with angle sensing disabled, so we
+        receive live under-bed light on/off + colour state from the bed."""
+        return self._caps.light != "none"
 
     # Capability properties
     @property
@@ -455,9 +463,9 @@ class LeggettGen2Controller(BedController):
     async def lights_off(self) -> None:
         """Turn off the under-bed light.
 
-        The app's only on/off primitive is the toggle, so this is best-effort
-        until the live light-state layer lands. Home Assistant only issues "off"
-        when it believes the light is on, so a toggle is a reasonable proxy.
+        The app's only on/off primitive is the toggle. Home Assistant tracks the
+        live on/off state from STATE notifications and only issues "off" when it
+        believes the light is on, so the toggle resolves to the intended state.
         """
         await self.write_command(LeggettGen2Commands.LIGHT_TOGGLE)
 
@@ -467,6 +475,56 @@ class LeggettGen2Controller(BedController):
         if not all(0 <= v <= 255 for v in (r, g, b)):
             raise ValueError(f"RGB values must be 0-255, got {rgb_color}")
         await self.write_command(LeggettGen2Commands.rgb_set(r, g, b))
+
+    # ---- Live light state from 45e25103 STATE notifications -----------------
+    async def start_notify(self, callback: Callable[[str, float], None] | None = None) -> None:
+        """Subscribe to the STATE characteristic for live light on/off + colour.
+
+        The position callback is unused (Gen2 reports no motor angle); we parse the
+        under-bed light state ourselves and publish it as controller state.
+        """
+        client = self.client
+        if client is None or not client.is_connected:
+            raise ConnectionError("Not connected to bed")
+        if not self._notify_started:
+            async with self._ble_lock:
+                await client.start_notify(
+                    LEGGETT_GEN2_READ_CHAR_UUID, self._handle_state_notification
+                )
+            self._notify_started = True
+            _LOGGER.debug("Started Gen2 STATE notifications for %s", self._coordinator.address)
+
+    async def stop_notify(self) -> None:
+        """Unsubscribe from the STATE characteristic."""
+        client = self.client
+        if client is not None and client.is_connected and self._notify_started:
+            with contextlib.suppress(Exception):
+                async with self._ble_lock:
+                    await client.stop_notify(LEGGETT_GEN2_READ_CHAR_UUID)
+        self._notify_started = False
+
+    def _handle_state_notification(self, _sender: Any, data: bytearray) -> None:
+        """Parse a Gen2 STATE frame for the under-bed light state.
+
+        Per the app's StateChangeParser: byte 6 is the light OperatingMode
+        (0x01 = constant-colour/on, 0x04 = off) and bytes 7-9 are R, G, B (byte 10
+        is alpha). Other frame types leave byte 6 outside {0x01, 0x04} and are
+        ignored here.
+        """
+        self.forward_raw_notification(LEGGETT_GEN2_READ_CHAR_UUID, bytes(data))
+        if len(data) <= 10:
+            return
+        mode = data[6]
+        if mode == 0x01:
+            light_on = True
+            self._light_rgb = (data[7], data[8], data[9])
+        elif mode == 0x04:
+            light_on = False
+        else:
+            return
+        if light_on != self._light_on:
+            self._light_on = light_on
+            self.forward_controller_state_update("under_bed_lights_on", light_on)
 
     # Massage methods. Gen2 intensity is relative (VII raise/lower), so no level is
     # tracked locally. "Off" sets all four channels to 0 (matching the app's

--- a/custom_components/adjustable_bed/beds/leggett_gen2_profiles.py
+++ b/custom_components/adjustable_bed/beds/leggett_gen2_profiles.py
@@ -28,6 +28,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Final, Literal
 
+from ..const import MANUFACTURER_ID_LEGGETT_GEN2
+
 # Under-bed light style declared by the profile's ``lightConfig.colorPallet`` +
 # ``ublEnabled``: no light, a plain on/off toggle, a single (non-RGB) colour, or
 # full RGB colour control.
@@ -134,15 +136,12 @@ def compute_product_id(manufacturer_data: Mapping[int, bytes] | None) -> int | N
     """
     if not manufacturer_data:
         return None
-    for payload in manufacturer_data.values():
-        if payload[:2] in _GEN2_PREFIXES:
-            hex_bytes = [f"{b:02x}" for b in payload]
-            hex_bytes.reverse()
-            try:
-                return int("".join(hex_bytes[:4]), 16)
-            except ValueError:
-                return None
-    return None
+    payload = manufacturer_data.get(MANUFACTURER_ID_LEGGETT_GEN2)
+    if payload is None or len(payload) < 6 or payload[:2] not in _GEN2_PREFIXES:
+        return None
+    # Reverse the hex of the four bytes after the prefix and parse base-16 — this
+    # is exactly the four payload bytes [2:6] read little-endian.
+    return int.from_bytes(payload[2:6], "little")
 
 
 def capabilities_for_product(product_id: int | None) -> Gen2Capabilities:

--- a/custom_components/adjustable_bed/beds/leggett_gen2_profiles.py
+++ b/custom_components/adjustable_bed/beds/leggett_gen2_profiles.py
@@ -1,0 +1,152 @@
+"""Per-model capability profiles for Leggett & Platt Gen2 (LP Comfort Connect) beds.
+
+Gen2 beds do NOT report their capabilities over BLE at runtime. Instead the LP
+Control app (``com.leggett.android.universal``) ships a bundled JSON profile per
+product (``assets/ID_<productId>.json``) and selects it by a ``productId`` that
+it derives from the BLE advertisement's manufacturer-specific data. The profile
+declares which under-bed light (none / toggle / single-colour / RGB), actuators
+(pillow, lumbar, head, foot), massage, and memory slots the model has.
+
+This module ports that mechanism:
+
+* :func:`compute_product_id` reproduces the app's ``productId(ScanResult)``
+  algorithm (``Gen2BedControlBoxInterface.java:572-598``) from the manufacturer
+  data we already detect on.
+* :data:`GEN2_PROFILES` is the distilled capability table extracted from the 33
+  bundled ``ID_*.json`` profiles (furnitureType AB = bed, CHR = chair).
+* :func:`capabilities_for_product` looks up a product, falling back to a generous
+  default (the app's default ``ID_7`` set) for unknown ids so unrecognised beds
+  keep a full entity set rather than losing controls.
+
+Source: reverse engineering of LP Control v2.9.0; see docs/beds/leggett-platt.md.
+Values are unverified on hardware (tracked under issue #385).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Final, Literal
+
+# Under-bed light style declared by the profile's ``lightConfig.colorPallet`` +
+# ``ublEnabled``: no light, a plain on/off toggle, a single (non-RGB) colour, or
+# full RGB colour control.
+LightStyle = Literal["none", "toggle", "single", "rgb"]
+
+# Manufacturer payload prefixes that mark an LP Comfort Connect advertisement.
+_GEN2_PREFIXES: Final = (b"XP", b"CP")
+
+
+@dataclass(frozen=True, slots=True)
+class Gen2Capabilities:
+    """Distilled capability set for one Gen2 product."""
+
+    light: LightStyle
+    light_brightness: bool
+    has_pillow: bool
+    has_lumbar: bool
+    has_head: bool
+    has_foot: bool
+    has_massage: bool
+    has_massage_wave: bool
+    memory_slots: int
+    is_chair: bool = False
+
+
+def _c(  # noqa: PLR0913 - mirrors the profile JSON fields one-to-one
+    light: LightStyle,
+    brightness: bool,
+    pillow: bool,
+    lumbar: bool,
+    head: bool,
+    foot: bool,
+    massage: bool,
+    wave: bool,
+    memory: int,
+    chair: bool,
+) -> Gen2Capabilities:
+    return Gen2Capabilities(
+        light=light,
+        light_brightness=brightness,
+        has_pillow=pillow,
+        has_lumbar=lumbar,
+        has_head=head,
+        has_foot=foot,
+        has_massage=massage,
+        has_massage_wave=wave,
+        memory_slots=memory,
+        is_chair=chair,
+    )
+
+
+# productId -> capabilities, distilled from assets/ID_<productId>.json.
+# Columns: light, brightness, pillow, lumbar, head, foot, massage, wave, memory, chair
+GEN2_PROFILES: Final[dict[int, Gen2Capabilities]] = {
+    5: _c("rgb", True, True, True, True, True, True, True, 3, False),
+    7: _c("rgb", True, True, True, True, True, True, True, 3, False),
+    8: _c("toggle", True, False, False, True, True, True, True, 3, False),
+    9: _c("toggle", True, True, False, True, True, True, True, 3, False),
+    10: _c("rgb", True, False, False, True, True, True, True, 3, False),
+    11: _c("rgb", True, True, False, True, True, True, True, 3, False),
+    12: _c("rgb", True, False, False, True, True, True, True, 3, False),
+    13: _c("rgb", True, True, False, True, True, True, True, 3, False),
+    14: _c("rgb", True, False, False, True, True, True, True, 3, False),
+    15: _c("rgb", True, False, False, True, True, True, True, 3, False),
+    16: _c("rgb", True, True, False, True, True, True, True, 3, False),
+    10000: _c("rgb", True, False, False, True, True, True, True, 3, False),
+    10002: _c("rgb", True, True, False, True, True, True, True, 3, False),
+    10010: _c("rgb", True, True, True, True, True, True, True, 3, False),
+    10011: _c("none", False, False, False, True, False, False, False, 3, False),
+    10012: _c("single", False, False, False, True, True, True, False, 3, False),
+    10013: _c("none", False, True, False, True, True, False, False, 3, False),
+    10014: _c("rgb", True, False, False, False, False, True, True, 3, False),
+    10015: _c("single", True, True, True, False, False, True, False, 3, False),
+    10016: _c("single", True, False, True, False, False, True, False, 3, False),
+    10017: _c("none", False, False, True, True, True, True, True, 3, False),
+    10018: _c("none", False, True, True, True, True, False, False, 3, False),
+    10019: _c("single", True, False, False, True, False, False, False, 3, False),
+    10022: _c("rgb", True, True, True, True, True, True, True, 3, False),
+    10027: _c("rgb", True, False, False, True, True, True, True, 3, False),
+    10029: _c("rgb", True, False, False, True, True, True, True, 3, False),
+    10030: _c("none", False, False, True, True, True, False, False, 0, True),
+    10031: _c("none", False, False, True, True, True, False, False, 0, True),
+    10032: _c("none", False, False, False, True, True, False, False, 0, True),
+    10034: _c("toggle", True, False, False, True, True, True, True, 3, False),
+    10036: _c("rgb", True, True, True, True, True, True, True, 3, False),
+    10038: _c("none", False, False, False, True, True, False, False, 0, True),
+    10039: _c("none", False, False, False, True, True, False, False, 0, True),
+}
+
+# Fallback for unknown product ids: the app's default GEN2_BED profile (ID_7) —
+# a fully-featured bed. Keeping unknown beds fully-featured avoids hiding controls
+# a bed may actually have; known ids get accurate gating.
+GEN2_FALLBACK: Final[Gen2Capabilities] = GEN2_PROFILES[7]
+
+
+def compute_product_id(manufacturer_data: Mapping[int, bytes] | None) -> int | None:
+    """Derive the Gen2 productId from advertisement manufacturer data.
+
+    Reproduces ``Gen2BedControlBoxInterface.productId(ScanResult)``: take the
+    manufacturer payload that begins with ASCII ``XP``/``CP``, hex-encode each
+    byte, reverse the list of hex bytes, join the first four, and parse as a
+    base-16 integer. e.g. ``58 50 05 00 00 00`` -> ``["00","00","00","05",…]`` ->
+    ``0x00000005`` -> ``5``.
+    """
+    if not manufacturer_data:
+        return None
+    for payload in manufacturer_data.values():
+        if payload[:2] in _GEN2_PREFIXES:
+            hex_bytes = [f"{b:02x}" for b in payload]
+            hex_bytes.reverse()
+            try:
+                return int("".join(hex_bytes[:4]), 16)
+            except ValueError:
+                return None
+    return None
+
+
+def capabilities_for_product(product_id: int | None) -> Gen2Capabilities:
+    """Return the capability profile for a product id (generous fallback)."""
+    if product_id is None:
+        return GEN2_FALLBACK
+    return GEN2_PROFILES.get(product_id, GEN2_FALLBACK)

--- a/custom_components/adjustable_bed/beds/sleep_number_mcr.py
+++ b/custom_components/adjustable_bed/beds/sleep_number_mcr.py
@@ -158,6 +158,11 @@ class SleepNumberMcrController(BedController):
         return True
 
     @property
+    def requires_persistent_connection(self) -> bool:
+        """MCR beds are kept connected for the entry's lifetime."""
+        return True
+
+    @property
     def supports_motor_control(self) -> bool:
         """This initial implementation exposes presets, not live motor control."""
         return False

--- a/custom_components/adjustable_bed/button.py
+++ b/custom_components/adjustable_bed/button.py
@@ -507,11 +507,11 @@ def _should_add_button(
     if description.requires_massage and not has_massage:
         return False
 
-    # Persistent-connection beds (e.g. LP Comfort Connect) only accept a BLE
-    # connection while in pairing mode and cannot reconnect on demand, so a manual
-    # Disconnect would strand the integration until the user re-pairs. Hide it.
+    # Hide the manual Disconnect for beds that can't recover from it — e.g. LP
+    # Comfort Connect only accepts a connection while in pairing mode. Beds that
+    # stay connected but CAN reconnect on demand (e.g. Sleep Number MCR) keep it.
     if description.key == "disconnect" and getattr(
-        controller, "requires_persistent_connection", False
+        controller, "manual_disconnect_strands_connection", False
     ):
         return False
 

--- a/custom_components/adjustable_bed/button.py
+++ b/custom_components/adjustable_bed/button.py
@@ -507,6 +507,14 @@ def _should_add_button(
     if description.requires_massage and not has_massage:
         return False
 
+    # Persistent-connection beds (e.g. LP Comfort Connect) only accept a BLE
+    # connection while in pairing mode and cannot reconnect on demand, so a manual
+    # Disconnect would strand the integration until the user re-pairs. Hide it.
+    if description.key == "disconnect" and getattr(
+        controller, "requires_persistent_connection", False
+    ):
+        return False
+
     if description.key == "toggle_light" and controller is not None:
         if getattr(controller, "supports_discrete_light_control", False) or getattr(
             controller, "supports_light_color_control", False

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -47,6 +47,7 @@ from .const import (
     BED_TYPE_JENSEN,
     BED_TYPE_KAIDI,
     BED_TYPE_KEESON,
+    BED_TYPE_LEGGETT_GEN2,
     BED_TYPE_LEGGETT_OKIN,
     BED_TYPE_LEGGETT_PLATT,
     BED_TYPE_OCTO,
@@ -96,6 +97,7 @@ from .const import (
     DEFAULT_PROTOCOL_VARIANT,
     DOMAIN,
     KEESON_VARIANT_ERGOMOTION,
+    LEGGETT_VARIANT_GEN2,
     POSITION_MODE_ACCURACY,
     POSITION_MODE_SPEED,
     RICHMAT_REMOTE_AUTO,
@@ -153,6 +155,22 @@ CONNECTION_PROFILE_OPTIONS: dict[str, str] = {
 # BLE connection) never makes setup feel slow. The probe is best-effort and never
 # blocks entry creation.
 _PROBE_TIMEOUT_SECONDS = 15.0
+
+
+def _skips_setup_connection_probe(bed_type: str | None, variant: str | None) -> bool:
+    """Return True for beds whose single connection must not be spent on the probe.
+
+    The setup verify probe connects read-only and always disconnects afterwards.
+    LP Comfort Connect (Leggett & Platt Gen2) only accepts a BLE connection while
+    in pairing mode and refuses reconnection afterwards, so probing would consume
+    the pairing-window connection and leave ``async_setup_entry`` unable to
+    reconnect (issue #385). Skip the probe and create the entry directly for those.
+    """
+    if bed_type == BED_TYPE_LEGGETT_GEN2:
+        return True
+    if bed_type == BED_TYPE_LEGGETT_PLATT:
+        return variant in (VARIANT_AUTO, LEGGETT_VARIANT_GEN2, None)
+    return False
 
 
 @dataclass
@@ -1948,9 +1966,12 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         """Stash the finalized entry and route through the verify_connection step.
 
         Skips the verify step (creating the entry directly) when no connectable
-        scanner is available to probe through.
+        scanner is available to probe through, or for one-connection pairing-window
+        beds whose single connection must be left for setup (issue #385).
         """
-        if not self._verification_possible():
+        if not self._verification_possible() or _skips_setup_connection_probe(
+            entry_data.get(CONF_BED_TYPE), entry_data.get(CONF_PROTOCOL_VARIANT)
+        ):
             return self.async_create_entry(title=title, data=entry_data)
         self._pending_entry = entry_data
         self._pending_title = title

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -435,10 +435,17 @@ LOGICDATA_CHAR_UUID: Final = "b9934c44-5c91-462b-80a1-30fccc29d758"
 MANUFACTURER_ID_LOGICDATA: Final = 1351  # 0x0547
 
 # Leggett & Platt specific UUIDs
-# Gen2 variant (Richmat-based, ASCII commands)
+# Gen2 variant (a.k.a. LP Comfort Connect, control box 209-M001, ESP32-based;
+# Richmat-derived ASCII commands)
 LEGGETT_GEN2_SERVICE_UUID: Final = "45e25100-3171-4cfc-ae89-1d83cf8d8071"
 LEGGETT_GEN2_WRITE_CHAR_UUID: Final = "45e25101-3171-4cfc-ae89-1d83cf8d8071"
 LEGGETT_GEN2_READ_CHAR_UUID: Final = "45e25103-3171-4cfc-ae89-1d83cf8d8071"
+# LP Comfort Connect beds advertise NO service UUID — only manufacturer data
+# under company ID 0x092D whose payload begins with ASCII "XP" or "CP". The LP
+# Control app (com.leggett.android.universal) recognizes these beds purely by
+# this prefix (isGen2Box()); the company ID is an additional filter.
+MANUFACTURER_ID_LEGGETT_GEN2: Final = 0x092D  # 2349
+LEGGETT_GEN2_MANUFACTURER_PREFIXES: Final = (b"XP", b"CP")
 
 # Okin variant (requires pairing)
 LEGGETT_OKIN_SERVICE_UUID: Final = "62741523-52f9-8864-b1ab-3b3a8d65950b"

--- a/custom_components/adjustable_bed/controller_factory.py
+++ b/custom_components/adjustable_bed/controller_factory.py
@@ -360,7 +360,7 @@ async def create_controller(
     if bed_type == BED_TYPE_LEGGETT_GEN2:
         from .beds.leggett_gen2 import LeggettGen2Controller
 
-        return LeggettGen2Controller(coordinator)
+        return LeggettGen2Controller(coordinator, manufacturer_data=manufacturer_data)
 
     if bed_type == BED_TYPE_LEGGETT_OKIN:
         from .beds.leggett_okin import LeggettOkinController
@@ -642,13 +642,13 @@ async def create_controller(
             from .beds.leggett_gen2 import LeggettGen2Controller
 
             _LOGGER.debug("Using Gen2 Leggett & Platt variant (no WiLinke UUID found)")
-            return LeggettGen2Controller(coordinator)
+            return LeggettGen2Controller(coordinator, manufacturer_data=manufacturer_data)
         else:
             # Explicit gen2 variant
             from .beds.leggett_gen2 import LeggettGen2Controller
 
             _LOGGER.debug("Using Gen2 Leggett & Platt variant (configured)")
-            return LeggettGen2Controller(coordinator)
+            return LeggettGen2Controller(coordinator, manufacturer_data=manufacturer_data)
 
     if bed_type == BED_TYPE_REVERIE:
         from .beds.reverie import ReverieController

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -1650,6 +1650,16 @@ class AdjustableBedCoordinator:
                     self._address,
                     connectable=True,
                 )
+                if advertisement is None or not advertisement.manufacturer_data:
+                    # Fall back to the non-connectable advert: this integration
+                    # supports misclassified ESPHome/proxy advertisements, and the
+                    # manufacturer data (e.g. the Gen2 XP/CP product id) carries
+                    # capability info we'd otherwise lose on that path.
+                    advertisement = bluetooth.async_last_service_info(
+                        self.hass,
+                        self._address,
+                        connectable=False,
+                    )
                 if advertisement and advertisement.manufacturer_data:
                     manufacturer_data = dict(advertisement.manufacturer_data)
                     _LOGGER.debug(

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -118,7 +118,7 @@ from .const import (
     DEFAULT_PROTOCOL_VARIANT,
     DEVICE_INFO_CHARS,
     DOMAIN,
-    LEGGETT_VARIANT_GEN2,
+    LEGGETT_VARIANT_MLRM,
     OKIMAT_SERVICE_UUID,
     OKIN_CST_POSITION_AXES,
     OKIN_FOOT_MAX_ANGLE,
@@ -949,16 +949,21 @@ class AdjustableBedCoordinator:
         for the lifetime of the entry instead (issue #385). Trade-off: the physical
         remote cannot be used while Home Assistant is connected.
 
-        This also covers legacy ``leggett_platt`` entries pinned to the Gen2
-        variant. The ``auto`` variant is deliberately excluded because it can
-        resolve to the WiLinke/MlRM controller at connect time (a different,
-        non-persistent controller); such users should select the ``gen2`` variant
-        explicitly.
+        Once a controller is resolved it is authoritative via
+        ``requires_persistent_connection`` — this correctly handles legacy
+        ``leggett_platt`` entries on ``auto`` that resolve to *either* the Gen2
+        controller (persistent) or the WiLinke/MlRM controller (not), which the
+        raw bed type/variant alone cannot distinguish. Before the controller
+        exists we fall back to a bed-type heuristic (assume persistent for
+        ``leggett_platt`` unless explicitly MlRM, since auto defaults to Gen2).
         """
+        controller = self._controller
+        if controller is not None:
+            return controller.requires_persistent_connection
         if self._bed_type in (BED_TYPE_SLEEP_NUMBER_MCR, BED_TYPE_LEGGETT_GEN2):
             return True
         if self._bed_type == BED_TYPE_LEGGETT_PLATT:
-            return self._protocol_variant == LEGGETT_VARIANT_GEN2
+            return self._protocol_variant != LEGGETT_VARIANT_MLRM
         return False
 
     def _disconnect_after_operation_enabled(self) -> bool:

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -118,8 +118,7 @@ from .const import (
     DEFAULT_PROTOCOL_VARIANT,
     DEVICE_INFO_CHARS,
     DOMAIN,
-    LEGGETT_VARIANT_MLRM,
-    LEGGETT_VARIANT_OKIN,
+    LEGGETT_VARIANT_GEN2,
     OKIMAT_SERVICE_UUID,
     OKIN_CST_POSITION_AXES,
     OKIN_FOOT_MAX_ANGLE,
@@ -950,16 +949,16 @@ class AdjustableBedCoordinator:
         for the lifetime of the entry instead (issue #385). Trade-off: the physical
         remote cannot be used while Home Assistant is connected.
 
-        This also covers legacy ``leggett_platt`` entries that resolve to the Gen2
-        controller (i.e. every variant except Okin and WiLinke/MlRM).
+        This also covers legacy ``leggett_platt`` entries pinned to the Gen2
+        variant. The ``auto`` variant is deliberately excluded because it can
+        resolve to the WiLinke/MlRM controller at connect time (a different,
+        non-persistent controller); such users should select the ``gen2`` variant
+        explicitly.
         """
         if self._bed_type in (BED_TYPE_SLEEP_NUMBER_MCR, BED_TYPE_LEGGETT_GEN2):
             return True
         if self._bed_type == BED_TYPE_LEGGETT_PLATT:
-            return self._protocol_variant not in (
-                LEGGETT_VARIANT_OKIN,
-                LEGGETT_VARIANT_MLRM,
-            )
+            return self._protocol_variant == LEGGETT_VARIANT_GEN2
         return False
 
     def _disconnect_after_operation_enabled(self) -> bool:

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -118,7 +118,7 @@ from .const import (
     DEFAULT_PROTOCOL_VARIANT,
     DEVICE_INFO_CHARS,
     DOMAIN,
-    LEGGETT_VARIANT_MLRM,
+    LEGGETT_VARIANT_GEN2,
     OKIMAT_SERVICE_UUID,
     OKIN_CST_POSITION_AXES,
     OKIN_FOOT_MAX_ANGLE,
@@ -132,6 +132,7 @@ from .const import (
     POSITION_TOLERANCE,
     REVERIE_BACK_MAX_ANGLE,
     RICHMAT_REMOTE_AUTO,
+    VARIANT_AUTO,
     get_richmat_features,
     get_richmat_motor_count,
     passive_position_reconciliation_default_enabled,
@@ -265,6 +266,11 @@ class AdjustableBedCoordinator:
 
         self._client: BleakClient | None = None
         self._controller: BedController | None = None
+        # Persistence is a property of the resolved controller, but _on_disconnect
+        # clears the controller before the reconnect decision runs. Cache the last
+        # resolved value so connection-lifecycle checks stay correct across the
+        # disconnect (issue #385 review).
+        self._persistent_connection_resolved: bool | None = None
         self._disconnect_timer: asyncio.TimerHandle | None = None
         self._reconnect_timer: asyncio.TimerHandle | None = None
         self._lock = asyncio.Lock()
@@ -949,21 +955,25 @@ class AdjustableBedCoordinator:
         for the lifetime of the entry instead (issue #385). Trade-off: the physical
         remote cannot be used while Home Assistant is connected.
 
-        Once a controller is resolved it is authoritative via
-        ``requires_persistent_connection`` — this correctly handles legacy
-        ``leggett_platt`` entries on ``auto`` that resolve to *either* the Gen2
-        controller (persistent) or the WiLinke/MlRM controller (not), which the
-        raw bed type/variant alone cannot distinguish. Before the controller
-        exists we fall back to a bed-type heuristic (assume persistent for
-        ``leggett_platt`` unless explicitly MlRM, since auto defaults to Gen2).
+        Resolution order:
+        1. The live controller's ``requires_persistent_connection`` (authoritative).
+        2. The value cached from the last resolved controller — needed because
+           ``_on_disconnect`` clears the controller *before* the reconnect
+           decision runs, so an Okin/MlRM bed must still be recognised as
+           non-persistent and get its reconnect timer.
+        3. A pre-first-connect bed-type heuristic. Only ``auto``/``gen2``
+           ``leggett_platt`` entries are assumed persistent here; ``okin`` and
+           ``mlrm`` are not (they reconnect normally).
         """
         controller = self._controller
         if controller is not None:
             return controller.requires_persistent_connection
+        if self._persistent_connection_resolved is not None:
+            return self._persistent_connection_resolved
         if self._bed_type in (BED_TYPE_SLEEP_NUMBER_MCR, BED_TYPE_LEGGETT_GEN2):
             return True
         if self._bed_type == BED_TYPE_LEGGETT_PLATT:
-            return self._protocol_variant != LEGGETT_VARIANT_MLRM
+            return self._protocol_variant in (VARIANT_AUTO, LEGGETT_VARIANT_GEN2)
         return False
 
     def _disconnect_after_operation_enabled(self) -> bool:
@@ -1664,6 +1674,11 @@ class AdjustableBedCoordinator:
                 )
                 self._controller_state_refresh_retry_count = 0
                 self._controller_state_refresh_completed = False
+                # Remember the resolved persistence so reconnect/idle decisions are
+                # correct even after _on_disconnect clears the controller.
+                self._persistent_connection_resolved = (
+                    self._controller.requires_persistent_connection
+                )
                 _LOGGER.debug("Controller created successfully")
 
                 if self._bed_type == BED_TYPE_SLEEP_NUMBER_MCR:

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -118,6 +118,8 @@ from .const import (
     DEFAULT_PROTOCOL_VARIANT,
     DEVICE_INFO_CHARS,
     DOMAIN,
+    LEGGETT_VARIANT_MLRM,
+    LEGGETT_VARIANT_OKIN,
     OKIMAT_SERVICE_UUID,
     OKIN_CST_POSITION_AXES,
     OKIN_FOOT_MAX_ANGLE,
@@ -939,8 +941,26 @@ class AdjustableBedCoordinator:
             return await self._async_connect_locked()
 
     def _uses_persistent_connection(self) -> bool:
-        """Return True when this controller should stay connected indefinitely."""
-        return self._bed_type == BED_TYPE_SLEEP_NUMBER_MCR
+        """Return True when this controller should stay connected indefinitely.
+
+        Leggett & Platt Gen2 (LP Comfort Connect, 209-M001) is included because
+        its ESP32 controller only accepts a BLE connection while in pairing mode
+        and refuses reconnection afterwards. Idle-disconnecting it leaves the bed
+        unreachable until it is power-cycled / re-paired, so we hold the link open
+        for the lifetime of the entry instead (issue #385). Trade-off: the physical
+        remote cannot be used while Home Assistant is connected.
+
+        This also covers legacy ``leggett_platt`` entries that resolve to the Gen2
+        controller (i.e. every variant except Okin and WiLinke/MlRM).
+        """
+        if self._bed_type in (BED_TYPE_SLEEP_NUMBER_MCR, BED_TYPE_LEGGETT_GEN2):
+            return True
+        if self._bed_type == BED_TYPE_LEGGETT_PLATT:
+            return self._protocol_variant not in (
+                LEGGETT_VARIANT_OKIN,
+                LEGGETT_VARIANT_MLRM,
+            )
+        return False
 
     def _disconnect_after_operation_enabled(self) -> bool:
         """Return True when commands should disconnect immediately after completion."""

--- a/custom_components/adjustable_bed/cover.py
+++ b/custom_components/adjustable_bed/cover.py
@@ -181,12 +181,16 @@ async def async_setup_entry(
     coordinator: AdjustableBedCoordinator = hass.data[DOMAIN][entry.entry_id]
     controller = coordinator.controller
 
-    # Skip motor cover entities if bed doesn't support motor control
+    # Skip motor cover entities if bed doesn't support motor control. Still run
+    # stale cleanup first, so covers left over from an older config (e.g. a Gen2
+    # entry that resolved to a no-actuator profile) are removed rather than left
+    # registered and unavailable.
     if controller is not None and not controller.supports_motor_control:
         _LOGGER.debug(
             "Skipping motor covers for %s - bed only supports presets",
             coordinator.name,
         )
+        _async_remove_stale_cover_entities(hass, coordinator, controller)
         return
 
     # Skip motor cover entities if bed uses discrete motor control (buttons instead)

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -97,6 +97,7 @@ from .const import (
     KEESON_JSON_SERVICE_UUID,
     KEESON_NAME_PATTERNS,
     KEESON_SINO_NAME_PATTERNS,
+    LEGGETT_GEN2_MANUFACTURER_PREFIXES,
     LEGGETT_GEN2_SERVICE_UUID,
     LEGGETT_OKIN_NAME_PATTERNS,
     LEGGETT_RICHMAT_NAME_PATTERNS,
@@ -112,6 +113,7 @@ from .const import (
     MALOUF_NEW_OKIN_ADVERTISED_SERVICE_UUID,
     MALOUF_NEW_OKIN_WRITE_CHAR_UUID,
     MANUFACTURER_ID_DEWERTOKIN,
+    MANUFACTURER_ID_LEGGETT_GEN2,
     MANUFACTURER_ID_LOGICDATA,
     MANUFACTURER_ID_OKIN,
     MANUFACTURER_ID_VIBRADORM,
@@ -262,6 +264,14 @@ def _check_manufacturer_data(
     # Source: at.silvermotion app disassembly
     if MANUFACTURER_ID_LOGICDATA in manufacturer_data:
         return BED_TYPE_LOGICDATA, 0.95, MANUFACTURER_ID_LOGICDATA
+
+    # Leggett & Platt Gen2 / LP Comfort Connect (control box 209-M001): advertises
+    # only manufacturer data under company 0x092D with an "XP"/"CP" payload prefix
+    # and NO service UUID. Matches the LP Control app's isGen2Box() check.
+    # Source: com.leggett.android.universal disassembly.
+    lp_payload = manufacturer_data.get(MANUFACTURER_ID_LEGGETT_GEN2)
+    if lp_payload is not None and lp_payload[:2] in LEGGETT_GEN2_MANUFACTURER_PREFIXES:
+        return BED_TYPE_LEGGETT_GEN2, 0.95, MANUFACTURER_ID_LEGGETT_GEN2
 
     # Note: OKIN Automotive (ID 89) is NOT checked here because it should be
     # a fallback after UUID-based detection. See detect_bed_type_detailed().

--- a/custom_components/adjustable_bed/light.py
+++ b/custom_components/adjustable_bed/light.py
@@ -176,24 +176,25 @@ class AdjustableBedLight(AdjustableBedEntity, RestoreEntity, LightEntity):
         """Restore the last light state and subscribe to live light state."""
         await super().async_added_to_hass()
 
+        # Restore the persisted HA state FIRST, then subscribe — registering the
+        # callback can fire immediately with live bed state, which must win over
+        # the older restored value rather than be overwritten by it.
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_is_on = last_state.state == STATE_ON
+            if self._attr_color_mode == ColorMode.RGBW:
+                restored_rgbw = _normalize_rgbw_color(last_state.attributes.get(ATTR_RGBW_COLOR))
+                if restored_rgbw is not None:
+                    self._attr_rgbw_color = restored_rgbw
+            else:
+                restored_rgb = _normalize_rgb_color(last_state.attributes.get(ATTR_RGB_COLOR))
+                if restored_rgb is not None:
+                    self._attr_rgb_color = restored_rgb
+
         # Reflect bed-reported on/off + colour where the controller publishes it
         # (e.g. Leggett Gen2). No-op for controllers that don't report light state.
         self._unregister_light_state = self._coordinator.register_controller_state_callback(
             self._handle_light_state
         )
-
-        if (last_state := await self.async_get_last_state()) is None:
-            return
-
-        self._attr_is_on = last_state.state == STATE_ON
-        if self._attr_color_mode == ColorMode.RGBW:
-            restored_rgbw = _normalize_rgbw_color(last_state.attributes.get(ATTR_RGBW_COLOR))
-            if restored_rgbw is not None:
-                self._attr_rgbw_color = restored_rgbw
-        else:
-            restored_rgb = _normalize_rgb_color(last_state.attributes.get(ATTR_RGB_COLOR))
-            if restored_rgb is not None:
-                self._attr_rgb_color = restored_rgb
 
     async def async_will_remove_from_hass(self) -> None:
         """Unsubscribe from live light-state updates."""
@@ -205,20 +206,29 @@ class AdjustableBedLight(AdjustableBedEntity, RestoreEntity, LightEntity):
 
     @callback
     def _handle_light_state(self, state: dict[str, Any]) -> None:
-        """Update on/off + colour from controller-reported light state."""
+        """Update on/off + colour from controller-reported light state.
+
+        Only writes HA state when a value actually changes, to avoid event churn
+        on repeated/identical telemetry packets.
+        """
         changed = False
         if "under_bed_lights_on" in state:
-            self._attr_is_on = bool(state["under_bed_lights_on"])
-            changed = True
+            is_on = bool(state["under_bed_lights_on"])
+            if is_on != self._attr_is_on:
+                self._attr_is_on = is_on
+                changed = True
         rgb = state.get("under_bed_lights_rgb")
         if rgb is not None and len(rgb) == 3:
             r, g, b = rgb
             if self._attr_color_mode == ColorMode.RGBW:
                 w = self._attr_rgbw_color[3] if self._attr_rgbw_color else 255
-                self._attr_rgbw_color = (r, g, b, w)
-            else:
+                new_rgbw = (r, g, b, w)
+                if new_rgbw != self._attr_rgbw_color:
+                    self._attr_rgbw_color = new_rgbw
+                    changed = True
+            elif (r, g, b) != self._attr_rgb_color:
                 self._attr_rgb_color = (r, g, b)
-            changed = True
+                changed = True
         if changed:
             self.async_write_ha_state()
 

--- a/custom_components/adjustable_bed/light.py
+++ b/custom_components/adjustable_bed/light.py
@@ -173,8 +173,14 @@ class AdjustableBedLight(AdjustableBedEntity, RestoreEntity, LightEntity):
             self._attr_rgb_color = self._default_rgb_color
 
     async def async_added_to_hass(self) -> None:
-        """Restore the last light state when available."""
+        """Restore the last light state and subscribe to live light state."""
         await super().async_added_to_hass()
+
+        # Reflect bed-reported on/off + colour where the controller publishes it
+        # (e.g. Leggett Gen2). No-op for controllers that don't report light state.
+        self._unregister_light_state = self._coordinator.register_controller_state_callback(
+            self._handle_light_state
+        )
 
         if (last_state := await self.async_get_last_state()) is None:
             return
@@ -188,6 +194,33 @@ class AdjustableBedLight(AdjustableBedEntity, RestoreEntity, LightEntity):
             restored_rgb = _normalize_rgb_color(last_state.attributes.get(ATTR_RGB_COLOR))
             if restored_rgb is not None:
                 self._attr_rgb_color = restored_rgb
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unsubscribe from live light-state updates."""
+        unregister = getattr(self, "_unregister_light_state", None)
+        if unregister is not None:
+            unregister()
+            self._unregister_light_state = None
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _handle_light_state(self, state: dict[str, Any]) -> None:
+        """Update on/off + colour from controller-reported light state."""
+        changed = False
+        if "under_bed_lights_on" in state:
+            self._attr_is_on = bool(state["under_bed_lights_on"])
+            changed = True
+        rgb = state.get("under_bed_lights_rgb")
+        if rgb is not None and len(rgb) == 3:
+            r, g, b = rgb
+            if self._attr_color_mode == ColorMode.RGBW:
+                w = self._attr_rgbw_color[3] if self._attr_rgbw_color else 255
+                self._attr_rgbw_color = (r, g, b, w)
+            else:
+                self._attr_rgb_color = (r, g, b)
+            changed = True
+        if changed:
+            self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on and optionally set a specific color."""

--- a/custom_components/adjustable_bed/manifest.json
+++ b/custom_components/adjustable_bed/manifest.json
@@ -43,6 +43,14 @@
       "service_uuid": "45e25100-3171-4cfc-ae89-1d83cf8d8071"
     },
     {
+      "manufacturer_id": 2349,
+      "manufacturer_data_start": [88, 80]
+    },
+    {
+      "manufacturer_id": 2349,
+      "manufacturer_data_start": [67, 80]
+    },
+    {
       "service_uuid": "62741523-52f9-8864-b1ab-3b3a8d65950b"
     },
     {

--- a/docs/beds/leggett-platt.md
+++ b/docs/beds/leggett-platt.md
@@ -15,6 +15,7 @@
 | Analyzed | App | Package ID |
 |----------|-----|------------|
 | ✅ | [L&P Adjustable Base](https://play.google.com/store/apps/details?id=com.richmat.lp2) | `com.richmat.lp2` |
+| ✅ | [LP Control](https://play.google.com/store/apps/details?id=com.leggett.android.universal) (LP Comfort Connect) | `com.leggett.android.universal` |
 
 ## Features
 
@@ -35,8 +36,20 @@
 Leggett & Platt beds have three protocol variants with different detection methods:
 
 ### Gen2 Variant
-- **Service UUID:** `45e25100-...` (unique to Gen2)
-- Detection: Automatic by service UUID
+- **Service UUID:** `45e25100-...` (unique to Gen2), when advertised
+- **LP Comfort Connect (control box 209-M001, ESP32):** advertises **no service
+  UUID** — only manufacturer data under company ID `0x092D` (2349) whose payload
+  begins with ASCII `XP` or `CP` (e.g. `58 50 05 00 00 00` = `"XP"…`). Detected
+  from that prefix, matching the LP Control app's `isGen2Box()` check.
+- Detection: automatic by service UUID **or** the `XP`/`CP` manufacturer prefix.
+
+> **Connection note (LP Comfort Connect):** the ESP32 controller only accepts a
+> BLE connection while the bed is **in pairing mode**, and refuses reconnection
+> afterwards. The integration therefore keeps the link open for this bed type
+> (no idle disconnect). If Home Assistant loses the connection (e.g. a restart),
+> put the bed back into pairing mode (pull the remote's batteries / re-enable
+> pairing) before it can reconnect. While Home Assistant is connected the
+> physical remote cannot be used.
 
 ### Okin Variant
 - **Service UUID:** `62741523-...` (shared with Okimat and Nectar)
@@ -80,21 +93,32 @@ See also: [Okin Protocol Family](../SUPPORTED_ACTUATORS.md#okin-protocol-family)
 
 ### Motor Commands
 
-Format: `M {up}:{down}:{stop}` where each field is a comma-separated list of motor numbers.
+Format: `M {down}:{up}:{stop}` — three colon-separated fields, each a list of
+motor numbers. For a single press the motor number goes in **exactly one**
+field and the others are empty; there is no trailing stop list. The app
+re-sends the move command every 200 ms while a button is held and sends a
+per-actuator stop on release.
 
 Motor numbers: 0=head, 1=feet, 2=pillow, 3=lumbar
 
+> **Corrected from the LP Control app (`com.leggett.android.universal`).** The
+> earlier values (smartbed-mqtt-derived) had up/down swapped and appended a stop
+> list; they were never confirmed on hardware.
+
 | Command | Text | Description |
 |---------|------|-------------|
-| Head Up | `M 0::123` | Head up, stop feet/pillow/lumbar |
-| Head Down | `M :0:123` | Head down, stop feet/pillow/lumbar |
-| Feet Up | `M 1::023` | Feet up, stop head/pillow/lumbar |
-| Feet Down | `M :1:023` | Feet down, stop head/pillow/lumbar |
-| Pillow Up | `M 2::013` | Pillow up, stop head/feet/lumbar |
-| Pillow Down | `M :2:013` | Pillow down, stop head/feet/lumbar |
-| Lumbar Up | `M 3::012` | Lumbar up, stop head/feet/pillow |
-| Lumbar Down | `M :3:012` | Lumbar down, stop head/feet/pillow |
-| Stop All | `M ::0123` | Stop all motors |
+| Head Up | `M :0:` | Raise head |
+| Head Down | `M 0::` | Lower head |
+| Head Stop | `M ::0` | Stop head |
+| Feet Up | `M :1:` | Raise feet |
+| Feet Down | `M 1::` | Lower feet |
+| Pillow Up | `M :2:` | Raise pillow |
+| Pillow Down | `M 2::` | Lower pillow |
+| Lumbar Up | `M :3:` | Raise lumbar |
+| Lumbar Down | `M 3::` | Lower lumbar |
+| Stop All | `STOP` | Stop all motors |
+
+Combined moves put codes in two fields, e.g. head down + feet up = `M 0:1:`.
 
 ### Massage Commands
 

--- a/docs/beds/leggett-platt.md
+++ b/docs/beds/leggett-platt.md
@@ -118,15 +118,15 @@ Combined moves put codes in two fields, e.g. head down + feet up = `M 0:1:`.
 ### Massage Commands
 
 Gen2 massage intensity is relative (`VII`); an absolute set (`MVI`) also exists
-and is used to switch everything off. Location/channel: 0=head, 1=foot.
+and is used to switch everything off. Channel: 0=head, 1=foot, `0123`=all.
+Mode codes: 0=wave, 1=pulse, 2=always-on.
 
 | Command | Text |
 |---------|------|
-| Increase intensity | `VII :{location}` |
-| Decrease intensity | `VII {location}::` |
-| Set intensity (absolute) | `MVI {location}:{level}` (level 0-3; 0=off) |
-| Set massage mode | `MMODE {modeGroup}:{mode}` |
-| Set wave speed | `WSP {modeGroup}:{waveSpeed}` |
+| Increase intensity | `VII :{channel}` |
+| Decrease intensity | `VII {channel}::` |
+| Set intensity (absolute) | `MVI {channel}:{level}` (level 0-3; 0=off) |
+| Set massage mode | `MMODE 0:{mode}` |
 | Toggle wave | `WVE TOGGLE` |
 
 ### Light Commands

--- a/docs/beds/leggett-platt.md
+++ b/docs/beds/leggett-platt.md
@@ -89,7 +89,6 @@ See also: [Okin Protocol Family](../SUPPORTED_ACTUATORS.md#okin-protocol-family)
 | Save Sleep | `SMEM 2` |
 | Save Wake Up | `SMEM 3` |
 | Save Relax | `SMEM 4` |
-| Save Anti-Snore | `SNPOS 0` |
 
 ### Motor Commands
 
@@ -100,10 +99,6 @@ re-sends the move command every 200 ms while a button is held and sends a
 per-actuator stop on release.
 
 Motor numbers: 0=head, 1=feet, 2=pillow, 3=lumbar
-
-> **Corrected from the LP Control app (`com.leggett.android.universal`).** The
-> earlier values (smartbed-mqtt-derived) had up/down swapped and appended a stop
-> list; they were never confirmed on hardware.
 
 | Command | Text | Description |
 |---------|------|-------------|
@@ -122,23 +117,39 @@ Combined moves put codes in two fields, e.g. head down + feet up = `M 0:1:`.
 
 ### Massage Commands
 
+Gen2 massage uses an increase/decrease model (no absolute level):
+
 | Command | Text |
 |---------|------|
-| Head Massage (0-10) | `MVI 0:{level}` |
-| Foot Massage (0-10) | `MVI 1:{level}` |
-| Wave On | `MMODE 0:0` |
-| Wave Off | `MMODE 0:2` |
-| Wave Level | `WSP 0:{level}` |
+| Increase intensity | `VII :{location}` |
+| Decrease intensity | `VII {location}:` |
+| Set massage mode | `MMODE {modeGroup}:{mode}` |
+| Set wave speed | `WSP {modeGroup}:{waveSpeed}` |
 
 ### Light Commands
 
-Gen2 beds with RGB lighting expose a **Light** entity with a color picker instead of a simple on/off switch. The default color is white (255, 255, 255).
+Under-bed light (LightID `0`). The toggle is the only on/off primitive.
 
 | Command | Text | Description |
 |---------|------|-------------|
-| Get State | `GET STATE` | Query current bed state |
-| RGB Off | `RGBENABLE 0:0` | Turn off RGB lights |
-| RGB Set | `RGBSET 0:{RRGGBBBB}` | Set RGB color + brightness (hex RRGGBBBB, brightness fixed at FF) |
+| Toggle | `UBL TOGGLE` | Toggle the under-bed light on/off |
+| Set colour | `RGBSET 0:RRGGBBAA` | Set colour (8 hex: red, green, blue, alpha/brightness) |
+| Set brightness | `RGBBRT 0:AA` | Set brightness (2 hex) |
+| Default colour | `RGD 0[,<decimal>]` | Get/set the stored default colour |
+
+Live light state (on/off + colour) is reported in the `45e25103` STATE frame via a
+mode byte (`OperatingMode` `CONSTANT_COLOR`/`OFF`) with RGBA bytes.
+
+### Per-model capabilities
+
+Gen2 beds **do not report their feature set over BLE**. The app ships a bundled
+profile per model (`assets/ID_<productId>.json`) and selects it by a `productId`
+it derives from the advertisement manufacturer data (hex each payload byte after
+the `XP`/`CP` prefix, reverse, take the first four, parse base-16 — e.g.
+`58 50 05 …` → `5`). The profile declares the under-bed light style
+(**none / toggle / single-colour / RGB**), which actuators are present (**pillow
+and lumbar vary by model**), massage, and memory slot count (**typically 3**).
+Unknown product ids fall back to a fully-featured profile.
 
 ## Okin Variant (Binary)
 

--- a/docs/beds/leggett-platt.md
+++ b/docs/beds/leggett-platt.md
@@ -117,14 +117,17 @@ Combined moves put codes in two fields, e.g. head down + feet up = `M 0:1:`.
 
 ### Massage Commands
 
-Gen2 massage uses an increase/decrease model (no absolute level):
+Gen2 massage intensity is relative (`VII`); an absolute set (`MVI`) also exists
+and is used to switch everything off. Location/channel: 0=head, 1=foot.
 
 | Command | Text |
 |---------|------|
 | Increase intensity | `VII :{location}` |
-| Decrease intensity | `VII {location}:` |
+| Decrease intensity | `VII {location}::` |
+| Set intensity (absolute) | `MVI {location}:{level}` (level 0-3; 0=off) |
 | Set massage mode | `MMODE {modeGroup}:{mode}` |
 | Set wave speed | `WSP {modeGroup}:{waveSpeed}` |
+| Toggle wave | `WVE TOGGLE` |
 
 ### Light Commands
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -24,6 +24,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_KAIDI,
     BED_TYPE_KEESON,
     BED_TYPE_LEGGETT_GEN2,
+    BED_TYPE_LEGGETT_PLATT,
     BED_TYPE_LEGGETT_WILINKE,
     BED_TYPE_LINAK,
     BED_TYPE_MOTOSLEEP,
@@ -73,6 +74,23 @@ from custom_components.adjustable_bed.kaidi_protocol import (
     KAIDI_ADV_TYPE_BROADCAST,
     KaidiAdvertisement,
 )
+
+
+def test_skips_setup_connection_probe_for_pairing_window_beds() -> None:
+    """LP Comfort Connect (Gen2) must skip the disconnecting setup probe so its
+    single pairing-window connection is left for setup (issue #385 review)."""
+    from custom_components.adjustable_bed.config_flow import _skips_setup_connection_probe
+
+    assert _skips_setup_connection_probe(BED_TYPE_LEGGETT_GEN2, "auto") is True
+    assert _skips_setup_connection_probe(BED_TYPE_LEGGETT_PLATT, "auto") is True
+    assert _skips_setup_connection_probe(BED_TYPE_LEGGETT_PLATT, "gen2") is True
+    assert _skips_setup_connection_probe(BED_TYPE_LEGGETT_PLATT, None) is True
+    # MlRM/Okin Leggett beds reconnect normally, so the probe is fine.
+    assert _skips_setup_connection_probe(BED_TYPE_LEGGETT_PLATT, "mlrm") is False
+    assert _skips_setup_connection_probe(BED_TYPE_LEGGETT_PLATT, "okin") is False
+    # Unrelated beds are unaffected.
+    assert _skips_setup_connection_probe(BED_TYPE_KEESON, "auto") is False
+    assert _skips_setup_connection_probe(None, None) is False
 
 
 class TestPairingInstructions:

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -305,6 +305,29 @@ class TestDetectBedTypeByServiceUUID:
         )
         assert detect_bed_type(service_info) == BED_TYPE_LEGGETT_GEN2
 
+    def test_detect_leggett_gen2_by_manufacturer_data(self):
+        """LP Comfort Connect advertises no UUID, only mfr data (company 0x092D,
+        'XP'/'CP' payload prefix) — detect it from that (issue #385)."""
+        # Real-device payload from the support bundle: "XP" + 05 00 00 00.
+        service_info = _make_service_info(
+            name="Smart Bed 22D8",
+            service_uuids=[],
+            manufacturer_data={0x092D: bytes.fromhex("585005000000")},
+        )
+        assert detect_bed_type(service_info) == BED_TYPE_LEGGETT_GEN2
+
+        # "CP" prefix is also accepted.
+        cp = _make_service_info(
+            name="Smart Bed", manufacturer_data={0x092D: b"CP\x00\x00"}
+        )
+        assert detect_bed_type(cp) == BED_TYPE_LEGGETT_GEN2
+
+        # Same company id but an unrelated payload must NOT match.
+        other = _make_service_info(
+            name="Smart Bed", manufacturer_data={0x092D: b"ZZ\x00\x00"}
+        )
+        assert detect_bed_type(other) != BED_TYPE_LEGGETT_GEN2
+
     def test_detect_reverie_nightstand_by_uuid(self):
         """Test Reverie Nightstand detection by unique service UUID."""
         service_info = _make_service_info(

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2104,13 +2104,9 @@ class TestLightEntities:
             blocking=True,
         )
 
-        # Should send lights_on (white RGBSET) then set_light_color (custom RGBSET)
+        # Gen2 has no explicit-on command, so turn_on just sets the colour
+        # (RGBSET turns an RGB light on); no separate white-on is sent.
         assert mock_bleak_client.write_gatt_char.call_args_list == [
-            call(
-                LEGGETT_GEN2_WRITE_CHAR_UUID,
-                LeggettGen2Commands.rgb_set(255, 255, 255, 255),
-                response=True,
-            ),
             call(
                 LEGGETT_GEN2_WRITE_CHAR_UUID,
                 b"RGBSET 0:FF0080FF",
@@ -2175,11 +2171,11 @@ class TestLightEntities:
             blocking=True,
         )
 
-        # Should send lights_off which is RGBENABLE 0:0
+        # Should send lights_off which is the confirmed toggle (UBL TOGGLE)
         assert mock_bleak_client.write_gatt_char.call_args_list == [
             call(
                 LEGGETT_GEN2_WRITE_CHAR_UUID,
-                LeggettGen2Commands.RGB_OFF,
+                LeggettGen2Commands.LIGHT_TOGGLE,
                 response=True,
             )
         ]

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2063,7 +2063,7 @@ class TestLightEntities:
         mock_bleak_client: MagicMock,
         enable_custom_integrations,
     ):
-        """Leggett Gen2 light turn_on with rgb_color should send lights_on + RGBSET."""
+        """Leggett Gen2 light turn_on with rgb_color sends RGBSET only (no separate on)."""
         del mock_coordinator_connected, enable_custom_integrations
         entry = MockConfigEntry(
             domain=DOMAIN,
@@ -2125,7 +2125,7 @@ class TestLightEntities:
         mock_bleak_client: MagicMock,
         enable_custom_integrations,
     ):
-        """Leggett Gen2 light turn_off should send RGBENABLE 0:0."""
+        """Leggett Gen2 light turn_off should send the toggle (UBL TOGGLE)."""
         del mock_coordinator_connected, enable_custom_integrations
         entry = MockConfigEntry(
             domain=DOMAIN,

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -27,6 +27,7 @@ from custom_components.adjustable_bed.const import (
     LEGGETT_GEN2_WRITE_CHAR_UUID,
     LEGGETT_VARIANT_GEN2,
     LEGGETT_VARIANT_MLRM,
+    LEGGETT_VARIANT_OKIN,
     VARIANT_AUTO,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
@@ -167,18 +168,20 @@ class TestLeggettGen2Connection:
         [
             (BED_TYPE_LEGGETT_GEN2, VARIANT_AUTO, True),
             (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_GEN2, True),
-            # Before a controller is resolved, leggett_platt + auto is assumed
-            # persistent (auto defaults to Gen2); only explicit MlRM is excluded.
+            # Before a controller is resolved, only auto/gen2 leggett_platt is
+            # assumed persistent; okin and mlrm reconnect normally.
             (BED_TYPE_LEGGETT_PLATT, VARIANT_AUTO, True),
             (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_MLRM, False),
+            (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_OKIN, False),
         ],
     )
     async def test_persistent_connection_fallback(
         self, hass: HomeAssistant, bed_type: str, variant: str, expected: bool
     ):
-        """Pre-connect (no controller yet): fall back to the bed-type heuristic."""
+        """Pre-connect (no controller, no cache): fall back to the bed-type heuristic."""
         coordinator = self._coordinator(hass, bed_type, variant)
         assert coordinator._controller is None
+        assert coordinator._persistent_connection_resolved is None
         assert coordinator._uses_persistent_connection() is expected
 
     async def test_resolved_controller_is_authoritative(self, hass: HomeAssistant):
@@ -196,6 +199,22 @@ class TestLeggettGen2Connection:
         assert coordinator._uses_persistent_connection() is False
 
         coordinator._controller = LeggettGen2Controller(coordinator)
+        assert coordinator._uses_persistent_connection() is True
+
+    async def test_persistence_cached_across_disconnect(self, hass: HomeAssistant):
+        """_on_disconnect clears the controller before the reconnect decision, so
+        the cached resolved value must drive it — an MlRM bed resolved via auto
+        must stay non-persistent (and thus reconnect) after the drop (issue #385
+        review)."""
+        coordinator = self._coordinator(hass, BED_TYPE_LEGGETT_PLATT, VARIANT_AUTO)
+
+        # Resolved to a non-persistent controller, then cleared on disconnect.
+        coordinator._persistent_connection_resolved = False
+        coordinator._controller = None
+        assert coordinator._uses_persistent_connection() is False
+
+        # Resolved to a persistent (Gen2) controller, then cleared.
+        coordinator._persistent_connection_resolved = True
         assert coordinator._uses_persistent_connection() is True
 
 

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -636,17 +636,51 @@ class TestLeggettMassage:
 class TestLeggettPositionNotifications:
     """Test Leggett & Platt position notification handling."""
 
-    async def test_start_notify_no_support(
+    async def test_start_notify_subscribes_to_state_char(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_gen2_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Gen2 subscribes to the 45e25103 STATE characteristic for light state."""
+        from custom_components.adjustable_bed.const import LEGGETT_GEN2_READ_CHAR_UUID
+
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.start_notify(None)
+
+        chars = [c.args[0] for c in mock_bleak_client.start_notify.call_args_list]
+        assert LEGGETT_GEN2_READ_CHAR_UUID in chars
+        assert coordinator.controller._notify_started is True
+
+    async def test_light_state_notification_parses_on_off(
         self,
         hass: HomeAssistant,
         mock_leggett_gen2_config_entry,
         mock_coordinator_connected,
     ):
-        """Test start_notify stores callback without BLE subscription."""
+        """STATE byte 6 = OperatingMode (0x01 on / 0x04 off); 7-9 = RGB."""
         coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
         await coordinator.async_connect()
+        controller = coordinator.controller
 
-        callback = MagicMock()
-        await coordinator.controller.start_notify(callback)
+        # Constant-colour (on), red: bytes [..6 header.., 0x01, FF, 00, 00, FF, ...]
+        on_frame = bytearray([0x6E, 0x20, 0x00, 0x04, 0x01, 0x03, 0x01, 0xFF, 0x00, 0x00, 0xFF])
+        controller._handle_state_notification(None, on_frame)
+        assert controller._light_on is True
+        assert controller._light_rgb == (0xFF, 0x00, 0x00)
+        assert coordinator.controller_state.get("under_bed_lights_on") is True
 
-        assert coordinator.controller._notify_callback is callback
+        # Off frame (byte 6 = 0x04).
+        off_frame = bytearray([0x6E, 0x20, 0x00, 0x04, 0x01, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00])
+        controller._handle_state_notification(None, off_frame)
+        assert controller._light_on is False
+        assert coordinator.controller_state.get("under_bed_lights_on") is False
+
+        # A non-light frame (byte 6 outside {0x01,0x04}) is ignored.
+        controller._handle_state_notification(
+            None, bytearray([0] * 6 + [0x09] + [0] * 5)
+        )
+        assert controller._light_on is False  # unchanged

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -300,6 +300,34 @@ class TestLeggettGen2Capabilities:
         keys = {spec.key for spec in c.motor_control_specs}
         assert {"back", "legs"} <= keys
 
+    async def test_stale_motor_keys_for_absent_actuators(
+        self, hass: HomeAssistant, mock_leggett_gen2_config_entry
+    ):
+        # Product 10011: head only -> legs/pillow/lumbar covers should be removable.
+        c = self._controller(hass, mock_leggett_gen2_config_entry, 10011)
+        assert c.stale_motor_entity_keys == frozenset({"legs", "pillow", "lumbar"})
+        # Full profile (5): nothing stale.
+        assert self._controller(
+            hass, mock_leggett_gen2_config_entry, 5
+        ).stale_motor_entity_keys == frozenset()
+
+    async def test_set_light_color_updates_cache(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_gen2_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        # RGBSET is the RGB turn-on path -> cache must flip on, so a later off works.
+        await controller.set_light_color((255, 0, 0))
+        assert controller._light_on is True
+        await controller.set_light_color((0, 0, 0))
+        assert controller._light_on is False
+
     async def test_massage_toggle_gated_on_wave(
         self, hass: HomeAssistant, mock_leggett_gen2_config_entry
     ):

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -272,6 +272,29 @@ class TestLeggettGen2Capabilities:
         c = self._controller(hass, mock_leggett_gen2_config_entry, 999999)
         assert c.supports_light_color_control and c.has_pillow_support
 
+    async def test_no_light_no_massage_profile_suppresses_helpers(
+        self, hass: HomeAssistant, mock_leggett_gen2_config_entry
+    ):
+        # Product 10011: head-only, no foot, no light, no massage.
+        c = self._controller(hass, mock_leggett_gen2_config_entry, 10011)
+        # Light + massage capability helpers are gated off (no phantom entities).
+        assert not c.supports_light_toggle_control
+        assert not c.supports_under_bed_lights
+        assert not c.supports_massage_off_control
+        assert not c.supports_massage_toggle_control
+        # Motor specs expose only present primary actuators (head, not foot).
+        keys = {spec.key for spec in c.motor_control_specs}
+        assert "back" in keys  # head present
+        assert "legs" not in keys  # no foot
+
+    async def test_full_profile_keeps_helpers(
+        self, hass: HomeAssistant, mock_leggett_gen2_config_entry
+    ):
+        c = self._controller(hass, mock_leggett_gen2_config_entry, 5)
+        assert c.supports_light_toggle_control and c.supports_massage_off_control
+        keys = {spec.key for spec in c.motor_control_specs}
+        assert {"back", "legs"} <= keys
+
 
 class TestLeggettMovement:
     """Test Leggett & Platt movement commands."""
@@ -451,16 +474,22 @@ class TestLeggettLights:
         mock_coordinator_connected,
         mock_bleak_client: MagicMock,
     ):
-        """Test lights on Gen2 sends RGB white command."""
+        """Lights on (state unknown) sends the toggle; idempotent once state known."""
         coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
         await coordinator.async_connect()
+        controller = coordinator.controller
 
-        await coordinator.controller.lights_on()
-
-        expected = LeggettGen2Commands.rgb_set(255, 255, 255, 255)
+        # State unknown -> toggle to turn on.
+        await controller.lights_on()
         mock_bleak_client.write_gatt_char.assert_called_with(
-            LEGGETT_GEN2_WRITE_CHAR_UUID, expected, response=True
+            LEGGETT_GEN2_WRITE_CHAR_UUID, LeggettGen2Commands.LIGHT_TOGGLE, response=True
         )
+
+        # Once the bed reports the light is on, lights_on is a no-op (no inversion).
+        controller._light_on = True
+        mock_bleak_client.write_gatt_char.reset_mock()
+        await controller.lights_on()
+        mock_bleak_client.write_gatt_char.assert_not_called()
 
     async def test_lights_off_gen2(
         self,

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -116,6 +116,40 @@ class TestLeggettOkinController:
         assert command[2:] == bytes([0x00, 0x00, 0x00, 0x01])
 
 
+class TestLeggettGen2CommandFormat:
+    """Verify Gen2 motor command bytes match the LP Control app (issue #385)."""
+
+    def test_motor_command_bytes(self):
+        """Format is ``M {down}:{up}:{stop}`` with the code in exactly one field."""
+        c = LeggettGen2Commands
+        assert c.MOTOR_HEAD_UP == b"M :0:"
+        assert c.MOTOR_HEAD_DOWN == b"M 0::"
+        assert c.MOTOR_HEAD_STOP == b"M ::0"
+        assert c.MOTOR_FEET_UP == b"M :1:"
+        assert c.MOTOR_FEET_DOWN == b"M 1::"
+        assert c.MOTOR_FEET_STOP == b"M ::1"
+        assert c.MOTOR_PILLOW_UP == b"M :2:"
+        assert c.MOTOR_LUMBAR_UP == b"M :3:"
+        assert c.MOTOR_STOP_ALL == b"STOP"
+
+    def test_motor_move_builder(self):
+        """The builder lays fields out as down:up:stop."""
+        assert LeggettGen2Commands.motor_move(up="0") == b"M :0:"
+        assert LeggettGen2Commands.motor_move(down="1") == b"M 1::"
+        assert LeggettGen2Commands.motor_move(stop="2") == b"M ::2"
+
+
+class TestLeggettGen2Connection:
+    """Gen2 / LP Comfort Connect connection behaviour."""
+
+    async def test_uses_persistent_connection(
+        self, hass: HomeAssistant, mock_leggett_gen2_config_entry
+    ):
+        """LP Comfort Connect must stay connected (it can't reconnect once idle)."""
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
+        assert coordinator._uses_persistent_connection() is True
+
+
 class TestLeggettMovement:
     """Test Leggett & Platt movement commands."""
 
@@ -132,10 +166,13 @@ class TestLeggettMovement:
 
         await coordinator.controller.move_head_up()
 
-        # _move_with_stop sends the motor command then MOTOR_STOP_ALL
+        # _move_with_stop sends the head-up command then the per-actuator stop
         assert mock_bleak_client.write_gatt_char.called
         last_call = mock_bleak_client.write_gatt_char.call_args
-        assert last_call[0][1] == LeggettGen2Commands.MOTOR_STOP_ALL
+        assert last_call[0][1] == LeggettGen2Commands.MOTOR_HEAD_STOP
+        # The move command itself (head up = "M :0:") was sent before the stop
+        sent = [c[0][1] for c in mock_bleak_client.write_gatt_char.call_args_list]
+        assert LeggettGen2Commands.MOTOR_HEAD_UP in sent
 
     async def test_move_head_stop_gen2(
         self,
@@ -144,14 +181,14 @@ class TestLeggettMovement:
         mock_coordinator_connected,
         mock_bleak_client: MagicMock,
     ):
-        """Test move head stop sends MOTOR_STOP_ALL command."""
+        """Test move head stop sends the per-actuator head stop command."""
         coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
         await coordinator.async_connect()
 
         await coordinator.controller.move_head_stop()
 
         mock_bleak_client.write_gatt_char.assert_called_with(
-            LEGGETT_GEN2_WRITE_CHAR_UUID, LeggettGen2Commands.MOTOR_STOP_ALL, response=True
+            LEGGETT_GEN2_WRITE_CHAR_UUID, LeggettGen2Commands.MOTOR_HEAD_STOP, response=True
         )
 
     async def test_stop_all_gen2(

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -299,17 +299,45 @@ class TestLeggettGen2Capabilities:
         assert c.supports_light_toggle_control and c.supports_massage_off_control
         keys = {spec.key for spec in c.motor_control_specs}
         assert {"back", "legs"} <= keys
+        # Gen2 never exposes the base's duplicate head/feet specs.
+        assert not ({"head", "feet"} & keys)
+
+    async def test_no_massage_profile_hides_zone_buttons(
+        self, hass: HomeAssistant, mock_leggett_gen2_config_entry
+    ):
+        # Product 10011: no massage -> all massage helpers (incl. zone) report False.
+        c = self._controller(hass, mock_leggett_gen2_config_entry, 10011)
+        assert not c.supports_head_massage_intensity_step_control
+        assert not c.supports_foot_massage_intensity_step_control
+        assert not c.supports_massage_off_control
+
+    async def test_manual_disconnect_strands_connection(
+        self, hass: HomeAssistant, mock_leggett_gen2_config_entry
+    ):
+        # Gen2 can only reconnect in pairing mode -> manual disconnect strands it.
+        assert self._controller(
+            hass, mock_leggett_gen2_config_entry, 5
+        ).manual_disconnect_strands_connection is True
 
     async def test_stale_motor_keys_for_absent_actuators(
         self, hass: HomeAssistant, mock_leggett_gen2_config_entry
     ):
-        # Product 10011: head only -> legs/pillow/lumbar covers should be removable.
+        # Product 10011: head only -> legs/pillow/lumbar removable, plus the
+        # duplicate head/feet keys Gen2 never exposes.
         c = self._controller(hass, mock_leggett_gen2_config_entry, 10011)
-        assert c.stale_motor_entity_keys == frozenset({"legs", "pillow", "lumbar"})
-        # Full profile (5): nothing stale.
+        assert c.stale_motor_entity_keys == frozenset(
+            {"legs", "pillow", "lumbar", "head", "feet"}
+        )
+        # Full profile (5): only the duplicate head/feet keys are stale.
         assert self._controller(
             hass, mock_leggett_gen2_config_entry, 5
-        ).stale_motor_entity_keys == frozenset()
+        ).stale_motor_entity_keys == frozenset({"head", "feet"})
+        # No-actuator profile (10014): everything is stale.
+        assert self._controller(
+            hass, mock_leggett_gen2_config_entry, 10014
+        ).stale_motor_entity_keys == frozenset(
+            {"back", "legs", "pillow", "lumbar", "head", "feet"}
+        )
 
     async def test_set_light_color_updates_cache(
         self,

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -27,7 +27,6 @@ from custom_components.adjustable_bed.const import (
     LEGGETT_GEN2_WRITE_CHAR_UUID,
     LEGGETT_VARIANT_GEN2,
     LEGGETT_VARIANT_MLRM,
-    LEGGETT_VARIANT_OKIN,
     VARIANT_AUTO,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
@@ -148,24 +147,8 @@ class TestLeggettGen2CommandFormat:
 class TestLeggettGen2Connection:
     """Gen2 / LP Comfort Connect connection behaviour."""
 
-    @pytest.mark.parametrize(
-        ("bed_type", "variant", "expected"),
-        [
-            # LP Comfort Connect (explicit gen2) must stay connected.
-            (BED_TYPE_LEGGETT_GEN2, VARIANT_AUTO, True),
-            # Legacy leggett_platt pinned to gen2 → persistent.
-            (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_GEN2, True),
-            # leggett_platt + auto can resolve to MlRM, so it must NOT be forced
-            # persistent (would block the physical remote) — issue #385 review.
-            (BED_TYPE_LEGGETT_PLATT, VARIANT_AUTO, False),
-            (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_MLRM, False),
-            (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_OKIN, False),
-        ],
-    )
-    async def test_uses_persistent_connection(
-        self, hass: HomeAssistant, bed_type: str, variant: str, expected: bool
-    ):
-        """Only explicit Gen2 (LP Comfort Connect) holds the link open."""
+    @staticmethod
+    def _coordinator(hass: HomeAssistant, bed_type: str, variant: str):
         entry = MockConfigEntry(
             domain=DOMAIN,
             data={
@@ -177,8 +160,43 @@ class TestLeggettGen2Connection:
             unique_id="AA:BB:CC:DD:EE:FF",
         )
         entry.add_to_hass(hass)
-        coordinator = AdjustableBedCoordinator(hass, entry)
+        return AdjustableBedCoordinator(hass, entry)
+
+    @pytest.mark.parametrize(
+        ("bed_type", "variant", "expected"),
+        [
+            (BED_TYPE_LEGGETT_GEN2, VARIANT_AUTO, True),
+            (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_GEN2, True),
+            # Before a controller is resolved, leggett_platt + auto is assumed
+            # persistent (auto defaults to Gen2); only explicit MlRM is excluded.
+            (BED_TYPE_LEGGETT_PLATT, VARIANT_AUTO, True),
+            (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_MLRM, False),
+        ],
+    )
+    async def test_persistent_connection_fallback(
+        self, hass: HomeAssistant, bed_type: str, variant: str, expected: bool
+    ):
+        """Pre-connect (no controller yet): fall back to the bed-type heuristic."""
+        coordinator = self._coordinator(hass, bed_type, variant)
+        assert coordinator._controller is None
         assert coordinator._uses_persistent_connection() is expected
+
+    async def test_resolved_controller_is_authoritative(self, hass: HomeAssistant):
+        """Once resolved, the controller decides — a leggett_platt+auto that
+        resolved to WiLinke/MlRM is NOT persistent; one that resolved to Gen2 is
+        (issue #385 review, both directions)."""
+        from custom_components.adjustable_bed.beds.leggett_gen2 import LeggettGen2Controller
+        from custom_components.adjustable_bed.beds.leggett_wilinke import (
+            LeggettWilinkeController,
+        )
+
+        coordinator = self._coordinator(hass, BED_TYPE_LEGGETT_PLATT, VARIANT_AUTO)
+
+        coordinator._controller = LeggettWilinkeController(coordinator)
+        assert coordinator._uses_persistent_connection() is False
+
+        coordinator._controller = LeggettGen2Controller(coordinator)
+        assert coordinator._uses_persistent_connection() is True
 
 
 class TestLeggettMovement:

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -15,14 +15,20 @@ from custom_components.adjustable_bed.beds.leggett_okin import (
     LeggettOkinController,
 )
 from custom_components.adjustable_bed.const import (
+    BED_TYPE_LEGGETT_GEN2,
     BED_TYPE_LEGGETT_PLATT,
     CONF_BED_TYPE,
     CONF_DISABLE_ANGLE_SENSING,
     CONF_HAS_MASSAGE,
     CONF_MOTOR_COUNT,
     CONF_PREFERRED_ADAPTER,
+    CONF_PROTOCOL_VARIANT,
     DOMAIN,
     LEGGETT_GEN2_WRITE_CHAR_UUID,
+    LEGGETT_VARIANT_GEN2,
+    LEGGETT_VARIANT_MLRM,
+    LEGGETT_VARIANT_OKIN,
+    VARIANT_AUTO,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
 
@@ -142,12 +148,37 @@ class TestLeggettGen2CommandFormat:
 class TestLeggettGen2Connection:
     """Gen2 / LP Comfort Connect connection behaviour."""
 
+    @pytest.mark.parametrize(
+        ("bed_type", "variant", "expected"),
+        [
+            # LP Comfort Connect (explicit gen2) must stay connected.
+            (BED_TYPE_LEGGETT_GEN2, VARIANT_AUTO, True),
+            # Legacy leggett_platt pinned to gen2 → persistent.
+            (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_GEN2, True),
+            # leggett_platt + auto can resolve to MlRM, so it must NOT be forced
+            # persistent (would block the physical remote) — issue #385 review.
+            (BED_TYPE_LEGGETT_PLATT, VARIANT_AUTO, False),
+            (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_MLRM, False),
+            (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_OKIN, False),
+        ],
+    )
     async def test_uses_persistent_connection(
-        self, hass: HomeAssistant, mock_leggett_gen2_config_entry
+        self, hass: HomeAssistant, bed_type: str, variant: str, expected: bool
     ):
-        """LP Comfort Connect must stay connected (it can't reconnect once idle)."""
-        coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
-        assert coordinator._uses_persistent_connection() is True
+        """Only explicit Gen2 (LP Comfort Connect) holds the link open."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:FF",
+                CONF_NAME: "LP Bed",
+                CONF_BED_TYPE: bed_type,
+                CONF_PROTOCOL_VARIANT: variant,
+            },
+            unique_id="AA:BB:CC:DD:EE:FF",
+        )
+        entry.add_to_hass(hass)
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        assert coordinator._uses_persistent_connection() is expected
 
 
 class TestLeggettMovement:

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -9,7 +9,10 @@ from homeassistant.const import CONF_ADDRESS, CONF_NAME
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.adjustable_bed.beds.leggett_gen2 import LeggettGen2Commands
+from custom_components.adjustable_bed.beds.leggett_gen2 import (
+    LeggettGen2Commands,
+    LeggettGen2Controller,
+)
 from custom_components.adjustable_bed.beds.leggett_okin import (
     LeggettOkinCommands,
     LeggettOkinController,
@@ -144,6 +147,18 @@ class TestLeggettGen2CommandFormat:
         assert LeggettGen2Commands.motor_move(down="1") == b"M 1::"
         assert LeggettGen2Commands.motor_move(stop="2") == b"M ::2"
 
+    def test_massage_command_bytes(self):
+        """Massage uses VII (relative) / MVI (absolute) / WSP / WVE TOGGLE."""
+        c = LeggettGen2Commands
+        assert c.MASSAGE_HEAD_UP == b"VII :0"
+        assert c.MASSAGE_HEAD_DOWN == b"VII 0::"
+        assert c.MASSAGE_FOOT_UP == b"VII :1"
+        assert c.MASSAGE_FOOT_DOWN == b"VII 1::"
+        assert c.WAVE_TOGGLE == b"WVE TOGGLE"
+        assert c.massage_set(0, 0) == b"MVI 0:0"  # off, head channel
+        assert c.massage_set(1, 3) == b"MVI 1:3"  # foot channel, high
+        assert c.wave_speed(2) == b"WSP 0:2"  # fast
+
 
 class TestLeggettGen2Connection:
     """Gen2 / LP Comfort Connect connection behaviour."""
@@ -216,6 +231,46 @@ class TestLeggettGen2Connection:
         # Resolved to a persistent (Gen2) controller, then cleared.
         coordinator._persistent_connection_resolved = True
         assert coordinator._uses_persistent_connection() is True
+
+
+class TestLeggettGen2Capabilities:
+    """Gen2 capabilities are gated per model by the bundled product profile."""
+
+    @staticmethod
+    def _controller(hass, entry, product_id: int) -> LeggettGen2Controller:
+        # Payload encodes the productId: "XP" + little-endian bytes -> reversed
+        # first 4 hex -> base16. For ids < 256 that is just byte[2].
+        payload = bytes([0x58, 0x50]) + product_id.to_bytes(4, "little")
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        return LeggettGen2Controller(coordinator, manufacturer_data={0x092D: payload})
+
+    async def test_rgb_bed_with_pillow_lumbar(
+        self, hass: HomeAssistant, mock_leggett_gen2_config_entry
+    ):
+        c = self._controller(hass, mock_leggett_gen2_config_entry, 5)
+        assert c.supports_lights and c.supports_light_color_control
+        assert c.has_pillow_support and c.has_lumbar_support
+        assert c.memory_slot_count == 3  # not the old hardcoded 4
+
+    async def test_toggle_light_bed_without_pillow_lumbar(
+        self, hass: HomeAssistant, mock_leggett_gen2_config_entry
+    ):
+        c = self._controller(hass, mock_leggett_gen2_config_entry, 8)
+        assert c.supports_lights and not c.supports_light_color_control
+        assert not c.has_pillow_support and not c.has_lumbar_support
+
+    async def test_bed_without_light(
+        self, hass: HomeAssistant, mock_leggett_gen2_config_entry
+    ):
+        c = self._controller(hass, mock_leggett_gen2_config_entry, 10011)
+        assert not c.supports_lights and not c.supports_light_color_control
+        assert c.default_light_rgb_color is None
+
+    async def test_unknown_product_falls_back_to_full_featured(
+        self, hass: HomeAssistant, mock_leggett_gen2_config_entry
+    ):
+        c = self._controller(hass, mock_leggett_gen2_config_entry, 999999)
+        assert c.supports_light_color_control and c.has_pillow_support
 
 
 class TestLeggettMovement:
@@ -378,15 +433,16 @@ class TestLeggettLights:
         mock_coordinator_connected,
         mock_bleak_client: MagicMock,
     ):
-        """Test lights toggle on Gen2 sends RGB_OFF command."""
+        """Test lights toggle on Gen2 sends the UBL TOGGLE command."""
         coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
         await coordinator.async_connect()
 
         await coordinator.controller.lights_toggle()
 
         mock_bleak_client.write_gatt_char.assert_called_with(
-            LEGGETT_GEN2_WRITE_CHAR_UUID, LeggettGen2Commands.RGB_OFF, response=True
+            LEGGETT_GEN2_WRITE_CHAR_UUID, LeggettGen2Commands.LIGHT_TOGGLE, response=True
         )
+        assert LeggettGen2Commands.LIGHT_TOGGLE == b"UBL TOGGLE"
 
     async def test_lights_on_gen2(
         self,
@@ -413,14 +469,14 @@ class TestLeggettLights:
         mock_coordinator_connected,
         mock_bleak_client: MagicMock,
     ):
-        """Test lights off Gen2 sends RGB_OFF command."""
+        """Test lights off Gen2 uses the confirmed toggle (UBL TOGGLE)."""
         coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
         await coordinator.async_connect()
 
         await coordinator.controller.lights_off()
 
         mock_bleak_client.write_gatt_char.assert_called_with(
-            LEGGETT_GEN2_WRITE_CHAR_UUID, LeggettGen2Commands.RGB_OFF, response=True
+            LEGGETT_GEN2_WRITE_CHAR_UUID, LeggettGen2Commands.LIGHT_TOGGLE, response=True
         )
 
 
@@ -445,11 +501,12 @@ class TestLeggettGen2RgbLights:
         mock_leggett_gen2_config_entry,
         mock_coordinator_connected,
     ):
-        """Test Gen2 controller reports explicit light on support."""
+        """Gen2 has no separate explicit on command (only UBL TOGGLE); setting a
+        colour turns RGB lights on, so explicit-on is reported False."""
         coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
         await coordinator.async_connect()
 
-        assert coordinator.controller.supports_explicit_light_on_control is True
+        assert coordinator.controller.supports_explicit_light_on_control is False
 
     async def test_default_light_rgb_color(
         self,
@@ -546,17 +603,16 @@ class TestLeggettMassage:
         mock_coordinator_connected,
         mock_bleak_client: MagicMock,
     ):
-        """Test head massage up on Gen2."""
+        """Head massage up on Gen2 sends the relative increase command (VII :0)."""
         coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
         await coordinator.async_connect()
 
         await coordinator.controller.massage_head_up()
 
-        # Level should increment to 1
-        expected = LeggettGen2Commands.massage_head_strength(1)
         mock_bleak_client.write_gatt_char.assert_called_with(
-            LEGGETT_GEN2_WRITE_CHAR_UUID, expected, response=True
+            LEGGETT_GEN2_WRITE_CHAR_UUID, LeggettGen2Commands.MASSAGE_HEAD_UP, response=True
         )
+        assert LeggettGen2Commands.MASSAGE_HEAD_UP == b"VII :0"
 
     async def test_massage_toggle_gen2(
         self,
@@ -565,15 +621,16 @@ class TestLeggettMassage:
         mock_coordinator_connected,
         mock_bleak_client: MagicMock,
     ):
-        """Test massage toggle on Gen2."""
+        """Massage toggle on Gen2 sends the wave toggle (WVE TOGGLE)."""
         coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
         await coordinator.async_connect()
 
         await coordinator.controller.massage_toggle()
 
         mock_bleak_client.write_gatt_char.assert_called_with(
-            LEGGETT_GEN2_WRITE_CHAR_UUID, LeggettGen2Commands.MASSAGE_WAVE_ON, response=True
+            LEGGETT_GEN2_WRITE_CHAR_UUID, LeggettGen2Commands.WAVE_TOGGLE, response=True
         )
+        assert LeggettGen2Commands.WAVE_TOGGLE == b"WVE TOGGLE"
 
 
 class TestLeggettPositionNotifications:

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -800,6 +800,8 @@ class TestLeggettPositionNotifications:
         assert controller._light_on is True
         assert controller._light_rgb == (0xFF, 0x00, 0x00)
         assert coordinator.controller_state.get("under_bed_lights_on") is True
+        # RGB must be published to controller state, not just cached privately.
+        assert coordinator.controller_state.get("under_bed_lights_rgb") == (0xFF, 0x00, 0x00)
 
         # Off frame (byte 6 = 0x04).
         off_frame = bytearray([0x6E, 0x20, 0x00, 0x04, 0x01, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00])

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -148,16 +148,21 @@ class TestLeggettGen2CommandFormat:
         assert LeggettGen2Commands.motor_move(stop="2") == b"M ::2"
 
     def test_massage_command_bytes(self):
-        """Massage uses VII (relative) / MVI (absolute) / WSP / WVE TOGGLE."""
+        """Massage uses VII (relative) / MVI (absolute) / MMODE / WVE TOGGLE."""
         c = LeggettGen2Commands
         assert c.MASSAGE_HEAD_UP == b"VII :0"
         assert c.MASSAGE_HEAD_DOWN == b"VII 0::"
         assert c.MASSAGE_FOOT_UP == b"VII :1"
         assert c.MASSAGE_FOOT_DOWN == b"VII 1::"
+        assert c.MASSAGE_ALL_UP == b"VII :0123"
+        assert c.MASSAGE_ALL_DOWN == b"VII 0123::"
         assert c.WAVE_TOGGLE == b"WVE TOGGLE"
         assert c.massage_set(0, 0) == b"MVI 0:0"  # off, head channel
         assert c.massage_set(1, 3) == b"MVI 1:3"  # foot channel, high
-        assert c.wave_speed(2) == b"WSP 0:2"  # fast
+        # Mode codes verified from Gen2CommandFormatter: wave=0, pulse=1, always-on=2.
+        assert c.massage_mode(c.MODE_WAVE) == b"MMODE 0:0"
+        assert c.massage_mode(c.MODE_PULSE) == b"MMODE 0:1"
+        assert c.massage_mode(c.MODE_ALWAYS_ON) == b"MMODE 0:2"
 
 
 class TestLeggettGen2Connection:
@@ -294,6 +299,69 @@ class TestLeggettGen2Capabilities:
         assert c.supports_light_toggle_control and c.supports_massage_off_control
         keys = {spec.key for spec in c.motor_control_specs}
         assert {"back", "legs"} <= keys
+
+    async def test_massage_toggle_gated_on_wave(
+        self, hass: HomeAssistant, mock_leggett_gen2_config_entry
+    ):
+        # Product 10012: massage but NO wave -> no massage toggle (WVE TOGGLE),
+        # but intensity step + mode step are still available.
+        c = self._controller(hass, mock_leggett_gen2_config_entry, 10012)
+        assert c.supports_massage_off_control
+        assert c.supports_massage_intensity_step_control
+        assert c.supports_massage_mode_step_control
+        assert not c.supports_massage_toggle_control
+        # Product 5 has wave -> toggle available.
+        assert self._controller(
+            hass, mock_leggett_gen2_config_entry, 5
+        ).supports_massage_toggle_control
+
+    async def test_massage_intensity_all_and_mode_step(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_gen2_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        await controller.massage_intensity_up()
+        assert mock_bleak_client.write_gatt_char.call_args[0][1] == b"VII :0123"
+        await controller.massage_intensity_down()
+        assert mock_bleak_client.write_gatt_char.call_args[0][1] == b"VII 0123::"
+
+        # Mode step cycles wave -> pulse -> always-on -> wave (fallback profile has wave).
+        sent = []
+        for _ in range(4):
+            await controller.massage_mode_step()
+            sent.append(mock_bleak_client.write_gatt_char.call_args[0][1])
+        assert sent == [b"MMODE 0:1", b"MMODE 0:2", b"MMODE 0:0", b"MMODE 0:1"]
+
+    async def test_lights_on_off_idempotent_and_optimistic(
+        self,
+        hass: HomeAssistant,
+        mock_leggett_gen2_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        # Unknown state -> on toggles and caches True; repeat is a no-op.
+        await controller.lights_on()
+        assert controller._light_on is True
+        mock_bleak_client.write_gatt_char.reset_mock()
+        await controller.lights_on()
+        mock_bleak_client.write_gatt_char.assert_not_called()
+
+        # Off toggles once and caches False; repeat is a no-op (no inversion).
+        await controller.lights_off()
+        assert controller._light_on is False
+        mock_bleak_client.write_gatt_char.reset_mock()
+        await controller.lights_off()
+        mock_bleak_client.write_gatt_char.assert_not_called()
 
 
 class TestLeggettMovement:

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -436,6 +436,7 @@ class TestLeggettPresets:
         """Test preset flat command on Gen2."""
         coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
         await coordinator.async_connect()
+        mock_bleak_client.write_gatt_char.reset_mock()  # ignore the GET STATE on connect
 
         await coordinator.controller.preset_flat()
 
@@ -452,6 +453,7 @@ class TestLeggettPresets:
         """Test preset anti-snore command on Gen2."""
         coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
         await coordinator.async_connect()
+        mock_bleak_client.write_gatt_char.reset_mock()  # ignore the GET STATE on connect
 
         await coordinator.controller.preset_anti_snore()
 
@@ -479,6 +481,7 @@ class TestLeggettPresets:
         """Test preset memory commands on Gen2."""
         coordinator = AdjustableBedCoordinator(hass, mock_leggett_gen2_config_entry)
         await coordinator.async_connect()
+        mock_bleak_client.write_gatt_char.reset_mock()  # ignore the GET STATE on connect
 
         await coordinator.controller.preset_memory(memory_num)
 

--- a/tests/test_leggett_gen2_profiles.py
+++ b/tests/test_leggett_gen2_profiles.py
@@ -1,0 +1,76 @@
+"""Tests for Leggett & Platt Gen2 (LP Comfort Connect) capability profiles."""
+
+from __future__ import annotations
+
+from custom_components.adjustable_bed.beds.leggett_gen2_profiles import (
+    GEN2_FALLBACK,
+    GEN2_PROFILES,
+    capabilities_for_product,
+    compute_product_id,
+)
+
+
+class TestComputeProductId:
+    """Reproduce the app's productId(ScanResult) algorithm."""
+
+    def test_real_device_payload(self):
+        # Reporter's bed: company 0x092D payload "XP" + 05 00 00 00 -> productId 5.
+        assert compute_product_id({0x092D: bytes.fromhex("585005000000")}) == 5
+
+    def test_cp_prefix_accepted(self):
+        # "CP" (0x43 0x50) + 07 00 00 00 -> reversed first 4 -> 0x00000007 -> 7.
+        assert compute_product_id({0x092D: bytes.fromhex("435007000000")}) == 7
+
+    def test_non_gen2_prefix_returns_none(self):
+        assert compute_product_id({0x092D: b"ZZ\x00\x00"}) is None
+
+    def test_empty_returns_none(self):
+        assert compute_product_id({}) is None
+        assert compute_product_id(None) is None
+
+    def test_picks_the_gen2_entry_among_several(self):
+        data = {0x004C: b"\x10\x20", 0x092D: bytes.fromhex("585005000000")}
+        assert compute_product_id(data) == 5
+
+
+class TestCapabilityLookup:
+    """Capability gating differs per product (the whole point of the table)."""
+
+    def test_rgb_bed_with_pillow_and_lumbar(self):
+        caps = capabilities_for_product(5)
+        assert caps.light == "rgb"
+        assert caps.has_pillow and caps.has_lumbar
+        assert caps.has_massage and caps.memory_slots == 3
+
+    def test_toggle_light_bed_without_pillow_lumbar(self):
+        caps = capabilities_for_product(8)
+        assert caps.light == "toggle"
+        assert not caps.has_pillow and not caps.has_lumbar
+
+    def test_bed_with_no_light(self):
+        assert capabilities_for_product(10011).light == "none"
+
+    def test_chair_profile(self):
+        caps = capabilities_for_product(10030)
+        assert caps.is_chair
+        assert caps.light == "none" and not caps.has_massage and caps.memory_slots == 0
+
+    def test_unknown_product_uses_generous_fallback(self):
+        # Unknown ids keep a full entity set (the app's default ID_7 profile).
+        caps = capabilities_for_product(999999)
+        assert caps is GEN2_FALLBACK
+        assert caps.light == "rgb" and caps.has_pillow and caps.has_lumbar
+
+    def test_none_product_uses_fallback(self):
+        assert capabilities_for_product(None) is GEN2_FALLBACK
+
+
+def test_profile_table_is_well_formed():
+    """Every profile has a valid light style and non-negative memory count."""
+    for product_id, caps in GEN2_PROFILES.items():
+        assert isinstance(product_id, int)
+        assert caps.light in ("none", "toggle", "single", "rgb")
+        assert caps.memory_slots >= 0
+        # Chairs carry no under-bed light, massage, or memory in the profiles.
+        if caps.is_chair:
+            assert caps.light == "none" and not caps.has_massage and caps.memory_slots == 0

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -23,3 +23,20 @@ def test_manifest_discovers_okin_receiver_name_only_advertisements() -> None:
     }.issubset(
         {entry["local_name"] for entry in manifest["bluetooth"] if "local_name" in entry}
     )
+
+
+def test_manifest_discovers_leggett_gen2_manufacturer_advertisements() -> None:
+    """LP Comfort Connect (Gen2) advertises no service UUID, so discovery must
+    match on manufacturer id 0x092D + "XP"/"CP" prefix (issue #385 review)."""
+    manifest_path = (
+        Path(__file__).parents[1] / "custom_components" / "adjustable_bed" / "manifest.json"
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    starts = {
+        tuple(entry["manufacturer_data_start"])
+        for entry in manifest["bluetooth"]
+        if entry.get("manufacturer_id") == 0x092D and "manufacturer_data_start" in entry
+    }
+    assert (88, 80) in starts  # "XP"
+    assert (67, 80) in starts  # "CP"


### PR DESCRIPTION
## Summary

Adds support for **Leggett & Platt "LP Comfort Connect"** bases (control box **209-M001**, an ESP32-WROOM-32D board) — reported in #385, where the bed connected once at setup and then "controls never worked".

The control box uses the **same protocol as the existing `leggett_gen2` controller**, but it never worked on real hardware for three independent reasons, all fixed here. Protocol verified by decompiling the **LP Control** app (`com.leggett.android.universal`).

## What was wrong & the fixes

1. **Not auto-detected** — these beds advertise **no service UUID**, only manufacturer data under company `0x092D` (2349) with an `"XP"`/`"CP"` payload prefix (the observed `58 50 05…` = `"XP"`). The user was forced to guess the protocol. → Detect from the manufacturer prefix, matching the app's `isGen2Box()`.
2. **Couldn't stay connected (the actual blocker)** — the ESP32 only accepts a BLE connection **while in pairing mode** and refuses reconnection afterwards. Our idle-disconnect dropped the link and then every reconnect timed out (the `CONNECTION TIMEOUT` logs in the issue). → Treat `leggett_gen2` (and legacy `leggett_platt` resolving to Gen2) as a **persistent connection** — never idle-disconnected.
3. **Motor commands were wrong** — the prior smartbed-mqtt-derived `M` bytes had **up/down swapped** and appended a stop list (`M :0:123`). → Corrected to the app's `M {down}:{up}:{stop}` with the code in exactly one field, per-actuator stop on release, and plain `STOP` for stop-all.

## ⚠️ NEEDS TESTING

The maintainers have no LP Comfort Connect hardware. Detection, command bytes, and checksum-free framing come from the decompiled app, but the **persistent-connection behavior and corrected motor commands are unverified on a real bed**. The #385 reporter has the hardware.

Note the inherent trade-off (documented): while Home Assistant holds the connection, the **physical remote can't be used**, and after an HA restart the bed must be put back into pairing mode to reconnect.

## Tests

New: manufacturer-data detection (`test_detection.py`), corrected command bytes + builder, persistent-connection (`test_leggett.py`). Updated the two motor tests for the new stop semantics. `test_leggett.py` + `test_detection.py` + `test_coordinator.py` + `test_entities.py` all green; ruff + pyright clean.

Docs: `docs/beds/leggett-platt.md` updated with the corrected Gen2 commands, the manufacturer-data detection, and the pairing-mode connection note.

Ref #385

https://claude.ai/code/session_014FuCngQyFrUN7oWnYudZVw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Leggett & Platt Gen2 (LP Comfort Connect) detection via manufacturer data and per-product capability profiles.
  * Added live under-bed lighting updates from device telemetry (on/off and RGB/RGBW where supported).
* **Bug Fixes**
  * Corrected Gen2 motor, massage, and lighting commands (including protocol-aligned stop/toggle and state parsing).
  * Improved connection lifecycle by honoring “persistent connection” capability during idle/disconnect handling.
* **Documentation**
  * Refreshed LP Comfort Connect pairing and ASCII command references.
* **Tests**
  * Expanded Gen2 detection, persistence resolution, capability gating, and STATE/light parsing coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->