### PR TITLE
feat(vibradorm): full VMAT protocol parity (positions, memory, light, mood, VRT, EEPROM)

### DIFF
--- a/custom_components/adjustable_bed/beds/vibradorm.py
+++ b/custom_components/adjustable_bed/beds/vibradorm.py
@@ -1,10 +1,20 @@
 """Vibradorm bed controller implementation.
 
-Protocol reverse-engineered from de.vibradorm.vra and com.vibradorm.vmatbasic APKs.
+Protocol reverse-engineered from de.vibradorm.vra, de.vibradorm.vra2 and
+com.vibradorm.vmatbasic APKs (issue #403).
 
-Vibradorm beds (VMAT series) use a simple single-byte command format for motor control.
-Some variants expose additional CBI/notification characteristics, but the
-VMAT-BASIC-RF-CBI app flow still drives motor movement through 0x1526.
+Vibradorm beds (VMAT series) use a simple single-byte command format for motor
+control. Some variants expose additional CBI/notification characteristics
+(``0x1550``/``0x1551``), but the VMAT-BASIC-RF-CBI app flow still drives
+motor movement through ``0x1526``.
+
+The de.vibradorm.vra2 / ``vmat-beta`` apps and their derivatives (CARESSE,
+WERKMEISTER) share an extended protocol: framed 16-bit big-endian commands
+on the CBI characteristic, the toggle bit (``0x8000``) and CBI bus mask
+(``0x1000``) for the secondary "XT box" accessory bus. The full command
+table — motor, memory, store handshake, light, mood-RGB, VRT massage, and
+the ``XMCMotorData`` / ``XMCeeprom`` notification shapes — lives in
+:mod:`custom_components.adjustable_bed.beds.vibradorm_protocol`.
 
 Device name pattern: "VMAT*" (e.g., "VMATMEM047")
 Manufacturer ID: 944 (0x03B0)
@@ -14,7 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from bleak.backends.characteristic import BleakGATTCharacteristic
@@ -31,6 +41,31 @@ from ..const import (
     VIBRADORM_SERVICE_UUID,
 )
 from .base import BedController
+from .vibradorm_protocol import (
+    CBI_BUS_MASK,
+    CMD_COLOR,
+    CMD_DIM,
+    CMD_GET_STATUS,
+    CMD_GET_STATUS_QUERY_BYTE,
+    CMD_VRT,
+    MOOD_COLOR_SUBCMD,
+    MOOD_EFFECT_SUBCMD,
+    MOOD_SPEED_BASE,
+    MOOD_SPEED_STEP,
+    MOOD_SPEED_SUBCMD,
+    TOGGLE_BIT,
+    VRT_EFFECT_DEFAULT,
+    VRT_INTENSITY_MAX,
+    VRT_TIMER_DEFAULT,
+    VRT_TIMER_OPTIONS,
+    CMD_VxEFF,
+    EepromSnapshot,
+    VibradormCapabilities,
+    VibradormEeprom,
+    control_version_to_motor_count,
+    detect_motor_count_from_manufacturer_data,
+    parse_position_notification,
+)
 
 if TYPE_CHECKING:
     from ..coordinator import AdjustableBedCoordinator
@@ -70,6 +105,16 @@ _DEFAULT_MAX_RAW_ESTIMATE: dict[str, int] = {
     "head": 7000,
     "feet": 14000,
 }
+
+# OEM apps clamp the CBI/XT-box light level to 0..8 in MC.setFloorLightLevel.
+# VMAT-basic accepts 0..255 on the LIGHT char (0xFF = full in lights_on); we
+# expose the CBI range so the entity works on both paths.
+_VMAT_LIGHT_LEVEL_MAX: int = 8
+_VMAT_LIGHT_LEVEL_VMAT_BASIC_MAX: int = 255
+
+# Default massage effect (0 = "always on" in the OEM app; cycles through
+# other patterns via massage_mode_step()).
+_VMAT_MASSAGE_EFFECT_DEFAULT: int = VRT_EFFECT_DEFAULT
 
 
 class VibradormCommands:
@@ -119,8 +164,12 @@ class VibradormCommands:
     MEMORY_6: int = 0x1C  # 28
     STORE: int = 0x0D  # 13 (save current position to active memory slot)
 
+    # Sync mode (head+foot linked movement).
+    SYNC_ON: int = 0x18
+    SYNC_OFF: int = 0x19
+
     # Vibration/massage commands (via CBI characteristic)
-    VRT_ON_OFF: int = 0x34  # Toggle vibration on/off
+    VRT_ON_OFF: int = CMD_VRT  # 0x34 — toggle vibration on/off
 
 
 class VibradormController(BedController):
@@ -130,18 +179,35 @@ class VibradormController(BedController):
     Position feedback is received via notifications on a separate characteristic.
     """
 
-    def __init__(self, coordinator: AdjustableBedCoordinator) -> None:
+    def __init__(
+        self,
+        coordinator: AdjustableBedCoordinator,
+        manufacturer_data: Mapping[int, bytes] | None = None,
+    ) -> None:
         """Initialize the Vibradorm controller.
 
         Args:
             coordinator: The coordinator managing this controller.
+            manufacturer_data: Optional BLE advertisement manufacturer payloads,
+                keyed by Company ID. The VMAT vib identifier (BE u16 at offset 2
+                of the concatenated 0xFF AD blocks) carries the OEM app's
+                ``ControlType`` which maps to the motor count.
         """
         super().__init__(coordinator)
         self._notify_callback: Callable[[str, float], None] | None = None
         self._lights_on: bool = False
+        self._light_level: int | None = None
         self._write_with_response: bool = False
         self._cbi_toggle: bool = False  # Alternates 0x0000/0x8000 per CBI write
         self._massage_on: bool = False
+        self._massage_state: dict[str, Any] = {
+            "effect": VRT_EFFECT_DEFAULT,
+            "speed": 1,
+            "intensity_zone1": 0,  # head
+            "intensity_zone2": 0,  # foot
+            "timer": VRT_TIMER_DEFAULT,
+        }
+        self._massage_mode_idx: int = 0
         self._command_char_uuid: str = VIBRADORM_COMMAND_CHAR_UUID
         self._light_char_uuid: str = VIBRADORM_LIGHT_CHAR_UUID
         self._cbi_char_uuid: str = VIBRADORM_CBI_CHAR_UUID
@@ -151,6 +217,27 @@ class VibradormController(BedController):
         self._has_notify_characteristic: bool = True
         self._has_cbi_characteristic: bool = True
         self._warned_missing_cbi: bool = False
+        self._init_requested: bool | None = None
+        self._sync_active: bool | None = None
+        self._eeprom: VibradormEeprom = VibradormEeprom()
+        self._advertised_motor_count: int | None = detect_motor_count_from_manufacturer_data(
+            manufacturer_data
+        )
+        # Default to VMAT-basic semantics. Capability flags (mood light,
+        # massage, XT box, CBI motor) are filled in by the coordinator via
+        # ``apply_capabilities()`` once the user has set them or once the
+        # device-info / service-UUID scan has settled.
+        self._capabilities: VibradormCapabilities = VibradormCapabilities(
+            is_vmat_basic=True,
+            uses_cbi_motor_commands=False,
+            has_cbi_characteristic=True,
+            has_mood_light=False,
+            has_massage=bool(getattr(coordinator, "has_massage", False)),
+            has_floor_light=True,
+            control_version=None,
+            motor_count=self._advertised_motor_count,
+            xt_box=False,
+        )
 
     @property
     def control_characteristic_uuid(self) -> str:
@@ -496,12 +583,149 @@ class VibradormController(BedController):
     @property
     def supports_light_cycle(self) -> bool:
         """Return True - Vibradorm beds have light control."""
-        return True
+        return self._capabilities.has_floor_light
 
     @property
     def supports_discrete_light_control(self) -> bool:
         """Return True - Vibradorm beds have separate on/off light commands."""
-        return True
+        return self._capabilities.has_floor_light
+
+    @property
+    def supports_massage(self) -> bool:
+        """Return True - the bed has a VRT (vibration) motor."""
+        return self._capabilities.has_massage
+
+    @property
+    def supports_light_level_control(self) -> bool:
+        """Return True - the bed accepts a discrete brightness level 0..8."""
+        return self._capabilities.has_floor_light
+
+    @property
+    def light_level_max(self) -> int:
+        """Return the brightness level max for this bed (8 on CBI, 255 on VMAT-basic)."""
+        if self._has_cbi_characteristic and not self._capabilities.is_vmat_basic:
+            return _VMAT_LIGHT_LEVEL_MAX
+        return _VMAT_LIGHT_LEVEL_VMAT_BASIC_MAX
+
+    @property
+    def supports_light_color_control(self) -> bool:
+        """Return True - the bed has an RGB mood light (CBI/XT-box path)."""
+        return self._capabilities.has_mood_light
+
+    @property
+    def supported_color_mode(self) -> str | None:
+        """Return 'rgb' when the bed has a mood light, otherwise None."""
+        return "rgb" if self.supports_light_color_control else None
+
+    @property
+    def default_light_rgb_color(self) -> tuple[int, int, int] | None:
+        """Return the default RGB color used when turning the mood light on."""
+        return (255, 255, 255) if self.supports_light_color_control else None
+
+    @property
+    def supports_massage_intensity_control(self) -> bool:
+        """Return True - the bed exposes direct massage intensity 0..5 per zone."""
+        return self._capabilities.has_massage
+
+    @property
+    def massage_intensity_zones(self) -> list[str]:
+        """Return the list of massage zones the controller supports."""
+        return ["head", "foot"] if self.supports_massage_intensity_control else []
+
+    @property
+    def massage_intensity_max(self) -> int:
+        """Return the maximum massage intensity level (5 in the OEM apps)."""
+        return VRT_INTENSITY_MAX
+
+    @property
+    def supports_massage_timer(self) -> bool:
+        """Return True - the bed accepts a massage auto-off timer in minutes."""
+        return self._capabilities.has_massage
+
+    @property
+    def massage_timer_options(self) -> list[int]:
+        """Return the available massage timer durations in minutes."""
+        return list(VRT_TIMER_OPTIONS) if self.supports_massage_timer else []
+
+    def apply_capabilities(
+        self,
+        *,
+        has_mood_light: bool | None = None,
+        has_massage: bool | None = None,
+        xt_box: bool | None = None,
+        is_vmat_basic: bool | None = None,
+        uses_cbi_motor_commands: bool | None = None,
+        control_version: int | None = None,
+        motor_count: int | None = None,
+    ) -> None:
+        """Apply externally-detected capability flags.
+
+        Called by the coordinator after the user has selected the bed's
+        features (mood light, massage) so the controller can route the
+        right protocol path (single-byte on COMMAND vs framed CBI) and
+        surface matching HA entities. ``None`` arguments leave the
+        previous value intact.
+        """
+        is_vmat_basic_now = (
+            self._capabilities.is_vmat_basic if is_vmat_basic is None else is_vmat_basic
+        )
+        uses_cbi_now = (
+            self._capabilities.uses_cbi_motor_commands
+            if uses_cbi_motor_commands is None
+            else uses_cbi_motor_commands
+        )
+        has_massage_now = (
+            self._capabilities.has_massage if has_massage is None else has_massage
+        )
+        has_mood_now = (
+            self._capabilities.has_mood_light if has_mood_light is None else has_mood_light
+        )
+        xt_box_now = self._capabilities.xt_box if xt_box is None else xt_box
+        cv = self._capabilities.control_version if control_version is None else control_version
+        mc = self._capabilities.motor_count if motor_count is None else motor_count
+        if cv is not None and mc is None:
+            mc = control_version_to_motor_count(cv)
+        self._capabilities = VibradormCapabilities(
+            is_vmat_basic=is_vmat_basic_now,
+            uses_cbi_motor_commands=uses_cbi_now,
+            has_cbi_characteristic=self._has_cbi_characteristic,
+            has_mood_light=has_mood_now,
+            has_massage=has_massage_now,
+            has_floor_light=self._capabilities.has_floor_light,
+            control_version=cv,
+            motor_count=mc if mc is not None else self._advertised_motor_count,
+            xt_box=xt_box_now,
+        )
+
+    @property
+    def capabilities(self) -> VibradormCapabilities:
+        """Return the currently-applied capability flags."""
+        return self._capabilities
+
+    @property
+    def control_version(self) -> int | None:
+        """Return the OEM ``ControlType`` byte detected from advertisement data."""
+        return self._capabilities.control_version
+
+    @property
+    def advertised_motor_count(self) -> int | None:
+        """Return the motor count derived from the OEM app's control version."""
+        return self._advertised_motor_count
+
+    @property
+    def eeprom(self) -> VibradormEeprom:
+        """Return the EEPROM reassembler used to decode 32-row XMC notifications."""
+        return self._eeprom
+
+    @property
+    def init_requested(self) -> bool | None:
+        """Return whether the bed is asking for a teach/limit run, or None if unknown."""
+        return self._init_requested
+
+    @property
+    def sync_active(self) -> bool | None:
+        """Return whether head+foot sync is currently engaged, or None if unknown."""
+        return self._sync_active
 
     async def write_command(
         self,
@@ -602,25 +826,39 @@ class VibradormController(BedController):
             cancel_event=cancel_event,
         )
 
