### PR TITLE
fix: Use DewertOkin write characteristic

### DIFF
--- a/custom_components/adjustable_bed/beds/okin_handle.py
+++ b/custom_components/adjustable_bed/beds/okin_handle.py
@@ -1,13 +1,14 @@
-"""Okin handle-based bed controller implementation.
+"""DewertOkin/Okin 6-byte bed controller implementation.
 
 Reverse engineering by Richard Hopton (smartbed-mqtt).
 
-This controller handles beds that use the Okin 6-byte protocol via BLE handle writes.
+This controller handles beds that use the Okin 6-byte protocol via the shared Okin
+write characteristic.
 Known brands using this protocol:
 - DewertOkin (A H Beard, HankookGallery)
 
 Protocol details:
-    Write handle: 0x0013 (not UUID-based)
+    Write characteristic: 62741525-52f9-8864-b1ab-3b3a8d65950b
     Address type: Random
     Command format: 6-byte Okin frame [0x04, 0x02, <4-byte-command-big-endian>]
     See okin_protocol.py for shared frame building functions.
@@ -39,7 +40,7 @@ from typing import TYPE_CHECKING
 
 from bleak.exc import BleakError
 
-from ..const import DEWERTOKIN_WRITE_HANDLE
+from ..const import OKIMAT_WRITE_CHAR_UUID
 from .base import BedController
 
 if TYPE_CHECKING:
@@ -49,7 +50,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class OkinHandleCommands:
-    """Okin handle-based command constants (6-byte arrays)."""
+    """Okin 6-byte command constants."""
 
     # Presets
     FLAT = bytes.fromhex("040210000000")
@@ -79,9 +80,11 @@ class OkinHandleCommands:
 
 
 class OkinHandleController(BedController):
-    """Controller for beds using Okin handle-based protocol.
+    """Controller for beds using the DewertOkin/Okin 6-byte protocol.
 
