### PR TITLE
fix(support): capture recent logs from the HA log file

### DIFF
--- a/custom_components/adjustable_bed/support_bundle.py
+++ b/custom_components/adjustable_bed/support_bundle.py
@@ -70,6 +70,8 @@ async def generate_support_bundle(
         controller = {"initialized": False, "class": None, "characteristic_uuid": None}
         position_data = {}
 
+    recent_logs = await _get_recent_logs(hass) if include_logs else []
+
     report: dict[str, Any] = {
         "metadata": {
             "report_version": "2.0",
@@ -101,7 +103,7 @@ async def generate_support_bundle(
         "notifications": diagnostics_report.notifications,
         "notification_summary": diagnostics_report.notification_summary,
         "command_trace": diagnostics_report.command_trace if coordinator is not None else [],
-        "recent_logs": _get_recent_logs() if include_logs else [],
+        "recent_logs": recent_logs,
         "supported_bed_types": list(SUPPORTED_BED_TYPES),
         "errors": list(diagnostics_report.errors),
     }

--- a/custom_components/adjustable_bed/support_report.py
+++ b/custom_components/adjustable_bed/support_report.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import sys
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -44,6 +45,24 @@ _LOGGER = logging.getLogger(__name__)
 # Maximum number of log entries to include
 MAX_LOG_ENTRIES = 100
 
+# How much of the tail of home-assistant.log to scan (bytes). Debug runs are
+# verbose, so keep enough history to cover a reproduction without reading the
+# whole (potentially multi-MB) file.
+_LOG_TAIL_BYTES = 512 * 1024
+
+# Standard Home Assistant log line:
+#   2026-06-24 13:26:56.557 DEBUG (MainThread) [logger.name] message
+_LOG_LINE_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[.,]\d+) "
+    r"(?P<level>[A-Z]+) "
+    r"\([^)]*\) "
+    r"\[(?P<name>[^\]]+)\] "
+    r"(?P<msg>.*)$"
+)
+
+# Logger-name fragments worth keeping for bed debugging.
+_RELEVANT_LOG_NAMES = (DOMAIN, "bluetooth", "bleak", "habluetooth")
+
 
 async def generate_support_report(
     hass: HomeAssistant,
@@ -76,7 +95,7 @@ async def generate_support_report(
     }
 
     if include_logs:
-        report["recent_logs"] = _get_recent_logs()
+        report["recent_logs"] = await _get_recent_logs(hass)
 
     # Redact sensitive data (partial MAC redaction - keeps OUI for debugging)
     return redact_data(report)  # type: ignore[no-any-return]
@@ -230,47 +249,81 @@ async def _get_bluetooth_info(
     return info
 
 
-def _get_recent_logs() -> list[dict[str, str]]:
-    """Get recent log entries related to the integration."""
-    logs: list[dict[str, str]] = []
+async def _get_recent_logs(hass: HomeAssistant) -> list[dict[str, str]]:
+    """Return recent integration-related entries from the HA log file.
 
+    Home Assistant does not keep an in-memory debug-log buffer we can read, so
+    this tails the on-disk ``home-assistant.log`` (off-loop, in an executor) and
+    keeps only lines emitted by the integration, the Bluetooth stack, or bleak.
+    """
+    log_path = hass.config.path("home-assistant.log")
+    return await hass.async_add_executor_job(_read_log_file, log_path)
+
+
+def _is_relevant_log_name(name: str) -> bool:
+    """Return True if a logger name belongs to the bed/Bluetooth stack."""
+    lowered = name.lower()
+    return any(fragment in lowered for fragment in _RELEVANT_LOG_NAMES)
+
+
+def _tail_text(log_path: str, max_bytes: int) -> str:
+    """Read up to the last ``max_bytes`` of a UTF-8 log file as text."""
+    with open(log_path, "rb") as handle:  # noqa: PTH123 - plain path from HA config
+        handle.seek(0, 2)
+        size = handle.tell()
+        start = max(0, size - max_bytes)
+        handle.seek(start)
+        data = handle.read()
+    # If we seeked into the middle of the file, drop the partial first line.
+    if start > 0:
+        newline = data.find(b"\n")
+        if newline != -1:
+            data = data[newline + 1 :]
+    return data.decode("utf-8", errors="replace")
+
+
+def _read_log_file(log_path: str) -> list[dict[str, str]]:
+    """Parse relevant entries out of the tail of the HA log file.
+
+    Runs in an executor (blocking file I/O). Continuation lines (e.g. traceback
+    bodies) are appended to the entry they belong to so multi-line records stay
+    readable.
+    """
     try:
-        # Access the logging memory handler if available
-        # This is a best-effort approach since HA doesn't expose logs directly
-        root_logger = logging.getLogger()
-        for handler in root_logger.handlers:
-            handler_buffer = getattr(handler, "buffer", None)
-            if handler_buffer is not None:
-                # MemoryHandler or similar
-                for record in list(handler_buffer)[-500:]:
-                    if (
-                        DOMAIN in record.name
-                        or "bluetooth" in record.name.lower()
-                        or "bleak" in record.name.lower()
-                    ):
-                        # Only redact PINs in log messages — MACs/names are needed for debugging
-                        redacted_message = redact_pins_only({"msg": record.getMessage()})["msg"]
-                        logs.append(
-                            {
-                                "timestamp": datetime.fromtimestamp(
-                                    record.created, tz=UTC
-                                ).isoformat(),
-                                "level": record.levelname,
-                                "name": record.name,
-                                "message": redacted_message,
-                            }
-                        )
-    except Exception as err:
-        _LOGGER.debug("Could not retrieve log entries: %s", err)
-        logs.append(
+        raw = _tail_text(log_path, _LOG_TAIL_BYTES)
+    except OSError as err:
+        _LOGGER.debug("Could not read %s: %s", log_path, err)
+        return [
             {
                 "timestamp": datetime.now(UTC).isoformat(),
                 "level": "INFO",
                 "name": DOMAIN,
-                "message": f"Could not retrieve historical logs: {err}. "
-                "Enable debug logging and reproduce the issue to capture logs.",
+                "message": (
+                    f"Could not read {log_path}: {err}. File logging may be "
+                    "disabled; enable it and reproduce the issue to capture logs."
+                ),
             }
-        )
+        ]
 
-    # Limit and return most recent
+    logs: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    for line in raw.splitlines():
+        match = _LOG_LINE_RE.match(line)
+        if match:
+            if not _is_relevant_log_name(match.group("name")):
+                current = None
+                continue
+            # Only redact PINs — MACs/names are needed for debugging and the
+            # caller applies its own MAC redaction over the whole report.
+            current = {
+                "timestamp": match.group("ts"),
+                "level": match.group("level"),
+                "name": match.group("name"),
+                "message": redact_pins_only({"msg": match.group("msg")})["msg"],
+            }
+            logs.append(current)
+        elif current is not None:
+            # Continuation of the current (relevant) entry, e.g. a traceback.
+            current["message"] += "\n" + redact_pins_only({"msg": line})["msg"]
+
     return logs[-MAX_LOG_ENTRIES:]

--- a/tests/test_support_report_logs.py
+++ b/tests/test_support_report_logs.py
@@ -1,0 +1,139 @@
+"""Tests for support-report recent-log capture (reads home-assistant.log)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.adjustable_bed.support_report import (
+    MAX_LOG_ENTRIES,
+    _get_recent_logs,
+    _read_log_file,
+    _tail_text,
+)
+
+# A standard HA log line: "<ts> <LEVEL> (<thread>) [<logger>] <message>"
+_RELEVANT = (
+    "2026-06-24 13:26:56.557 DEBUG (MainThread) "
+    "[custom_components.adjustable_bed.coordinator] Sending head up\n"
+)
+_BLUETOOTH = (
+    "2026-06-24 13:26:56.600 INFO (MainThread) "
+    "[homeassistant.components.bluetooth] Adapter ready\n"
+)
+_BLEAK_WITH_TRACEBACK = (
+    "2026-06-24 13:26:57.000 ERROR (MainThread) [bleak.backends.device] boom\n"
+    "Traceback (most recent call last):\n"
+    '  File "x.py", line 1, in <module>\n'
+    "ValueError: nope\n"
+)
+_IRRELEVANT = (
+    "2026-06-24 13:26:56.700 WARNING (MainThread) "
+    "[homeassistant.components.light] Unrelated entry\n"
+    "2026-06-24 13:26:57.500 DEBUG (MainThread) "
+    "[custom_components.other] also unrelated\n"
+)
+
+
+def _write_log(tmp_path: Path, content: str) -> str:
+    log = tmp_path / "home-assistant.log"
+    log.write_text(content, encoding="utf-8")
+    return str(log)
+
+
+def test_read_log_file_filters_and_parses(tmp_path: Path) -> None:
+    """Only bed/Bluetooth/bleak loggers are kept, with fields parsed out."""
+    path = _write_log(
+        tmp_path, _RELEVANT + _BLUETOOTH + _IRRELEVANT + _BLEAK_WITH_TRACEBACK
+    )
+
+    entries = _read_log_file(path)
+
+    names = [e["name"] for e in entries]
+    assert names == [
+        "custom_components.adjustable_bed.coordinator",
+        "homeassistant.components.bluetooth",
+        "bleak.backends.device",
+    ]
+    assert all("light" not in n and "other" not in n for n in names)
+
+    coordinator = entries[0]
+    assert coordinator["level"] == "DEBUG"
+    assert coordinator["timestamp"] == "2026-06-24 13:26:56.557"
+    assert coordinator["message"] == "Sending head up"
+
+
+def test_read_log_file_joins_continuation_lines(tmp_path: Path) -> None:
+    """Traceback bodies are appended to the relevant entry they follow."""
+    path = _write_log(tmp_path, _BLEAK_WITH_TRACEBACK)
+
+    entries = _read_log_file(path)
+
+    assert len(entries) == 1
+    message = entries[0]["message"]
+    assert message.startswith("boom")
+    assert "Traceback (most recent call last):" in message
+    assert "ValueError: nope" in message
+
+
+def test_read_log_file_drops_orphan_continuation(tmp_path: Path) -> None:
+    """A continuation line after an *irrelevant* entry is not captured."""
+    path = _write_log(
+        tmp_path,
+        "2026-06-24 13:26:56.700 ERROR (MainThread) "
+        "[homeassistant.components.light] boom\n"
+        "Traceback (most recent call last):\n"
+        "ValueError: nope\n",
+    )
+
+    assert _read_log_file(path) == []
+
+
+def test_read_log_file_caps_at_max_entries(tmp_path: Path) -> None:
+    """Only the most recent MAX_LOG_ENTRIES relevant lines are returned."""
+    lines = "".join(
+        f"2026-06-24 13:26:{i % 60:02d}.000 DEBUG (MainThread) "
+        f"[custom_components.adjustable_bed.coordinator] line {i}\n"
+        for i in range(MAX_LOG_ENTRIES + 50)
+    )
+    path = _write_log(tmp_path, lines)
+
+    entries = _read_log_file(path)
+
+    assert len(entries) == MAX_LOG_ENTRIES
+    # The tail is kept, so the last line must be present and the first dropped.
+    assert entries[-1]["message"] == f"line {MAX_LOG_ENTRIES + 49}"
+    assert entries[0]["message"] == "line 50"
+
+
+def test_read_log_file_missing_file_returns_notice() -> None:
+    """A missing/unreadable log file yields a single explanatory entry."""
+    entries = _read_log_file("/nonexistent/path/home-assistant.log")
+
+    assert len(entries) == 1
+    assert entries[0]["level"] == "INFO"
+    assert "Could not read" in entries[0]["message"]
+
+
+def test_tail_text_drops_partial_first_line(tmp_path: Path) -> None:
+    """When truncating mid-file, the partial leading line is discarded."""
+    path = _write_log(tmp_path, "FIRST line aaaaaaaaaa\nSECOND\nTHIRD\n")
+
+    # max_bytes small enough to seek into the middle of the first line.
+    tail = _tail_text(path, max_bytes=12)
+
+    assert "FIRST" not in tail
+    assert "THIRD" in tail
+
+
+async def test_get_recent_logs_reads_ha_log(hass: HomeAssistant) -> None:
+    """_get_recent_logs reads the configured home-assistant.log path."""
+    log_path = Path(hass.config.path("home-assistant.log"))
+    log_path.write_text(_RELEVANT + _IRRELEVANT, encoding="utf-8")
+
+    entries = await _get_recent_logs(hass)
+
+    assert len(entries) == 1
+    assert entries[0]["name"] == "custom_components.adjustable_bed.coordinator"
+    assert entries[0]["message"] == "Sending head up"


### PR DESCRIPTION
## Problem

The support bundle's `recent_logs` is **always empty**, regardless of whether debug logging is enabled. `_get_recent_logs()` scanned the root logger for a handler exposing a `.buffer` attribute (a `logging.handlers.MemoryHandler`):

```python
for handler in root_logger.handlers:
    handler_buffer = getattr(handler, "buffer", None)
    if handler_buffer is not None:   # never true in HA
```

The integration never installs such a handler, and Home Assistant's default handlers (rotating file handler, console stream, and `system_log`'s WARNING+ deque) don't expose `.buffer`. So the loop matched nothing, no exception was raised (so even the "enable debug logging" fallback never fired), and every bundle shipped `recent_logs: []`.

Surfaced while debugging #372 — every bundle came back with `recent_logs: []`. (`command_trace` is captured by the coordinator's own ring buffer and was unaffected, which is what made that debugging possible.)

## Fix

Read the tail of `home-assistant.log` instead (off-loop via an executor), keeping only lines from the integration, the Bluetooth stack, and bleak. Standard HA log lines are parsed into `{timestamp, level, name, message}`; continuation lines (e.g. tracebacks) are joined onto the entry they follow; and a missing/disabled log file yields a single explanatory notice instead of silent emptiness.

Both call sites (`generate_support_report`, `generate_support_bundle`) already have `hass` and are async, so they now `await _get_recent_logs(hass)`.

## Tests

New `tests/test_support_report_logs.py` covers filtering by logger name, field parsing, traceback continuation joining, orphan-continuation dropping, the `MAX_LOG_ENTRIES` cap, the missing-file notice, mid-file tail truncation, and the `hass` log-path integration. Existing `test_support_bundle.py` / `test_init.py` (46 tests) still pass; ruff + pyright clean.

Ref #372

https://claude.ai/code/session_01JbTTAAnxqRPbqrkq7aFWmC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support reports now include a filtered tail of recent log entries when available.
  * Multi-line log entries are preserved more clearly, making tracebacks easier to read.

* **Bug Fixes**
  * Log messages now properly remove PIN details before being included in support reports.
  * Recent logs are capped to the latest entries to keep reports manageable.
  * Missing or unreadable log files now return a clear notice instead of failing silently.

* **Tests**
  * Added coverage for log filtering, multiline handling, truncation, and missing-file behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->