### PR TITLE
fix: OKIMAT 4 bed misdetected as okin_rf_eco_bt single actuator

### DIFF
--- a/custom_components/adjustable_bed/beds/okin_uuid.py
+++ b/custom_components/adjustable_bed/beds/okin_uuid.py
@@ -308,6 +308,17 @@ class OkinUuidController(BedController):
         return OKIMAT_WRITE_CHAR_UUID
 
     @property
+    def stale_motor_entity_keys(self) -> frozenset[str]:
+        """Remove the single-actuator stair cover when recovering an OKIMAT bed.
+
+        Installs misdetected as the RF ECO BT stair profile registered a
+        ``<address>_stair`` cover. When they are promoted back to this
+        multi-motor profile (issue #406), drop that orphaned stair entity so the
+        registry and Lovelace card no longer expose a dead control.
+        """
+        return frozenset({"stair"})
+
+    @property
     def supports_memory_presets(self) -> bool:
         """Return True if this remote supports memory presets."""
         # Check if at least memory_1 is available for this remote variant

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -1579,6 +1579,7 @@ class AdjustableBedCoordinator:
                     corrected_bed_type,
                     self._client.services,
                     self._protocol_variant,
+                    ble_model,
                 )
                 corrected_bed_type = refine_nordic_uart_protocol_from_device_info(
                     corrected_bed_type,

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -619,6 +619,18 @@ def refine_okin_shared_uuid_protocol_from_gatt(
             # the bare signature is not enough to downgrade to the single-actuator
             # stair profile. The Device Info model proves this is a multi-motor
             # bed (issue #406), so keep its detected profile.
+            if bed_type == BED_TYPE_OKIN_RF_ECO_BT:
+                # Installations that connected with the old logic already
+                # persisted CONF_BED_TYPE as the single-actuator stair profile.
+                # Recover them to a multi-motor OKIN profile now that the model
+                # proves this is an OKIMAT bed, otherwise the entry stays stuck
+                # exposing only the back/stair actuator (issue #406).
+                _LOGGER.info(
+                    "Recovered OKIMAT bed model %r from persisted RF ECO BT profile to %s",
+                    ble_model,
+                    BED_TYPE_OKIN_UUID,
+                )
+                return BED_TYPE_OKIN_UUID
             _LOGGER.debug(
                 "Keeping %s profile for OKIMAT bed model %r despite RF ECO BT GATT signature",
                 bed_type,

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -187,6 +187,18 @@ OKIN_SHARED_UUID_GATT_REFINABLE_TYPES: frozenset[str] = frozenset(
     }
 )
 
+# Shared-UUID profiles that already drive an OKIMAT bed acceptably, so a connected
+# OKIMAT Device Info model must not rewrite them. BED_TYPE_OKIMAT and
+# BED_TYPE_OKIN_UUID resolve to the same controller; BED_TYPE_OKIN_CST is its own
+# deliberately preserved full-bed profile (see refine_okin_shared_uuid_protocol_from_gatt).
+OKIMAT_COMPATIBLE_PROFILES: frozenset[str] = frozenset(
+    {
+        BED_TYPE_OKIMAT,
+        BED_TYPE_OKIN_UUID,
+        BED_TYPE_OKIN_CST,
+    }
+)
+
 NORA_CONTROLLER_NORMALIZED_NAMES: frozenset[str] = frozenset({"noracon"})
 
 # Manufacturer ID 89 is Nordic Semiconductor's company ID (0x0059), shared by many
@@ -616,27 +628,30 @@ def refine_okin_shared_uuid_protocol_from_gatt(
     if gatt_detection.bed_type in {BED_TYPE_OKIN_CST, BED_TYPE_OKIN_RF_ECO_BT}:
         if gatt_detection.bed_type == BED_TYPE_OKIN_RF_ECO_BT and _is_okimat_bed_model(ble_model):
             # Full OKIMAT beds share the RF ECO BT stair's CSS GATT signature, so
-            # the bare signature is not enough to downgrade to the single-actuator
-            # stair profile. The Device Info model proves this is a multi-motor
-            # bed (issue #406), so keep its detected profile.
-            if bed_type == BED_TYPE_OKIN_RF_ECO_BT:
-                # Installations that connected with the old logic already
-                # persisted CONF_BED_TYPE as the single-actuator stair profile.
-                # Recover them to a multi-motor OKIN profile now that the model
-                # proves this is an OKIMAT bed, otherwise the entry stays stuck
-                # exposing only the back/stair actuator (issue #406).
-                _LOGGER.info(
-                    "Recovered OKIMAT bed model %r from persisted RF ECO BT profile to %s",
+            # the bare signature is not enough to pick the single-actuator stair
+            # profile. The Device Info model proves this is a multi-motor OKIMAT
+            # bed (issue #406).
+            if bed_type in OKIMAT_COMPATIBLE_PROFILES:
+                # Already on an OKIMAT-compatible controller; keep the saved label
+                # (BED_TYPE_OKIMAT/OKIN_UUID resolve to the same controller, and
+                # OKIN CST is its own deliberately preserved full-bed profile).
+                _LOGGER.debug(
+                    "Keeping %s profile for OKIMAT bed model %r despite RF ECO BT GATT signature",
+                    bed_type,
                     ble_model,
-                    BED_TYPE_OKIN_UUID,
                 )
-                return BED_TYPE_OKIN_UUID
-            _LOGGER.debug(
-                "Keeping %s profile for OKIMAT bed model %r despite RF ECO BT GATT signature",
+                return bed_type
+            # Any other shared-UUID guess — a persisted RF ECO BT stair entry, or
+            # an incompatible profile such as Nectar / OKIN 7-byte / Leggett OKIN —
+            # is the wrong controller for an OKIMAT bed. Promote it to the
+            # multi-motor OKIN UUID profile so the bed recovers (issue #406).
+            _LOGGER.info(
+                "Promoted %s to %s for OKIMAT bed model %r despite RF ECO BT GATT signature",
                 bed_type,
+                BED_TYPE_OKIN_UUID,
                 ble_model,
             )
-            return bed_type
+            return BED_TYPE_OKIN_UUID
         if bed_type == BED_TYPE_OKIN_CST and gatt_detection.bed_type == BED_TYPE_OKIN_RF_ECO_BT:
             return bed_type
         if gatt_detection.bed_type != bed_type:

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -588,10 +588,22 @@ def refine_malouf_protocol_from_gatt(bed_type: str, gatt_services: Any) -> str:
     return bed_type
 
 
+def _is_okimat_bed_model(ble_model: str | None) -> bool:
+    """Return True when Device Info identifies a multi-motor OKIMAT bed actuator.
+
+    OKIMAT bed actuators (e.g. ``OKIMAT 4 IPS/M`` from issue #406) expose the same
+    OKIN write + Smart-Remote-CSS GATT signature as the ELDA single-actuator stair
+    (issue #344, ``MEGAMAT MBZ``). The connected Device Information model is the
+    only reliable way to tell a full bed apart from the niche stair profile.
+    """
+    return "okimat" in (ble_model or "").strip().lower()
+
+
 def refine_okin_shared_uuid_protocol_from_gatt(
     bed_type: str,
     gatt_services: Any,
     protocol_variant: str | None = None,
+    ble_model: str | None = None,
 ) -> str:
     """Correct shared OKIN UUID profiles once connected GATT services are known."""
     is_leggett_okin_variant = (
@@ -602,6 +614,17 @@ def refine_okin_shared_uuid_protocol_from_gatt(
 
     gatt_detection = detect_bed_type_from_gatt_services(gatt_services)
     if gatt_detection.bed_type in {BED_TYPE_OKIN_CST, BED_TYPE_OKIN_RF_ECO_BT}:
+        if gatt_detection.bed_type == BED_TYPE_OKIN_RF_ECO_BT and _is_okimat_bed_model(ble_model):
+            # Full OKIMAT beds share the RF ECO BT stair's CSS GATT signature, so
+            # the bare signature is not enough to downgrade to the single-actuator
+            # stair profile. The Device Info model proves this is a multi-motor
+            # bed (issue #406), so keep its detected profile.
+            _LOGGER.debug(
+                "Keeping %s profile for OKIMAT bed model %r despite RF ECO BT GATT signature",
+                bed_type,
+                ble_model,
+            )
+            return bed_type
         if bed_type == BED_TYPE_OKIN_CST and gatt_detection.bed_type == BED_TYPE_OKIN_RF_ECO_BT:
             return bed_type
         if gatt_detection.bed_type != bed_type:

--- a/docs/beds/okin-rf-eco-bt.md
+++ b/docs/beds/okin-rf-eco-bt.md
@@ -41,6 +41,14 @@ If the same device also exposes Nordic DFU service
 `00001530-1212-efde-1523-785feabcd123`, it may be a full bed controller using
 [Okin CST](okin-cst.md), not this single-actuator stair profile.
 
+Full OKIMAT beds expose the **same** OKIN write + CSS GATT signature as this
+stair profile (see [issue #406](https://github.com/kristofferR/ha-adjustable-bed/issues/406),
+an OKIMAT 4 IPS/M Lattoflex bed). The GATT signature alone is therefore not
+enough to choose this single-actuator profile. The auto-refinement only
+downgrades to RF ECO BT when the connected Device Information **model** is not a
+multi-motor OKIMAT bed: the ELDA stair reports `MEGAMAT MBZ`, whereas a real bed
+reports e.g. `OKIMAT 4 IPS/M` and keeps its multi-motor profile.
+
 Generic `OKIN-*` devices remain ambiguous because multiple unrelated OKIN
 protocols use that naming pattern.
 

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1141,6 +1141,18 @@ class TestOkinUUIDDisambiguation:
                 == BED_TYPE_OKIN_UUID
             )
 
+        # The legacy Leggett/OKIN variant takes its own entry path into the
+        # refiner and must promote to okin_uuid too.
+        assert (
+            refine_okin_shared_uuid_protocol_from_gatt(
+                BED_TYPE_LEGGETT_PLATT,
+                gatt_services,
+                LEGGETT_VARIANT_OKIN,
+                ble_model="OKIMAT 4 IPS/M",
+            )
+            == BED_TYPE_OKIN_UUID
+        )
+
     def test_shared_okin_gatt_refinement_keeps_cst_for_okimat_model(self):
         """An explicit OKIN CST entry is preserved even with an OKIMAT model."""
         gatt_services = [

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1039,6 +1039,71 @@ class TestOkinUUIDDisambiguation:
             == BED_TYPE_OKIN_RF_ECO_BT
         )
 
+    def test_shared_okin_gatt_refinement_keeps_okimat_bed_with_okimat_model(self):
+        """A full OKIMAT bed (#406) shares the RF ECO BT CSS signature.
+
+        The Device Info model ``OKIMAT 4 IPS/M`` proves it is a multi-motor bed,
+        so it must keep its profile instead of being downgraded to the single
+        actuator stair profile (issue #406).
+        """
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
+                ],
+            ),
+        ]
+
+        assert (
+            refine_okin_shared_uuid_protocol_from_gatt(
+                BED_TYPE_OKIMAT,
+                gatt_services,
+                ble_model="OKIMAT 4 IPS/M",
+            )
+            == BED_TYPE_OKIMAT
+        )
+        assert (
+            refine_okin_shared_uuid_protocol_from_gatt(
+                BED_TYPE_OKIN_UUID,
+                gatt_services,
+                ble_model="OKIMAT 4 IPS/M",
+            )
+            == BED_TYPE_OKIN_UUID
+        )
+
+    def test_shared_okin_gatt_refinement_downgrades_non_okimat_model_to_rf_eco_bt(self):
+        """The ELDA stair (#344, ``MEGAMAT MBZ``) keeps the RF ECO BT downgrade."""
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
+                ],
+            ),
+        ]
+
+        assert (
+            refine_okin_shared_uuid_protocol_from_gatt(
+                BED_TYPE_OKIMAT,
+                gatt_services,
+                ble_model="MEGAMAT MBZ",
+            )
+            == BED_TYPE_OKIN_RF_ECO_BT
+        )
+
     def test_shared_okin_gatt_refinement_preserves_explicit_cst_without_dfu(self):
         """A manually selected CST entry should not require DFU to remain CST."""
         gatt_services = [

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1078,6 +1078,63 @@ class TestOkinUUIDDisambiguation:
             == BED_TYPE_OKIN_UUID
         )
 
+    def test_shared_okin_gatt_refinement_recovers_persisted_rf_eco_bt_okimat_bed(self):
+        """An entry already saved as RF ECO BT recovers when the model is OKIMAT.
+
+        Installations that connected with the old logic persisted the bed type as
+        ``okin_rf_eco_bt``; on upgrade the OKIMAT model must promote them back to
+        a multi-motor profile instead of staying stuck on the stair profile (#406).
+        """
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
+                ],
+            ),
+        ]
+
+        assert (
+            refine_okin_shared_uuid_protocol_from_gatt(
+                BED_TYPE_OKIN_RF_ECO_BT,
+                gatt_services,
+                ble_model="OKIMAT 4 IPS/M",
+            )
+            == BED_TYPE_OKIN_UUID
+        )
+
+    def test_shared_okin_gatt_refinement_keeps_persisted_rf_eco_bt_non_okimat(self):
+        """A genuine RF ECO BT stair (non-OKIMAT model) stays on its profile."""
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
+                ],
+            ),
+        ]
+
+        assert (
+            refine_okin_shared_uuid_protocol_from_gatt(
+                BED_TYPE_OKIN_RF_ECO_BT,
+                gatt_services,
+                ble_model="MEGAMAT MBZ",
+            )
+            == BED_TYPE_OKIN_RF_ECO_BT
+        )
+
     def test_shared_okin_gatt_refinement_downgrades_non_okimat_model_to_rf_eco_bt(self):
         """The ELDA stair (#344, ``MEGAMAT MBZ``) keeps the RF ECO BT downgrade."""
         gatt_services = [

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1109,6 +1109,64 @@ class TestOkinUUIDDisambiguation:
             == BED_TYPE_OKIN_UUID
         )
 
