### PR TITLE
Vibradorm VMAT: protocol parity (massage, light level/timer, sync, RGB mood light, notification flags)

### DIFF
--- a/custom_components/adjustable_bed/beds/vibradorm.py
+++ b/custom_components/adjustable_bed/beds/vibradorm.py
@@ -119,8 +119,42 @@ class VibradormCommands:
     MEMORY_6: int = 0x1C  # 28
     STORE: int = 0x0D  # 13 (save current position to active memory slot)
 
+    # Sync mode (head + foot move together)
+    SYNC_ON: int = 0x18  # 24
+    SYNC_OFF: int = 0x19  # 25
+
+    # CBI framed command codes (16-bit, written to CBI 0x1550 with toggle bit).
+    # VMAT-basic variants use the plain code; XT-box accessories OR in CBI_BUS_MASK.
+    CBI_BUS_MASK: int = 0x1000
+
     # Vibration/massage commands (via CBI characteristic)
-    VRT_ON_OFF: int = 0x34  # Toggle vibration on/off
+    VRT_ON_OFF: int = 0x34  # 52 — CmdVRTOnOff (vmat)
+    VRT_SETTINGS: int = 0x30  # 48 — CmdVRT effect/speed/intensity/timer (vmat)
+
+    # Floor / night light via CBI (vmat code; XT-box adds CBI_BUS_MASK)
+    LIGHT_CBI: int = 0x11  # 17 — CmdLightCBI / CmdMotorVMAT CMD_DIM
+
+    # RGB mood light via CBI (vmat code; XT-box adds CBI_BUS_MASK)
+    MOOD_COLOR: int = 0x77  # 119 — CmdMoodColor / CmdMoodEffect / CmdEffectSpeed
+
+    # Status request (CmdGetStatusMotMon)
+    GET_STATUS: int = 0x3D  # 61
+
+    # Notification status flags (byte-scanned from index 2 on CBI_RESPONSE)
+    STATUS_ED_ACTIVE: int = 0xC9  # 201 — "ED active"
+    STATUS_STORE_COMPLETED: int = 0x0E  # 14 — memory store completed
+    STATUS_LINK_FAILURE: int = 0x79  # 121 — link failure
+
+    # Motor-data notification flags (byte 2 of the position packet)
+    FLAG_INIT_REQUESTED: int = 0x10  # controller needs a teach/limit run
+    FLAG_SYNC_ACTIVE: int = 0x40  # sync mode active
+
+    # Floor light level range (MC.setFloorLightLevel clamps 0-8)
+    FLOOR_LIGHT_LEVEL_MAX: int = 8
+
+    # Massage ranges (MassageSettings)
+    MASSAGE_INTENSITY_MAX: int = 5  # intensity zones 0-5 (0 = zone off)
+    MASSAGE_SPEED_MAX: int = 5  # speed 1-5
 
 
 class VibradormController(BedController):
@@ -151,6 +185,28 @@ class VibradormController(BedController):
         self._has_notify_characteristic: bool = True
         self._has_cbi_characteristic: bool = True
         self._warned_missing_cbi: bool = False
+
+        # Floor light state (CmdLightVMAT path: [level, 0, timerMinutes]).
+        self._light_level: int = 0  # 0-8, 0 = off
+        self._light_timer_minutes: int = 0  # 0 = no auto-off timer
+
+        # VRT massage state (CmdVRT packet: effect, speed, zone1, zone2, timer).
+        # zone1 = head, zone2 = foot; intensity 0-5 (0 = zone off); speed 1-5.
+        self._massage_effect: int = 0
+        self._massage_speed: int = 1
+        self._massage_head_intensity: int = 0
+        self._massage_foot_intensity: int = 0
+        self._massage_timer_minutes: int = 0  # 0 = off
+
+        # RGB mood light state (CmdMoodColor/Effect/EffectSpeed on CBI 0x77).
+        self._mood_light_on: bool = False
+        self._mood_light_rgb: tuple[int, int, int] = (255, 255, 255)
+        self._mood_light_effect: int = 0
+        self._mood_light_speed: int = 3  # internal UI speed 1-5
+
+        # Notification status flags surfaced from CBI_RESPONSE.
+        self._init_requested: bool = False
+        self._sync_active: bool = False
 
     @property
     def control_characteristic_uuid(self) -> str:
@@ -503,6 +559,106 @@ class VibradormController(BedController):
         """Return True - Vibradorm beds have separate on/off light commands."""
         return True
 
