### PR TITLE
fix: stop nagging Repairs about non-bed BLE devices

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -56,7 +56,10 @@ from .const import (
 from .coordinator import AdjustableBedCoordinator
 from .detection import detect_richmat_remote_from_name
 from .kaidi_metadata import add_kaidi_entry_metadata, resolve_kaidi_advertisement
-from .unsupported import create_pairing_required_issue
+from .unsupported import (
+    async_clear_unsupported_device_issues,
+    create_pairing_required_issue,
+)
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
@@ -117,6 +120,10 @@ PLATFORMS: list[Platform] = [
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Adjustable Bed integration domain."""
     hass.data.setdefault(DOMAIN, {})
+
+    # Clear obsolete "unsupported BLE device" Repairs issues from older versions
+    # that nagged about every discovered non-bed device (feature removed).
+    async_clear_unsupported_device_issues(hass)
 
     from .download import SupportBundleDownloadView
 

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -114,7 +114,6 @@ from .detection import (
     detect_bed_type,
     detect_bed_type_detailed,
     detect_richmat_remote_from_name,
-    determine_unsupported_reason,
     get_bed_type_options,
     is_mac_like_name,
 )
@@ -127,8 +126,6 @@ from .kaidi_metadata import add_kaidi_entry_metadata, resolve_kaidi_advertisemen
 from .unsupported import (
     build_misidentified_issue_url,
     capture_device_info,
-    create_unsupported_device_issue,
-    log_unsupported_device,
 )
 from .validators import (
     get_available_adapters,
@@ -453,18 +450,13 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         bed_type = detection_result.bed_type
 
         if bed_type is None:
-            # Check if device was excluded as a known non-bed device
-            is_excluded = any(s.startswith("excluded:") for s in detection_result.signals)
-
-            if not is_excluded:
-                # Only create Repairs issue for genuinely unknown devices,
-                # not for devices already identified as non-bed (speakers, etc.)
-                device_info = capture_device_info(discovery_info)
-                reason = determine_unsupported_reason(discovery_info)
-                created = await create_unsupported_device_issue(self.hass, device_info, reason)
-                if created:
-                    log_unsupported_device(device_info, reason)
-
+            # Devices that match our broad Bluetooth manifest matchers but aren't
+            # recognised as a bed are silently ignored. We deliberately do NOT
+            # raise a Repairs issue here: most matches are unrelated BLE devices
+            # (the manifest matches generic manufacturer IDs / name prefixes), so
+            # nagging the user about every passing speaker, sensor or phone would
+            # be noise. Discovery simply aborts; users add unsupported beds via
+            # the manual flow, which offers a support bundle.
             _LOGGER.debug(
                 "Device %s is not a supported bed type, aborting",
                 discovery_info.address,

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -1831,24 +1831,3 @@ async def detect_bed_type_by_characteristics(
         _LOGGER.debug("Characteristic detection failed (malformed service): %s", err)
 
     return None
-
-
-def determine_unsupported_reason(service_info: BluetoothServiceInfoBleak) -> str:
-    """Determine why a device was not detected as a supported bed."""
-    device_name = (service_info.name or "").lower()
-
-    # Check if it was excluded
-    for pattern in EXCLUDED_DEVICE_PATTERNS:
-        if pattern in device_name:
-            return f"Device name contains excluded pattern '{pattern}' (non-bed device)"
-
-    # Check if it has any service UUIDs at all
-    if not service_info.service_uuids:
-        return "No BLE service UUIDs advertised"
-
-    # Check if it has manufacturer data but unknown protocol
-    if service_info.manufacturer_data:
-        return "Has manufacturer data but no recognized service UUIDs"
-
-    # Generic reason
-    return "No matching service UUIDs or name patterns found"

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -760,10 +760,6 @@
     }
   },
   "issues": {
-    "unsupported_device": {
-      "title": "Unsupported BLE device: {name}",
-      "description": "A Bluetooth device was detected that could not be identified as a supported adjustable bed.\n\n**Device:** {name}\n**Address:** `{address}`\n**Reason:** {reason}\n\nIf this is an adjustable bed that you'd like to see supported, please [report it on GitHub]({github_url}) with as much information as possible about your bed model.\n\nYou can also run **Generate Support Bundle** (`adjustable_bed.generate_support_bundle`) with this device's address to capture protocol data that can help us add support."
-    },
     "pairing_required": {
       "title": "Bluetooth pairing required for {name}",
       "fix_flow": {

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -763,10 +763,6 @@
     }
   },
   "issues": {
-    "unsupported_device": {
-      "title": "Unsupported BLE device: {name}",
-      "description": "A Bluetooth device was detected that could not be identified as a supported adjustable bed.\n\n**Device:** {name}\n**Address:** `{address}`\n**Reason:** {reason}\n\nIf this is an adjustable bed that you'd like to see supported, please [report it on GitHub]({github_url}) with as much information as possible about your bed model.\n\nYou can also run **Generate Support Bundle** (`adjustable_bed.generate_support_bundle`) with this device's address to capture protocol data that can help us add support."
-    },
     "pairing_required": {
       "title": "Bluetooth pairing required for {name}",
       "fix_flow": {

--- a/custom_components/adjustable_bed/unsupported.py
+++ b/custom_components/adjustable_bed/unsupported.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from urllib.parse import quote
@@ -28,9 +27,12 @@ _LOGGER = logging.getLogger(__name__)
 GITHUB_REPO = "kristofferR/ha-adjustable-bed"
 GITHUB_NEW_ISSUE_URL = f"https://github.com/{GITHUB_REPO}/issues/new"
 
-# In-memory set of issue_ids already processed this session.
-# Prevents repeated registry lookups and log spam from BLE advertisements.
-_notified_devices: set[str] = set()
+# Prefix for the legacy "unsupported BLE device" Repairs issues. These were
+# created automatically on discovery, but proved to be noise (the integration's
+# Bluetooth matchers are broad, so most matches are unrelated BLE devices). We no
+# longer create them and clear any stragglers on setup; see
+# ``async_clear_unsupported_device_issues``.
+_UNSUPPORTED_ISSUE_PREFIX = "unsupported_device_"
 
 
 @dataclass
@@ -42,69 +44,6 @@ class UnsupportedDeviceInfo:
     service_uuids: list[str]
     manufacturer_data: dict[int, bytes]
     rssi: int | None = None
-
-    def to_log_string(self) -> str:
-        """Format device info for logging."""
-        lines = [
-            f"Address: {self.address}",
-            f"Name: {self.name or 'Unknown'}",
-            f"RSSI: {self.rssi or 'N/A'}",
-            f"Service UUIDs: {self.service_uuids or 'None'}",
-        ]
-        if self.manufacturer_data:
-            mfr_lines = [f"  {hex(k)}: {v.hex()}" for k, v in self.manufacturer_data.items()]
-            lines.append("Manufacturer data:")
-            lines.extend(mfr_lines)
-        else:
-            lines.append("Manufacturer data: None")
-        return "\n".join(lines)
-
-    def to_issue_body(self, reason: str) -> str:
-        """Format device info for GitHub issue body."""
-        mfr_str = ""
-        if self.manufacturer_data:
-            mfr_items = [f"  - `{hex(k)}`: `{v.hex()}`" for k, v in self.manufacturer_data.items()]
-            mfr_str = "\n".join(mfr_items)
-        else:
-            mfr_str = "  None"
-
-        uuid_str = ""
-        if self.service_uuids:
-            uuid_items = [f"  - `{uuid}`" for uuid in self.service_uuids]
-            uuid_str = "\n".join(uuid_items)
-        else:
-            uuid_str = "  None"
-
-        return f"""## Device Information
-
-**Reason for non-detection:** {reason}
-
-| Property | Value |
-|----------|-------|
-| Address | `{self.address}` |
-| Name | `{self.name or "Unknown"}` |
-| RSSI | {self.rssi or "N/A"} |
-
-### Service UUIDs
-{uuid_str}
-
-### Manufacturer Data
-{mfr_str}
-
-## Bed Information
-
-Please provide the following information about your bed:
-
-- **Bed manufacturer/brand:**
-- **Bed model name:**
-- **Remote control model (if visible):**
-- **App used to control the bed (if any):**
-
-## Additional Context
-
-<!-- Add any other context about your bed here -->
-
-"""
 
     def to_misidentified_details(
         self,
@@ -178,30 +117,6 @@ def capture_device_info(
     )
 
 
-def log_unsupported_device(device_info: UnsupportedDeviceInfo, reason: str) -> None:
-    """Log detailed information about an unsupported device."""
-    _LOGGER.warning(
-        "Unsupported BLE device detected during discovery:\n"
-        "Reason: %s\n"
-        "%s\n"
-        "If this is an adjustable bed, please report it at:\n"
-        "%s",
-        reason,
-        device_info.to_log_string(),
-        _generate_github_url(device_info, reason),
-    )
-
-
-def _generate_github_url(device_info: UnsupportedDeviceInfo, reason: str) -> str:
-    """Generate a pre-filled GitHub issue URL."""
-    title = f"Support request: {device_info.name or 'Unknown device'}"
-    body = device_info.to_issue_body(reason)
-
-    # URL encode the parameters
-    params = f"?template=new-bed-support.yml&title={quote(title)}&body={quote(body)}"
-    return f"{GITHUB_NEW_ISSUE_URL}{params}"
-
-
 def build_misidentified_issue_url(
     device_info: UnsupportedDeviceInfo,
     detected_bed_type: str | None,
@@ -221,70 +136,28 @@ def build_misidentified_issue_url(
     return f"{GITHUB_NEW_ISSUE_URL}{params}"
 
 
-def _make_unsupported_issue_id(device_info: UnsupportedDeviceInfo) -> str:
-    """Generate a stable issue ID, preferring device name over MAC address.
+def async_clear_unsupported_device_issues(hass: HomeAssistant) -> None:
+    """Delete any leftover "unsupported BLE device" Repairs issues.
 
-    BLE devices may use randomized MAC addresses, so keying by name prevents
-    duplicate Repairs entries for the same device across address changes.
+    Earlier versions raised a persistent Repairs issue for every discovered BLE
+    device that wasn't recognised as a bed. Because the integration's Bluetooth
+    matchers are intentionally broad, this nagged users about unrelated devices,
+    so the feature was removed. Issues created by those versions linger in the
+    registry, so we clear them on setup to make the upgrade self-cleaning.
     """
-    if device_info.name:
-        sanitized = re.sub(r"[^a-z0-9]", "_", device_info.name.lower()).strip("_")
-        if sanitized:
-            return f"unsupported_device_{sanitized}"
-    # Fallback to MAC for unnamed devices
-    return f"unsupported_device_{device_info.address.replace(':', '_').lower()}"
-
-
-async def create_unsupported_device_issue(
-    hass: HomeAssistant,
-    device_info: UnsupportedDeviceInfo,
-    reason: str,
-) -> bool:
-    """Create a persistent issue in the Repairs dashboard for an unsupported device.
-
-    Returns True if the issue was newly created, False if it already existed.
-    Deduplicates by device name (or MAC for unnamed devices) to handle BLE
-    address randomization and prevent repeated repairs after dismissal.
-    """
-    issue_id = _make_unsupported_issue_id(device_info)
-
-    # Fast path: already processed this session
-    if issue_id in _notified_devices:
-        return False
-
-    # Check if issue already exists in registry (respects dismissed state across restarts)
     registry = async_get_issue_registry(hass)
-    if registry.async_get_issue(DOMAIN, issue_id) is not None:
-        _notified_devices.add(issue_id)
-        return False
-
-    github_url = _generate_github_url(device_info, reason)
-
-    async_create_issue(
-        hass,
-        DOMAIN,
-        issue_id,
-        is_fixable=False,
-        is_persistent=True,
-        severity=IssueSeverity.WARNING,
-        translation_key="unsupported_device",
-        translation_placeholders={
-            "name": device_info.name or "Unknown device",
-            "address": device_info.address,
-            "reason": reason,
-            "github_url": github_url,
-        },
-    )
-
-    _notified_devices.add(issue_id)
-
-    _LOGGER.debug(
-        "Created Repairs issue for unsupported device %s (%s)",
-        device_info.name or "Unknown",
-        device_info.address,
-    )
-
-    return True
+    stale_ids = [
+        issue_id
+        for (domain, issue_id) in list(registry.issues)
+        if domain == DOMAIN and issue_id.startswith(_UNSUPPORTED_ISSUE_PREFIX)
+    ]
+    for issue_id in stale_ids:
+        async_delete_issue(hass, DOMAIN, issue_id)
+    if stale_ids:
+        _LOGGER.debug(
+            "Cleared %d obsolete unsupported-device Repairs issue(s)",
+            len(stale_ids),
+        )
 
 
 def _pairing_required_issue_id(address: str) -> str:

--- a/tests/test_unsupported.py
+++ b/tests/test_unsupported.py
@@ -2,7 +2,54 @@
 
 from __future__ import annotations
 
-from custom_components.adjustable_bed.unsupported import UnsupportedDeviceInfo
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+
+from custom_components.adjustable_bed.const import DOMAIN
+from custom_components.adjustable_bed.unsupported import (
+    UnsupportedDeviceInfo,
+    async_clear_unsupported_device_issues,
+)
+
+
+async def test_clear_unsupported_device_issues(hass: HomeAssistant) -> None:
+    """Cleanup removes obsolete unsupported-device issues, leaving others alone."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "unsupported_device_abxm2",
+        is_fixable=False,
+        is_persistent=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="unsupported_device",
+    )
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "unsupported_device_d1_28_41_53_59_9d",
+        is_fixable=False,
+        is_persistent=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="unsupported_device",
+    )
+    # An unrelated issue that must survive the cleanup.
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "pairing_required_aa_bb_cc_dd_ee_ff",
+        is_fixable=True,
+        is_persistent=True,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="pairing_required",
+    )
+
+    registry = ir.async_get(hass)
+    assert len(registry.issues) == 3
+
+    async_clear_unsupported_device_issues(hass)
+
+    remaining = {issue_id for (domain, issue_id) in registry.issues if domain == DOMAIN}
+    assert remaining == {"pairing_required_aa_bb_cc_dd_ee_ff"}
 
 
 def test_misidentified_details_rounds_confidence() -> None:


### PR DESCRIPTION
## Problem

The Bluetooth manifest matchers are intentionally broad (generic manufacturer IDs like Nordic `89`, name prefixes like `Bed*`/`Star*`). So HA routes a stream of unrelated BLE devices — phones, Telink gadgets, random-MAC devices — into the config flow. For **every** device not recognised as a bed, the flow raised a persistent **Repairs** issue, nagging users about things that clearly aren't beds.

Users were seeing repairs like *"Unsupported BLE device: ABXM2 — No BLE service UUIDs advertised"* for arbitrary nearby Bluetooth devices.

## Change

Remove the unsupported-device Repairs nag entirely, and make the upgrade self-cleaning:

- **`config_flow.py`** — unrecognised discovered devices now abort silently (no Repairs issue, no warning log). Discovery aborting with `not_supported` already shows no discovery card, so there is no user-facing nag left.
- **`unsupported.py`** — delete the issue-creation machinery (`create_unsupported_device_issue`, `log_unsupported_device`, `_generate_github_url`, `to_issue_body`, `to_log_string`, issue-id helper, dedup set) and add `async_clear_unsupported_device_issues()` to purge leftover `unsupported_device_*` issues created by older versions.
- **`__init__.py`** — run that cleanup once on setup, so issues created by older versions disappear on upgrade.
- **`detection.py`** — drop the now-orphaned `determine_unsupported_reason()`.
- **`strings.json` / `translations/en.json`** — remove the `unsupported_device` issue text.

**Unchanged:** misidentified-bed reporting, the manual unsupported-device → support-bundle flow (both user-initiated), and `pairing_required` repairs.

## Notes

The deeper root cause — broad matchers like `manufacturer_id: 89` (Nordic) — is left alone here, since narrowing them risks dropping discovery for real beds that depend on them. This PR removes the nag without touching discovery matching.

## Validation

- `ruff` + `pyright` clean on changed files
- Full suite: **1928 passed**, including a new `test_clear_unsupported_device_issues` confirming cleanup removes `unsupported_device_*` while leaving `pairing_required_*` intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unsupported BLE devices no longer generate repair issues; unrecognized devices are now silently ignored during discovery.
  * Integration automatically removes legacy unsupported device issues from previous versions on startup.

* **Chores**
  * Removed user-facing messages and translations related to unsupported device reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->