+    def test_shared_okin_gatt_refinement_promotes_incompatible_profile_for_okimat_model(self):
+        """An incompatible shared-UUID guess is promoted when the model is OKIMAT.
+
+        Nectar / OKIN 7-byte / Leggett OKIN drive different frame formats, so an
+        OKIMAT bed saved as one of them must be promoted to okin_uuid rather than
+        left on the wrong controller (#406).
+        """
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
+                ],
+            ),
+        ]
+
+        for stale_type in (BED_TYPE_NECTAR, BED_TYPE_OKIN_7BYTE):
+            assert (
+                refine_okin_shared_uuid_protocol_from_gatt(
+                    stale_type,
+                    gatt_services,
+                    ble_model="OKIMAT 4 IPS/M",
+                )
+                == BED_TYPE_OKIN_UUID
+            )
+
+    def test_shared_okin_gatt_refinement_keeps_cst_for_okimat_model(self):
+        """An explicit OKIN CST entry is preserved even with an OKIMAT model."""
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
+                ],
+            ),
+        ]
+
+        assert (
+            refine_okin_shared_uuid_protocol_from_gatt(
+                BED_TYPE_OKIN_CST,
+                gatt_services,
+                ble_model="OKIMAT 4 IPS/M",
+            )
+            == BED_TYPE_OKIN_CST
+        )
+
     def test_shared_okin_gatt_refinement_keeps_persisted_rf_eco_bt_non_okimat(self):
         """A genuine RF ECO BT stair (non-OKIMAT model) stays on its profile."""
         gatt_services = [

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -21,6 +21,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_MALOUF_NEW_OKIN,
     BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_RF_ECO_BT,
+    BED_TYPE_OKIN_UUID,
     BED_TYPE_RICHMAT,
     BED_TYPE_SLEEP_NUMBER,
     BED_TYPE_SLEEP_NUMBER_MCR,
@@ -189,6 +190,52 @@ class TestCoverEntities:
 
         assert registry.async_get_entity_id("cover", DOMAIN, "AA:BB:CC:DD:EE:02_head") is None
         assert registry.async_get_entity_id("cover", DOMAIN, "AA:BB:CC:DD:EE:02_feet") is None
+
+    async def test_okin_uuid_setup_removes_stale_stair_cover(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """Recovering an OKIMAT bed removes the orphaned RF ECO BT stair cover (#406)."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Recovered OKIMAT Bed",
+            data={
+                "address": "AA:BB:CC:DD:EE:46",
+                "name": "Recovered OKIMAT Bed",
+                CONF_BED_TYPE: BED_TYPE_OKIN_UUID,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:46",
+            entry_id="recovered_okimat_entry",
+        )
+        entry.add_to_hass(hass)
+
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        # Seed the orphaned stair cover left behind by the old RF ECO BT profile.
+        registry.async_get_or_create(
+            "cover",
+            DOMAIN,
+            "AA:BB:CC:DD:EE:46_stair",
+            config_entry=entry,
+            suggested_object_id="recovered_okimat_bed_stair",
+        )
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert registry.async_get_entity_id("cover", DOMAIN, "AA:BB:CC:DD:EE:46_stair") is None
+        for key in ("back", "legs"):
+            assert (
+                registry.async_get_entity_id("cover", DOMAIN, f"AA:BB:CC:DD:EE:46_{key}")
+                is not None
+            )
 
     async def test_box25_cover_entities_use_box25_layout(
         self,


### PR DESCRIPTION
## Problem

Ref #406. A DewertOkin **OKIMAT 4 IPS/M** (Lattoflex, 2 motors + memory + light) is auto-detected as `okin_uuid`, but after connecting it is reclassified to `okin_rf_eco_bt` — the niche **ELDA single-actuator stair** profile from #344. After the downgrade only the **Back** motor is exposed; Legs, Memory and Light disappear.

## Root cause

`detect_bed_type_from_gatt_services()` treats *OKIN write char + Smart-Remote-CSS service* as the RF ECO BT signature. But full OKIMAT beds expose **exactly the same** GATT signature as the stair lift, so `refine_okin_shared_uuid_protocol_from_gatt()` downgraded a real multi-motor bed to the single-actuator profile. The GATT signature alone cannot tell the two apart.

## Fix

Disambiguate using the connected **Device Information model**, which is already read before the refinement runs:

- ELDA stair (#344) reports `MEGAMAT MBZ` → still refines to `okin_rf_eco_bt`.
- Real bed (#406) reports `OKIMAT 4 IPS/M` → keeps its detected multi-motor profile (`okimat` / `okin_uuid`).

`refine_okin_shared_uuid_protocol_from_gatt()` gains an optional `ble_model` arg; the coordinator passes the model it already read. When the model identifies an OKIMAT bed, the RF ECO BT downgrade is skipped.

## Tests

- New: OKIMAT model keeps its profile (`okimat` and `okin_uuid` cases).
- New: non-OKIMAT model (`MEGAMAT MBZ`) still downgrades to RF ECO BT.
- Existing unknown-model behavior unchanged.
- Full suite: 2011 passed; ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bed-type/profile detection by incorporating the connected device model to avoid incorrect downgrades for multi-motor OKIMAT beds with overlapping Bluetooth signatures, including safer promotion/downgrade of shared-UUID and persisted profiles.
  * Automatically cleans up orphaned “stair” cover entities when transitioning to the OKIN UUID profile.
* **Documentation**
  * Clarified OKIMAT bed compatibility with the OKIN RF ECO BT signature and how device model affects auto-refinement.
* **Tests**
  * Expanded unit and entity regression coverage for model-based refinement and stale-entity removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->