-    These beds use handle-based writes to handle 0x0013.
+    Older notes described these beds as handle-based, but handles vary by device
+    and firmware. Use the stable Okin write characteristic UUID so Bleak resolves
+    the current handle from live GATT services.
     They support motor control, presets, massage, and under-bed lighting.
     """
 
@@ -92,8 +95,8 @@ class OkinHandleController(BedController):
 
     @property
     def control_characteristic_uuid(self) -> str:
-        """Return placeholder - this controller uses handle-based writes."""
-        return f"handle-0x{DEWERTOKIN_WRITE_HANDLE:04x}"
+        """Return the Okin write characteristic UUID."""
+        return OKIMAT_WRITE_CHAR_UUID
 
     # Capability properties
     @property
@@ -140,7 +143,7 @@ class OkinHandleController(BedController):
         repeat_delay_ms: int = 100,
         cancel_event: asyncio.Event | None = None,
     ) -> None:
-        """Write a command to the bed using handle 0x0013."""
+        """Write a command to the bed using the live Okin write characteristic."""
         if self.client is None or not self.client.is_connected:
             _LOGGER.error("Cannot write command: BLE client not connected")
             raise ConnectionError("Not connected to bed")
@@ -148,8 +151,9 @@ class OkinHandleController(BedController):
         effective_cancel = cancel_event or self._coordinator.cancel_command
 
         _LOGGER.debug(
-            "Writing command to Okin handle bed (handle 0x%04x): %s (repeat: %d, delay: %dms, response=True)",
-            DEWERTOKIN_WRITE_HANDLE,
+            "Writing command to DewertOkin/Okin characteristic %s: %s "
+            "(repeat: %d, delay: %dms, response=True)",
+            OKIMAT_WRITE_CHAR_UUID,
             command.hex(),
             repeat_count,
             repeat_delay_ms,
@@ -161,9 +165,12 @@ class OkinHandleController(BedController):
                 return
 
             try:
-                # Write to handle directly (Bleak supports integer handles)
                 async with self._ble_lock:
-                    await self.client.write_gatt_char(DEWERTOKIN_WRITE_HANDLE, command, response=True)
+                    await self.client.write_gatt_char(
+                        OKIMAT_WRITE_CHAR_UUID,
+                        command,
+                        response=True,
+                    )
             except BleakError:
                 _LOGGER.exception("Failed to write command")
                 raise

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -537,7 +537,8 @@ LIMOSS_SERVICE_UUID: Final = "0000ffe0-0000-1000-8000-00805f9b34fb"
 LIMOSS_CHAR_UUID: Final = "0000ffe1-0000-1000-8000-00805f9b34fb"
 
 # DewertOkin specific (A H Beard, HankookGallery beds)
-# Uses handle-based writes rather than UUID
+# Legacy handle from older traces. Handles are device/firmware-specific; the
+# controller writes to the stable shared Okin characteristic UUID instead.
 DEWERTOKIN_WRITE_HANDLE: Final = 0x0013
 
 # DewertOkin manufacturer data (BLE Company ID)

--- a/docs/SUPPORTED_ACTUATORS.md
+++ b/docs/SUPPORTED_ACTUATORS.md
@@ -58,7 +58,7 @@ Several bed brands use Okin-based BLE controllers. While they share common roots
 | [Okin 64-bit](beds/okin-64bit.md) | 10-byte (64-bit cmd) | Nordic UART or UUID | ❌ No | `NORA_CON` / `NORACON`, manual selection |
 | [Leggett & Platt Okin](beds/leggett-platt.md) | 6-byte (32-bit cmd) | UUID `62741525-...` | ✅ Yes | Name patterns |
 | [Nectar](beds/nectar.md) | 7-byte (32-bit cmd) | UUID `62741525-...` without response | ❌ No | Name contains "nectar" or generic `OKIN-*` disambiguation |
-| [DewertOkin](beds/dewertokin.md) | 6-byte (32-bit cmd) | Handle `0x0013` | ❌ No | Name patterns |
+| [DewertOkin](beds/dewertokin.md) | 6-byte (32-bit cmd) | UUID `62741525-...` | ❌ No | Name patterns |
 | [Mattress Firm 900](beds/mattressfirm.md) | 7-byte (32-bit cmd) | Nordic UART | ❌ No | Name starts with "iflex" |
 | [Malouf](beds/malouf.md) | 8-byte (32-bit cmd) | Nordic UART or FFE5 | ❌ No | Service UUID detection |
 | [Keeson/Ergomotion](beds/keeson.md) | 8-byte (32-bit cmd) | Nordic UART | ❌ No | Name patterns |
@@ -69,7 +69,8 @@ Several bed brands use Okin-based BLE controllers. While they share common roots
 **Key differences:**
 - **6-byte vs 7-byte vs 8-byte vs 10-byte vs 14-byte**: Different command structures - not interchangeable
 - **32-bit vs 64-bit commands**: Okin 64-bit uses 8-byte command values instead of 4-byte
-- **UUID vs Handle**: DewertOkin writes to a BLE handle instead of a characteristic UUID
+- **Characteristic handles vary**: Okin-family beds share stable UUIDs, but numeric
+  handles differ by device/firmware and must not be hardcoded
 - **Nordic UART**: Many newer beds use the Nordic UART service
 
 **If auto-detection picks the wrong type:** Go to Settings → Devices & Services → Adjustable Bed → Configure and change the bed type.

--- a/docs/beds/dewertokin.md
+++ b/docs/beds/dewertokin.md
@@ -111,7 +111,9 @@ DewertOkin uses the same Okin 6-byte command format (`[0x04, 0x02, <4-byte>]`) a
 - **Okimat** - UUID-based writes to `62741525-...`
 - **Leggett & Platt Okin** - UUID-based writes to `62741525-...`
 
-The key difference is that DewertOkin writes to a BLE **handle** (`0x0013`) rather than a UUID-based characteristic.
+Earlier reverse-engineering notes described DewertOkin writes as handle-based, but
+the numeric handle is not stable across devices and firmware. Use the shared Okin
+write characteristic UUID instead.
 
 Detection is by **device name patterns** ("dewertokin", "dewert", "a h beard", "hankook"), not service UUID.
 
@@ -119,11 +121,13 @@ See also: [Okin Protocol Family](../SUPPORTED_ACTUATORS.md#okin-protocol-family)
 
 ## Protocol Details
 
-**Write Handle:** `0x0013`
+**Write Characteristic:** `62741525-52f9-8864-b1ab-3b3a8d65950b`
 **Format:** 6-byte fixed packets
 **Address Type:** Random
 
-**Note:** DewertOkin uses handle-based writes rather than characteristic UUIDs.
+**Note:** Do not hardcode numeric handles such as `0x0013`; GATT handles are
+assigned per device/service layout. Issue #394 reported a bed where the write
+characteristic was handle `0x000d` and `0x0013` belonged to another attribute.
 
 ### Motor Commands
 

--- a/tests/test_okin_handle.py
+++ b/tests/test_okin_handle.py
@@ -1,4 +1,4 @@
-"""Tests for Okin handle-based bed controller."""
+"""Tests for DewertOkin/Okin 6-byte bed controller."""
 
 from __future__ import annotations
 
@@ -20,8 +20,8 @@ from custom_components.adjustable_bed.const import (
     CONF_HAS_MASSAGE,
     CONF_MOTOR_COUNT,
     CONF_PREFERRED_ADAPTER,
-    DEWERTOKIN_WRITE_HANDLE,
     DOMAIN,
+    OKIMAT_WRITE_CHAR_UUID,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
 
@@ -65,13 +65,11 @@ class TestOkinHandleController:
         mock_okin_handle_config_entry,
         mock_coordinator_connected,
     ):
-        """Test controller reports correct handle-based identifier."""
+        """Test controller reports the stable Okin write characteristic."""
         coordinator = AdjustableBedCoordinator(hass, mock_okin_handle_config_entry)
         await coordinator.async_connect()
 
-        # Okin handle uses handle-based writes, so UUID is a handle placeholder
-        expected = f"handle-0x{DEWERTOKIN_WRITE_HANDLE:04x}"
-        assert coordinator.controller.control_characteristic_uuid == expected
+        assert coordinator.controller.control_characteristic_uuid == OKIMAT_WRITE_CHAR_UUID
 
     async def test_write_command(
         self,
@@ -87,9 +85,8 @@ class TestOkinHandleController:
         command = OkinHandleCommands.STOP
         await coordinator.controller.write_command(command)
 
-        # Okin handle uses handle-based writes (integer handle)
         mock_bleak_client.write_gatt_char.assert_called_with(
-            DEWERTOKIN_WRITE_HANDLE, command, response=True
+            OKIMAT_WRITE_CHAR_UUID, command, response=True
         )
 
     async def test_write_command_with_repeat(
@@ -231,7 +228,7 @@ class TestOkinHandleMovement:
         await coordinator.controller.stop_all()
 
         mock_bleak_client.write_gatt_char.assert_called_with(
-            DEWERTOKIN_WRITE_HANDLE, OkinHandleCommands.STOP, response=True
+            OKIMAT_WRITE_CHAR_UUID, OkinHandleCommands.STOP, response=True
         )
 
 
@@ -362,7 +359,7 @@ class TestOkinHandleLights:
         await coordinator.controller.lights_toggle()
 
         mock_bleak_client.write_gatt_char.assert_called_with(
-            DEWERTOKIN_WRITE_HANDLE, OkinHandleCommands.UNDERLIGHT, response=True
+            OKIMAT_WRITE_CHAR_UUID, OkinHandleCommands.UNDERLIGHT, response=True
         )
 
     async def test_lights_on(
@@ -379,7 +376,7 @@ class TestOkinHandleLights:
         await coordinator.controller.lights_on()
 
         mock_bleak_client.write_gatt_char.assert_called_with(
-            DEWERTOKIN_WRITE_HANDLE, OkinHandleCommands.UNDERLIGHT, response=True
+            OKIMAT_WRITE_CHAR_UUID, OkinHandleCommands.UNDERLIGHT, response=True
         )
 
 
@@ -400,7 +397,7 @@ class TestOkinHandleMassage:
         await coordinator.controller.massage_toggle()
 
         mock_bleak_client.write_gatt_char.assert_called_with(
-            DEWERTOKIN_WRITE_HANDLE, OkinHandleCommands.WAVE_MASSAGE, response=True
+            OKIMAT_WRITE_CHAR_UUID, OkinHandleCommands.WAVE_MASSAGE, response=True
         )
 
     async def test_massage_off(
@@ -417,7 +414,7 @@ class TestOkinHandleMassage:
         await coordinator.controller.massage_off()
 
         mock_bleak_client.write_gatt_char.assert_called_with(
-            DEWERTOKIN_WRITE_HANDLE, OkinHandleCommands.MASSAGE_OFF, response=True
+            OKIMAT_WRITE_CHAR_UUID, OkinHandleCommands.MASSAGE_OFF, response=True
         )
 
     async def test_massage_head_toggle(
@@ -434,7 +431,7 @@ class TestOkinHandleMassage:
         await coordinator.controller.massage_head_toggle()
 
         mock_bleak_client.write_gatt_char.assert_called_with(
-            DEWERTOKIN_WRITE_HANDLE, OkinHandleCommands.HEAD_MASSAGE, response=True
+            OKIMAT_WRITE_CHAR_UUID, OkinHandleCommands.HEAD_MASSAGE, response=True
         )
 
     async def test_massage_foot_toggle(
@@ -451,7 +448,7 @@ class TestOkinHandleMassage:
         await coordinator.controller.massage_foot_toggle()
 
         mock_bleak_client.write_gatt_char.assert_called_with(
-            DEWERTOKIN_WRITE_HANDLE, OkinHandleCommands.FOOT_MASSAGE, response=True
+            OKIMAT_WRITE_CHAR_UUID, OkinHandleCommands.FOOT_MASSAGE, response=True
         )
 
 


### PR DESCRIPTION
## Summary
- write DewertOkin commands to the stable Okin characteristic UUID instead of hardcoded handle 0x0013
- update DewertOkin docs to note that GATT handles vary by device/firmware
- update Okin handle tests to assert the UUID write target

## Root cause
Ref #394 reported a DewertOkin bed whose write characteristic `62741525-52f9-8864-b1ab-3b3a8d65950b` was handle `0x000d`, while the integration wrote to the old hardcoded handle `0x0013`. On that device, `0x0013` belonged to another attribute, producing `INSUFFICIENT_AUTHORIZATION`.

## Validation
- `uv run --extra dev pytest -q tests/test_okin_handle.py`
- `uv run --extra dev ruff check custom_components/adjustable_bed/beds/okin_handle.py tests/test_okin_handle.py custom_components/adjustable_bed/const.py`
- `uvx pyright custom_components/adjustable_bed/beds/okin_handle.py tests/test_okin_handle.py custom_components/adjustable_bed/const.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Okin bed controller now uses a stable characteristic UUID for communication instead of device-specific handles, improving reliability and compatibility across different firmware versions.

* **Documentation**
  * Updated protocol documentation to reflect the new UUID-based communication method for Okin beds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->