### PR TITLE
Detect Smartbed428 as Malouf New Okin

### DIFF
--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -195,6 +195,12 @@ NORA_CONTROLLER_NORMALIZED_NAMES: frozenset[str] = frozenset({"noracon"})
 # gadget (e.g. "ABXM2", #366) is not misidentified as a bed.
 OKIN_CB24_MANUFACTURER_NAME_HINTS: frozenset[str] = frozenset({"okin", "smartbed"})
 
+# Malouf S755 / DewertOkin CB.24.42.28 bases have been observed advertising only
+# Nordic UART plus OKIN's company ID, without the usual Malouf 01000001 family
+# UUID. The name prefix appears to encode the CB.24.42.28 control-box family.
+MALOUF_NEW_OKIN_SMARTBED_NAME_PREFIXES: frozenset[str] = frozenset({"smartbed428"})
+MALOUF_NEW_OKIN_OKIN_PAYLOAD_PREFIXES: tuple[bytes, ...] = (b"AB\x01\x02",)
+
 
 def detect_richmat_remote_from_name(device_name: str | None) -> str | None:
     """Extract Richmat remote code from device name.
@@ -303,6 +309,28 @@ def _normalize_compact_identifier(value: str | None) -> str:
 def _is_nora_controller_identifier(value: str | None) -> bool:
     """Return True for NORA_CON / NORACON controller identifiers."""
     return _normalize_compact_identifier(value) in NORA_CONTROLLER_NORMALIZED_NAMES
+
+
+def _is_malouf_new_okin_smartbed_signature(
+    device_name: str,
+    service_uuids: list[str],
+    manufacturer_data: dict[int, bytes] | None,
+) -> bool:
+    """Return True for Nordic-only Malouf New Okin Smartbed advertisements."""
+    if RICHMAT_NORDIC_SERVICE_UUID.lower() not in service_uuids:
+        return False
+    if not any(
+        device_name.startswith(prefix) for prefix in MALOUF_NEW_OKIN_SMARTBED_NAME_PREFIXES
+    ):
+        return False
+    if not manufacturer_data:
+        return False
+
+    okin_payload = manufacturer_data.get(MANUFACTURER_ID_OKIN)
+    return bool(
+        okin_payload
+        and okin_payload.startswith(MALOUF_NEW_OKIN_OKIN_PAYLOAD_PREFIXES)
+    )
 
 
 # Solace naming convention pattern (e.g., S4-Y-192-461000AD)
@@ -1087,6 +1115,29 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
         )
         return DetectionResult(bed_type=BED_TYPE_MALOUF_NEW_OKIN, confidence=1.0, signals=signals)
 
+    if _is_malouf_new_okin_smartbed_signature(
+        device_name,
+        service_uuids,
+        service_info.manufacturer_data,
+    ):
+        signals.append("uuid:nordic_uart")
+        signals.append("name:smartbed428")
+        signals.append(f"manufacturer_id:{MANUFACTURER_ID_OKIN}")
+        signals.append("manufacturer_payload:ab0102")
+        _LOGGER.info(
+            "Detected Malouf NEW_OKIN Smartbed at %s (name: %s) by Nordic UART "
+            "Smartbed428 advertisement",
+            service_info.address,
+            service_info.name,
+        )
+        return DetectionResult(
+            bed_type=BED_TYPE_MALOUF_NEW_OKIN,
+            confidence=0.85,
+            signals=signals,
+            ambiguous_types=[BED_TYPE_OKIN_CB24],
+            manufacturer_id=MANUFACTURER_ID_OKIN,
+        )
+
     # Check for Linak - most specific first
     # Some Linak beds may advertise position service but not control service
     if (
@@ -1726,6 +1777,7 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
 
         # If OKIN manufacturer ID is also present, this is likely a CB24 device
         # (e.g., SmartBed by Okin / Lucid L600) that also advertises Nordic UART.
+        # Nordic-only Malouf Smartbed428 variants are handled before this branch.
         if (
             service_info.manufacturer_data
             and MANUFACTURER_ID_OKIN in service_info.manufacturer_data

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -319,8 +319,10 @@ def _is_malouf_new_okin_smartbed_signature(
     """Return True for Nordic-only Malouf New Okin Smartbed advertisements."""
     if RICHMAT_NORDIC_SERVICE_UUID.lower() not in service_uuids:
         return False
+    normalized_name = device_name.lower()
     if not any(
-        device_name.startswith(prefix) for prefix in MALOUF_NEW_OKIN_SMARTBED_NAME_PREFIXES
+        normalized_name.startswith(prefix)
+        for prefix in MALOUF_NEW_OKIN_SMARTBED_NAME_PREFIXES
     ):
         return False
     if not manufacturer_data:

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -1134,7 +1134,6 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
             bed_type=BED_TYPE_MALOUF_NEW_OKIN,
             confidence=0.85,
             signals=signals,
-            ambiguous_types=[BED_TYPE_OKIN_CB24],
             manufacturer_id=MANUFACTURER_ID_OKIN,
         )
 

--- a/docs/beds/malouf.md
+++ b/docs/beds/malouf.md
@@ -56,6 +56,11 @@ Malouf beds use two distinct protocols. The integration auto-detects which one y
 **Write Characteristic:** `6e400002-b5a3-f393-e0a9-e50e24dcca9e`
 **Format:** 8 bytes `[0x05, 0x02, (cmd>>24)&0xFF, (cmd>>16)&0xFF, (cmd>>8)&0xFF, cmd&0xFF, 0x00, 0x00]`
 
+Some newer Malouf S755 / DewertOkin `CB.24.42.28` bases advertise only the
+Nordic UART service with a `Smartbed428...` name and OKIN manufacturer payload
+starting `AB 01 02`. Those are still the NEW_OKIN/Malouf 8-byte protocol, not
+the CB24 7-byte protocol.
+
 ### LEGACY_OKIN (FFE5)
 
 **Service UUID:** `0000ffe5-0000-1000-8000-00805f9b34fb`

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -715,7 +715,7 @@ class TestDetectBedTypeByManufacturerData:
         assert result.manufacturer_id == MANUFACTURER_ID_OKIN
         assert "name:smartbed428" in result.signals
         assert "manufacturer_payload:ab0102" in result.signals
-        assert result.ambiguous_types == [BED_TYPE_OKIN_CB24]
+        assert result.ambiguous_types is None
 
     def test_cb24_ab_payload_still_detects_cb24(self):
         """Known CB24AB advertisements must keep the CB24 detection path."""

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -698,6 +698,38 @@ class TestDetectBedTypeByManufacturerData:
         assert result.manufacturer_id == MANUFACTURER_ID_OKIN
         assert BED_TYPE_RICHMAT in result.ambiguous_types
 
+    def test_detect_smartbed428_ab010204_as_malouf_new_okin(self):
+        """Smartbed428 Malouf S755 / CB.24.42.28 uses Malouf New Okin packets.
+
+        GitHub issue #393: this device advertises only Nordic UART plus OKIN
+        manufacturer data, so the generic CB24 fallback must not claim it.
+        """
+        service_info = _make_service_info(
+            name="Smartbed428000193",
+            service_uuids=[RICHMAT_NORDIC_SERVICE_UUID],
+            manufacturer_data={MANUFACTURER_ID_OKIN: bytes.fromhex("4142010204")},
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type == BED_TYPE_MALOUF_NEW_OKIN
+        assert result.confidence == 0.85
+        assert result.manufacturer_id == MANUFACTURER_ID_OKIN
+        assert "name:smartbed428" in result.signals
+        assert "manufacturer_payload:ab0102" in result.signals
+        assert result.ambiguous_types == [BED_TYPE_OKIN_CB24]
+
+    def test_cb24_ab_payload_still_detects_cb24(self):
+        """Known CB24AB advertisements must keep the CB24 detection path."""
+        service_info = _make_service_info(
+            name="Smartbed209008942",
+            service_uuids=[RICHMAT_NORDIC_SERVICE_UUID],
+            manufacturer_data={MANUFACTURER_ID_OKIN: b"AB\x08\x01\x02"},
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type == BED_TYPE_OKIN_CB24
+        assert result.confidence == 0.7
+        assert result.manufacturer_id == MANUFACTURER_ID_OKIN
+        assert BED_TYPE_RICHMAT in result.ambiguous_types
+
     def test_nordic_uart_without_okin_mfr_still_detects_richmat(self):
         """Ensure Nordic UART without OKIN manufacturer ID still returns Richmat."""
         service_info = _make_service_info(


### PR DESCRIPTION
## Summary
- detect Smartbed428 Malouf S755 / DewertOkin CB.24.42.28 advertisements as Malouf New Okin
- keep the generic Nordic UART + OKIN manufacturer fallback on CB24 for other Smartbed variants
- document the observed S755 advertisement signature

## Validation
- `uv run pytest tests/test_detection.py -q`
- `uvx ruff check custom_components tests`
- `uvx pyright`
- `uv run pytest -q`

Ref #393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bed-type detection for newer Malouf/DewertOkin Smartbed variants by recognizing a Smartbed428 Nordic UART + manufacturer payload signature, reducing misclassification into older CB24 handling.
* **Documentation**
  * Clarified the “New OKIN (Nordic UART)” protocol for newer Malouf S755 / DewertOkin CB.24.42.28 models, including the expected Smartbed428 naming and payload prefix and protocol mapping.
* **Tests**
  * Added regression tests to verify Smartbed428 “New OKIN” detection and ensure existing CB24 payloads remain correctly categorized, including ambiguity behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->