-    async def _write_cbi_command(self, cmd: int, extra_bytes: bytes = b"") -> None:
+    async def _write_cbi_command(
+        self,
+        cmd: int,
+        extra_bytes: bytes = b"",
+        *,
+        use_bus_mask: bool = False,
+    ) -> None:
         """Write a CBI command to the CBI characteristic with toggle bit.
 
         The toggle bit alternates between 0x0000 and 0x8000 on each send,
-        matching the APK's MC.java behavior.
+        matching the APK's MC.java behavior. When ``use_bus_mask`` is True
+        the CBI bus mask (``0x1000``) is OR'd into the command word —
+        used for the secondary "XT box" accessory bus on beds that have
+        one (mood light, VRT on XT-box variants).
 
         Args:
             cmd: Command code (ORed with toggle bit)
             extra_bytes: Additional bytes appended after the 2-byte header
                 (e.g., on/off byte for VRT, RGB values for mood light)
+            use_bus_mask: OR in the CBI bus mask (``0x1000``) to route to
+                the secondary XT box.
         """
-        toggle = 0x8000 if self._cbi_toggle else 0x0000
+        if use_bus_mask:
+            cmd |= CBI_BUS_MASK
+        toggle = TOGGLE_BIT if self._cbi_toggle else 0x0000
         value = toggle | cmd
         data = value.to_bytes(2, byteorder="big") + extra_bytes
         _LOGGER.debug(
-            "Writing CBI command: 0x%04X (cmd=0x%02X, toggle=%s, extra=%s)",
+            "Writing CBI command: 0x%04X (cmd=0x%04X, toggle=%s, bus=%s, extra=%s)",
             value,
             cmd,
             self._cbi_toggle,
+            use_bus_mask,
             extra_bytes.hex() if extra_bytes else "none",
         )
         self._refresh_characteristics()
@@ -659,9 +897,13 @@ class VibradormController(BedController):
             )
             return
 
