### PR TITLE
chore: release 3.0.1

### DIFF
--- a/custom_components/adjustable_bed/manifest.json
+++ b/custom_components/adjustable_bed/manifest.json
@@ -174,5 +174,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/kristofferR/ha-adjustable-bed/issues",
   "requirements": ["bleak>=1.0.0", "bleak-retry-connector>=3.5.0"],
-  "version": "3.0.0"
+  "version": "3.0.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-adjustable-bed"
-version = "3.0.0"
+version = "3.0.1"
 description = "Home Assistant integration for adjustable beds"
 requires-python = ">=3.14"
 


### PR DESCRIPTION
Patch release **3.0.1**. Bumps `manifest.json` and `pyproject.toml` to `3.0.1`. Full suite green (1985 passed).

Ships the fixes and small features merged to `master` since v3.0.0:

**New bed support / features**
- Leggett & Platt **LP Comfort Connect** (Gen2 / 209-M001) — live under-bed light state, per-model Gen2 capabilities, all-intensity + mode-step massage (#389)
- Config flow: **"Auto-detect"** default in the manual bed-type list and the "Show all BLE devices" path, gated on detection confidence (#388, ref #385)

**Bug fixes**
- Detect **Smartbed428** as Malouf New Okin; keep detection unambiguous (#397, ref #393)
- Use the correct **DewertOkin** write characteristic (#396, ref #394)
- **CB25/BOX25**: commit presets with a trailing STOP (arm-then-commit) and resend preset frames at 100ms instead of firing once (#391, ref #372)
- Stop nagging **Repairs** about non-bed BLE devices (#392)
- Name-guard the **Richmat/Nokia W5** UUID to stop non-bed false positives (#383, #386, ref #382)
- Quiet expected idle disconnects and surface them as "idle"; don't report "idle" after a failed reconnect (#387, ref #385)