+    @property
+    def supports_light_level_control(self) -> bool:
+        """Return True - floor light brightness is settable (level 0-8)."""
+        return True
+
+    @property
+    def light_level_max(self) -> int:
+        """Return max floor light level (MC.setFloorLightLevel clamps 0-8)."""
+        return VibradormCommands.FLOOR_LIGHT_LEVEL_MAX
+
+    @property
+    def supports_light_timer(self) -> bool:
+        """Return True - floor light supports an auto-off timer (minutes)."""
+        return True
+
+    @property
+    def light_timer_options(self) -> list[str]:
+        """Return available floor light timer options."""
+        return ["Off", "10 min", "20 min", "30 min", "60 min"]
+
+    @property
+    def supports_synchro(self) -> bool:
+        """Return True - Vibradorm exposes sync on/off (head + foot move together)."""
+        return True
+
+    @property
+    def supports_massage(self) -> bool:
+        """Return True - Vibradorm beds support vibration/massage (VRT) commands."""
+        return True
+
+    @property
+    def supports_massage_intensity_control(self) -> bool:
+        """Return True - VRT intensity is settable per zone (head/foot, 0-5)."""
+        return True
+
+    @property
+    def massage_intensity_zones(self) -> list[str]:
+        """Return the VRT intensity zones (zone1=head, zone2=foot)."""
+        return ["head", "foot"]
+
+    @property
+    def massage_intensity_max(self) -> int:
+        """Return max VRT intensity per zone (0-5, 0 = zone off)."""
+        return VibradormCommands.MASSAGE_INTENSITY_MAX
+
+    @property
+    def supports_massage_timer(self) -> bool:
+        """Return True - VRT supports a massage timer (minutes)."""
+        return True
+
+    @property
+    def massage_timer_options(self) -> list[int]:
+        """Return available VRT timer durations in minutes."""
+        return [10, 20, 30]
+
+    @property
+    def supports_massage_mode_step_control(self) -> bool:
+        """Return True - VRT effect can be cycled via massage_mode_step."""
+        return True
+
+    @property
+    def supports_head_massage_toggle_control(self) -> bool:
+        """Return True - VRT head zone (zone1) can be toggled on/off."""
+        return True
+
+    @property
+    def supports_foot_massage_toggle_control(self) -> bool:
+        """Return True - VRT foot zone (zone2) can be toggled on/off."""
+        return True
+
+    @property
+    def supports_head_massage_intensity_step_control(self) -> bool:
+        """Return True - VRT head zone intensity can be stepped up/down."""
+        return True
+
+    @property
+    def supports_foot_massage_intensity_step_control(self) -> bool:
+        """Return True - VRT foot zone intensity can be stepped up/down."""
+        return True
+
+    @property
+    def supports_mood_light(self) -> bool:
+        """Return True - Vibradorm exposes an RGB mood light (CBI 0x77)."""
+        return True
+
+    @property
+    def mood_light_effect_list(self) -> list[str]:
+        """Return the RGB mood light effect names (selectable via light.effect)."""
+        return ["Static", "Effect 1", "Effect 2", "Effect 3", "Effect 4"]
+
+    @property
+    def mood_light_speed_max(self) -> int:
+        """Return max mood light effect speed (1-5)."""
+        return VibradormCommands.MASSAGE_SPEED_MAX
+
+    @property
+    def supports_mood_light_speed_control(self) -> bool:
+        """Return True - mood light effect speed is settable (1-5)."""
+        return True
+
     async def write_command(
         self,
         command: bytes,
@@ -698,6 +854,51 @@ class VibradormController(BedController):
         max_angle = self._coordinator.get_max_angle(motor)
         return round((percent / 100.0) * max_angle, 1)
 
+    def _handle_motor_data_flags(self, flags: int) -> None:
+        """Process XMCMotorData flags (byte 2 of the position packet)."""
+        init_requested = bool(flags & VibradormCommands.FLAG_INIT_REQUESTED)
+        sync_active = bool(flags & VibradormCommands.FLAG_SYNC_ACTIVE)
+        updates: dict[str, Any] = {}
+
+        if init_requested != self._init_requested:
+            self._init_requested = init_requested
+            updates["init_requested"] = init_requested
+            if init_requested:
+                _LOGGER.warning(
+                    "Vibradorm %s reports init requested (0x10): positions may be "
+                    "unreliable until a teach/limit run completes",
+                    self._coordinator.address,
+                )
+        if sync_active != self._sync_active:
+            self._sync_active = sync_active
+            updates["sync_active"] = sync_active
+        if updates:
+            self.forward_controller_state_updates(updates)
+
+    def _scan_status_flags(self, data: bytearray) -> None:
+        """Scan a non-position notification for known status flag bytes.
+
+        The app byte-scans from index 2 for: 0xC9 (ED active),
+        0x0E (memory store completed), 0x79 (link failure).
+        """
+        for byte in data[2:]:
+            value = byte & 0xFF
+            if value == VibradormCommands.STATUS_STORE_COMPLETED:
+                _LOGGER.info(
+                    "Vibradorm %s: memory store completed (0x0E)", self._coordinator.address
+                )
+                self.forward_controller_state_update("memory_store_completed", True)
+            elif value == VibradormCommands.STATUS_ED_ACTIVE:
+                _LOGGER.info(
+                    "Vibradorm %s: ED active (0xC9)", self._coordinator.address
+                )
+                self.forward_controller_state_update("ed_active", True)
+            elif value == VibradormCommands.STATUS_LINK_FAILURE:
+                _LOGGER.warning(
+                    "Vibradorm %s: link failure (0x79)", self._coordinator.address
+                )
+                self.forward_controller_state_update("link_failure", True)
+
     def _handle_notification(self, _sender: BleakGATTCharacteristic, data: bytearray) -> None:
         """Handle BLE notification data.
 
@@ -730,6 +931,7 @@ class VibradormController(BedController):
                     data.hex(),
                     data[1],
                 )
+                self._scan_status_flags(data)
                 return
             if len(data) < 7:
                 _LOGGER.debug(
@@ -754,7 +956,12 @@ class VibradormController(BedController):
                 data.hex(),
                 data[0],
             )
+            self._scan_status_flags(data)
             return
+
+        # Flags byte sits immediately before the motor positions (XMCMotorData).
+        flags = data[payload_offset - 1] & 0xFF
+        self._handle_motor_data_flags(flags)
 
         # Parse motor positions as big-endian uint16 values.
         back_raw = int.from_bytes(data[payload_offset : payload_offset + 2], byteorder="big")
@@ -1103,52 +1310,162 @@ class VibradormController(BedController):
         _LOGGER.info("Saved position to memory slot %d", memory_num)
 
     # Light methods
-    async def lights_on(self) -> None:
-        """Turn on lights."""
-        # Light command format: [level, 0, timer]
-        # level > 0 turns on, level = 0 turns off
+    async def _send_floor_light_command(self, level: int, timer_minutes: int) -> None:
+        """Send a VMAT floor-light command to the LIGHT characteristic.
+
+        CmdLightVMAT format: ``[level, 0x00, timerMinutes]`` written to 0x1529.
+        Level is clamped to 0-8 (MC.setFloorLightLevel); 0 turns the light off.
+        """
         if self.client is None or not self.client.is_connected:
             raise ConnectionError("Not connected to bed")
 
+        clamped_level = max(
+            0, min(level, VibradormCommands.FLOOR_LIGHT_LEVEL_MAX)
+        )
         self._refresh_characteristics()
-        try:
-            await self._write_gatt_with_retry(
-                self._light_char_uuid,
-                bytes([0xFF, 0x00, 0x00]),  # Full brightness, no timer
-                response=self._write_with_response,
-            )
-            self._lights_on = True
-            _LOGGER.debug("Vibradorm lights turned on")
-        except BleakError as err:
-            _LOGGER.warning("Failed to turn on lights: %s", err)
-            raise
+        await self._write_gatt_with_retry(
+            self._light_char_uuid,
+            bytes([clamped_level, 0x00, timer_minutes & 0xFF]),
+            response=self._write_with_response,
+        )
+
+    async def lights_on(self) -> None:
+        """Turn on the floor light at the last non-zero level (or full)."""
+        level = self._light_level if self._light_level > 0 else VibradormCommands.FLOOR_LIGHT_LEVEL_MAX
+        await self._send_floor_light_command(level, self._light_timer_minutes)
+        self._light_level = level
+        self._lights_on = True
+        self._publish_light_state()
+        _LOGGER.debug("Vibradorm floor light turned on (level=%d)", level)
 
     async def lights_off(self) -> None:
-        """Turn off lights."""
-        if self.client is None or not self.client.is_connected:
-            raise ConnectionError("Not connected to bed")
-
-        self._refresh_characteristics()
-        try:
-            await self._write_gatt_with_retry(
-                self._light_char_uuid,
-                bytes([0x00, 0x00, 0x00]),  # Off
-                response=self._write_with_response,
-            )
-            self._lights_on = False
-            _LOGGER.debug("Vibradorm lights turned off")
-        except BleakError as err:
-            _LOGGER.warning("Failed to turn off lights: %s", err)
-            raise
+        """Turn off the floor light (remember the last level for re-on)."""
+        await self._send_floor_light_command(0, self._light_timer_minutes)
+        self._lights_on = False
+        self._publish_light_state()
+        _LOGGER.debug("Vibradorm floor light turned off")
 
     async def lights_toggle(self) -> None:
-        """Toggle lights."""
+        """Toggle the floor light."""
         if self._lights_on:
             await self.lights_off()
         else:
             await self.lights_on()
 
+    async def set_light_level(self, level: int) -> None:
+        """Set floor light brightness (0-8; 0 turns off).
+
+        Args:
+            level: Brightness level 0 to light_level_max (0 = off)
+        """
+        clamped = max(0, min(level, VibradormCommands.FLOOR_LIGHT_LEVEL_MAX))
+        await self._send_floor_light_command(clamped, self._light_timer_minutes)
+        self._light_level = clamped
+        self._lights_on = clamped > 0
+        self._publish_light_state()
+        _LOGGER.debug("Vibradorm floor light level set to %d", clamped)
+
+    async def set_light_timer(self, timer_option: str) -> None:
+        """Set the floor light auto-off timer.
+
+        Args:
+            timer_option: One of light_timer_options ("Off", "10 min", ...)
+        """
+        minutes = self._parse_timer_option(timer_option)
+        self._light_timer_minutes = minutes
+        # Re-send the current light state so the new timer takes effect.
+        await self._send_floor_light_command(
+            self._light_level if self._lights_on else 0, minutes
+        )
+        self._publish_light_state()
+        _LOGGER.debug("Vibradorm floor light timer set to %d min", minutes)
+
+    @staticmethod
+    def _parse_timer_option(timer_option: str) -> int:
+        """Parse a light_timer_options string into minutes (0 = off)."""
+        if not timer_option or timer_option.lower() == "off":
+            return 0
+        try:
+            return int(timer_option.split()[0])
+        except (ValueError, IndexError):
+            return 0
+
+    def _publish_light_state(self) -> None:
+        """Publish the current floor light state to the coordinator."""
+        self.forward_controller_state_updates(
+            {
+                "light_level": self._light_level,
+                "light_timer_option": self._timer_minutes_to_option(
+                    self._light_timer_minutes
+                ),
+                "under_bed_lights_on": self._lights_on,
+            }
+        )
+
+    @staticmethod
+    def _timer_minutes_to_option(minutes: int) -> str:
+        """Convert a timer in minutes to a light_timer_options string."""
+        if minutes <= 0:
+            return "Off"
+        return f"{minutes} min"
+
+    def get_light_state(self) -> dict[str, Any]:
+        """Return the current floor light state."""
+        return {
+            "is_on": self._lights_on,
+            "light_level": self._light_level,
+            "light_timer_option": self._timer_minutes_to_option(
+                self._light_timer_minutes
+            ),
+            "light_timer_minutes": self._light_timer_minutes,
+        }
+
+    # Sync mode
+    async def set_synchro(self, enabled: bool) -> None:
+        """Enable or disable synchronized head+foot movement (SYNC_ON/OFF)."""
+        cmd = VibradormCommands.SYNC_ON if enabled else VibradormCommands.SYNC_OFF
+        _LOGGER.debug("Setting Vibradorm sync mode: %s (cmd=0x%02X)", enabled, cmd)
+        await self._write_motor_command(
+            cmd,
+            repeat_count=1,
+            cancel_event=asyncio.Event(),
+        )
+        self._sync_active = enabled
+        self.forward_controller_state_updates(
+            {"sync_active": enabled}
+        )
+
     # Massage/vibration methods (via CBI characteristic)
+    async def _send_vrt_settings(self) -> None:
+        """Send the full VRT settings packet (CmdVRT).
+
+        Format: ``[msb(toggle|0x30), lsb, effect, speed, zone1, zone2, 0, 0, 0, timer]``
+        where zone1=head, zone2=foot, intensity 0-5 (0 = zone off), speed 1-5.
+        """
+        payload = bytes(
+            [
+                self._massage_effect & 0xFF,
+                self._massage_speed & 0xFF,
+                self._massage_head_intensity & 0xFF,
+                self._massage_foot_intensity & 0xFF,
+                0,
+                0,
+                0,
+                self._massage_timer_minutes & 0xFF,
+            ]
+        )
+        await self._write_cbi_command(VibradormCommands.VRT_SETTINGS, extra_bytes=payload)
+        self._publish_massage_state()
+
+    def _publish_massage_state(self) -> None:
+        """Publish the current massage state to listening entities."""
+        self.forward_controller_state_updates(
+            {
+                "massage_head_intensity": self._massage_head_intensity,
+                "massage_foot_intensity": self._massage_foot_intensity,
+            }
+        )
+
     async def massage_toggle(self) -> None:
         """Toggle vibration on/off via 3-byte CBI command.
 
@@ -1158,6 +1475,218 @@ class VibradormController(BedController):
         if self.client is None or not self.client.is_connected:
             raise ConnectionError("Not connected to bed")
 
-        self._massage_on = not getattr(self, "_massage_on", False)
+        self._massage_on = not self._massage_on
         on_off = b"\x01" if self._massage_on else b"\x00"
         await self._write_cbi_command(VibradormCommands.VRT_ON_OFF, extra_bytes=on_off)
+        if self._massage_on and self._massage_head_intensity == 0 and self._massage_foot_intensity == 0:
+            # Turning on with both zones off would do nothing; enable both at a
+            # sensible default so the user feels the vibration immediately.
+            self._massage_head_intensity = 3
+            self._massage_foot_intensity = 3
+            await self._send_vrt_settings()
+        self._publish_massage_state()
+
+    async def massage_off(self) -> None:
+        """Turn off all vibration: send VRT off and clear both zones."""
+        if self.client is None or not self.client.is_connected:
+            raise ConnectionError("Not connected to bed")
+
+        self._massage_on = False
+        self._massage_head_intensity = 0
+        self._massage_foot_intensity = 0
+        await self._write_cbi_command(VibradormCommands.VRT_ON_OFF, extra_bytes=b"\x00")
+        await self._send_vrt_settings()
+        self._publish_massage_state()
+
+    async def set_massage_intensity(self, zone: str, level: int) -> None:
+        """Set VRT intensity for a zone (head/foot, 0-5; 0 = zone off).
+
+        Args:
+            zone: Massage zone ("head" = zone1, "foot" = zone2)
+            level: Intensity level 0 to massage_intensity_max
+        """
+        clamped = max(0, min(level, VibradormCommands.MASSAGE_INTENSITY_MAX))
+        if zone == "head":
+            self._massage_head_intensity = clamped
+        elif zone == "foot":
+            self._massage_foot_intensity = clamped
+        else:
+            _LOGGER.warning("Unknown VRT zone: %s", zone)
+            return
+
+        # Applying a non-zero intensity implies massage on.
+        if clamped > 0 and not self._massage_on:
+            self._massage_on = True
+            await self._write_cbi_command(
+                VibradormCommands.VRT_ON_OFF, extra_bytes=b"\x01"
+            )
+        await self._send_vrt_settings()
+        if clamped == 0 and self._massage_head_intensity == 0 and self._massage_foot_intensity == 0:
+            self._massage_on = False
+
+    async def set_massage_timer(self, minutes: int) -> None:
+        """Set the VRT massage timer (minutes; 0 = off)."""
+        self._massage_timer_minutes = max(0, int(minutes))
+        await self._send_vrt_settings()
+
+    async def massage_head_toggle(self) -> None:
+        """Toggle the head (zone1) vibration on/off."""
+        if self._massage_head_intensity > 0:
+            self._massage_head_intensity = 0
+        else:
+            self._massage_head_intensity = 3
+        self._massage_on = (
+            self._massage_head_intensity > 0 or self._massage_foot_intensity > 0
+        )
+        await self._write_cbi_command(
+            VibradormCommands.VRT_ON_OFF,
+            extra_bytes=b"\x01" if self._massage_on else b"\x00",
+        )
+        await self._send_vrt_settings()
+
+    async def massage_foot_toggle(self) -> None:
+        """Toggle the foot (zone2) vibration on/off."""
+        if self._massage_foot_intensity > 0:
+            self._massage_foot_intensity = 0
+        else:
+            self._massage_foot_intensity = 3
+        self._massage_on = (
+            self._massage_head_intensity > 0 or self._massage_foot_intensity > 0
+        )
+        await self._write_cbi_command(
+            VibradormCommands.VRT_ON_OFF,
+            extra_bytes=b"\x01" if self._massage_on else b"\x00",
+        )
+        await self._send_vrt_settings()
+
+    async def massage_head_up(self) -> None:
+        """Increase head (zone1) vibration intensity (max 5)."""
+        if self._massage_head_intensity < VibradormCommands.MASSAGE_INTENSITY_MAX:
+            self._massage_head_intensity += 1
+            self._massage_on = True
+            await self._send_vrt_settings()
+
+    async def massage_head_down(self) -> None:
+        """Decrease head (zone1) vibration intensity (min 0)."""
+        if self._massage_head_intensity > 0:
+            self._massage_head_intensity -= 1
+            await self._send_vrt_settings()
+            if self._massage_head_intensity == 0 and self._massage_foot_intensity == 0:
+                self._massage_on = False
+
+    async def massage_foot_up(self) -> None:
+        """Increase foot (zone2) vibration intensity (max 5)."""
+        if self._massage_foot_intensity < VibradormCommands.MASSAGE_INTENSITY_MAX:
+            self._massage_foot_intensity += 1
+            self._massage_on = True
+            await self._send_vrt_settings()
+
+    async def massage_foot_down(self) -> None:
+        """Decrease foot (zone2) vibration intensity (min 0)."""
+        if self._massage_foot_intensity > 0:
+            self._massage_foot_intensity -= 1
+            await self._send_vrt_settings()
+            if self._massage_head_intensity == 0 and self._massage_foot_intensity == 0:
+                self._massage_on = False
+
+    async def massage_mode_step(self) -> None:
+        """Cycle the VRT effect (small effect id range, wraps to 0)."""
+        self._massage_effect = (self._massage_effect + 1) % 5
+        await self._send_vrt_settings()
+
+    def get_massage_state(self) -> dict[str, Any]:
+        """Return the current VRT massage state."""
+        return {
+            "head_intensity": self._massage_head_intensity,
+            "foot_intensity": self._massage_foot_intensity,
+            "head_active": self._massage_head_intensity > 0,
+            "foot_active": self._massage_foot_intensity > 0,
+            "timer_mode": str(self._massage_timer_minutes) if self._massage_timer_minutes else None,
+        }
+
+    # RGB mood light methods (via CBI characteristic, cmd 0x77)
+    async def _send_mood_color(self, rgb: tuple[int, int, int]) -> None:
+        """Send CmdMoodColor: ``[msb(toggle|0x77), lsb, 0x01, 0x00, R, G, B]``."""
+        r, g, b = rgb
+        payload = bytes([0x01, 0x00, r & 0xFF, g & 0xFF, b & 0xFF])
+        await self._write_cbi_command(VibradormCommands.MOOD_COLOR, extra_bytes=payload)
+
+    async def _send_mood_effect(self, effect_id: int) -> None:
+        """Send CmdMoodEffect: ``[msb(toggle|0x77), lsb, 0x08, effect]``."""
+        await self._write_cbi_command(
+            VibradormCommands.MOOD_COLOR, extra_bytes=bytes([0x08, effect_id & 0xFF])
+        )
+
+    async def _send_mood_speed(self, ui_speed: int) -> None:
+        """Send CmdEffectSpeed: ``[msb(toggle|0x77), lsb, 0x09, speed]``.
+
+        APK maps UI speed (1-5) to wire value ``20 - (uiSpeed * 2)``.
+        """
+        wire = 20 - (max(1, min(5, ui_speed)) * 2)
+        await self._write_cbi_command(
+            VibradormCommands.MOOD_COLOR, extra_bytes=bytes([0x09, wire & 0xFF])
+        )
+
+    async def mood_light_toggle(self) -> None:
+        """Toggle the RGB mood light on/off (CmdMoodLightToggle, cmd 0x1077)."""
+        self._mood_light_on = not self._mood_light_on
+        toggle = 0x1077  # APK CmdMoodLightToggle always uses the XT-box bus code.
+        value = toggle | (0x8000 if self._cbi_toggle else 0x0000)
+        data = value.to_bytes(2, byteorder="big")
+        _LOGGER.debug(
+            "Writing mood light toggle: 0x%04X (toggle=%s)", value, self._cbi_toggle
+        )
+        self._refresh_characteristics()
+        await self._write_gatt_with_retry(
+            self._cbi_char_uuid, data, response=self._write_with_response
+        )
+        self._cbi_toggle = not self._cbi_toggle
+        self._publish_mood_light_state()
+
+    async def set_mood_light_color(self, rgb_color: tuple[int, int, int]) -> None:
+        """Set the RGB mood light color (turns it on)."""
+        self._mood_light_rgb = rgb_color
+        self._mood_light_on = True
+        await self._send_mood_color(rgb_color)
+        self._publish_mood_light_state()
+
+    async def set_mood_light_effect(self, effect_name: str) -> None:
+        """Set the RGB mood light effect by name (from mood_light_effect_list)."""
+        effects = self.mood_light_effect_list
+        try:
+            effect_id = effects.index(effect_name)
+        except ValueError:
+            _LOGGER.warning("Unknown mood light effect: %s", effect_name)
+            return
+        self._mood_light_effect = effect_id
+        self._mood_light_on = True
+        await self._send_mood_effect(effect_id)
+        self._publish_mood_light_state()
+
+    async def set_mood_light_speed(self, speed: int) -> None:
+        """Set the RGB mood light effect speed (1-5)."""
+        self._mood_light_speed = max(1, min(5, int(speed)))
+        await self._send_mood_speed(self._mood_light_speed)
+        self._publish_mood_light_state()
+
+    def _publish_mood_light_state(self) -> None:
+        """Publish the current mood light state to listening entities."""
+        self.forward_controller_state_updates(
+            {
+                "mood_light_on": self._mood_light_on,
+                "mood_light_effect": self.mood_light_effect_list[
+                    self._mood_light_effect % len(self.mood_light_effect_list)
+                ],
+                "mood_light_speed": self._mood_light_speed,
+            }
+        )
+
+    def get_mood_light_state(self) -> dict[str, Any]:
+        """Return the current RGB mood light state."""
+        effects = self.mood_light_effect_list
+        return {
+            "is_on": self._mood_light_on,
+            "rgb_color": self._mood_light_rgb,
+            "effect": effects[self._mood_light_effect % len(effects)],
+            "speed": self._mood_light_speed,
+        }

--- a/custom_components/adjustable_bed/light.py
+++ b/custom_components/adjustable_bed/light.py
@@ -36,6 +36,13 @@ LIGHT_DESCRIPTION = LightEntityDescription(
     icon="mdi:led-strip-variant",
 )
 
+MOOD_LIGHT_DESCRIPTION = LightEntityDescription(
+    key="mood_light",
+    translation_key="mood_light",
+    icon="mdi:led-strip-variant",
+    entity_registry_enabled_default=False,
+)
+
 
 def _normalize_rgb_color(value: Any) -> tuple[int, int, int] | None:
     """Normalize an RGB-like value to a strict 3-tuple."""
@@ -83,17 +90,20 @@ async def async_setup_entry(
     if getattr(controller, "supports_light_color_control", False):
         _async_remove_stale_switch_entity(hass, coordinator)
         async_add_entities([AdjustableBedLight(coordinator, LIGHT_DESCRIPTION)])
-        return
-
-    if (
+    elif (
         coordinator.bed_type == BED_TYPE_SLEEP_NUMBER_MCR
         and getattr(controller, "supports_discrete_light_control", False)
     ):
         _async_remove_stale_switch_entity(hass, coordinator)
         async_add_entities([AdjustableBedOnOffLight(coordinator, LIGHT_DESCRIPTION)])
-        return
+    else:
+        _async_remove_stale_light_entity(hass, coordinator)
 
-    _async_remove_stale_light_entity(hass, coordinator)
+    # RGB mood light is a separate, optional light surface (e.g. Vibradorm VMAT
+    # XT-box). Additive to the under-bed light above; disabled by default so beds
+    # without the hardware don't gain a dead entity.
+    if getattr(controller, "supports_mood_light", False):
+        async_add_entities([AdjustableBedMoodLight(coordinator, MOOD_LIGHT_DESCRIPTION)])
 
 
 def _async_remove_stale_light_entity(
@@ -356,5 +366,99 @@ class AdjustableBedOnOffLight(AdjustableBedEntity, RestoreEntity, LightEntity):
             lambda ctrl: ctrl.lights_off(),
             cancel_running=False,
         )
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+
+class AdjustableBedMoodLight(AdjustableBedEntity, RestoreEntity, LightEntity):
+    """RGB mood light entity (e.g. Vibradorm VMAT XT-box mood light)."""
+
+    entity_description: LightEntityDescription
+
+    _attr_assumed_state = True
+    _attr_color_mode = ColorMode.RGB
+    _attr_supported_color_modes = {ColorMode.RGB}
+
+    def __init__(
+        self,
+        coordinator: AdjustableBedCoordinator,
+        description: LightEntityDescription,
+    ) -> None:
+        """Initialize the mood light."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.address}_{description.key}"
+        controller = coordinator.controller
+        effects = (
+            getattr(controller, "mood_light_effect_list", []) if controller is not None else []
+        )
+        self._attr_effect_list = effects or None
+        self._attr_is_on = False
+        self._attr_rgb_color = (255, 255, 255)
+        self._attr_effect = effects[0] if effects else None
+        self._unregister_callback: Callable[[], None] | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last mood-light state and subscribe to updates."""
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_is_on = last_state.state == STATE_ON
+            restored_rgb = _normalize_rgb_color(last_state.attributes.get(ATTR_RGB_COLOR))
+            if restored_rgb is not None:
+                self._attr_rgb_color = restored_rgb
+            restored_effect = last_state.attributes.get("effect")
+            if isinstance(restored_effect, str) and self._attr_effect_list and restored_effect in self._attr_effect_list:
+                self._attr_effect = restored_effect
+        self._unregister_callback = self._coordinator.register_controller_state_callback(
+            self._handle_controller_state_update
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Clean up controller-state callback registration."""
+        if self._unregister_callback is not None:
+            self._unregister_callback()
+            self._unregister_callback = None
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _handle_controller_state_update(self, state: dict[str, Any]) -> None:
+        """Update state from controller mood-light telemetry when available."""
+        if "mood_light_on" in state:
+            self._attr_is_on = bool(state["mood_light_on"])
+        if "mood_light_effect" in state and self._attr_effect_list:
+            effect = state["mood_light_effect"]
+            if isinstance(effect, str) and effect in self._attr_effect_list:
+                self._attr_effect = effect
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the mood light on, optionally setting color and/or effect."""
+        requested_rgb = _normalize_rgb_color(kwargs.get(ATTR_RGB_COLOR))
+        target_rgb = requested_rgb or self._attr_rgb_color or (255, 255, 255)
+        requested_effect = kwargs.get("effect")
+        target_effect = requested_effect if isinstance(requested_effect, str) else self._attr_effect
+
+        async def _turn_on(ctrl: BedController) -> None:
+            await ctrl.set_mood_light_color(target_rgb)  # type: ignore[attr-defined]
+            if target_effect is not None and self._attr_effect_list:
+                await ctrl.set_mood_light_effect(target_effect)  # type: ignore[attr-defined]
+
+        await self._coordinator.async_execute_controller_command(_turn_on, cancel_running=False)
+        self._attr_is_on = True
+        self._attr_rgb_color = target_rgb
+        if target_effect is not None:
+            self._attr_effect = target_effect
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the mood light off (toggle-based, like the OEM app)."""
+        del kwargs
+        if not self._attr_is_on:
+            return
+
+        async def _turn_off(ctrl: BedController) -> None:
+            await ctrl.mood_light_toggle()  # type: ignore[attr-defined]
+
+        await self._coordinator.async_execute_controller_command(_turn_off, cancel_running=False)
         self._attr_is_on = False
         self.async_write_ha_state()

--- a/custom_components/adjustable_bed/number.py
+++ b/custom_components/adjustable_bed/number.py
@@ -192,6 +192,17 @@ LIGHT_LEVEL_DESCRIPTION = NumberEntityDescription(
     mode=NumberMode.SLIDER,
 )
 
+MOOD_LIGHT_SPEED_DESCRIPTION = NumberEntityDescription(
+    key="mood_light_speed",
+    translation_key="mood_light_speed",
+    icon="mdi:speedometer",
+    native_min_value=1,
+    native_max_value=5,
+    native_step=1,
+    mode=NumberMode.SLIDER,
+    entity_registry_enabled_default=False,
+)
+
 SLEEP_NUMBER_SETTING_DESCRIPTION = NumberEntityDescription(
     key="sleep_number_setting",
     translation_key="sleep_number_setting",
@@ -521,6 +532,21 @@ async def async_setup_entry(
         )
         entities.append(AdjustableBedLightLevelNumber(coordinator, light_adjusted))
 
+    # Set up mood light effect-speed number entity (only for beds that support it)
+    if controller is not None and getattr(controller, "supports_mood_light_speed_control", False):
+        max_speed = getattr(controller, "mood_light_speed_max", 5)
+        mood_speed_desc = NumberEntityDescription(
+            key=MOOD_LIGHT_SPEED_DESCRIPTION.key,
+            translation_key=MOOD_LIGHT_SPEED_DESCRIPTION.translation_key,
+            icon=MOOD_LIGHT_SPEED_DESCRIPTION.icon,
+            native_min_value=1,
+            native_max_value=max_speed,
+            native_step=1,
+            mode=NumberMode.SLIDER,
+            entity_registry_enabled_default=False,
+        )
+        entities.append(AdjustableBedMoodLightSpeedNumber(coordinator, mood_speed_desc))
+
     sleep_number_sides = tuple(getattr(controller, "sleep_number_setting_sides", ()))
     if sleep_number_sides:
         _LOGGER.debug(
@@ -787,6 +813,65 @@ class AdjustableBedLightLevelNumber(AdjustableBedEntity, NumberEntity):
             await ctrl.set_light_level(level)
 
         await self._coordinator.async_execute_controller_command(_set_level)
+
+
+class AdjustableBedMoodLightSpeedNumber(AdjustableBedEntity, NumberEntity):
+    """Number entity for RGB mood light effect speed control."""
+
+    entity_description: NumberEntityDescription
+
+    def __init__(
+        self,
+        coordinator: AdjustableBedCoordinator,
+        description: NumberEntityDescription,
+    ) -> None:
+        """Initialize the mood light speed number entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.address}_{description.key}"
+        self._unregister_callback: Callable[[], None] | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity is added to hass."""
+        await super().async_added_to_hass()
+        self._unregister_callback = self._coordinator.register_controller_state_callback(
+            self._handle_controller_state_update
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity is removed from hass."""
+        if self._unregister_callback:
+            self._unregister_callback()
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _handle_controller_state_update(self, state: dict[str, Any]) -> None:
+        """Write state when the controller publishes mood-light updates."""
+        if "mood_light_speed" in state:
+            self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current mood light effect speed."""
+        speed = self._coordinator.controller_state.get("mood_light_speed")
+        if speed is None:
+            return None
+        return float(speed)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the mood light effect speed."""
+        speed = round(value)
+
+        _LOGGER.info(
+            "Mood light speed set requested: %d (device: %s)",
+            speed,
+            self._coordinator.name,
+        )
+
+        async def _set_speed(ctrl: BedController) -> None:
+            await ctrl.set_mood_light_speed(speed)  # type: ignore[attr-defined]
+
+        await self._coordinator.async_execute_controller_command(_set_speed)
 
 
 class AdjustableBedSleepNumberSettingNumber(AdjustableBedEntity, NumberEntity):

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -532,6 +532,9 @@
     "light": {
       "under_bed_lights": {
         "name": "Under Bed Lights"
+      },
+      "mood_light": {
+        "name": "Mood Light"
       }
     },
     "switch": {
@@ -580,6 +583,9 @@
       },
       "light_level": {
         "name": "Light Level"
+      },
+      "mood_light_speed": {
+        "name": "Mood Light Effect Speed"
       },
       "sleep_number_setting": {
         "name": "Sleep Number Setting"

--- a/docs/beds/vibradorm.md
+++ b/docs/beds/vibradorm.md
@@ -15,6 +15,8 @@
 |----------|-----|------------|
 | ✅ | VIBRADORM Remote | `de.vibradorm.vra` |
 | ✅ | VIBRADORM Remote for Beds | `com.vibradorm.vmatbasic` |
+| ✅ | VIBRADORM Diamant (vra2) | `de.vibradorm.diamant` |
+| ✅ | Vib Control (VMAT beta) | `de.vibradorm.vmat` |
 
 ## Features
 
@@ -22,12 +24,14 @@
 |---------|-----------|
 | Motor Control | ✅ |
 | Position Feedback | ✅ |
-| Memory Presets | ✅ (6 slots) |
+| Memory Presets | ✅ (6 slots, recall + programming) |
 | Flat Preset | ✅ |
-| Light Control | ✅ |
-| Massage | ✅ (vibration toggle via CBI characteristic) |
+| Floor Light | ✅ (level 0-8 + auto-off timer) |
+| RGB Mood Light | ✅ (color, effect, effect speed; disabled by default) |
+| Massage (VRT) | ✅ (on/off, head/foot intensity 0-5, timer, effect cycle) |
+| Sync Mode | ✅ (head + foot move together) |
 
-**Position Feedback:** The bed reports motor positions via BLE notifications. Position values are raw encoder counts that are converted to percentages.
+**Position Feedback:** The bed reports motor positions via BLE notifications on the CBI_RESPONSE characteristic (`0x1551`). Position values are raw encoder counts converted to percentages. The notification flags byte exposes *init requested* (`0x10`, positions unreliable until a teach run) and *sync active* (`0x40`); status bytes `0xC9` (ED active), `0x0E` (memory store completed) and `0x79` (link failure) are also parsed and logged.
 
 **Motor Configurations:** The bed supports 2, 3, or 4 motor configurations. The standard 2-motor config has head/back and legs motors.
 
@@ -35,15 +39,23 @@
 
 **Primary Service UUID:** `00001525-9f03-0de5-96c5-b8f4f3081186`
 **Secondary Service UUID (some VMAT-BASIC-RF-CBI beds):** `00001527-9f03-0de5-96c5-b8f4f3081186`
-**Command Characteristic:** `00001526-9f03-0de5-96c5-b8f4f3081186` (fallbacks: `00001528`, `00001534`)
+**Command Characteristic (single-byte motor):** `00001526-9f03-0de5-96c5-b8f4f3081186` (fallbacks: `00001528`, `00001534`)
+**CBI Characteristic (framed commands):** `00001550-9f03-0de5-96c5-b8f4f3081186`
 **Light Characteristic:** `00001529-9f03-0de5-96c5-b8f4f3081186`
 **Notify Characteristic:** `00001551-9f03-0de5-96c5-b8f4f3081186`
 
 **Manufacturer ID:** 944 (0x03B0)
 
-### Command Format
+### Command paths
 
-Commands are single bytes written to the command characteristic:
+VMAT has two write paths:
+
+- **VMAT-basic motor commands** — a *single byte* written to `COMMAND` (`0x1526`). STOP is `[0xFF]` on `COMMAND`.
+- **CBI framed commands** — a *16-bit big-endian command word* (OR'd with an alternating toggle bit `0x0000`/`0x8000`) plus payload, written to `CBI` (`0x1550`). Memory, store, light (CBI), mood light and massage all use this path. STOP is `[0x00, 0xFF]` on `CBI`.
+
+The XT-box accessory bus adds `0x1000` (`CBI_BUS_MASK`) to CBI command codes. The integration uses the VMAT-basic codes by default (consistent with the single-byte motor path); mood-light toggle follows the APK and always uses `0x1077`.
+
+### Motor commands (single-byte, `COMMAND` `0x1526`)
 
 | Command | Value | Hex |
 |---------|-------|-----|
@@ -52,30 +64,68 @@ Commands are single bytes written to the command characteristic:
 | Head Down | 10 | `0x0A` |
 | Legs Up | 9 | `0x09` |
 | Legs Down | 8 | `0x08` |
+| Foot Up (4-motor) | 5 | `0x05` |
+| Foot Down (4-motor) | 4 | `0x04` |
+| Neck Up (3/4-motor) | 3 | `0x03` |
+| Neck Down (3/4-motor) | 2 | `0x02` |
+| All Up | 16 | `0x10` |
 | All Down/Flat | 0 | `0x00` |
-| Memory 1 | 14 | `0x0E` |
-| Memory 2 | 15 | `0x0F` |
-| Memory 3 | 12 | `0x0C` |
-| Memory 4 | 26 | `0x1A` |
-| Memory 5 | 27 | `0x1B` |
-| Memory 6 | 28 | `0x1C` |
+| Sync On | 24 | `0x18` |
+| Sync Off | 25 | `0x19` |
 
-### Light Control
+### Memory (CBI `0x1550`, `[msb(cmd\|toggle), lsb]`)
 
-Light commands are 3 bytes written to the light characteristic:
+| Slot | Code | Hex |
+|------|------|-----|
+| M1 | 14 | `0x0E` |
+| M2 | 15 | `0x0F` |
+| M3 | 12 | `0x0C` |
+| M4 | 26 | `0x1A` |
+| M5 | 27 | `0x1B` |
+| M6 | 28 | `0x1C` |
+| Store | 13 | `0x0D` |
+
+Store-to-memory handshake: `STORE (0x0D)` ×4 → `Memory(slot)` → `STOP` ×4.
+
+### Floor light (CmdLightVMAT, `LIGHT` `0x1529`)
 
 ```text
-[brightness, 0x00, timer]
+[level, 0x00, timerMinutes]
 ```
-- `brightness`: 0 = off, 0xFF = full brightness
-- `timer`: Auto-off timer value (0 = no timer)
+- `level`: 0-8 (0 = off, 8 = brightest); clamped per `MC.setFloorLightLevel`
+- `timerMinutes`: auto-off timer (0 = no timer)
+
+### RGB mood light (CBI `0x1550`, cmd `0x77`)
+
+- **Color:** `[msb, lsb, 0x01, 0x00, R, G, B]`
+- **Effect select:** `[msb, lsb, 0x08, effectId]`
+- **Effect speed:** `[msb, lsb, 0x09, speed]` where `speed = 20 - (uiSpeed * 2)` (UI speed 1-5 → wire 18,16,14,12,10)
+- **Toggle on/off:** `[msb, lsb]` with cmd `0x1077` (always XT-box bus, per APK)
+
+The mood light entity is disabled by default; enable it in HA if your bed has the hardware.
+
+### Massage / VRT (CBI `0x1550`)
+
+- **On/off** (cmd `0x34`): `[msb, lsb, on_off]` (1 = on, 0 = off)
+- **Settings** (cmd `0x30`): `[msb, lsb, effect, speed, zone1, zone2, 0, 0, 0, timer]`
+  - `zone1` = head, `zone2` = foot; intensity 0-5 (0 = zone off)
+  - `speed` 1-5, `effect` small id, `timer` in minutes
+
+### Status request (CBI `0x1550`, cmd `0x3D`)
+
+`[msb(toggle|0x3D), lsb, 0x3F]` — triggers a position notification on `CBI_RESPONSE`.
 
 ### Position Feedback
 
-Notifications provide motor positions as 16-bit little-endian values:
-- Bytes 3-4: Motor 1 (head/back) position
-- Bytes 5-6: Motor 2 (legs) position
-- Higher values = more raised, 0 = flat
+Notifications on `CBI_RESPONSE` (`0x1551`):
+
+```text
+[0x20, 0x3F, flags, M1hi, M1lo, M2hi, M2lo, M3hi, M3lo, M4hi, M4lo]
+```
+(or the short form without the `0x20` prefix). Motor positions are **big-endian** uint16 values:
+- M1 = back/Kopf, M2 = legs/Oberschenkel, M3 = head/Nacken, M4 = feet/Fuß
+
+Flags byte: `0x10` = init requested (teach run needed), `0x40` = sync active.
 
 ## Detection
 
@@ -97,4 +147,6 @@ The bed is detected by:
 ## References
 
 - [GitHub Issue #162](https://github.com/kristofferR/ha-adjustable-bed/issues/162)
-- APK analysis in `disassembly/output/de.vibradorm.vra/ANALYSIS.md`
+- [GitHub Issue #403](https://github.com/kristofferR/ha-adjustable-bed/issues/403) — full VMAT protocol parity
+- APK analysis in `disassembly/output/de.vibradorm.diamant/jadx/sources/de/vibradorm/vra2/`
+- Full protocol notes in `disassembly/output/de.vibradorm.vmat-beta/PROTOCOL.md`

--- a/tests/test_vibradorm.py
+++ b/tests/test_vibradorm.py
@@ -26,6 +26,7 @@ from custom_components.adjustable_bed.const import (
     DOMAIN,
     VIBRADORM_CBI_CHAR_UUID,
     VIBRADORM_COMMAND_CHAR_UUID,
+    VIBRADORM_LIGHT_CHAR_UUID,
     VIBRADORM_NOTIFY_CHAR_UUID,
     VIBRADORM_SECONDARY_ALT_COMMAND_CHAR_UUID,
     VIBRADORM_SECONDARY_COMMAND_CHAR_UUID,
@@ -1417,3 +1418,480 @@ class TestVibradormPositionFeedback:
         )
 
         assert updates == []
+
+
+class TestVibradormCapabilities:
+    """Test newly exposed capability properties."""
+
+    async def test_light_level_capability(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Floor light level + timer should be advertised."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        assert controller.supports_light_level_control is True
+        assert controller.light_level_max == 8
+        assert controller.supports_light_timer is True
+        assert controller.light_timer_options == ["Off", "10 min", "20 min", "30 min", "60 min"]
+
+    async def test_synchro_capability(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Sync mode should be advertised."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+
+        assert coordinator.controller.supports_synchro is True
+
+    async def test_massage_capabilities(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """VRT massage capabilities should be advertised."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        assert controller.supports_massage is True
+        assert controller.supports_massage_intensity_control is True
+        assert controller.massage_intensity_zones == ["head", "foot"]
+        assert controller.massage_intensity_max == 5
+        assert controller.supports_massage_timer is True
+        assert controller.massage_timer_options == [10, 20, 30]
+        assert controller.supports_massage_mode_step_control is True
+        assert controller.supports_head_massage_toggle_control is True
+        assert controller.supports_foot_massage_toggle_control is True
+        assert controller.supports_head_massage_intensity_step_control is True
+        assert controller.supports_foot_massage_intensity_step_control is True
+
+    async def test_mood_light_capabilities(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """RGB mood light capabilities should be advertised."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        assert controller.supports_mood_light is True
+        assert controller.mood_light_effect_list == [
+            "Static",
+            "Effect 1",
+            "Effect 2",
+            "Effect 3",
+            "Effect 4",
+        ]
+        assert controller.mood_light_speed_max == 5
+        assert controller.supports_mood_light_speed_control is True
+
+
+class TestVibradormMassage:
+    """Test VRT massage command framing."""
+
+    async def test_massage_toggle_sends_vrt_on_with_default_zones(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """massage_toggle from off enables both zones at 3 and sends VRT on + settings."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        mock_client = coordinator._client
+        mock_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.massage_toggle()
+
+        sent = [call.args[1] for call in mock_client.write_gatt_char.call_args_list]
+        # First: VRT_ON_OFF (0x34) on, toggle=0 -> [0x00, 0x34, 0x01]
+        assert sent[0] == bytes([0x00, VibradormCommands.VRT_ON_OFF, 0x01])
+        # Then VRT settings (0x30) with both zones at 3, toggle=1
+        assert sent[1] == bytes(
+            [0x80, VibradormCommands.VRT_SETTINGS, 0, 1, 3, 3, 0, 0, 0, 0]
+        )
+
+    async def test_massage_off_clears_zones(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """massage_off sends VRT off and a settings packet with zeroed zones."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        mock_client = coordinator._client
+        mock_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.massage_off()
+
+        sent = [call.args[1] for call in mock_client.write_gatt_char.call_args_list]
+        assert sent[0] == bytes([0x00, VibradormCommands.VRT_ON_OFF, 0x00])
+        assert sent[1] == bytes(
+            [0x80, VibradormCommands.VRT_SETTINGS, 0, 1, 0, 0, 0, 0, 0, 0]
+        )
+        assert coordinator.controller.get_massage_state()["head_intensity"] == 0
+
+    async def test_set_massage_intensity_head_sends_settings_packet(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """set_massage_intensity sends VRT on + a settings packet with the new zone."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        mock_client = coordinator._client
+        mock_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.set_massage_intensity("head", 4)
+
+        sent = [call.args[1] for call in mock_client.write_gatt_char.call_args_list]
+        # Turning on a zone from off first sends VRT on.
+        assert sent[0] == bytes([0x00, VibradormCommands.VRT_ON_OFF, 0x01])
+        # Settings: effect=0, speed=1, zone1(head)=4, zone2(foot)=0, timer=0.
+        assert sent[1] == bytes(
+            [0x80, VibradormCommands.VRT_SETTINGS, 0, 1, 4, 0, 0, 0, 0, 0]
+        )
+        state = coordinator.controller.get_massage_state()
+        assert state["head_intensity"] == 4
+        assert state["head_active"] is True
+
+    async def test_set_massage_intensity_clamps_to_max(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Intensity above the max should be clamped to 5."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        controller._massage_on = True  # avoid the extra VRT-on write
+        mock_client = coordinator._client
+        mock_client.write_gatt_char.reset_mock()
+
+        await controller.set_massage_intensity("foot", 99)
+
+        sent = [call.args[1] for call in mock_client.write_gatt_char.call_args_list]
+        # zone2(foot) clamped to 5.
+        assert sent[0] == bytes(
+            [0x00, VibradormCommands.VRT_SETTINGS, 0, 1, 0, 5, 0, 0, 0, 0]
+        )
+        assert controller.get_massage_state()["foot_intensity"] == 5
+
+    async def test_set_massage_timer_sends_timer_in_packet(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """set_massage_timer encodes minutes in the trailing timer byte."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        controller._massage_on = True
+        mock_client = coordinator._client
+        mock_client.write_gatt_char.reset_mock()
+
+        await controller.set_massage_timer(20)
+
+        sent = [call.args[1] for call in mock_client.write_gatt_char.call_args_list]
+        assert sent[0] == bytes(
+            [0x00, VibradormCommands.VRT_SETTINGS, 0, 1, 0, 0, 0, 0, 0, 20]
+        )
+
+    async def test_massage_mode_step_cycles_effect(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """massage_mode_step should increment the effect id (wraps at 5)."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        controller._massage_on = True
+        controller._massage_effect = 4
+        mock_client = coordinator._client
+        mock_client.write_gatt_char.reset_mock()
+
+        await controller.massage_mode_step()
+
+        sent = [call.args[1] for call in mock_client.write_gatt_char.call_args_list]
+        # effect wraps from 4 -> 0.
+        assert sent[0] == bytes(
+            [0x00, VibradormCommands.VRT_SETTINGS, 0, 1, 0, 0, 0, 0, 0, 0]
+        )
+
+
+class TestVibradormLight:
+    """Test floor light level + timer command framing."""
+
+    async def test_set_light_level_sends_level_to_light_char(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """set_light_level writes [level, 0, timer] to the LIGHT characteristic."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        mock_client = coordinator._client
+        mock_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.set_light_level(5)
+
+        calls = mock_client.write_gatt_char.call_args_list
+        char_uuid = str(calls[0].args[0]).lower()
+        assert char_uuid == VIBRADORM_LIGHT_CHAR_UUID
+        assert calls[0].args[1] == bytes([5, 0, 0])
+
+    async def test_set_light_level_clamps_to_8(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Levels above 8 should be clamped to the VMAT maximum."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        mock_client = coordinator._client
+        mock_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.set_light_level(42)
+
+        assert mock_client.write_gatt_char.call_args_list[0].args[1] == bytes([8, 0, 0])
+
+    async def test_set_light_level_zero_turns_off(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Level 0 turns the floor light off."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        mock_client = coordinator._client
+        mock_client.write_gatt_char.reset_mock()
+
+        await controller.set_light_level(0)
+
+        assert mock_client.write_gatt_char.call_args_list[0].args[1] == bytes([0, 0, 0])
+        assert controller.get_light_state()["is_on"] is False
+
+    async def test_set_light_timer_resends_with_timer_byte(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """set_light_timer stores the timer and re-sends the light command with it."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        mock_client = coordinator._client
+        mock_client.write_gatt_char.reset_mock()
+
+        await controller.set_light_timer("20 min")
+
+        assert mock_client.write_gatt_char.call_args_list[0].args[1] == bytes([0, 0, 20])
+        assert controller.get_light_state()["light_timer_option"] == "20 min"
+
+    async def test_lights_on_defaults_to_full_when_no_level(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """lights_on with no stored level uses full brightness (8)."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        mock_client = coordinator._client
+        mock_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.lights_on()
+
+        assert mock_client.write_gatt_char.call_args_list[0].args[1] == bytes([8, 0, 0])
+
+
+class TestVibradormSync:
+    """Test sync mode command framing."""
+
+    async def test_set_synchro_on_sends_sync_on(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """set_synchro(True) sends SYNC_ON (0x18) to the command characteristic."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        mock_client = coordinator._client
+        mock_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.set_synchro(True)
+
+        assert mock_client.write_gatt_char.call_args_list[0].args[1] == bytes(
+            [VibradormCommands.SYNC_ON]
+        )
+
+    async def test_set_synchro_off_sends_sync_off(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """set_synchro(False) sends SYNC_OFF (0x19)."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        mock_client = coordinator._client
+        mock_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.set_synchro(False)
+
+        assert mock_client.write_gatt_char.call_args_list[0].args[1] == bytes(
+            [VibradormCommands.SYNC_OFF]
+        )
+
+
+class TestVibradormMoodLight:
+    """Test RGB mood light command framing."""
+
+    async def test_set_mood_light_color_sends_rgb(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """set_mood_light_color sends [0x01, 0x00, R, G, B] on CBI cmd 0x77."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        mock_client = coordinator._client
+        mock_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.set_mood_light_color((255, 0, 128))
+
+        sent = mock_client.write_gatt_char.call_args_list[0].args[1]
+        # toggle=0 -> [0x00, 0x77, 0x01, 0x00, 0xFF, 0x00, 0x80]
+        assert sent == bytes([0x00, VibradormCommands.MOOD_COLOR, 0x01, 0x00, 0xFF, 0x00, 0x80])
+
+    async def test_mood_light_toggle_sends_xtbox_bus_code(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """mood_light_toggle uses cmd 0x1077 (always XT-box bus, per APK)."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        mock_client = coordinator._client
+        mock_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.mood_light_toggle()
+
+        sent = mock_client.write_gatt_char.call_args_list[0].args[1]
+        # toggle=0 -> 0x1077 -> [0x10, 0x77]
+        assert sent == bytes([0x10, 0x77])
+
+    async def test_set_mood_light_speed_sends_wire_value(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ):
+        """set_mood_light_speed maps UI speed to wire value 20 - speed*2."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        mock_client = coordinator._client
+        mock_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.set_mood_light_speed(3)
+
+        sent = mock_client.write_gatt_char.call_args_list[0].args[1]
+        # speed 3 -> wire 20 - 6 = 14 (0x0E)
+        assert sent == bytes([0x00, VibradormCommands.MOOD_COLOR, 0x09, 0x0E])
+
+
+class TestVibradormNotificationFlags:
+    """Test notification flag + status-byte parsing."""
+
+    def test_init_requested_flag_forwarded(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+    ) -> None:
+        """The 0x10 flag should surface init_requested in controller state."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        controller = VibradormController(coordinator)
+        controller._notify_callback = lambda *_: None
+
+        controller._handle_notification(
+            MagicMock(),
+            bytearray([0x20, 0x3F, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+        )
+
+        assert coordinator.controller_state.get("init_requested") is True
+
+    def test_sync_active_flag_forwarded(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+    ) -> None:
+        """The 0x40 flag should surface sync_active in controller state."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        controller = VibradormController(coordinator)
+        controller._notify_callback = lambda *_: None
+
+        controller._handle_notification(
+            MagicMock(),
+            bytearray([0x3F, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+        )
+
+        assert coordinator.controller_state.get("sync_active") is True
+
+    def test_store_completed_status_flag_forwarded(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+    ) -> None:
+        """A 0x0E byte in a non-position notification surfaces memory_store_completed."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        controller = VibradormController(coordinator)
+        controller._notify_callback = lambda *_: None
+
+        controller._handle_notification(
+            MagicMock(),
+            bytearray([0x20, 0xEF, 0x0E]),
+        )
+
+        assert coordinator.controller_state.get("memory_store_completed") is True
+
+    def test_link_failure_status_flag_forwarded(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+    ) -> None:
+        """A 0x79 byte surfaces link_failure in controller state."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        controller = VibradormController(coordinator)
+        controller._notify_callback = lambda *_: None
+
+        controller._handle_notification(
+            MagicMock(),
+            bytearray([0x20, 0xEF, 0x79]),
+        )
+
+        assert coordinator.controller_state.get("link_failure") is True


### PR DESCRIPTION
Brings the Vibradorm VMAT controller up to parity with the decompiled `de.vibradorm.diamant` (vra2) protocol. Ref #403.

## What's new

All command framing is taken verbatim from the APK (`CBICommands/*`, `utilities/VibCommandCodes.java`): 16-bit big-endian CBI word with the alternating `0x0000`/`0x8000` toggle bit, VMAT-basic single-byte motor path on `0x1526` kept separate.

### VRT massage (CBI `0x30` / `0x34`)
- On/off toggle, off, and per-zone toggles (head = zone1, foot = zone2)
- **Head / foot intensity sliders** (0-5, 0 = zone off) → number entities
- **Timer** select (10/20/30 min)
- Effect cycle (`massage_mode_step`) + per-zone intensity step up/down buttons
- Sends the full `CmdVRT` packet `[msb, lsb, effect, speed, zone1, zone2, 0, 0, 0, timer]`
- `get_massage_state()` for entity feedback

### Floor light (CmdLightVMAT, `0x1529`)
- **Level slider** (0-8, clamped per `MC.setFloorLightLevel`) → number entity
- **Auto-off timer** select → select entity
- `lights_on/off` now track and re-apply the stored level/timer instead of always sending `0xFF`/`0x00`

### Sync mode (`0x18`/`0x19`)
- New synchro switch entity (head + foot move together)

### RGB mood light (CBI `0x77`) — disabled by default
- Separate additive `light.mood_light` entity: RGB color + effect list + on/off
  (`CmdMoodColor` `[0x01, 0x00, R, G, B]`, `CmdMoodEffect`, `CmdMoodLightToggle`)
- **Effect speed** number entity (1-5; wire value `20 - speed*2` per `CmdEffectSpeed`)
- Toggle uses the APK's `0x1077` XT-box bus code exactly

### Notifications (`CBI_RESPONSE` `0x1551`)
- Parses `XMCMotorData` flags: `0x10` init-requested (warns positions are unreliable until a teach run), `0x40` sync-active → forwarded as controller state
- Scans non-position notifications for status bytes `0xC9` (ED active), `0x0E` (memory store completed), `0x79` (link failure)

## Mapping to the #403 checklist
- [x] CBI command set: memory recall (M1-M6, already present), store handshake, status request, sync on/off
- [x] Light: VMAT floor light level 0-8 + timer
- [x] RGB mood light: color, effect, effect speed, on/off toggle
- [x] Massage/VRT: on/off + settings (effect, speed 1-5, two intensity zones 0-5, timer)
- [x] Toggle bit + ~100 ms repeat pacing; VMAT-basic single-byte path kept separate
- [x] Notification flags (init requested / sync) + status flags
- [ ] Full EEPROM read (32x8-row reassembly → diagnostic sensors) — deferred; tracked in #403
- [ ] Verify against @zaxxon72's MC4-MD08 — needs on-device confirmation; tracked in #403

## Testing
- New unit tests cover massage/light/sync/mood-light framing + notification flag parsing (83 Vibradorm tests, 2009 total green)
- `ruff` + `pyright` clean
- No changes to existing motor/memory/light-switch behavior (all prior tests pass unchanged)

The mood light + speed entities are `entity_registry_enabled_default=False` so beds without the XT-box hardware don't gain dead entities; users enable them when present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new mood light with color and effect controls.
  * Added a mood light effect speed setting.
  * Expanded support for floor light brightness, timer options, sync mode, and massage controls.

* **Bug Fixes**
  * Improved device status reporting so app updates reflect more controller states accurately.
  * Better handling of light and massage settings to keep the interface in sync with the bed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->