### PR TITLE
fix(box25): drive Star presets with StarCode framing, not CB25

### DIFF
--- a/custom_components/adjustable_bed/beds/sleepys_box25.py
+++ b/custom_components/adjustable_bed/beds/sleepys_box25.py
@@ -99,6 +99,21 @@ class Box25Commands:
         MEMORY_STORE_4,
     )
 
+    # ─── StarCode presets (5A 01 03 10 30 KK A5, 7 bytes) ────────────────
+    # Star* devices (the "is StarCode" device flag is set) drive presets with
+    # StarCode framing, NOT the CB25 "05 02 …" framing above. Verified against
+    # com.starcode.adjustablem1x12 — the app for these beds (Star252201… /
+    # Ashley/Nectar M1X1232): flat()/callMemory() enqueue the preset key ×3 then
+    # the StarCode terminator 0x0F (NOT the 0x1F motor-interrupt) to commit.
+    # The bed accepts CB25 framing for motors/lights/massage (kept above), but the
+    # CB25 preset bytes never committed on real hardware (#372); these do.
+    # key = 0x03103000 | idx  →  big-endian bytes 03 10 30 <idx>.
+    STAR_PRESET_FLAT = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x10, 0xA5])
+    STAR_PRESET_ZERO_GRAVITY = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x13, 0xA5])
+    STAR_PRESET_ANTI_SNORE = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x16, 0xA5])
+    STAR_PRESET_LOUNGE = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x17, 0xA5])  # app "reading"
+    STAR_PRESET_TERMINATOR = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x0F, 0xA5])
+
     # ─── Lighting (04 E0 prefix, 6 bytes) ────────────────────────────────
     LIGHT_OFF = bytes([0x04, 0xE0, 0x01, 0x00, 0x00, 0x00])
     LIGHT_ON_WHITE = bytes([0x04, 0xE0, 0x01, 0x01, 0x00, 0x00])
@@ -117,10 +132,12 @@ _WAKE_DELAY = 0.15
 _INIT_DELAY = 0.08
 
 # Preset send tuning, mirroring the decompiled "Adjustable Comfort M1X12" app
-# (StarCode/DewertOkin CB25 protocol). The app enqueues every preset/memory
-# recall as four packets drained 100 ms apart by its periodic BLE sender: the
-# preset key ×3, then the all-zero STOP/idle packet (05 02 00 00 00 00 00). The
-# trailing STOP is what *commits* the preset — see _send_preset (#372).
+# (StarCode/DewertOkin CB25 protocol). The app enqueues every preset as four
+# packets drained 100 ms apart by its periodic BLE sender: the preset key ×3,
+# then a terminator that *commits* the preset — the bed arms while it keeps
+# receiving the key and only drives to the target once the terminator arrives.
+# For Star* devices the terminator is the StarCode 0x0F packet; the legacy CB25
+# memory path still uses the 05 02 00…00 STOP. See _send_preset (#372).
 _PRESET_REPEAT_COUNT = 3
 _PRESET_REPEAT_DELAY_MS = 100
 _PRESET_COMMIT_DELAY = 0.1
@@ -565,20 +582,24 @@ class SleepysBox25Controller(BedController):
 
     # ─── Presets ─────────────────────────────────────────────────────────
 
-    async def _send_preset(self, preset_cmd: bytes) -> None:
-        """Send a BOX25/CB25 preset or memory recall, then commit it with STOP.
+    async def _send_preset(self, preset_cmd: bytes, terminator: bytes) -> None:
+        """Send a preset (key ×3 at 100 ms), then commit it with `terminator`.
 
         The decompiled "Adjustable Comfort M1X12" app (StarCode/DewertOkin CB25
         protocol, e.g. Star252201 / Ashley/Nectar M1X1232) sends every preset as
-        the preset key ×3 at 100 ms followed by the all-zero STOP/idle packet
-        (MOTOR_STOP, 05 02 00 00 00 00 00). The trailing STOP is what *commits*
-        the preset: the bed arms while it keeps receiving the key and only drives
-        to the target once the STOP arrives.
+        the preset key ×3 at 100 ms followed by a terminator packet. The trailing
+        terminator is what *commits* the preset: the bed arms while it keeps
+        receiving the key and only drives to the target once the terminator
+        arrives.
 