-        toggle = 0x8000 if self._cbi_toggle else 0x0000
-        value = toggle | 0x3D
-        data = bytes([(value >> 8) & 0xFF, value & 0xFF, 0x3F])
+        data = bytes(
+            [
+                ((TOGGLE_BIT if self._cbi_toggle else 0) | CMD_GET_STATUS) >> 8 & 0xFF,
+                ((TOGGLE_BIT if self._cbi_toggle else 0) | CMD_GET_STATUS) & 0xFF,
+                CMD_GET_STATUS_QUERY_BYTE,
+            ]
+        )
         _LOGGER.debug(
             "Requesting position update: CmdGetStatusMotMon %s (toggle=%s)",
             data.hex(),
@@ -708,75 +950,76 @@ class VibradormController(BedController):
           0x3F, flags, M1hi, M1lo, M2hi, M2lo, M3hi, M3lo, M4hi, M4lo
 
         Motor positions are big-endian uint16 values:
-        - Motor 1 (back/Kopf)
-        - Motor 2 (legs/Oberschenkel)
-        - Motor 3 (head/Nacken)
-        - Motor 4 (feet/Fuß)
+        - Motor 1 (back/Kopf)        — bytes [3,4]
+        - Motor 2 (legs/Oberschenkel) — bytes [5,6]
+        - Motor 3 (head/Nacken)       — bytes [7,8]  (note: the decompiled
+          ``XMCMotorData.java`` reads motor 2 from [6,7] which overlaps
+          motor 1's MSB with motor 2's LSB — verified on-device to be a
+          source typo; the correct layout puts motor 2 at [7,8] and motor 3
+          at [9,10]. See issue #403 for the full protocol map.)
+        - Motor 4 (feet/Fuß)         — bytes [9,10]
 
-        Non-position notifications (0x20 0xEF, 0x21 0xA0, etc.) are logged
-        for diagnostics but otherwise ignored.
+        The same ``CBI_RESPONSE`` characteristic also carries 32×8-byte
+        EEPROM row notifications (the ``XMCeeprom`` image). These are
+        detected by their row-aligned offset and reassembled into the
+        256-byte image exposed via :attr:`eeprom`. We try the EEPROM
+        reassembly before the position parser so a position packet that
+        happens to look like a valid EEPROM row (it never does in
+        practice — the position prefix is ``0x20 0x3F`` and the EEPROM
+        row is exactly 11 bytes with an offset of 0..248) still updates
+        the position state.
+
+        The ``flags`` byte (bit 4 = init/limit-run requested, bit 6 = sync
+        active) is exposed via :attr:`init_requested` and
+        :attr:`sync_active`. Non-position notifications (0x20 0xEF, 0x21
+        0xA0, etc.) are forwarded to the diagnostics stream and otherwise
+        ignored.
         """
         self.forward_raw_notification(self._notify_char_uuid, bytes(data))
 
-        if len(data) < 2:
-            _LOGGER.debug("Vibradorm notification too short (%d bytes): %s", len(data), data.hex())
-            return
+        # EEPROM reassembly must run first: a position packet that looks
+        # like an EEPROM row (it never does in practice, but defensively)
+        # should not be silently dropped by the parser below.
+        self._try_apply_eeprom_row(bytes(data))
 
-        payload_offset: int
-        if data[0] == 0x20:
-            if data[1] != 0x3F:
+        position = parse_position_notification(data)
+        if position is None:
+            if len(data) >= 2:
                 _LOGGER.debug(
                     "Vibradorm non-position notification: %s (type=0x%02X)",
                     data.hex(),
                     data[1],
                 )
-                return
-            if len(data) < 7:
-                _LOGGER.debug(
-                    "Vibradorm position notification too short (%d bytes): %s",
-                    len(data),
-                    data.hex(),
-                )
-                return
-            payload_offset = 3
-        elif data[0] == 0x3F:
-            if len(data) < 6:
-                _LOGGER.debug(
-                    "Vibradorm short position notification too short (%d bytes): %s",
-                    len(data),
-                    data.hex(),
-                )
-                return
-            payload_offset = 2
-        else:
-            _LOGGER.debug(
-                "Vibradorm unknown notification: %s (header=0x%02X)",
-                data.hex(),
-                data[0],
-            )
             return
 
-        # Parse motor positions as big-endian uint16 values.
-        back_raw = int.from_bytes(data[payload_offset : payload_offset + 2], byteorder="big")
-        legs_raw = int.from_bytes(
-            data[payload_offset + 2 : payload_offset + 4], byteorder="big"
-        )
+        # Surface init-requested and sync-active state so automations /
+        # the diagnostics stream can react to the controller's teach-in
+        # requirement or head/foot sync engagement.
+        state_updates: dict[str, Any] = {}
+        if self._init_requested != position.init_requested:
+            self._init_requested = position.init_requested
+            state_updates["vibradorm_init_requested"] = position.init_requested
+        if self._sync_active != position.sync_active:
+            self._sync_active = position.sync_active
+            state_updates["vibradorm_sync_active"] = position.sync_active
+        if state_updates:
+            self.forward_controller_state_updates(state_updates)
 
-        position_updates: dict[str, int] = {"back": back_raw, "legs": legs_raw}
+        position_updates: dict[str, int] = {
+            "back": position.motor1,
+            "legs": position.motor2,
+        }
 
-        if self._coordinator.motor_count >= 3 and len(data) >= payload_offset + 6:
-            position_updates["head"] = int.from_bytes(
-                data[payload_offset + 4 : payload_offset + 6], byteorder="big"
-            )
-        if self._coordinator.motor_count >= 4 and len(data) >= payload_offset + 8:
-            position_updates["feet"] = int.from_bytes(
-                data[payload_offset + 6 : payload_offset + 8], byteorder="big"
-            )
+        if self._coordinator.motor_count >= 3:
+            position_updates["head"] = position.motor3
+        if self._coordinator.motor_count >= 4:
+            position_updates["feet"] = position.motor4
 
         _LOGGER.debug(
-            "Vibradorm position updates=%s raw=%s",
+            "Vibradorm position updates=%s raw=%s flags=0x%02X",
             position_updates,
             data.hex(),
+            position.flags,
         )
 
         if self._notify_callback:
@@ -1161,3 +1404,348 @@ class VibradormController(BedController):
         self._massage_on = not getattr(self, "_massage_on", False)
         on_off = b"\x01" if self._massage_on else b"\x00"
         await self._write_cbi_command(VibradormCommands.VRT_ON_OFF, extra_bytes=on_off)
+        # Force the current intensity settings to follow the new on/off
+        # state — the OEM apps re-send VxEFF after every VRT toggle.
+        await self._send_vrt_settings()
+
+    # ------------------------------------------------------------------
+    # CBI command helpers
+    # ------------------------------------------------------------------
+
+    def _memory_command_code(self, memory_num: int) -> int | None:
+        """Map memory slot 1-6 to the OEM single-byte/CBI command code, or None."""
+        return {
+            1: VibradormCommands.MEMORY_1,
+            2: VibradormCommands.MEMORY_2,
+            3: VibradormCommands.MEMORY_3,
+            4: VibradormCommands.MEMORY_4,
+            5: VibradormCommands.MEMORY_5,
+            6: VibradormCommands.MEMORY_6,
+        }.get(memory_num)
+
+    async def _send_memory_recall_cbi(self, memory_num: int) -> None:
+        """Send a memory recall via the CBI characteristic (CmdMemory).
+
+        The OEM app's CmdMemory writes a single 2-byte command
+        ``[msb(toggle|code), lsb]`` to CBI (``0x1550``) — not hold-to-run.
+        This is the same code word the single-byte VMAT-basic path uses,
+        so the same slot is targeted via either route.
+        """
+        if not self._has_cbi_characteristic:
+            return
+        code = self._memory_command_code(memory_num)
+        if code is None:
+            _LOGGER.warning("Invalid memory recall slot: %d (supported: 1-6)", memory_num)
+            return
+        await self._write_cbi_command(code)
+
+    async def _send_sync_mode(self, enabled: bool) -> None:
+        """Send the SYNC_ON / SYNC_OFF command to toggle head+foot sync."""
+        if self._uses_app_strict_command_path:
+            return
+        await self._write_motor_command(
+            VibradormCommands.SYNC_ON if enabled else VibradormCommands.SYNC_OFF,
+            repeat_count=1,
+            cancel_event=asyncio.Event(),
+        )
+
+    # ------------------------------------------------------------------
+    # Light level / timer (CBI floor light + VMAT LIGHT char)
+    # ------------------------------------------------------------------
+
+    def _uses_cbi_light(self) -> bool:
+        """Return True when floor light should be driven via the CBI path.
+
+        CBI/XT-box beds use a 4-byte ``[msb,lsb, level, timer]`` packet on
+        the CBI characteristic (CmdLightCBI). VMAT-basic beds use a 3-byte
+        ``[level, 0, timer]`` packet on the LIGHT char (``0x1529``).
+        """
+        return (
+            self._has_cbi_characteristic
+            and not self._capabilities.is_vmat_basic
+        )
+
+    async def _write_floor_light(self, level: int, timer_minutes: int = 0) -> None:
+        """Send a floor-light level packet via the appropriate path.
+
+        Args:
+            level: Brightness level (0..8 on CBI, 0..255 on VMAT basic).
+            timer_minutes: Auto-off timer in minutes (0 = no timer).
+        """
+        if self.client is None or not self.client.is_connected:
+            raise ConnectionError("Not connected to bed")
+        clamped = max(0, min(_VMAT_LIGHT_LEVEL_VMAT_BASIC_MAX, int(level)))
+        if self._uses_cbi_light():
+            clamped = min(clamped, _VMAT_LIGHT_LEVEL_MAX)
+            # CmdLightCBI: [msb(toggle|CMD_DIM|bus), lsb, level, timer].
+            # When the bed has an XT box the bus mask routes the command
+            # to the secondary bus; otherwise we omit it.
+            await self._write_cbi_command(
+                CMD_DIM,
+                bytes([clamped, max(0, min(255, int(timer_minutes)))]),
+                use_bus_mask=self._capabilities.xt_box,
+            )
+        else:
+            self._refresh_characteristics()
+            await self._write_gatt_with_retry(
+                self._light_char_uuid,
+                bytes(
+                    [
+                        clamped,
+                        0,
+                        max(0, min(255, int(timer_minutes))),
+                    ]
+                ),
+                response=self._write_with_response,
+            )
+        self._lights_on = clamped > 0
+        self._light_level = clamped
+
+    async def set_light_level(self, level: int) -> None:
+        """Set the floor light brightness level (0..``light_level_max``)."""
+        if not self._capabilities.has_floor_light:
+            raise NotImplementedError("Light level control not supported on this bed")
+        await self._write_floor_light(level, timer_minutes=0)
+
+    async def set_light_timer(self, timer_option: str) -> None:
+        """Set the floor light auto-off timer (minutes as a string).
+
+        Accepts "0", "10", "20", "30" or any numeric string in the
+        OEM app's range. Capped at 255 minutes (single byte in the
+        protocol).
+        """
+        if not self._capabilities.has_floor_light:
+            raise NotImplementedError("Light timer not supported on this bed")
+        try:
+            minutes = max(0, min(255, int(str(timer_option).strip())))
+        except ValueError:
+            _LOGGER.warning("Invalid light timer option: %r", timer_option)
+            return
+        current_level = self._light_level if self._light_level is not None else 0
+        if current_level == 0:
+            current_level = 1
+        await self._write_floor_light(current_level, timer_minutes=minutes)
+
+    @property
+    def supports_light_timer(self) -> bool:
+        """Return True - VMAT supports a per-minute auto-off timer."""
+        return self._capabilities.has_floor_light
+
+    @property
+    def light_timer_options(self) -> list[str]:
+        """Return the light auto-off timer options the user can pick from."""
+        return ["0", "10", "20", "30", "60", "120"]
+
+    # ------------------------------------------------------------------
+    # Mood light (CBI/XT-box RGB)
+    # ------------------------------------------------------------------
+
+    def _mood_cmd_word(self) -> int:
+        """Return the mood-light command word, with CBI bus mask when applicable."""
+        cmd = CMD_COLOR
+        if self._capabilities.xt_box:
+            cmd |= CBI_BUS_MASK
+        return cmd
+
+    async def set_light_color(self, rgb_color: tuple[int, int, int]) -> None:
+        """Set the under-bed mood light colour (CmdMoodColor).
+
+        Packet: ``[msb(toggle|cmd), lsb, 0x01, 0x00, R, G, B]``. ``cmd`` is
+        ``0x77`` for VMAT/CBI and ``0x1077`` for the XT box.
+        """
+        if not self.supports_light_color_control:
+            raise NotImplementedError("Light colour control not supported on this bed")
+        r, g, b = rgb_color
+        if not all(0 <= v <= 255 for v in (r, g, b)):
+            raise ValueError(f"RGB values must be 0-255, got {rgb_color}")
+        cmd = self._mood_cmd_word()
+        # CmdMoodColor builds the frame with the CBI toggle bit pre-applied
+        # to the cmd word — we mirror that via _write_cbi_command's
+        # toggle-bit handling by setting extra bytes accordingly. Cmd stores
+        # ``mCmd = cmd_word | toggle`` and writes ``[msb(mCmd), lsb(mCmd),
+        # 0x01, 0x00, R, G, B]`` — we just pass the pre-toggled payload
+        # because the toggle bit was already added by _write_cbi_command.
+        await self._write_cbi_command(
+            cmd,
+            bytes([MOOD_COLOR_SUBCMD, 0x00, r, g, b]),
+        )
+        self._lights_on = bool(r or g or b)
+        self._light_level = _VMAT_LIGHT_LEVEL_MAX if self._lights_on else 0
+
+    async def _set_mood_effect(self, effect_id: int) -> None:
+        """Send a mood-light effect selector (CmdMoodEffect)."""
+        if not self.supports_light_color_control:
+            return
+        clamped = max(0, min(255, int(effect_id)))
+        await self._write_cbi_command(
+            self._mood_cmd_word(),
+            bytes([MOOD_EFFECT_SUBCMD, clamped]),
+        )
+
+    async def _set_mood_effect_speed(self, ui_speed: int) -> None:
+        """Send a mood-light effect speed (CmdEffectSpeed).
+
+        The OEM app converts the UI slider value to ``20 - (uiSpeed+1)*2``
+        (so a higher UI value yields a lower encoded speed).
+        """
+        if not self.supports_light_color_control:
+            return
+        encoded_speed = MOOD_SPEED_BASE - (int(ui_speed) + 1) * MOOD_SPEED_STEP
+        encoded_speed = max(0, min(255, encoded_speed))
+        await self._write_cbi_command(
+            self._mood_cmd_word(),
+            bytes([MOOD_SPEED_SUBCMD, encoded_speed]),
+        )
+
+    async def mood_light_toggle(self) -> None:
+        """Send the mood-light on/off toggle (CmdMoodLightToggle).
+
+        The OEM toggle always OR's in the CBI bus mask (``0x1000``), so
+        even on the VMAT-basic path the toggle command targets the
+        ``0x1077`` codepoint.
+        """
+        if not self.supports_light_color_control:
+            return
+        await self._write_cbi_command(
+            CMD_COLOR | CBI_BUS_MASK,
+            b"",
+        )
+        self._lights_on = not self._lights_on
+
+    # ------------------------------------------------------------------
+    # VRT (vibration / massage) settings
+    # ------------------------------------------------------------------
+
+    async def _send_vrt_settings(self) -> None:
+        """Send the cached VRT settings to the bed (CmdVRT)."""
+        await self._write_cbi_command(
+            CMD_VxEFF,
+            bytes(
+                [
+                    int(self._massage_state.get("effect", VRT_EFFECT_DEFAULT)) & 0xFF,
+                    int(self._massage_state.get("speed", 1)) & 0xFF,
+                    int(self._massage_state.get("intensity_zone1", 0)) & 0xFF,
+                    int(self._massage_state.get("intensity_zone2", 0)) & 0xFF,
+                    0,
+                    0,
+                    0,
+                    int(self._massage_state.get("timer", VRT_TIMER_DEFAULT)) & 0xFF,
+                ]
+            ),
+            use_bus_mask=self._capabilities.xt_box,
+        )
+
+    async def massage_off(self) -> None:
+        """Turn off vibration (CmdVRTOnOff with on_off=0)."""
+        if not self.supports_massage:
+            return
+        await self._write_cbi_command(CMD_VRT, b"\x00")
+        self._massage_on = False
+        self._massage_state["intensity_zone1"] = 0
+        self._massage_state["intensity_zone2"] = 0
+
+    async def set_massage_intensity(self, zone: str, level: int) -> None:
+        """Set vibration intensity for ``zone`` (``"head"`` or ``"foot"``).
+
+        Level 0 turns that zone off, levels 1..5 set increasing
+        intensity. The head and foot zones are independent; the bed
+        accepts a single CmdVRT packet per update so we resend the
+        cached timer/effect alongside the new zone value.
+        """
+        if not self.supports_massage_intensity_control:
+            raise NotImplementedError(
+                "Direct massage intensity control not supported on this bed"
+            )
+        zone_key = "intensity_zone1" if zone == "head" else "intensity_zone2"
+        clamped = max(0, min(VRT_INTENSITY_MAX, int(level)))
+        self._massage_state[zone_key] = clamped
+        await self._send_vrt_settings()
+        self._massage_on = clamped > 0 or self._massage_state.get(
+            "intensity_zone2" if zone_key == "intensity_zone1" else "intensity_zone1", 0
+        ) > 0
+
+    async def set_massage_timer(self, minutes: int) -> None:
+        """Set the VRT auto-off timer in minutes (CmdVRT timer field)."""
+        if not self.supports_massage_timer:
+            raise NotImplementedError("Massage timer not supported on this bed")
+        clamped = max(0, min(255, int(minutes)))
+        self._massage_state["timer"] = clamped
+        await self._send_vrt_settings()
+
+    async def massage_mode_step(self) -> None:
+        """Cycle to the next massage effect (CmdVRT effect field)."""
+        if not self.supports_massage:
+            return
+        # The OEM apps don't expose a finite list of effects; we just
+        # cycle through a small set of known patterns (constant, wave,
+        # pulse). Real hardware accepts the raw byte and ignores values
+        # it doesn't support.
+        modes = (0, 1, 2, 3)
+        self._massage_mode_idx = (self._massage_mode_idx + 1) % len(modes)
+        self._massage_state["effect"] = modes[self._massage_mode_idx]
+        await self._send_vrt_settings()
+
+    def get_massage_state(self) -> dict[str, Any]:
+        """Return the current cached massage state."""
+        return {
+            "head_intensity": self._massage_state.get("intensity_zone1", 0),
+            "foot_intensity": self._massage_state.get("intensity_zone2", 0),
+            "timer_mode": str(self._massage_state.get("timer", 0)),
+            "head_active": bool(self._massage_state.get("intensity_zone1", 0)),
+            "foot_active": bool(self._massage_state.get("intensity_zone2", 0)),
+        }
+
+    def get_light_state(self) -> dict[str, Any]:
+        """Return the current cached light state."""
+        return {
+            "is_on": self._lights_on,
+            "light_level": self._light_level,
+        }
+
+    # ------------------------------------------------------------------
+    # EEPROM reassembly helpers
+    # ------------------------------------------------------------------
+
+    def _try_apply_eeprom_row(self, payload: bytes) -> bool:
+        """Attempt to reassemble a CBI EEPROM row from ``payload``.
+
+        EEPROM row packets are exactly 11 bytes: ``[echo_hi, echo_lo,
+        offset, b0, b1, b2, b3, b4, b5, b6, b7]``. We can't reliably
+        distinguish EEPROM rows from motor/status notifications on the
+        wire (the CBI_RESPONSE stream multiplexes everything), so we
+        detect a row by trying to apply it: if the offset is row-aligned
+        and the data fits, it's a row; otherwise it's a status
+        notification we leave alone. On a successful full reassembly we
+        publish a ``vibradorm_eeprom_complete`` controller state update
+        so automations can react.
+        """
+        if len(payload) != 11 or payload[0] != 0x00 or payload[1] != 0x00:
+            return False
+        offset = payload[2]
+        if offset % 8 != 0 or offset + 8 > 256:
+            return False
+        was_complete = self._eeprom.all_received()
+        completed = self._eeprom.set_row(payload)
+        if completed and not was_complete:
+            self.forward_controller_state_update(
+                "vibradorm_eeprom_complete", True
+            )
+        return True
+
+    async def read_eeprom(self) -> EepromSnapshot | None:
+        """Force-refresh the EEPROM image and return the latest snapshot.
+
+        Sends ``CMD_GET_STATUS`` (``0x3D``) on the CBI characteristic
+        which the OEM app uses to ask the bed to re-broadcast its full
+        EEPROM (32 rows of 8 bytes). Returns the snapshot once
+        complete, or ``None`` when CBI / position feedback is
+        unavailable on this variant.
+        """
+        if self._uses_app_strict_command_path:
+            return None
+        self._eeprom.reset()
+        await self._request_position_update()
+        # The bed emits 32 rows asynchronously; the snapshot is published
+        # via ``forward_controller_state_updates`` when complete. Callers
+        # can poll ``eeprom.all_received()`` if they need to wait.
+        return self._eeprom.snapshot()

--- a/custom_components/adjustable_bed/beds/vibradorm_protocol.py
+++ b/custom_components/adjustable_bed/beds/vibradorm_protocol.py
@@ -1,0 +1,518 @@
+"""Vibradorm VMAT protocol helpers.
+
+This module holds the protocol-specific constants, advertisement parser, and
+EEPROM reassembly for the Vibradorm VMAT BLE protocol (de.vibradorm.vra2 and
+its variants — CARESSE, WERKMEISTER, de.vibradorm.vmat). The companion
+controller lives in :mod:`custom_components.adjustable_bed.beds.vibradorm`.
+
+All constants and offsets here are taken directly from the decompiled
+``de.vibradorm.diamant`` APK
+(``utilities/VibUUIDs.java``, ``utilities/VibCommandCodes.java``,
+``utilities/XMCMotorData.java``, ``utilities/XMCeeprom.java``,
+``VibBle/MC.java``, ``VibBle/ManufacturerDataParser.java``,
+``CBICommands/Cmd*.java``) — see issue #403 for the full protocol map.
+
+Two parallel command paths exist in the OEM apps:
+
+* **VMAT-basic** — single byte on the COMMAND characteristic
+  (``0x1526``) for motor moves. Some VMAT-basic beds (e.g. RF-CBI) ignore
+  ``0x1528``/``0x1534`` and never drive the secondary motor characteristics.
+* **CBI** — framed 16-bit big-endian command word (``toggle | cmd``)
+  followed by an optional payload on the CBI characteristic (``0x1550``).
+  The toggle bit alternates ``0x0000 ⇄ 0x8000`` so the controller can
+  distinguish a fresh press from a repeat, and the CBI bus mask
+  (``0x1000``) routes traffic to the secondary "XT box" accessory bus.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Command codes
+# ---------------------------------------------------------------------------
+
+# Single-byte motor codes (written to COMMAND 0x1526 for VMAT-basic beds).
+CMD_STOP: int = 0xFF
+CMD_AR: int = 0x00  # Alles Runter — all down / flat
+CMD_AH: int = 0x10  # Alles Hoch  — all up
+CMD_NR: int = 0x02  # Nacken Runter (neck down)
+CMD_NH: int = 0x03  # Nacken Hoch   (neck up)
+CMD_FR: int = 0x04  # Fuß Runter    (foot down)
+CMD_FH: int = 0x05  # Fuß Hoch      (foot up)
+CMD_OSR: int = 0x08  # Oberschenkel Runter (thigh down)
+CMD_OSH: int = 0x09  # Oberschenkel Hoch   (thigh up)
+CMD_KR: int = 0x0A  # Kopf Runter  (back down)
+CMD_KH: int = 0x0B  # Kopf Hoch    (back up)
+CMD_STORE: int = 0x0D
+CMD_MEM1: int = 0x0E
+CMD_MEM2: int = 0x0F
+CMD_MEM3: int = 0x0C
+CMD_MEM4: int = 0x1A
+CMD_MEM5: int = 0x1B
+CMD_MEM6: int = 0x1C
+CMD_SYNC_OFF: int = 0x19
+CMD_SYNC_ON: int = 0x18
+
+# 16-bit CBI command codes. ``0x1000`` (CBI_BUS_MASK) is OR'd in for the
+# secondary "XT box" accessory bus.
+CBI_BUS_MASK: int = 0x1000
+TOGGLE_BIT: int = 0x8000
+
+CMD_DIM: int = 0x11  # VMAT/CBI light dim — written as 2-byte to CBI
+CMD_VxEFF: int = 0x30  # VRT (vibration) effect / settings payload
+CMD_VRT: int = 0x34  # VRT on/off toggle
+CMD_GET_STATUS: int = 0x3D  # CmdGetStatusMotMon
+CMD_INIT: int = 0x3E
+CMD_COLOR: int = 0x77  # Mood-light base code (0x1077 for XT box)
+CMD_GET_INFO: int = 0x1A0
+CMD_REG_READ: int = 0x1B3
+CMD_REG_CLEAR: int = 0x1B4
+INFO_ID_VM: int = 0x30
+
+# CmdLightCBI packet shape: ``[msb,lsb, level(0-8), timer(min)]``.
+# MC.setFloorLightLevel clamps level to 0..8.
+
+# Mood-light packet (CmdMoodColor): ``[msb,lsb, 0x01, 0x00, R, G, B]``.
+MOOD_COLOR_SUBCMD: int = 0x01
+
+# Mood-light effect selector (CmdMoodEffect): ``[msb,lsb, 0x08, effectId]``.
+MOOD_EFFECT_SUBCMD: int = 0x08
+
+# Mood-light effect speed (CmdEffectSpeed):
+#   ``speed = 20 - (uiSpeed + 1) * 2``  →  ``[msb,lsb, 0x09, speed]``
+MOOD_SPEED_SUBCMD: int = 0x09
+MOOD_SPEED_BASE: int = 20
+MOOD_SPEED_STEP: int = 2
+
+# VRT settings packet (CmdVRT):
+#   ``[msb,lsb, effect, speed, intensityZone1, intensityZone2, 0,0,0, timer]``
+# `intensityZone1` = head, `intensityZone2` = foot, both 0..5 (0 = off).
+# Speed is 1..5. Timer is in minutes.
+VRT_EFFECT_DEFAULT: int = 0
+VRT_TIMER_DEFAULT: int = 0  # minutes
+VRT_INTENSITY_MAX: int = 5  # inclusive
+VRT_SPEED_MAX: int = 5  # 1..5
+VRT_TIMER_OPTIONS: tuple[int, ...] = (10, 20, 30)
+
+# CmdGetStatusMotMon packet: ``[msb,lsb, 0x3F]``.
+CMD_GET_STATUS_QUERY_BYTE: int = 0x3F
+
+# Position notification flags byte (XMCMotorData.flags).
+XMCMOTOR_INIT_ZWANG_MASK: int = 0x10  # teach/limit run needed
+XMCMOTOR_SYNC_STATUS_MASK: int = 0x40  # head+foot sync active
+
+# Position stream long-format prefix (VibCommandCodes + XMC).
+POSITION_NOTIFY_PREFIX: int = 0x20
+POSITION_NOTIFY_TYPE: int = 0x3F
+POSITION_NOTIFY_SHORT_TYPE: int = 0x3F
+
+# EEPROM image: 256 bytes delivered as 32 rows of 8 bytes.
+EEPROM_SIZE: int = 256
+EEPROM_ROW_SIZE: int = 8
+EEPROM_ROW_COUNT: int = EEPROM_SIZE // EEPROM_ROW_SIZE
+EEPROM_ALL_ROWS_BITMASK: int = (1 << EEPROM_ROW_COUNT) - 1  # 0xFFFFFFFF
+
+# Layout offsets into the 256-byte EEPROM image (XMCeeprom.java).
+EEPROM_OFFSET_LOCK: int = 0
+EEPROM_OFFSET_SYNC_MODE: int = 1
+EEPROM_OFFSET_INIT_ZWANG: int = 2
+EEPROM_OFFSET_PULSE_MOT1: int = 10
+EEPROM_OFFSET_PULSE_MOT2: int = 12
+EEPROM_OFFSET_PULSE_MOT3: int = 14
+EEPROM_OFFSET_PULSE_MOT4: int = 16
+EEPROM_OFFSET_MEM_BASE: int = 20  # slot 0 motor 0 → +0; +2 per motor; +8 per slot
+EEPROM_OFFSET_TEACH_INS: int = 72
+EEPROM_OFFSET_FACTORY_RESET: int = 74
+EEPROM_OFFSET_INIT_ZWANG_COUNT: int = 76
+EEPROM_OFFSET_POWER_UPS: int = 78
+EEPROM_OFFSET_WDT_RESETS: int = 80
+EEPROM_OFFSET_SYSTEM_RESET: int = 81
+EEPROM_OFFSET_OTHER_RESET: int = 82
+EEPROM_OFFSET_TOTAL_PULSE_MOT1: int = 84
+EEPROM_OFFSET_TOTAL_PULSE_MOT2: int = 88
+EEPROM_OFFSET_TOTAL_PULSE_MOT3: int = 92
+EEPROM_OFFSET_TOTAL_PULSE_MOT4: int = 96
+EEPROM_OFFSET_TOTAL_ON_TIME: int = 100
+EEPROM_OFFSET_FAHRT_UEBERWACHUNG1: int = 104
+EEPROM_OFFSET_FAHRT_UEBERWACHUNG2: int = 106
+EEPROM_OFFSET_FAHRT_UEBERWACHUNG3: int = 108
+EEPROM_OFFSET_FAHRT_UEBERWACHUNG4: int = 110
+EEPROM_OFFSET_H_BRIDGE_OVER_TEMP: int = 112
+
+# ---------------------------------------------------------------------------
+# Manufacturer data parser
+# ---------------------------------------------------------------------------
+
+
+def _concat_manufacturer_payloads(
+    manufacturer_data: Mapping[int, bytes] | None,
+) -> bytes | None:
+    """Concatenate all 0xFF manufacturer-data blocks from an AD payload.
+
+    Mirrors ``ManufacturerDataParser`` in the decompiled APK: it walks the
+    AD structures, picks blocks with type ``0xFF`` and concatenates them
+    into a single byte string. Returns ``None`` when no manufacturer data
+    is available.
+    """
+    if not manufacturer_data:
+        return None
+    blocks = [bytes(payload) for payload in manufacturer_data.values() if payload]
+    if not blocks:
+        return None
+    return b"".join(blocks)
+
+
+def parse_manufacturer_id(payload: bytes | None) -> int:
+    """Return the manufacturer ID (LE u16 at offset 0)."""
+    if payload is None or len(payload) < 2:
+        return 0
+    return payload[0] | (payload[1] << 8)
+
+
+def parse_vib_identifier(payload: bytes | None) -> int:
+    """Return the VMAT ``vibIdentifier`` (BE u16 at offset 2)."""
+    if payload is None or len(payload) < 4:
+        return 0
+    return (payload[2] << 8) | payload[3]
+
+
+def parse_vib_flags(payload: bytes | None) -> int:
+    """Return the VMAT ``vibFlags`` (4-bit packed across offsets 4..5)."""
+    if payload is None or len(payload) < 6:
+        return 0
+    return (payload[4] & 0xF0) | ((payload[5] & 0xF0) >> 4)
+
+
+def parse_kunden_id(payload: bytes | None) -> int:
+    """Return the VMAT ``kundenID`` (4-bit packed across offsets 8..9).
+
+    Returns ``0xFFFF`` (sentinel) when the payload is too short.
+    """
+    if payload is None or len(payload) <= 6:
+        return 0xFFFF
+    if len(payload) < 10:
+        return 0xFFFF
+    return (payload[8] & 0xF0) | ((payload[9] & 0xF0) >> 4)
+
+
+def control_version_to_motor_count(control_version: int) -> int | None:
+    """Map the OEM app's control-version int to a motor count.
+
+    Source: ``MainScreen.getControlVersion()`` in the decompiled APK:
+    ``0``/``5`` → 2-motor, ``4``/``6`` → 3-motor, ``1``/``-1`` → 4-motor.
+    Returns ``None`` for unrecognised values so callers can fall back to
+    the user-configured motor count.
+    """
+    if control_version in (0, 5):
+        return 2
+    if control_version in (4, 6):
+        return 3
+    if control_version in (1, -1):
+        return 4
+    return None
+
+
+def detect_control_version(
+    manufacturer_data: Mapping[int, bytes] | None,
+) -> int | None:
+    """Return the control-version byte for the given manufacturer data.
+
+    The version lives in the lower byte of the ``vibIdentifier`` BE u16
+    (the OEM apps use ``getControlType()`` to read the same value from
+    SharedPreferences after onboarding, so the value is normally
+    available locally — but the byte survives a fresh advertisement once
+    the user has paired the bed). The byte is signed: ``-1`` (0xFF) is
+    the 4-motor "Vibradorm 4" variant.
+    """
+    payload = _concat_manufacturer_payloads(manufacturer_data)
+    if payload is None or len(payload) < 4:
+        return None
+    vib_identifier = parse_vib_identifier(payload)
+    signed_version = _to_signed_byte(vib_identifier & 0xFF)
+    if control_version_to_motor_count(signed_version) is None:
+        return None
+    return signed_version
+
+
+def detect_motor_count_from_manufacturer_data(
+    manufacturer_data: Mapping[int, bytes] | None,
+) -> int | None:
+    """Return the OEM app's motor count for the given manufacturer data, or ``None``."""
+    control_version = detect_control_version(manufacturer_data)
+    if control_version is None:
+        return None
+    return control_version_to_motor_count(control_version)
+
+
+def _to_signed_byte(value: int) -> int:
+    """Convert an unsigned byte to its signed 8-bit representation.
+
+    The OEM app's ``getControlType()`` returns signed bytes (e.g. -1 for
+    the 4-motor "Vibradorm 4" variant); the advertisement byte carries the
+    same value as an unsigned u8 (0xFF), so we re-sign before comparing
+    against the documented control-version constants.
+    """
+    value &= 0xFF
+    if value >= 0x80:
+        return value - 0x100
+    return value
+
+
+# ---------------------------------------------------------------------------
+# EEPROM reassembly
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EepromSnapshot:
+    """Decoded view of the 256-byte EEPROM image.
+
+    Mirrors the field accessors on ``XMCeeprom.java``. ``total_*`` fields
+    are 32-bit big-endian values; ``*_pulse``/``mem_pos`` are 16-bit
+    big-endian. ``h_bridge_over_temp`` and ``fahrt_ueberwachung`` are
+    raw diagnostic values the OEM apps surface as "ED active" / "link
+    failure" / over-temperature flags.
+    """
+
+    lock_flag: int
+    sync_mode: int
+    init_zwang: int
+    pulse_mot1: int
+    pulse_mot2: int
+    pulse_mot3: int
+    pulse_mot4: int
+    memory_positions: tuple[tuple[int, int, int, int], ...]  # 6 slots × 4 motors
+    teach_in_count: int
+    factory_reset_count: int
+    init_zwang_count: int
+    power_up_count: int
+    wdt_resets: int
+    system_resets: int
+    other_resets: int
+    total_pulse_mot1: int
+    total_pulse_mot2: int
+    total_pulse_mot3: int
+    total_pulse_mot4: int
+    total_on_time: int
+    fahrt_ueberwachung: tuple[int, int, int, int]
+    h_bridge_over_temp: int
+    complete: bool  # True when all 32 rows have been received
+
+
+def _word_be(data: bytes | bytearray, offset: int) -> int:
+    """Read a signed 16-bit big-endian value at ``offset`` (M.word)."""
+    if offset + 1 >= len(data):
+        return 0
+    value = (data[offset] << 8) | data[offset + 1]
+    if value >= 0x8000:
+        value -= 0x10000
+    return value
+
+
+def _long_be(data: bytes | bytearray, offset: int) -> int:
+    """Read an unsigned 32-bit big-endian value at ``offset`` (M.longWord)."""
+    if offset + 3 >= len(data):
+        return 0
+    return (
+        (data[offset] << 24)
+        | (data[offset + 1] << 16)
+        | (data[offset + 2] << 8)
+        | data[offset + 3]
+    )
+
+
+class VibradormEeprom:
+    """Reassemble 32×8 EEPROM row notifications into a 256-byte image.
+
+    Each CBI-response notification carrying an EEPROM row has the layout
+    ``[echoCmdHi, echoCmdLo, offset, b0, b1, b2, b3, b4, b5, b6, b7]``
+    (the OEM app's ``XMCeeprom.setRow``). The 8 data bytes are copied at
+    ``offset``; the row index is ``offset // 8`` and a 32-bit mask tracks
+    which rows have been received. ``all_received()`` returns True once
+    the mask equals ``(1 << 32) - 1``.
+    """
+
+    __slots__ = ("_data", "_rows_received")
+
+    def __init__(self) -> None:
+        """Initialise an empty EEPROM image."""
+        self._data: bytearray = bytearray(EEPROM_SIZE)
+        self._rows_received: int = 0
+
+    def reset(self) -> None:
+        """Discard the cached image and row mask."""
+        self._data = bytearray(EEPROM_SIZE)
+        self._rows_received = 0
+
+    @property
+    def rows_received(self) -> int:
+        """Return the bitmap of rows successfully received (LSB = row 0)."""
+        return self._rows_received
+
+    def set_row(self, payload: bytes | bytearray) -> bool:
+        """Apply a single EEPROM-row notification.
+
+        Returns True when this row completes the full 32-row image.
+        Rejects packets that aren't a full 11 bytes, that target an
+        offset outside the 256-byte image, or whose offset is not
+        row-aligned (rows are exactly 8 bytes per the OEM app's
+        ``XMCeeprom.setRow``).
+        """
+        if len(payload) < 3 + EEPROM_ROW_SIZE:
+            return False
+        offset = int(payload[2]) & 0xFF
+        if offset % EEPROM_ROW_SIZE != 0:
+            return False
+        if offset + EEPROM_ROW_SIZE > EEPROM_SIZE:
+            return False
+        for index in range(EEPROM_ROW_SIZE):
+            self._data[offset + index] = payload[3 + index]
+        self._rows_received |= 1 << (offset // EEPROM_ROW_SIZE)
+        return self.all_received()
+
+    def all_received(self) -> bool:
+        """Return True once all 32 rows have been received."""
+        return self._rows_received == EEPROM_ALL_ROWS_BITMASK
+
+    def snapshot(self) -> EepromSnapshot:
+        """Return a decoded view of the current image.
+
+        Safe to call before the full image is reassembled — any field
+        whose offset has not been received will read 0. Callers can
+        check ``snapshot.complete`` to filter on full-image availability.
+        """
+        memory_positions: list[tuple[int, int, int, int]] = []
+        for slot in range(6):
+            base = EEPROM_OFFSET_MEM_BASE + slot * 8
+            memory_positions.append(
+                (
+                    _word_be(self._data, base),
+                    _word_be(self._data, base + 2),
+                    _word_be(self._data, base + 4),
+                    _word_be(self._data, base + 6),
+                )
+            )
+        return EepromSnapshot(
+            lock_flag=self._data[EEPROM_OFFSET_LOCK] & 0xFF,
+            sync_mode=self._data[EEPROM_OFFSET_SYNC_MODE] & 0xFF,
+            init_zwang=self._data[EEPROM_OFFSET_INIT_ZWANG] & 0xFF,
+            pulse_mot1=_word_be(self._data, EEPROM_OFFSET_PULSE_MOT1),
+            pulse_mot2=_word_be(self._data, EEPROM_OFFSET_PULSE_MOT2),
+            pulse_mot3=_word_be(self._data, EEPROM_OFFSET_PULSE_MOT3),
+            pulse_mot4=_word_be(self._data, EEPROM_OFFSET_PULSE_MOT4),
+            memory_positions=tuple(memory_positions),
+            teach_in_count=_word_be(self._data, EEPROM_OFFSET_TEACH_INS),
+            factory_reset_count=_word_be(self._data, EEPROM_OFFSET_FACTORY_RESET),
+            init_zwang_count=_word_be(self._data, EEPROM_OFFSET_INIT_ZWANG_COUNT),
+            power_up_count=_word_be(self._data, EEPROM_OFFSET_POWER_UPS),
+            wdt_resets=self._data[EEPROM_OFFSET_WDT_RESETS] & 0xFF,
+            system_resets=self._data[EEPROM_OFFSET_SYSTEM_RESET] & 0xFF,
+            other_resets=self._data[EEPROM_OFFSET_OTHER_RESET] & 0xFF,
+            total_pulse_mot1=_long_be(self._data, EEPROM_OFFSET_TOTAL_PULSE_MOT1),
+            total_pulse_mot2=_long_be(self._data, EEPROM_OFFSET_TOTAL_PULSE_MOT2),
+            total_pulse_mot3=_long_be(self._data, EEPROM_OFFSET_TOTAL_PULSE_MOT3),
+            total_pulse_mot4=_long_be(self._data, EEPROM_OFFSET_TOTAL_PULSE_MOT4),
+            total_on_time=_long_be(self._data, EEPROM_OFFSET_TOTAL_ON_TIME),
+            fahrt_ueberwachung=(
+                self._data[EEPROM_OFFSET_FAHRT_UEBERWACHUNG1] & 0xFF,
+                self._data[EEPROM_OFFSET_FAHRT_UEBERWACHUNG2] & 0xFF,
+                self._data[EEPROM_OFFSET_FAHRT_UEBERWACHUNG3] & 0xFF,
+                self._data[EEPROM_OFFSET_FAHRT_UEBERWACHUNG4] & 0xFF,
+            ),
+            h_bridge_over_temp=self._data[EEPROM_OFFSET_H_BRIDGE_OVER_TEMP] & 0xFF,
+            complete=self.all_received(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Position notification helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MotorPositionPacket:
+    """Decoded view of an XMCMotorData position notification.
+
+    The OEM app's ``XMCMotorData`` constructor reads four motor positions
+    as BE 16-bit values from bytes [3..4], [5..6], [7..8], [9..10] (the
+    decompiled source mistakenly reads motor 2 from [6..7] which would
+    overlap motor 1's MSB with motor 2's LSB — verified on-device to be
+    a typo; the correct layout puts motor 2 at [7..8] and motor 3 at
+    [9..10]). The ``flags`` byte is parsed for the init/sync status
+    reported via ``isInitRequested()`` and ``isSyncActive()``.
+    """
+
+    flags: int
+    init_requested: bool
+    sync_active: bool
+    motor1: int  # back/Kopf
+    motor2: int  # legs/Oberschenkel
+    motor3: int  # head/Nacken (3-motor+)
+    motor4: int  # feet/Fuß   (4-motor)
+
+
+def parse_position_notification(payload: bytes | bytearray) -> MotorPositionPacket | None:
+    """Parse a VMAT position notification, returning ``None`` on no-match.
+
+    Accepts the long format (``0x20, 0x3F, flags, M1hi, M1lo, M2hi, M2lo,
+    M3hi, M3lo, M4hi, M4lo``) and the short format (``0x3F, flags, …``)
+    captured by some nRF Connect traces. Returns ``None`` for packets
+    that don't start with the known position-prefix bytes.
+    """
+    if not payload or len(payload) < 2:
+        return None
+    if len(payload) >= 7 and payload[0] == POSITION_NOTIFY_PREFIX and payload[1] == POSITION_NOTIFY_TYPE:
+        if len(payload) < 11:
+            return None
+        flags = payload[2]
+        motor1 = (payload[3] << 8) | payload[4]
+        motor2 = (payload[5] << 8) | payload[6]
+        motor3 = (payload[7] << 8) | payload[8]
+        motor4 = (payload[9] << 8) | payload[10]
+    elif payload[0] == POSITION_NOTIFY_SHORT_TYPE:
+        if len(payload) < 10:
+            return None
+        flags = payload[1]
+        motor1 = (payload[2] << 8) | payload[3]
+        motor2 = (payload[4] << 8) | payload[5]
+        motor3 = (payload[6] << 8) | payload[7]
+        motor4 = (payload[8] << 8) | payload[9]
+    else:
+        return None
+    return MotorPositionPacket(
+        flags=flags,
+        init_requested=bool(flags & XMCMOTOR_INIT_ZWANG_MASK),
+        sync_active=bool(flags & XMCMOTOR_SYNC_STATUS_MASK),
+        motor1=motor1,
+        motor2=motor2,
+        motor3=motor3,
+        motor4=motor4,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Capability container
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VibradormCapabilities:
+    """Detected/expected capabilities of a VMAT controller.
+
+    ``is_vmat_basic`` controls whether motor moves use single-byte
+    commands on ``COMMAND`` (``0x1526``) — true for VMAT-basic and the
+    RF-CBI variant — or the 2-byte CBI path. The other flags are
+    surfaced as Home Assistant entity capability properties.
+    """
+
+    is_vmat_basic: bool = True
+    uses_cbi_motor_commands: bool = False
+    has_cbi_characteristic: bool = True
+    has_mood_light: bool = False
+    has_massage: bool = False
+    has_floor_light: bool = True
+    control_version: int | None = None
+    motor_count: int | None = None
+    xt_box: bool = False

--- a/custom_components/adjustable_bed/controller_factory.py
+++ b/custom_components/adjustable_bed/controller_factory.py
@@ -785,7 +785,7 @@ async def create_controller(
     if bed_type == BED_TYPE_VIBRADORM:
         from .beds.vibradorm import VibradormController
 
-        return VibradormController(coordinator)
+        return VibradormController(coordinator, manufacturer_data=manufacturer_data)
 
     if bed_type == BED_TYPE_RONDURE:
         from .beds.rondure import RondureController

--- a/docs/beds/vibradorm.md
+++ b/docs/beds/vibradorm.md
@@ -1,6 +1,6 @@
 # Vibradorm
 
-**Status:** ✅ Tested
+**Status:** ✅ Tested (VMAT-basic), 🧪 Reverse-engineered from de.vibradorm.vra2 (CBI/mood light/VRT)
 
 **Credit:** Reverse engineering by [kristofferR](https://github.com/kristofferR/ha-adjustable-bed)
 
@@ -8,79 +8,177 @@
 
 - Vibradorm VMAT series beds
 - Device names starting with "VMAT" (e.g., "VMATMEM047")
+- CARESSE / WERKMEISTER / de.vibradorm.vmat (beta) — share the vra2 protocol
+- Older `de.vibradorm.vra` 1.11 — same family, slightly leaner command set
 
 ## Apps
 
 | Analyzed | App | Package ID |
 |----------|-----|------------|
 | ✅ | VIBRADORM Remote | `de.vibradorm.vra` |
+| ✅ | VIBRADORM Remote (vra2) | `de.vibradorm.diamant` / `de.vibradorm.vmat-beta` |
 | ✅ | VIBRADORM Remote for Beds | `com.vibradorm.vmatbasic` |
 
 ## Features
 
 | Feature | Supported |
 |---------|-----------|
-| Motor Control | ✅ |
-| Position Feedback | ✅ |
-| Memory Presets | ✅ (6 slots) |
+| Motor Control (2/3/4 motors) | ✅ |
+| Position Feedback (XMCMotorData) | ✅ (init/sync flags tracked) |
+| Memory Presets (recall + store) | ✅ (6 slots) |
 | Flat Preset | ✅ |
-| Light Control | ✅ |
-| Massage | ✅ (vibration toggle via CBI characteristic) |
+| Sync mode (head+foot linked) | ✅ |
+| Floor Light (level + timer) | ✅ (level 0..8 on CBI, 0..255 on VMAT-basic) |
+| Mood Light (RGB color / effect / speed / toggle) | ✅ (CBI/XT-box) |
+| Massage / VRT (effect, speed, intensity, timer) | ✅ (head + foot zones, 0..5) |
+| EEPROM diagnostics (32×8-row reassembly) | ✅ (256-byte image) |
+| Control-version → motor count (advertisement) | ✅ |
 
-**Position Feedback:** The bed reports motor positions via BLE notifications. Position values are raw encoder counts that are converted to percentages.
+**Position Feedback:** The bed reports motor positions via BLE notifications on `0x1551`. Position values are raw encoder counts that are converted to percentages of the per-motor max. The `flags` byte (bit 4 = init/limit-run requested, bit 6 = sync active) is exposed via `init_requested` and `sync_active` and forwarded to the controller-state stream.
 
-**Motor Configurations:** The bed supports 2, 3, or 4 motor configurations. The standard 2-motor config has head/back and legs motors.
+**Motor Configurations:** The bed supports 2, 3, or 4 motor configurations. The standard 2-motor config has head/back and legs motors. The motor count is normally derived from the OEM app's `ControlType` byte in the `vibIdentifier` field of the advertisement manufacturer data (control version `0`/`5` → 2-motor, `4`/`6` → 3-motor, `1`/`-1` → 4-motor); the user-configured `motor_count` option is used as a fallback.
 
 ## Protocol Details
 
 **Primary Service UUID:** `00001525-9f03-0de5-96c5-b8f4f3081186`
-**Secondary Service UUID (some VMAT-BASIC-RF-CBI beds):** `00001527-9f03-0de5-96c5-b8f4f3081186`
-**Command Characteristic:** `00001526-9f03-0de5-96c5-b8f4f3081186` (fallbacks: `00001528`, `00001534`)
-**Light Characteristic:** `00001529-9f03-0de5-96c5-b8f4f3081186`
-**Notify Characteristic:** `00001551-9f03-0de5-96c5-b8f4f3081186`
+**Secondary Service UUID (DEVICE_MANAGEMENT):** `00001527-9f03-0de5-96c5-b8f4f3081186`
+**Command Characteristic (VMAT-basic motor):** `00001526-9f03-0de5-96c5-b8f4f3081186` (fallbacks: `00001528`, `00001534`)
+**Light Characteristic (VMAT-basic floor light):** `00001529-9f03-0de5-96c5-b8f4f3081186`
+**CBI Characteristic (motor/memory/light/mood/VRT):** `00001550-9f03-0de5-96c5-b8f4f3081186`
+**CBI_RESPONSE Characteristic (motor/EEPROM notifications):** `00001551-9f03-0de5-96c5-b8f4f3081186`
+**Service Info (article/FW name notify):** `00001533-9f03-0de5-96c5-b8f4f3081186`
 
 **Manufacturer ID:** 944 (0x03B0)
 
-### Command Format
+There are two parallel command paths:
 
-Commands are single bytes written to the command characteristic:
+1. **VMAT-basic** (used by `de.vibradorm.vra` and the `vmat-basic-rf-cbi` model) — single byte written to the COMMAND characteristic. `disable_angle_sensing` is auto-enabled for the RF-CBI variant because the OEM app does not use position feedback.
+2. **CBI** (used by `de.vibradorm.vra2`/`vmat-beta` and their derivatives) — framed 16-bit big-endian command word `[msb, lsb, …payload]` on CBI. The toggle bit alternates `0x0000 ⇄ 0x8000` between writes (`MC.toggle()`), and the CBI bus mask `0x1000` OR'd in routes the command to the secondary "XT box" accessory bus.
 
-| Command | Value | Hex |
-|---------|-------|-----|
-| Stop | 255 | `0xFF` |
-| Head Up | 11 | `0x0B` |
-| Head Down | 10 | `0x0A` |
-| Legs Up | 9 | `0x09` |
-| Legs Down | 8 | `0x08` |
-| All Down/Flat | 0 | `0x00` |
-| Memory 1 | 14 | `0x0E` |
-| Memory 2 | 15 | `0x0F` |
-| Memory 3 | 12 | `0x0C` |
-| Memory 4 | 26 | `0x1A` |
-| Memory 5 | 27 | `0x1B` |
-| Memory 6 | 28 | `0x1C` |
+Both paths share the same code words for motors, memory, and store.
 
-### Light Control
+### VMAT-basic command format (single byte on `COMMAND` 0x1526)
 
-Light commands are 3 bytes written to the light characteristic:
+| Command | Hex | Meaning (de) | Action |
+|---------|-----|--------------|--------|
+| `STOP` | `0xFF` | Stop | Stop all motors |
+| `AR` | `0x00` | Alles Runter | All down / flat |
+| `AH` | `0x10` | Alles Hoch | All up |
+| `NR` / `NH` | `0x02` / `0x03` | Nacken r/h | Neck (3/4-motor) |
+| `FR` / `FH` | `0x04` / `0x05` | Fuß r/h | Foot (4-motor) |
+| `OSR` / `OSH` | `0x08` / `0x09` | Oberschenkel r/h | Legs |
+| `KR` / `KH` | `0x0A` / `0x0B` | Kopf r/h | Back |
+| `SYNC_OFF` / `SYNC_ON` | `0x19` / `0x18` | sync off/on | head+foot sync |
+| `STORE` | `0x0D` | Store | store-to-memory arming |
+| `MEM1`..`MEM6` | `0x0E` `0x0F` `0x0C` `0x1A` `0x1B` `0x1C` | Memory | memory slot recall |
+
+### CBI command set (2-byte BE word `[msb(toggle|cmd), lsb, …payload]` on `CBI` 0x1550)
+
+| Command | Hex (base) | Purpose | Payload |
+|---------|------------|---------|---------|
+| `CMD_STORE` | `0x0D` | store-to-memory arming | none |
+| `MEM1`..`MEM6` | `0x0E` `0x0F` `0x0C` `0x1A` `0x1B` `0x1C` | memory recall | none |
+| `CMD_DIM` | `0x11` | floor light (CBI variant) | `[level, timer_min]` |
+| `CMD_COLOR` | `0x77` (`0x1077` for XT box) | mood light base | varies by subcmd |
+| `CMD_VxEFF` | `0x30` (`0x1030` for XT box) | VRT settings | `[effect, speed, zone1, zone2, 0, 0, 0, timer]` |
+| `CMD_VRT` | `0x34` (`0x1034` for XT box) | VRT on/off | `[0|1]` |
+| `CMD_GET_STATUS` | `0x3D` | request motor + EEPROM update | `[0x3F]` |
+| `CMD_INIT` | `0x3E` | init/teach | — |
+| `CMD_GET_INFO` | `0x1A0` | device info | — |
+
+Mood-light subcommands ride on `CMD_COLOR` (or `0x1077` for XT box):
+
+| Subcmd | Hex | Payload | Meaning |
+|--------|-----|---------|---------|
+| color | `0x01` | `[0x01, 0x00, R, G, B]` | set RGB |
+| effect | `0x08` | `[0x08, effect_id]` | select effect |
+| effect speed | `0x09` | `[0x09, 20-(ui+1)*2]` | set effect speed |
+| toggle | — | (no payload) | on/off toggle (always uses bus mask) |
+
+### Light control (CmdLightVMAT / CmdLightCBI)
+
+VMAT-basic on `LIGHT` (`0x1529`):
 
 ```text
-[brightness, 0x00, timer]
+[level, 0x00, timer_min]
 ```
-- `brightness`: 0 = off, 0xFF = full brightness
-- `timer`: Auto-off timer value (0 = no timer)
 
-### Position Feedback
+- `level`: 0 = off, `0xFF` = full brightness (we expose `0..255` here).
+- `timer_min`: auto-off timer in minutes, 0 = no timer.
 
-Notifications provide motor positions as 16-bit little-endian values:
-- Bytes 3-4: Motor 1 (head/back) position
-- Bytes 5-6: Motor 2 (legs) position
-- Higher values = more raised, 0 = flat
+CBI / XT-box on `CBI` (`0x1550`):
+
+```text
+[msb(toggle|0x11|bus), lsb, level(0..8), timer_min]
+```
+
+- `level` clamped to `0..8` by `MC.setFloorLightLevel`.
+- For XT-box beds, OR in the CBI bus mask (`0x1000`).
+
+### Position feedback (XMCMotorData, on `CBI_RESPONSE` 0x1551)
+
+Long format (11 bytes):
+
+```text
+0x20, 0x3F, flags, M1hi, M1lo, M2hi, M2lo, M3hi, M3lo, M4hi, M4lo
+```
+
+Short format (10 bytes, no 0x20 prefix):
+
+```text
+0x3F, flags, M1hi, M1lo, M2hi, M2lo, M3hi, M3lo, M4hi, M4lo
+```
+
+Motor positions are big-endian u16:
+
+- Motor 1 (back/Kopf) — bytes `[3,4]`
+- Motor 2 (legs/Oberschenkel) — bytes `[5,6]`
+- Motor 3 (head/Nacken) — bytes `[7,8]`
+- Motor 4 (feet/Fuß) — bytes `[9,10]`
+
+> **Note:** the decompiled `XMCMotorData.java` reads motor 2 from bytes `[6,7]` which overlaps motor 1's MSB with motor 2's LSB. This is a source typo; the correct layout puts motor 2 at `[7,8]` and motor 3 at `[9,10]`. Our parser uses the corrected layout — see issue #403.
+
+`flags` byte:
+
+- `0x10` — init/limit run requested (the bed is asking the user to perform a teach-in before it can trust its positions)
+- `0x40` — sync active (head+foot motors are linked)
+
+Both bits are surfaced via the `vibradorm_init_requested` / `vibradorm_sync_active` controller-state keys (forwarded to the diagnostics stream and the `init_requested` / `sync_active` properties on the controller).
+
+### EEPROM diagnostics (XMCeeprom, 32×8-row reassembly)
+
+The same `CBI_RESPONSE` stream also carries 32 row notifications of 8 bytes each — the full 256-byte controller EEPROM. The layout follows `XMCeeprom.java` (issue #403 § 5c):
+
+| Offset | Field | Type |
+|--------|-------|------|
+| 0 | `lock_flag` | u8 |
+| 1 | `sync_mode` | u8 |
+| 2 | `initZwang` | u8 |
+| 10/12/14/16 | `pulseMot1..4` (live positions) | u16 |
+| 20 + slot*8 + motor*2 | memory positions (6 slots × 4 motors) | u16 |
+| 72/74/76/78 | `teachIn` / `factoryReset` / `initZwangCount` / `powerUp` counts | u16 |
+| 80/81/82 | `wdtReset` / `systemReset` / `otherReset` | u8 |
+| 84/88/92/96 | `totalPulseCountMot1..4` (lifetime travel) | u32 |
+| 100 | `totalOnTime` | u32 |
+| 104/106/108/110 | drive-monitoring 1..4 | u8 |
+| 112 | H-bridge over-temperature | u8 |
+
+`VibradormEeprom.set_row()` applies each notification; the controller publishes `vibradorm_eeprom_complete=True` once all 32 rows have been received. The `assets/md08eemap.xml` field labels are kept for the MD08 variant only; the generic runtime layout is the table above.
+
+### Advertising / detection (ManufacturerDataParser)
+
+The advertisement manufacturer-data block is parsed as:
+
+- `manufacturerID = data[0] | data[1]<<8` (LE)
+- `vibIdentifier = data[2]<<8 | data[3]` (BE) — its LSB is the OEM `ControlType` and maps to motor count (`0`/`5` → 2-motor, `4`/`6` → 3-motor, `1`/`-1` → 4-motor)
+- `vibFlags = (data[4]&0xF0) | (data[5]&0xF0)>>4`
+- `kundenID = (data[8]&0xF0) | (data[9]&0xF0)>>4` (or `0xFFFF` if ≤6 bytes)
 
 ## Detection
 
 The bed is detected by:
-1. **Manufacturer ID:** 944 (0x03B0) - highest priority
+
+1. **Manufacturer ID:** 944 (0x03B0) — highest priority
 2. **Service UUID:** `00001525-...` or `00001527-...`
 3. **Device name pattern:** Names starting with "VMAT"
 
@@ -94,7 +192,16 @@ The bed is detected by:
 - Position calibration may vary by bed model
 - Open an issue with your bed's position values for calibration assistance
 
+**Mood light / VRT / CBI light commands silently fail:**
+- These ride on the CBI characteristic (`0x1550`) — confirm the bed actually exposes it (some VMAT-basic and RF-CBI variants don't).
+- Enable `has_massage` / mood light in the controller's capability flags; the `vibradorm_eeprom_complete` and `vibradorm_init_requested` controller-state keys can help diagnose.
+
+**Octo-style 30s disconnect:**
+- N/A — that's a different protocol. Vibradorm does not require a PIN.
+
 ## References
 
-- [GitHub Issue #162](https://github.com/kristofferR/ha-adjustable-bed/issues/162)
-- APK analysis in `disassembly/output/de.vibradorm.vra/ANALYSIS.md`
+- [GitHub Issue #162](https://github.com/kristofferR/ha-adjustable-bed/issues/162) — "no positions" gap
+- [GitHub Issue #403](https://github.com/kristofferR/ha-adjustable-bed/issues/403) — VMAT full protocol parity
+- APK analysis in `disassembly/output/de.vibradorm.diamant/jadx/sources/de/vibradorm/vra2/`
+- `Vib Control_1.11-beta-vc49_de.vibradorm.vmat.apk`

--- a/tests/test_vibradorm.py
+++ b/tests/test_vibradorm.py
@@ -1417,3 +1417,708 @@ class TestVibradormPositionFeedback:
         )
 
         assert updates == []
+
+    def test_init_requested_flag_is_tracked(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+    ) -> None:
+        """Position notifications with bit 4 set should mark init_requested=True."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        controller = VibradormController(coordinator)
+
+        controller._handle_notification(
+            MagicMock(),
+            bytearray([0x20, 0x3F, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+        )
+
+        assert controller.init_requested is True
+        assert controller.sync_active is False
+
+    def test_sync_active_flag_is_tracked(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+    ) -> None:
+        """Position notifications with bit 6 set should mark sync_active=True."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        controller = VibradormController(coordinator)
+
+        controller._handle_notification(
+            MagicMock(),
+            bytearray([0x20, 0x3F, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+        )
+
+        assert controller.sync_active is True
+        assert controller.init_requested is False
+
+    def test_motor2_offset_uses_bytes_5_6_not_6_7(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+    ) -> None:
+        """Motor 2 should read from bytes [5,6] (the decompiled APK has a typo
+        that reads motor 2 from [6,7] and overlaps motor 1's MSB; see issue #403).
+        """
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        controller = VibradormController(coordinator)
+
+        updates: list[tuple[str, float]] = []
+        controller._notify_callback = lambda motor, value: updates.append((motor, value))
+
+        # bytes [3,4]=0x0000 back, [5,6]=0x0100 legs, [7,8]=0x0200 head (3-motor)
+        controller._handle_notification(
+            MagicMock(),
+            bytearray([0x20, 0x3F, 0x02, 0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00]),
+        )
+
+        # Filter for the legs value (calibrated against the default 14000 max).
+        # 256 / 14000 * 45 ≈ 0.82 — confirms motor 2 reads from [5,6], not
+        # [6,7] (which would yield 0x0002 = 2/14000*45 ≈ 0.006).
+        legs_update = next(value for motor, value in updates if motor == "legs")
+        assert legs_update == pytest.approx(0.82, abs=0.05)
+
+
+# -----------------------------------------------------------------------------
+# Capability / manufacturer data tests
+# -----------------------------------------------------------------------------
+
+
+class TestVibradormManufacturerData:
+    """Test detection of control version / motor count from manufacturer data."""
+
+    def test_detect_motor_count_from_manufacturer_data(self) -> None:
+        """Motor count should be derived from the vib identifier (BE u16 @ offset 2)."""
+        from custom_components.adjustable_bed.beds.vibradorm_protocol import (
+            detect_motor_count_from_manufacturer_data,
+        )
+
+        # 0 → 2-motor, 1 → 4-motor, 4 → 3-motor, 5 → 2-motor
+        for control_version, expected_motor_count in (
+            (0, 2),
+            (1, 4),
+            (4, 3),
+            (5, 2),
+            (6, 3),
+            (-1, 4),
+        ):
+            payload = bytes(
+                [0xB0, 0x03, 0x00, control_version & 0xFF, 0x00, 0x00, 0x00, 0x00]
+            )
+            assert (
+                detect_motor_count_from_manufacturer_data({944: payload})
+                == expected_motor_count
+            )
+
+    def test_detect_motor_count_returns_none_for_unrecognised(self) -> None:
+        """Unknown control versions should return None (fall back to user config)."""
+        from custom_components.adjustable_bed.beds.vibradorm_protocol import (
+            detect_motor_count_from_manufacturer_data,
+        )
+
+        payload = bytes([0xB0, 0x03, 0x00, 0x42, 0x00, 0x00, 0x00, 0x00])
+        assert detect_motor_count_from_manufacturer_data({944: payload}) is None
+
+    def test_detect_motor_count_returns_none_for_missing_data(self) -> None:
+        """Empty or missing manufacturer data should return None."""
+        from custom_components.adjustable_bed.beds.vibradorm_protocol import (
+            detect_motor_count_from_manufacturer_data,
+        )
+
+        assert detect_motor_count_from_manufacturer_data(None) is None
+        assert detect_motor_count_from_manufacturer_data({}) is None
+        assert detect_motor_count_from_manufacturer_data({944: b""}) is None
+
+    async def test_advertised_motor_count_exposed_on_controller(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ) -> None:
+        """Controller should expose the motor count detected from manufacturer data."""
+        from custom_components.adjustable_bed.beds.vibradorm_protocol import (
+            detect_motor_count_from_manufacturer_data,
+        )
+
+        # Re-create the controller with manufacturer data carrying control version 1
+        # (= 4-motor in the OEM app).
+        entry_data = {
+            **mock_vibradorm_config_entry.data,
+        }
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Vibradorm 4-motor Test Bed",
+            data=entry_data,
+            unique_id="AA:BB:CC:DD:EE:F4",
+            entry_id="vibradorm_test_entry_4_motor_advert",
+        )
+        entry.add_to_hass(hass)
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        await coordinator.async_connect()
+        # The coordinator's create_controller() already passes manufacturer_data,
+        # so we just verify the controller surfaces what was detected.
+        payload = bytes([0xB0, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00])
+        # Force a fresh controller with the manufacturer data to make sure
+        # the advertised_motor_count reflects the right input.
+        fresh = VibradormController(coordinator, manufacturer_data={944: payload})
+        assert fresh.advertised_motor_count == 4
+        assert detect_motor_count_from_manufacturer_data({944: payload}) == 4
+
+
+# -----------------------------------------------------------------------------
+# CBI light / mood light / VRT tests
+# -----------------------------------------------------------------------------
+
+
+class TestVibradormLightLevel:
+    """Test VMAT floor light level / timer commands."""
+
+    async def test_set_light_level_uses_light_char_on_vmat_basic(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ) -> None:
+        """VMAT-basic floor light should be a 3-byte packet on the LIGHT char."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        assert isinstance(controller, VibradormController)
+        mock_client = coordinator._client
+        assert mock_client is not None
+
+        mock_client.write_gatt_char.reset_mock()
+        await controller.set_light_level(5)
+
+        # Find the LIGHT-char write (UUID contains 1529).
+        light_calls = [
+            call
+            for call in mock_client.write_gatt_char.call_args_list
+            if "1529" in str(call.args[0]).lower()
+        ]
+        assert light_calls, "Expected a write to the LIGHT characteristic"
+        data = light_calls[-1].args[1]
+        assert data == bytes([5, 0, 0])
+
+    async def test_set_light_level_uses_cbi_on_cbi_beds(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ) -> None:
+        """CBI/XT-box floor light should be a 4-byte packet on the CBI char."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        assert isinstance(controller, VibradormController)
+        mock_client = coordinator._client
+        assert mock_client is not None
+
+        controller.apply_capabilities(
+            is_vmat_basic=False, xt_box=False
+        )
+        mock_client.write_gatt_char.reset_mock()
+        await controller.set_light_level(7)
+
+        cbi_calls = [
+            call
+            for call in mock_client.write_gatt_char.call_args_list
+            if "1550" in str(call.args[0]).lower()
+        ]
+        assert cbi_calls, "Expected a write to the CBI characteristic"
+        data = cbi_calls[-1].args[1]
+        # [msb, lsb, level(0..8), timer]
+        assert data[0] == 0x00  # toggle=0
+        assert data[1] == 0x11  # CMD_DIM
+        assert data[2] == 7
+        assert data[3] == 0
+
+    async def test_set_light_level_clamps_to_eight_on_cbi(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ) -> None:
+        """CBI light level should be clamped to 0..8 (matches MC.setFloorLightLevel)."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        assert isinstance(controller, VibradormController)
+        mock_client = coordinator._client
+        assert mock_client is not None
+
+        controller.apply_capabilities(is_vmat_basic=False)
+        mock_client.write_gatt_char.reset_mock()
+        await controller.set_light_level(42)
+
+        cbi_calls = [
+            call
+            for call in mock_client.write_gatt_char.call_args_list
+            if "1550" in str(call.args[0]).lower()
+        ]
+        assert cbi_calls
+        assert cbi_calls[-1].args[1][2] == 8
+
+    async def test_set_light_timer_preserves_current_level(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ) -> None:
+        """set_light_timer should keep the current light level when timer is set."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        assert isinstance(controller, VibradormController)
+        mock_client = coordinator._client
+        assert mock_client is not None
+
+        await controller.set_light_level(3)
+        mock_client.write_gatt_char.reset_mock()
+        await controller.set_light_timer("10")
+
+        light_calls = [
+            call
+            for call in mock_client.write_gatt_char.call_args_list
+            if "1529" in str(call.args[0]).lower()
+        ]
+        assert light_calls
+        data = light_calls[-1].args[1]
+        assert data == bytes([3, 0, 10])
+
+
+class TestVibradormMoodLight:
+    """Test CBI RGB mood light (color / effect / speed / toggle)."""
+
+    async def test_set_light_color_sends_cbi_packet(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ) -> None:
+        """set_light_color should send a 7-byte mood color packet on CBI."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        assert isinstance(controller, VibradormController)
+        mock_client = coordinator._client
+        assert mock_client is not None
+
+        controller.apply_capabilities(has_mood_light=True)
+        mock_client.write_gatt_char.reset_mock()
+        await controller.set_light_color((255, 128, 64))
+
+        cbi_calls = [
+            call
+            for call in mock_client.write_gatt_char.call_args_list
+            if "1550" in str(call.args[0]).lower()
+        ]
+        assert cbi_calls
+        data = cbi_calls[-1].args[1]
+        # [msb(toggle|0x77), lsb, 0x01, 0x00, R, G, B]
+        assert data[0] == 0x00  # toggle=0
+        assert data[1] == 0x77  # CMD_COLOR
+        assert data[2:7] == bytes([0x01, 0x00, 255, 128, 64])
+
+    async def test_set_light_color_uses_bus_mask_for_xt_box(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ) -> None:
+        """XT-box mood light should OR in the CBI bus mask (0x1000)."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        assert isinstance(controller, VibradormController)
+        mock_client = coordinator._client
+        assert mock_client is not None
+
+        controller.apply_capabilities(has_mood_light=True, xt_box=True)
+        mock_client.write_gatt_char.reset_mock()
+        await controller.set_light_color((0, 0, 0))
+
+        cbi_calls = [
+            call
+            for call in mock_client.write_gatt_char.call_args_list
+            if "1550" in str(call.args[0]).lower()
+        ]
+        assert cbi_calls
+        data = cbi_calls[-1].args[1]
+        # [msb(toggle|0x1077), lsb, …]
+        assert (data[0] << 8) | data[1] == 0x1077
+
+    async def test_set_light_color_raises_when_not_supported(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ) -> None:
+        """Calling set_light_color without mood light should raise NotImplementedError."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        assert isinstance(controller, VibradormController)
+
+        with pytest.raises(NotImplementedError):
+            await controller.set_light_color((255, 255, 255))
+
+
+class TestVibradormMassage:
+    """Test VRT (vibration / massage) commands."""
+
+    async def test_set_massage_intensity_head(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ) -> None:
+        """set_massage_intensity(head) should send a VxEFF packet with zone1 set."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        assert isinstance(controller, VibradormController)
+        mock_client = coordinator._client
+        assert mock_client is not None
+
+        controller.apply_capabilities(has_massage=True)
+        mock_client.write_gatt_char.reset_mock()
+        await controller.set_massage_intensity("head", 4)
+
+        cbi_calls = [
+            call
+            for call in mock_client.write_gatt_char.call_args_list
+            if "1550" in str(call.args[0]).lower()
+        ]
+        assert cbi_calls
+        data = cbi_calls[-1].args[1]
+        # [msb(toggle|0x30), lsb, effect, speed, zone1, zone2, 0,0,0, timer]
+        assert data[0] == 0x00  # toggle=0
+        assert data[1] == 0x30  # CMD_VxEFF
+        assert data[4] == 4  # head intensity
+        assert data[5] == 0  # foot intensity
+
+    async def test_set_massage_intensity_foot(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ) -> None:
+        """set_massage_intensity(foot) should send a VxEFF packet with zone2 set."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        assert isinstance(controller, VibradormController)
+        mock_client = coordinator._client
+        assert mock_client is not None
+
+        controller.apply_capabilities(has_massage=True)
+        mock_client.write_gatt_char.reset_mock()
+        await controller.set_massage_intensity("foot", 3)
+
+        cbi_calls = [
+            call
+            for call in mock_client.write_gatt_char.call_args_list
+            if "1550" in str(call.args[0]).lower()
+        ]
+        assert cbi_calls
+        data = cbi_calls[-1].args[1]
+        assert data[4] == 0  # head
+        assert data[5] == 3  # foot
+
+    async def test_set_massage_intensity_clamps_to_five(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ) -> None:
+        """Massage intensity should be clamped to 0..5."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        assert isinstance(controller, VibradormController)
+        mock_client = coordinator._client
+        assert mock_client is not None
+
+        controller.apply_capabilities(has_massage=True)
+        mock_client.write_gatt_char.reset_mock()
+        await controller.set_massage_intensity("head", 99)
+
+        cbi_calls = [
+            call
+            for call in mock_client.write_gatt_char.call_args_list
+            if "1550" in str(call.args[0]).lower()
+        ]
+        assert cbi_calls
+        data = cbi_calls[-1].args[1]
+        assert data[4] == 5
+
+    async def test_set_massage_timer(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ) -> None:
+        """set_massage_timer should send a VxEFF packet with timer field set."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        assert isinstance(controller, VibradormController)
+        mock_client = coordinator._client
+        assert mock_client is not None
+
+        controller.apply_capabilities(has_massage=True)
+        mock_client.write_gatt_char.reset_mock()
+        await controller.set_massage_timer(20)
+
+        cbi_calls = [
+            call
+            for call in mock_client.write_gatt_char.call_args_list
+            if "1550" in str(call.args[0]).lower()
+        ]
+        assert cbi_calls
+        data = cbi_calls[-1].args[1]
+        # timer is the last byte of the VxEFF payload.
+        assert data[9] == 20
+
+    async def test_massage_off_sends_vrt_zero(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ) -> None:
+        """massage_off should send CmdVRT with on_off=0."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        assert isinstance(controller, VibradormController)
+        mock_client = coordinator._client
+        assert mock_client is not None
+
+        controller.apply_capabilities(has_massage=True)
+        mock_client.write_gatt_char.reset_mock()
+        await controller.massage_off()
+
+        cbi_calls = [
+            call
+            for call in mock_client.write_gatt_char.call_args_list
+            if "1550" in str(call.args[0]).lower()
+        ]
+        assert cbi_calls
+        data = cbi_calls[-1].args[1]
+        # [msb(toggle|0x34), lsb, 0x00]
+        assert data[1] == 0x34  # CMD_VRT
+        assert data[2] == 0x00
+
+    async def test_get_massage_state_reports_current_intensity(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+        mock_coordinator_connected,
+    ) -> None:
+        """get_massage_state should return head/foot intensity from cached state."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        assert isinstance(controller, VibradormController)
+
+        controller.apply_capabilities(has_massage=True)
+        await controller.set_massage_intensity("head", 3)
+        await controller.set_massage_intensity("foot", 5)
+
+        state = controller.get_massage_state()
+        assert state["head_intensity"] == 3
+        assert state["foot_intensity"] == 5
+        assert state["head_active"] is True
+        assert state["foot_active"] is True
+
+
+# -----------------------------------------------------------------------------
+# EEPROM reassembly tests
+# -----------------------------------------------------------------------------
+
+
+class TestVibradormEeprom:
+    """Test EEPROM reassembly from 32x8 row notifications."""
+
+    def test_eeprom_not_complete_initially(self) -> None:
+        """Empty EEPROM should report incomplete."""
+        from custom_components.adjustable_bed.beds.vibradorm_protocol import (
+            VibradormEeprom,
+        )
+
+        eeprom = VibradormEeprom()
+        assert not eeprom.all_received()
+        assert eeprom.rows_received == 0
+
+    def test_eeprom_completes_after_32_rows(self) -> None:
+        """All 32 rows received should report complete."""
+        from custom_components.adjustable_bed.beds.vibradorm_protocol import (
+            VibradormEeprom,
+        )
+
+        eeprom = VibradormEeprom()
+        for i in range(32):
+            offset = i * 8
+            row = bytes([offset & 0xFF] * 8)
+            pkt = bytes([0x00, 0x00, offset]) + row
+            completed = eeprom.set_row(pkt)
+            if i < 31:
+                assert not completed
+            else:
+                assert completed
+        assert eeprom.all_received()
+
+    def test_eeprom_snapshots_known_fields(self) -> None:
+        """Snapshot should decode the documented XMC EEPROM field offsets."""
+        from custom_components.adjustable_bed.beds.vibradorm_protocol import (
+            EEPROM_OFFSET_H_BRIDGE_OVER_TEMP,
+            EEPROM_OFFSET_LOCK,
+            EEPROM_OFFSET_PULSE_MOT1,
+            EEPROM_OFFSET_PULSE_MOT4,
+            EEPROM_OFFSET_TEACH_INS,
+            EEPROM_OFFSET_TOTAL_ON_TIME,
+            VibradormEeprom,
+        )
+
+        eeprom = VibradormEeprom()
+        # Build a full image with known values at known offsets.
+        image = bytearray(256)
+        image[EEPROM_OFFSET_LOCK] = 0x01
+        image[EEPROM_OFFSET_PULSE_MOT1] = 0x10
+        image[EEPROM_OFFSET_PULSE_MOT1 + 1] = 0x20  # pulse_mot1 = 0x1020 = 4128
+        image[EEPROM_OFFSET_PULSE_MOT4] = 0x33
+        image[EEPROM_OFFSET_PULSE_MOT4 + 1] = 0x44  # pulse_mot4 = 0x3344 = 13124
+        image[EEPROM_OFFSET_TEACH_INS] = 0x00
+        image[EEPROM_OFFSET_TEACH_INS + 1] = 0x05  # teach_in_count = 5
+        # total_on_time at offset 100, 32-bit BE = 0x12345678
+        image[EEPROM_OFFSET_TOTAL_ON_TIME] = 0x12
+        image[EEPROM_OFFSET_TOTAL_ON_TIME + 1] = 0x34
+        image[EEPROM_OFFSET_TOTAL_ON_TIME + 2] = 0x56
+        image[EEPROM_OFFSET_TOTAL_ON_TIME + 3] = 0x78
+        image[EEPROM_OFFSET_H_BRIDGE_OVER_TEMP] = 0xAA
+
+        for i in range(32):
+            offset = i * 8
+            pkt = bytes([0x00, 0x00, offset]) + bytes(image[offset : offset + 8])
+            eeprom.set_row(pkt)
+
+        snap = eeprom.snapshot()
+        assert snap.complete
+        assert snap.lock_flag == 0x01
+        assert snap.pulse_mot1 == 0x1020
+        assert snap.pulse_mot4 == 0x3344
+        assert snap.teach_in_count == 5
+        assert snap.total_on_time == 0x12345678
+        assert snap.h_bridge_over_temp == 0xAA
+
+    def test_eeprom_ignores_unaligned_offsets(self) -> None:
+        """Rows with non-row-aligned offsets should be rejected."""
+        from custom_components.adjustable_bed.beds.vibradorm_protocol import (
+            VibradormEeprom,
+        )
+
+        eeprom = VibradormEeprom()
+        # offset 1 is not row-aligned (rows are 8 bytes).
+        assert eeprom.set_row(bytes([0x00, 0x00, 0x01] + [0xFF] * 8)) is False
+        assert eeprom.rows_received == 0
+
+    def test_eeprom_ignores_short_packets(self) -> None:
+        """Packets shorter than 11 bytes should be rejected."""
+        from custom_components.adjustable_bed.beds.vibradorm_protocol import (
+            VibradormEeprom,
+        )
+
+        eeprom = VibradormEeprom()
+        assert eeprom.set_row(bytes([0x00, 0x00, 0x00, 0x01])) is False
+        assert eeprom.rows_received == 0
+
+    async def test_eeprom_reassembly_via_notification(
+        self,
+        hass: HomeAssistant,
+        mock_vibradorm_config_entry,
+    ) -> None:
+        """The position-notification handler should also reassemble EEPROM rows."""
+        coordinator = AdjustableBedCoordinator(hass, mock_vibradorm_config_entry)
+        controller = VibradormController(coordinator)
+        controller._notify_callback = lambda *_: None
+
+        # Apply 32 row notifications in a row.
+        for i in range(32):
+            row = bytes([i] * 8)
+            pkt = bytearray([0x00, 0x00, i * 8]) + bytearray(row)
+            controller._handle_notification(MagicMock(), pkt)
+
+        assert controller.eeprom.all_received()
+        snap = controller.eeprom.snapshot()
+        assert snap.complete
+
+
+# -----------------------------------------------------------------------------
+# Position parser unit tests
+# -----------------------------------------------------------------------------
+
+
+class TestVibradormPositionParser:
+    """Test the protocol-module position notification parser."""
+
+    def test_long_format_parses_motor1_motor2(self) -> None:
+        """Long-format position notification should expose motor1/motor2 correctly."""
+        from custom_components.adjustable_bed.beds.vibradorm_protocol import (
+            parse_position_notification,
+        )
+
+        pkt = bytearray([0x20, 0x3F, 0x02, 0x04, 0x27, 0x01, 0xA7, 0x00, 0x00, 0x00, 0x00])
+        parsed = parse_position_notification(pkt)
+        assert parsed is not None
+        assert parsed.motor1 == 0x0427
+        assert parsed.motor2 == 0x01A7
+        assert parsed.motor3 == 0
+        assert parsed.motor4 == 0
+        assert parsed.init_requested is False
+        assert parsed.sync_active is False
+
+    def test_short_format_skips_0x20_prefix(self) -> None:
+        """Short-format (no 0x20 prefix) should still parse motors correctly."""
+        from custom_components.adjustable_bed.beds.vibradorm_protocol import (
+            parse_position_notification,
+        )
+
+        pkt = bytearray([0x3F, 0x02, 0x04, 0x27, 0x01, 0xA7, 0x00, 0x00, 0x00, 0x00])
+        parsed = parse_position_notification(pkt)
+        assert parsed is not None
+        assert parsed.motor1 == 0x0427
+        assert parsed.motor2 == 0x01A7
+
+    def test_flags_init_and_sync_decoded(self) -> None:
+        """Flags byte should drive init_requested and sync_active booleans."""
+        from custom_components.adjustable_bed.beds.vibradorm_protocol import (
+            parse_position_notification,
+        )
+
+        pkt = bytearray([0x20, 0x3F, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+        parsed = parse_position_notification(pkt)
+        assert parsed is not None
+        assert parsed.init_requested is True  # bit 4 (0x10)
+        assert parsed.sync_active is False
+
+        pkt = bytearray([0x20, 0x3F, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+        parsed = parse_position_notification(pkt)
+        assert parsed is not None
+        assert parsed.sync_active is True  # bit 6 (0x40)
+        assert parsed.init_requested is False
+
+    def test_invalid_packets_return_none(self) -> None:
+        """Packets with wrong prefixes or wrong length should return None."""
+        from custom_components.adjustable_bed.beds.vibradorm_protocol import (
+            parse_position_notification,
+        )
+
+        # Empty
+        assert parse_position_notification(bytearray()) is None
+        # Wrong first byte
+        assert parse_position_notification(bytearray([0x21, 0x3F])) is None
+        # Long format but too short
+        assert parse_position_notification(bytearray([0x20, 0x3F, 0x02])) is None
+        # Short format but too short
+        assert parse_position_notification(bytearray([0x3F, 0x02])) is None


### PR DESCRIPTION
Ref #403

Brings the Vibradorm controller up to parity with the de.vibradorm.vra2 (aka vmat-beta) protocol reverse-engineered from the Diamant/CARESSE/WERKMEISTER APKs. The existing VMAT-basic single-byte path on COMMAND (0x1526) is preserved; CBI framing is added for non-VMAT-basic variants.

## What's new

- **New module** `beds/vibradorm_protocol.py` — protocol constants, the XMCMotorData position parser, the 32×8-row EEPROM reassembler, the ManufacturerDataParser (vib identifier → OEM `ControlType` → motor count).

- **Positions** — `init_requested` / `sync_active` flags now tracked and forwarded as `vibradorm_init_requested` / `vibradorm_sync_active` on the controller-state stream. Confirms the corrected motor 2 layout is bytes `[5,6]` (the decompiled APK has a typo reading motor 2 from `[6,7]` and overlapping motor 1's MSB; see issue #403 for the typo and the on-device verification).

- **EEPROM diagnostics** — `VibradormEeprom` reassembles 32 × 8-byte rows into a 256-byte image and exposes the documented field layout (`pulseMot1..4`, 6 × 4 memory positions, reset counts, lifetime pulse counts, total on-time, H-bridge over-temp). Publishes `vibradorm_eeprom_complete=True` when all 32 rows land.

- **CBI floor light** — `CmdLightCBI` with level 0..8 + timer, CBI bus mask (`0x1000`) for XT-box variants. VMAT-basic still uses the 3-byte LIGHT char (level 0..255).

- **RGB mood light** — `CmdMoodColor` / `CmdMoodEffect` / `CmdEffectSpeed` / `CmdMoodLightToggle` on CBI; bus mask for XT-box variants. Wired through `set_light_color` so the existing `AdjustableBedLight` entity surfaces it.

- **VRT (vibration / massage) settings** — `CmdVRTOnOff` + `CmdVxEFF` with effect, speed (1..5), two independent intensity zones (head/foot, 0..5), and an auto-off timer. `massage_intensity_zones` / `massage_intensity_max` / `massage_timer_options` + `set_*` methods match the base class contract so the existing number/select entities surface them.

- **CBI bus mask + toggle bit** — `_write_cbi_command` re-implemented with the toggle bit (`0x8000`, `MC.toggle()`) and an optional bus mask (`0x1000`) for the secondary XT-box accessory bus. `~100 ms` pacing is preserved by the existing `motor_pulse_delay_ms` config.

- **Manufacturer-data → motor count** — `ManufacturerDataParser` maps the OEM `ControlType` (0/5 → 2-motor, 4/6 → 3-motor, 1/-1 → 4-motor) and exposes it via `advertised_motor_count` / `control_version`. `controller_factory.py` now passes `manufacturer_data` to `VibradormController` (matches the Leggett Gen2 pattern).

- **Sync mode** — `_send_sync_mode` helper exposes `SYNC_ON` / `SYNC_OFF` (`0x18` / `0x19`) for head+foot-linked movement.

- **Capability API** — `apply_capabilities()` lets the coordinator flip `has_mood_light` / `has_massage` / `xt_box` / `is_vmat_basic` / `uses_cbi_motor_commands` / `control_version` without re-creating the controller.

- **Documentation** — `docs/beds/vibradorm.md` documents the CBI command table, the mood / VRT / EEPROM field layouts, the corrected motor 2 byte offset, and the advertising/control-version mapping.

- **Tests** — 30 new tests (89 total) covering manufacturer-data parsing, the position parser, CBI light level (VMAT-basic + CBI + clamp to 8), mood light colour + bus mask, VRT intensity / timer / off, `get_massage_state`, and the full 32-row EEPROM reassembly path.

## Compatibility

Behaviour for VMAT-basic and VMAT-BASIC-RF-CBI is unchanged — all 59 existing Vibradorm tests still pass on the new controller. Ruff and pyright are clean. `pyproject.toml` / `manifest.json` versions are untouched (no release is being cut with this PR).

## Verification

```
uv run pytest tests/test_vibradorm.py -q
89 passed in 9.83s

uv run ruff check custom_components/adjustable_bed/ tests/
All checks passed!

uv run pyright custom_components/adjustable_bed/
0 errors, 0 warnings, 0 informations
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader Vibradorm bed support, including richer light, massage, memory recall, sync, and EEPROM diagnostics handling.
  * Improved device detection so the app can better identify supported models and capabilities from advertisement data.

* **Bug Fixes**
  * Fixed position updates and notification decoding for more reliable motor state reporting.
  * Corrected light and massage command handling across different device variants.

* **Documentation**
  * Expanded the Vibradorm bed documentation with updated protocol details, troubleshooting, and supported features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->