-        Without the STOP the bed stays armed but never moves until the user
-        manually presses Stop All or disconnects (#372). Conversely a STOP sent
-        too soon (the old 50 ms confirm) lands before the bed arms and cancels
-        the preset — hence the key is repeated first to hold it long enough.
+        Without it the bed stays armed but never moves until the user manually
+        presses Stop All or disconnects (#372). Conversely a terminator sent too
+        soon (the old 50 ms confirm) lands before the bed arms and cancels the
+        preset — hence the key is repeated first to hold it long enough.
+
+        Star* devices use StarCode framing (5A 01 03 10 30 KK A5) and the 0x0F
+        StarCode terminator; the legacy CB25 memory path passes the 05 02 00…00
+        MOTOR_STOP. The terminator's framing must match its preset key's framing.
         """
         try:
             await self.write_command(
@@ -589,39 +610,56 @@ class SleepysBox25Controller(BedController):
             await asyncio.sleep(_PRESET_COMMIT_DELAY)
         finally:
             try:
-                await self._send_stop()
+                # Fresh cancel event so a pending Stop All can't suppress the
+                # commit packet — without it the preset never executes.
+                await self.write_command(terminator, cancel_event=asyncio.Event())
             except (BleakError, ConnectionError):
                 _LOGGER.debug(
-                    "Failed to send committing STOP after BOX25 preset",
+                    "Failed to send committing terminator after preset",
                     exc_info=True,
                 )
 
     async def preset_flat(self) -> None:
-        await self._send_preset(Box25Commands.PRESET_FLAT)
+        await self._send_preset(
+            Box25Commands.STAR_PRESET_FLAT, Box25Commands.STAR_PRESET_TERMINATOR
+        )
 
     async def preset_zero_g(self) -> None:
-        await self._send_preset(Box25Commands.PRESET_ZERO_GRAVITY)
+        await self._send_preset(
+            Box25Commands.STAR_PRESET_ZERO_GRAVITY, Box25Commands.STAR_PRESET_TERMINATOR
+        )
 
     async def preset_anti_snore(self) -> None:
-        await self._send_preset(Box25Commands.PRESET_ANTI_SNORE)
+        await self._send_preset(
+            Box25Commands.STAR_PRESET_ANTI_SNORE, Box25Commands.STAR_PRESET_TERMINATOR
+        )
 
     async def preset_lounge(self) -> None:
         """Move bed to lounge or relax position."""
-        await self._send_preset(Box25Commands.PRESET_LOUNGE)
+        await self._send_preset(
+            Box25Commands.STAR_PRESET_LOUNGE, Box25Commands.STAR_PRESET_TERMINATOR
+        )
 
     async def preset_memory(self, memory_num: int) -> None:
         if memory_num < 1 or memory_num > len(Box25Commands.MEMORY_RECALL):
             _LOGGER.warning("Invalid memory slot %d (valid: 1-4)", memory_num)
             return
-        await self._send_preset(Box25Commands.MEMORY_RECALL[memory_num - 1])
+        # Memory recall/store still use the unverified CB25 keys + CB25 STOP
+        # terminator (#372 follow-up): the correct StarCode memory keys aren't
+        # pinned down yet, so this path is unchanged from the legacy behaviour.
+        await self._send_preset(
+            Box25Commands.MEMORY_RECALL[memory_num - 1], Box25Commands.MOTOR_STOP
+        )
 
     async def program_memory(self, memory_num: int) -> None:
         if memory_num < 1 or memory_num > len(Box25Commands.MEMORY_STORE):
             _LOGGER.warning("Invalid memory slot %d (valid: 1-4)", memory_num)
             return
         # Memory store uses the same arm-then-commit sequence as recall; see
-        # _send_preset for why a trailing STOP is required.
-        await self._send_preset(Box25Commands.MEMORY_STORE[memory_num - 1])
+        # _send_preset for why a trailing terminator is required.
+        await self._send_preset(
+            Box25Commands.MEMORY_STORE[memory_num - 1], Box25Commands.MOTOR_STOP
+        )
 
     # ─── Lights ──────────────────────────────────────────────────────────
 

--- a/tests/test_sleepys.py
+++ b/tests/test_sleepys.py
@@ -1246,19 +1246,20 @@ class TestSleepysBox25Controller:
         assert controller._motor_initialized is False
         mock_client.write_gatt_char.assert_not_called()
 
-    async def test_preset_arms_then_commits_with_stop(
+    async def test_preset_arms_then_commits_with_starcode_terminator(
         self,
         hass: HomeAssistant,
         mock_sleepys_box25_config_entry,
         mock_coordinator_connected,
     ):
-        """BOX25 presets are armed by repeating the key, then committed by STOP.
+        """Star presets arm with the StarCode key ×3, then the 0x0F terminator.
 
-        Regression test for #372: the decompiled Adjustable Comfort M1X12 app
-        sends every preset as the preset key ×3 followed by the all-zero
-        MOTOR_STOP that *commits* it. Sending the key without the trailing STOP
-        leaves the bed armed but stationary until the user manually presses Stop
-        All — exactly the reported symptom.
+        Regression test for #372. These beds (Star252201…, app
+        com.starcode.adjustablem1x12) use StarCode framing (5A 01 03 10 30 KK A5):
+        flat()/callMemory() enqueue the preset key ×3 then the StarCode terminator
+        0x0F to commit. The bed arms while it receives the key and only drives to
+        the target once the terminator arrives. The earlier CB25 (05 02 …) preset
+        bytes never committed on real hardware — the user had to manually Stop All.
         """
         coordinator = AdjustableBedCoordinator(hass, mock_sleepys_box25_config_entry)
         await coordinator.async_connect()
@@ -1266,15 +1267,55 @@ class TestSleepysBox25Controller:
 
         with (
             patch.object(controller, "write_command", AsyncMock()) as mock_write,
-            patch.object(controller, "_send_stop", AsyncMock()) as mock_stop,
             patch("custom_components.adjustable_bed.beds.sleepys_box25.asyncio.sleep", AsyncMock()),
         ):
             await controller.preset_flat()
 
-        mock_write.assert_awaited_once_with(
-            Box25Commands.PRESET_FLAT, repeat_count=3, repeat_delay_ms=100
+        assert mock_write.await_count == 2
+        # 1) StarCode flat key, repeated to arm the preset.
+        arm_call = mock_write.call_args_list[0]
+        assert arm_call.args[0] == Box25Commands.STAR_PRESET_FLAT
+        assert arm_call.kwargs == {"repeat_count": 3, "repeat_delay_ms": 100}
+        # 2) StarCode terminator commits it, with a fresh cancel event so a
+        #    pending Stop All can't suppress the commit packet.
+        commit_call = mock_write.call_args_list[1]
+        assert commit_call.args[0] == Box25Commands.STAR_PRESET_TERMINATOR
+        assert isinstance(commit_call.kwargs["cancel_event"], asyncio.Event)
+
+    async def test_named_presets_use_starcode_frames(
+        self,
+        hass: HomeAssistant,
+        mock_sleepys_box25_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Each named preset sends its StarCode arm frame, then the terminator."""
+        coordinator = AdjustableBedCoordinator(hass, mock_sleepys_box25_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        cases = (
+            (controller.preset_flat, Box25Commands.STAR_PRESET_FLAT),
+            (controller.preset_zero_g, Box25Commands.STAR_PRESET_ZERO_GRAVITY),
+            (controller.preset_anti_snore, Box25Commands.STAR_PRESET_ANTI_SNORE),
+            (controller.preset_lounge, Box25Commands.STAR_PRESET_LOUNGE),
         )
-        mock_stop.assert_awaited_once()
+        for method, arm_frame in cases:
+            # StarCode framing: 5A 01 … A5, 7 bytes.
+            assert arm_frame[0:2] == bytes([0x5A, 0x01])
+            assert arm_frame[-1] == 0xA5
+            assert len(arm_frame) == 7
+
+            with (
+                patch.object(controller, "write_command", AsyncMock()) as mock_write,
+                patch(
+                    "custom_components.adjustable_bed.beds.sleepys_box25.asyncio.sleep",
+                    AsyncMock(),
+                ),
+            ):
+                await method()
+
+            assert mock_write.call_args_list[0].args[0] == arm_frame
+            assert mock_write.call_args_list[1].args[0] == Box25Commands.STAR_PRESET_TERMINATOR
 
     async def test_program_memory_arms_then_commits_with_stop(
         self,
@@ -1282,22 +1323,28 @@ class TestSleepysBox25Controller:
         mock_sleepys_box25_config_entry,
         mock_coordinator_connected,
     ):
-        """BOX25 memory store uses the same arm-then-commit sequence (#372)."""
+        """Memory store still uses the legacy CB25 key + CB25 MOTOR_STOP (#372 follow-up).
+
+        The correct StarCode memory keys aren't pinned down yet, so the memory
+        path is intentionally left on the unverified CB25 framing.
+        """
         coordinator = AdjustableBedCoordinator(hass, mock_sleepys_box25_config_entry)
         await coordinator.async_connect()
         controller = coordinator.controller
 
         with (
             patch.object(controller, "write_command", AsyncMock()) as mock_write,
-            patch.object(controller, "_send_stop", AsyncMock()) as mock_stop,
             patch("custom_components.adjustable_bed.beds.sleepys_box25.asyncio.sleep", AsyncMock()),
         ):
             await controller.program_memory(1)
 
-        mock_write.assert_awaited_once_with(
-            Box25Commands.MEMORY_STORE[0], repeat_count=3, repeat_delay_ms=100
-        )
-        mock_stop.assert_awaited_once()
+        assert mock_write.await_count == 2
+        arm_call = mock_write.call_args_list[0]
+        assert arm_call.args[0] == Box25Commands.MEMORY_STORE[0]
+        assert arm_call.kwargs == {"repeat_count": 3, "repeat_delay_ms": 100}
+        commit_call = mock_write.call_args_list[1]
+        assert commit_call.args[0] == Box25Commands.MOTOR_STOP
+        assert isinstance(commit_call.kwargs["cancel_event"], asyncio.Event)
 
     async def test_set_motor_position_supports_lumbar(
         self,


### PR DESCRIPTION
## Problem

BOX25/Star preset buttons (Flat, Zero-G, Anti-Snore, Lounge) **never moved the bed** (#372) — presets only fired after the user manually pressed **Stop All** or disconnected Bluetooth. Reported by 3–4 users on Ashley/Nectar `M1X1232` (`Star252201…`).

## Root cause: framing, not timing

The prior fix added the correct arm-then-commit *pattern* (preset key ×3 @ 100 ms + terminator) but in the **wrong framing**. These beds are **StarCode devices** (`field_3f` = true — every bed HA routes to `sleepys_box25`, detected by the `Star25…` name). The real app (`com.starcode.adjustablem1x12`) drives presets with **StarCode framing** `5A 01 03 10 30 KK A5`, committing with the StarCode terminator `0x0F`.

The controller inherited **CB25 framing** (`05 02 … 00`) from a different app (OKIN Sleepy's). The bed accepts CB25 for motors/lights/massage (which is why those work), but its **CB25 preset bytes do nothing** — so the preset stayed armed-but-uncommitted until a manual stop/disconnect happened to supply a commit packet.

## Fix

`preset_flat / zero_g / anti_snore / lounge` now send the **StarCode** key ×3 @ 100 ms then the **StarCode `0x0F` terminator** (`5A 01 03 10 30 0F A5` — the preset-commit key, distinct from the `0x1F` motor-interrupt). Keys: flat `10`, zero-G `13`, anti-snore `16`, lounge/reading `17`.

- Motors / lights / massage stay on the working CB25 framing (untouched).
- Memory recall/store stay on the unverified CB25 keys + CB25 STOP — the correct StarCode memory keys aren't pinned down yet (separate follow-up).

## Verification

- **Decompiled byte-for-byte** from `com.starcode.adjustablem1x12` (blutter trace of `flat()`/`callMemory()` → `sendSingleData` ×3 + `0x0F` terminator, drained 100 ms apart by the `BleSender` `Timer.periodic`). StarCode frame builder confirmed `5A 01 <key big-endian> A5`, no checksum.
- These are the **same bytes that moved the bed** when users pressed Stop All on the `okin_cb35` controller (which emits identical StarCode frames) — confirmed in their support-bundle command traces.

## Tests

Updated `tests/test_sleepys.py`: the BOX25 preset test now asserts the StarCode arm frame + `0x0F` terminator (two `write_command` calls), a new test locks in the StarCode frame bytes for all four named presets, and the memory-store test asserts the legacy CB25 path is preserved. All 77 `test_sleepys.py` tests pass; ruff + pyright clean.

> Needs on-device confirmation: users must set bed type to **Sleepy's Elite (BOX25 Star)** (several are currently on `okin_cb35`).

Ref #372

https://claude.ai/code/session_01JbTTAAnxqRPbqrkq7aFWmC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preset and memory actions for adjustable beds so they commit more reliably after being sent.
  * Updated named bed positions to use the correct command framing, reducing failed or incomplete preset changes.
  * Memory recall/store actions now follow the expected send-then-commit flow, helping prevent interruptions from canceling the final step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->