### PR TITLE
fix: time-box Device Information GATT reads and survive slow-waking beds

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any, cast
@@ -104,6 +103,7 @@ MAX_TIMED_MOVE_DURATION_MS = 30000  # 30 seconds max
 # backoff between them. Beds that are slow to wake (e.g. just repowered) often
 # only connect on the second or third attempt; 45s cut the cycle short.
 SETUP_TIMEOUT = 120.0
+SETUP_CLEANUP_TIMEOUT = 5.0
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -362,8 +362,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         async with asyncio.timeout(SETUP_TIMEOUT):
             connected = await coordinator.async_connect()
     except TimeoutError:
-        with contextlib.suppress(Exception):
-            await coordinator.async_disconnect(reason="setup timeout cleanup")
+        try:
+            async with asyncio.timeout(SETUP_CLEANUP_TIMEOUT):
+                await coordinator.async_disconnect(reason="setup timeout cleanup")
+        except TimeoutError:
+            _LOGGER.warning(
+                "Timed out while disconnecting %s after setup timeout",
+                entry.title,
+            )
+        except Exception as err:  # Best-effort cleanup must not block setup retry
+            _LOGGER.warning(
+                "Failed to disconnect %s after setup timeout: %s",
+                entry.title,
+                err,
+            )
         await _maybe_create_pairing_issue()
         if entry.data.get(CONF_BED_TYPE) == BED_TYPE_DIAGNOSTIC:
             return await _async_setup_offline_diagnostic_entry(

--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any, cast
@@ -98,9 +99,11 @@ MAX_CAPTURE_DURATION = 300
 MIN_TIMED_MOVE_DURATION_MS = 100
 MAX_TIMED_MOVE_DURATION_MS = 30000  # 30 seconds max
 
-# Timeout for initial connection at startup
-# Must be long enough to cover at least one full connection attempt (30s) with margin
-SETUP_TIMEOUT = 45.0
+# Timeout for initial connection at startup.
+# Must cover a full connection retry cycle: up to 3 attempts of ~30s each plus
+# backoff between them. Beds that are slow to wake (e.g. just repowered) often
+# only connect on the second or third attempt; 45s cut the cycle short.
+SETUP_TIMEOUT = 120.0
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -359,6 +362,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         async with asyncio.timeout(SETUP_TIMEOUT):
             connected = await coordinator.async_connect()
     except TimeoutError:
+        with contextlib.suppress(Exception):
+            await coordinator.async_disconnect(reason="setup timeout cleanup")
         await _maybe_create_pairing_issue()
         if entry.data.get(CONF_BED_TYPE) == BED_TYPE_DIAGNOSTIC:
             return await _async_setup_offline_diagnostic_entry(

--- a/custom_components/adjustable_bed/adapter.py
+++ b/custom_components/adjustable_bed/adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 
@@ -12,7 +13,12 @@ from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.core import HomeAssistant
 
-from .const import ADAPTER_AUTO, DEVICE_INFO_CHARS, DEVICE_INFO_SERVICE_UUID
+from .const import (
+    ADAPTER_AUTO,
+    DEVICE_INFO_CHARS,
+    DEVICE_INFO_READ_TIMEOUT,
+    DEVICE_INFO_SERVICE_UUID,
+)
 
 # Sentinel value indicating RSSI is unavailable
 RSSI_UNAVAILABLE = -999
@@ -451,7 +457,9 @@ async def read_ble_device_info(client: BleakClient, address: str) -> tuple[str |
     # Read manufacturer name
     try:
         manufacturer_uuid = DEVICE_INFO_CHARS["manufacturer_name"]
-        value = await client.read_gatt_char(manufacturer_uuid)
+        value = await asyncio.wait_for(
+            client.read_gatt_char(manufacturer_uuid), DEVICE_INFO_READ_TIMEOUT
+        )
         try:
             manufacturer = value.decode("utf-8").rstrip("\x00")
             _LOGGER.debug("BLE manufacturer: %s", manufacturer)
@@ -463,7 +471,9 @@ async def read_ble_device_info(client: BleakClient, address: str) -> tuple[str |
     # Read model number
     try:
         model_uuid = DEVICE_INFO_CHARS["model_number"]
-        value = await client.read_gatt_char(model_uuid)
+        value = await asyncio.wait_for(
+            client.read_gatt_char(model_uuid), DEVICE_INFO_READ_TIMEOUT
+        )
         try:
             model = value.decode("utf-8").rstrip("\x00")
             _LOGGER.debug("BLE model: %s", model)

--- a/custom_components/adjustable_bed/adapter.py
+++ b/custom_components/adjustable_bed/adapter.py
@@ -465,7 +465,7 @@ async def read_ble_device_info(client: BleakClient, address: str) -> tuple[str |
             _LOGGER.debug("BLE manufacturer: %s", manufacturer)
         except UnicodeDecodeError:
             _LOGGER.debug("Could not decode manufacturer name as UTF-8")
-    except (BleakError, TimeoutError) as err:
+    except (BleakError, TimeoutError, OSError) as err:
         _LOGGER.debug("Could not read manufacturer name: %s", err)
 
     # Read model number
@@ -479,7 +479,7 @@ async def read_ble_device_info(client: BleakClient, address: str) -> tuple[str |
             _LOGGER.debug("BLE model: %s", model)
         except UnicodeDecodeError:
             _LOGGER.debug("Could not decode model number as UTF-8")
-    except (BleakError, TimeoutError) as err:
+    except (BleakError, TimeoutError, OSError) as err:
         _LOGGER.debug("Could not read model number: %s", err)
 
     return manufacturer, model

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -265,6 +265,11 @@ LEGACY_BED_TYPE_MAPPING: Final = {
     # controller_factory.py to determine gen2 (default), okin, or wilinke (mlrm)
 }
 
+# Some controllers (e.g. certain OKIN CST boards) accept a GATT read on a
+# Device Information characteristic but never answer it. Time-box these
+# reads so a silent characteristic cannot stall connection setup.
+DEVICE_INFO_READ_TIMEOUT: Final = 5.0
+
 # Standard BLE Device Information Service UUIDs
 DEVICE_INFO_SERVICE_UUID: Final = "0000180a-0000-1000-8000-00805f9b34fb"
 DEVICE_INFO_CHARS: Final = {

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -117,6 +117,7 @@ from .const import (
     DEFAULT_POSITION_MODE,
     DEFAULT_PROTOCOL_VARIANT,
     DEVICE_INFO_CHARS,
+    DEVICE_INFO_READ_TIMEOUT,
     DOMAIN,
     LEGGETT_VARIANT_GEN2,
     OKIMAT_SERVICE_UUID,
@@ -309,6 +310,8 @@ class AdjustableBedCoordinator:
         # BLE Device Information Service data
         self._ble_manufacturer: str | None = None
         self._ble_model: str | None = None
+        self._device_info_read_done: bool = False
+        self._bond_probe_timed_out: bool = False
 
         # Track if pairing is supported by the Bluetooth adapter (None = unknown)
         self._pairing_supported: bool | None = None
@@ -729,9 +732,19 @@ class AdjustableBedCoordinator:
         if client is None or not client.is_connected:
             return True
 
+        if self._bond_probe_timed_out:
+            _LOGGER.debug(
+                "Bond verification read previously timed out on %s; "
+                "skipping the probe for this session.",
+                self._address,
+            )
+            return True
+
         probe_uuid = DEVICE_INFO_CHARS["model_number"]
         try:
-            await client.read_gatt_char(probe_uuid)
+            await asyncio.wait_for(
+                client.read_gatt_char(probe_uuid), DEVICE_INFO_READ_TIMEOUT
+            )
         except BleakError as err:
             if _is_ble_authentication_error(err):
                 # We run inside _async_connect_locked, which holds self._lock —
@@ -745,8 +758,10 @@ class AdjustableBedCoordinator:
             )
             return True
         except (TimeoutError, OSError) as err:
+            self._bond_probe_timed_out = True
             _LOGGER.debug(
-                "Bond verification read for %s failed (%s); proceeding.",
+                "Bond verification read for %s failed (%s); proceeding and "
+                "skipping future probes for this session.",
                 self._address,
                 err,
             )
@@ -1565,11 +1580,22 @@ class AdjustableBedCoordinator:
                 ble_model: str | None = None
 
                 if not _defer_device_info:
-                    ble_manufacturer, ble_model = await read_ble_device_info(
-                        self._client, self._address
-                    )
-                    self._ble_manufacturer = ble_manufacturer
-                    self._ble_model = ble_model
+                    if self._device_info_read_done:
+                        ble_manufacturer = self._ble_manufacturer
+                        ble_model = self._ble_model
+                        _LOGGER.debug(
+                            "Reusing cached device info for %s (manufacturer=%s, model=%s)",
+                            self._address,
+                            ble_manufacturer,
+                            ble_model,
+                        )
+                    else:
+                        ble_manufacturer, ble_model = await read_ble_device_info(
+                            self._client, self._address
+                        )
+                        self._ble_manufacturer = ble_manufacturer
+                        self._ble_model = ble_model
+                        self._device_info_read_done = True
 
                 previous_bed_type = self._bed_type
                 corrected_bed_type = refine_malouf_protocol_from_gatt(

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -1793,11 +1793,22 @@ class AdjustableBedCoordinator:
                 # Read deferred BLE Device Information now that the
                 # notification channel and protocol handshake are done.
                 if _defer_device_info and self._client is not None and self._client.is_connected:
-                    ble_manufacturer, ble_model = await read_ble_device_info(
-                        self._client, self._address
-                    )
-                    self._ble_manufacturer = ble_manufacturer
-                    self._ble_model = ble_model
+                    if self._device_info_read_done:
+                        ble_manufacturer = self._ble_manufacturer
+                        ble_model = self._ble_model
+                        _LOGGER.debug(
+                            "Reusing cached device info for %s (manufacturer=%s, model=%s)",
+                            self._address,
+                            ble_manufacturer,
+                            ble_model,
+                        )
+                    else:
+                        ble_manufacturer, ble_model = await read_ble_device_info(
+                            self._client, self._address
+                        )
+                        self._ble_manufacturer = ble_manufacturer
+                        self._ble_model = ble_model
+                        self._device_info_read_done = True
 
                 if (
                     self._bed_type != BED_TYPE_SLEEP_NUMBER_MCR

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.core import HomeAssistant
 
 from custom_components.adjustable_bed.adapter import (
     get_ble_device_with_fallback,
     get_discovered_service_info,
+    read_ble_device_info,
 )
+from custom_components.adjustable_bed.const import DEVICE_INFO_SERVICE_UUID
 
 
 class TestAdapterFallbacks:
@@ -71,3 +74,34 @@ class TestAdapterFallbacks:
 
         assert device is fallback_device
         assert connectable is False
+
+
+class TestReadBleDeviceInfo:
+    """Device Information Service reads must be time-boxed."""
+
+    async def test_hung_reads_are_time_boxed(self) -> None:
+        """A characteristic that never answers cannot stall the read."""
+        device_info_service = MagicMock()
+        device_info_service.uuid = DEVICE_INFO_SERVICE_UUID
+
+        client = MagicMock()
+        client.services = [device_info_service]
+
+        async def _never_answers(*args, **kwargs):
+            await asyncio.Event().wait()
+
+        client.read_gatt_char = AsyncMock(side_effect=_never_answers)
+
+        with patch(
+            "custom_components.adjustable_bed.adapter.DEVICE_INFO_READ_TIMEOUT",
+            0.05,
+        ):
+            async with asyncio.timeout(5):
+                manufacturer, model = await read_ble_device_info(
+                    client, "AA:BB:CC:DD:EE:FF"
+                )
+
+        assert manufacturer is None
+        assert model is None
+        # Both characteristic reads were attempted and timed out.
+        assert client.read_gatt_char.await_count == 2

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -105,3 +105,20 @@ class TestReadBleDeviceInfo:
         assert model is None
         # Both characteristic reads were attempted and timed out.
         assert client.read_gatt_char.await_count == 2
+
+    async def test_oserror_reads_degrade_to_missing_values(self) -> None:
+        """Raw backend I/O errors must not abort the connection attempt."""
+        device_info_service = MagicMock()
+        device_info_service.uuid = DEVICE_INFO_SERVICE_UUID
+
+        client = MagicMock()
+        client.services = [device_info_service]
+        client.read_gatt_char = AsyncMock(side_effect=OSError("GATT I/O failed"))
+
+        manufacturer, model = await read_ble_device_info(
+            client, "AA:BB:CC:DD:EE:FF"
+        )
+
+        assert manufacturer is None
+        assert model is None
+        assert client.read_gatt_char.await_count == 2

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1941,6 +1941,57 @@ class TestCoordinatorWriteCommand:
         mock_delete_issue.assert_awaited_once_with(hass, TEST_ADDRESS)
 
 
+    async def test_verify_bonded_timeout_sets_flag_and_skips_future_probes(
+        self,
+        hass: HomeAssistant,
+    ):
+        """A probe that times out is skipped for the rest of the session."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=TEST_NAME,
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: TEST_NAME,
+                CONF_BED_TYPE: BED_TYPE_OKIMAT,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id="okimat_verify_bonded_timeout_test",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        client = MagicMock()
+        client.is_connected = True
+
+        async def _never_answers(*args, **kwargs):
+            await asyncio.Event().wait()
+
+        client.read_gatt_char = AsyncMock(side_effect=_never_answers)
+        coordinator._client = client
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator.DEVICE_INFO_READ_TIMEOUT",
+            0.05,
+        ):
+            async with asyncio.timeout(5):
+                bonded = await coordinator._async_verify_bonded()
+
+        assert bonded is True
+        assert coordinator._bond_probe_timed_out is True
+        assert client.read_gatt_char.await_count == 1
+
+        # Second verification must not touch the characteristic again.
+        async with asyncio.timeout(5):
+            bonded = await coordinator._async_verify_bonded()
+
+        assert bonded is True
+        assert client.read_gatt_char.await_count == 1
+
+
 class TestCoordinatorNotifications:
     """Test coordinator notification handling."""
 
@@ -2483,6 +2534,107 @@ class TestRuntimeBedTypeCorrection:
             coordinator._connection_attempt_details[0]["result"]
             == "retry_with_pairing_after_protocol_correction"
         )
+
+
+
+class TestDeviceInfoCache:
+    """Device Information Service results are cached across reconnects."""
+
+    async def test_device_info_read_once_across_reconnects(
+        self,
+        hass: HomeAssistant,
+        mock_bleak_client: MagicMock,
+    ):
+        """The DIS read runs on the first connect only; reconnects reuse it."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=TEST_NAME,
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: TEST_NAME,
+                CONF_BED_TYPE: BED_TYPE_OKIMAT,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+                CONF_BLE_BOND_ESTABLISHED: True,
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id="okimat_device_info_cache_test",
+        )
+        entry.add_to_hass(hass)
+
+        gatt_services: list[SimpleNamespace] = []
+        mock_bleak_client.services = MagicMock()
+        mock_bleak_client.services.__iter__ = lambda self: iter(gatt_services)
+        mock_bleak_client.services.__len__ = lambda self: len(gatt_services)
+        mock_bleak_client.services.get_service = MagicMock(return_value=None)
+
+        adapter_result = MagicMock()
+        adapter_result.device = MagicMock()
+        adapter_result.device.address = TEST_ADDRESS
+        adapter_result.device.name = TEST_NAME
+        adapter_result.device.details = {"source": "local"}
+        adapter_result.source = "local"
+        adapter_result.rssi = -60
+        adapter_result.connectable = True
+        adapter_result.available_sources = ["local"]
+
+        mock_controller = MagicMock()
+        mock_controller.start_notify = AsyncMock()
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.coordinator.select_adapter",
+                new_callable=AsyncMock,
+                return_value=adapter_result,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.establish_connection",
+                new_callable=AsyncMock,
+                return_value=mock_bleak_client,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.discover_services",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.read_ble_device_info",
+                new_callable=AsyncMock,
+                return_value=("OKIN", "Model X"),
+            ) as mock_read_device_info,
+            patch.object(
+                AdjustableBedCoordinator,
+                "_async_verify_bonded",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.create_controller",
+                new_callable=AsyncMock,
+                return_value=mock_controller,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.asyncio.sleep",
+                new=AsyncMock(),
+            ),
+        ):
+            coordinator = AdjustableBedCoordinator(hass, entry)
+            coordinator._max_retries = 1
+
+            assert await coordinator.async_connect() is True
+            assert mock_read_device_info.await_count == 1
+            assert coordinator._ble_manufacturer == "OKIN"
+            assert coordinator._ble_model == "Model X"
+
+            await coordinator.async_disconnect()
+
+            assert await coordinator.async_connect() is True
+            # Reconnect must reuse the cached values instead of re-reading.
+            assert mock_read_device_info.await_count == 1
+            assert coordinator._ble_manufacturer == "OKIN"
+            assert coordinator._ble_model == "Model X"
 
 
 class TestMultiMotorConfiguration:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2636,6 +2636,48 @@ class TestDeviceInfoCache:
             assert coordinator._ble_manufacturer == "OKIN"
             assert coordinator._ble_model == "Model X"
 
+    async def test_deferred_device_info_read_once_across_reconnects(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+    ):
+        """Timing-sensitive protocols also reuse DIS data after the handshake."""
+        del mock_coordinator_connected
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Sleep Number MCR Bed",
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: "64:DB:A0:07:DD:02",
+                CONF_BED_TYPE: BED_TYPE_SLEEP_NUMBER_MCR,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id="deferred_device_info_cache_test",
+        )
+        entry.add_to_hass(hass)
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator.read_ble_device_info",
+            new_callable=AsyncMock,
+            return_value=("Sleep Number", "MCR"),
+        ) as mock_read_device_info:
+            coordinator = AdjustableBedCoordinator(hass, entry)
+            coordinator._max_retries = 1
+
+            assert await coordinator.async_connect() is True
+            assert mock_read_device_info.await_count == 1
+
+            await coordinator.async_disconnect()
+
+            assert await coordinator.async_connect() is True
+            assert mock_read_device_info.await_count == 1
+            assert coordinator._ble_manufacturer == "Sleep Number"
+            assert coordinator._ble_model == "MCR"
+
 
 class TestMultiMotorConfiguration:
     """Test multi-motor configuration."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -104,6 +105,36 @@ class TestIntegrationSetup:
         assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
         assert hass.services.has_service(DOMAIN, SERVICE_GOTO_PRESET)
         assert hass.services.has_service(DOMAIN, SERVICE_GENERATE_SUPPORT_BUNDLE)
+
+    async def test_setup_entry_timeout_disconnects_cleanly(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_async_ble_device_from_address,
+        mock_bluetooth_adapters,
+        enable_custom_integrations,
+    ):
+        """A setup timeout must tear down the half-open connection."""
+
+        async def _hangs(*args, **kwargs):
+            await asyncio.Event().wait()
+
+        with (
+            patch("custom_components.adjustable_bed.SETUP_TIMEOUT", 0.1),
+            patch(
+                "custom_components.adjustable_bed.coordinator.AdjustableBedCoordinator.async_connect",
+                new=_hangs,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.AdjustableBedCoordinator.async_disconnect",
+                new_callable=AsyncMock,
+            ) as mock_disconnect,
+        ):
+            await hass.config_entries.async_setup(mock_config_entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+        mock_disconnect.assert_awaited_once_with(reason="setup timeout cleanup")
 
     async def test_setup_entry_connection_failed(
         self,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -136,6 +136,39 @@ class TestIntegrationSetup:
         assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
         mock_disconnect.assert_awaited_once_with(reason="setup timeout cleanup")
 
+    async def test_setup_entry_timeout_bounds_disconnect_cleanup(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_async_ble_device_from_address,
+        mock_bluetooth_adapters,
+        enable_custom_integrations,
+    ):
+        """A stalled cleanup disconnect must not block the setup retry."""
+
+        async def _hangs(*args, **kwargs):
+            await asyncio.Event().wait()
+
+        with (
+            patch("custom_components.adjustable_bed.SETUP_TIMEOUT", 0.05),
+            patch("custom_components.adjustable_bed.SETUP_CLEANUP_TIMEOUT", 0.05),
+            patch(
+                "custom_components.adjustable_bed.coordinator.AdjustableBedCoordinator.async_connect",
+                new=_hangs,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.AdjustableBedCoordinator.async_disconnect",
+                new_callable=AsyncMock,
+                side_effect=_hangs,
+            ) as mock_disconnect,
+        ):
+            async with asyncio.timeout(5):
+                await hass.config_entries.async_setup(mock_config_entry.entry_id)
+                await hass.async_block_till_done()
+
+        assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+        mock_disconnect.assert_awaited_once_with(reason="setup timeout cleanup")
+
     async def test_setup_entry_connection_failed(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## Problem

Some OKIN CST receivers accept GATT reads on Device Information Service characteristics but **never answer them**. Every read stalls until bleak's internal timeout instead of failing fast. On an affected bed, three of these hung reads run back-to-back during every connection:

1. the bond verification probe (`model_number` read in `_async_verify_bonded`)
2. the manufacturer name read in `read_ble_device_info`
3. the model number read in `read_ble_device_info`

That's ~26 seconds of dead time per connection, which causes two user-visible failures:

- **Setup can never finish on a slow-waking bed.** A bed that was just repowered typically only accepts a connection on the 2nd or 3rd attempt. With `SETUP_TIMEOUT = 45.0`, the retry cycle gets cut short and the entry lands in `ConfigEntryNotReady` forever.
- **Every reconnect pays the stall again.** With idle-disconnect active, the first button press after idle triggers a reconnect that burns the same ~26s before the command goes out — the press feels dead and users press again.

## Fix

- Time-box the bond verification probe and both device-info reads at 5s (`DEVICE_INFO_READ_TIMEOUT` in `const.py`). The timeout lands in the existing `except (BleakError, TimeoutError)` / `except (TimeoutError, OSError)` handlers, so failure semantics are unchanged — it just fails in 5s instead of hanging.
- Once the bond probe times out, skip it for the rest of the session. A probe that times out (as opposed to raising an auth error) will time out again on every reconnect; genuine bond loss still surfaces as auth errors on real command writes.
- Cache the device-info result after the first read attempt and reuse it on reconnects. The values are static, and re-reading on every reconnect re-buys the stall on affected beds. Note: this intentionally also caches a `(None, None)` result — on affected hardware the reads never succeed, and retrying each reconnect costs 10s each time. Happy to switch to only-cache-success if you prefer.
- Raise `SETUP_TIMEOUT` to 120s so a full 3-attempt retry cycle (with backoff) fits inside the setup budget.
- On setup timeout, disconnect the coordinator before raising `ConfigEntryNotReady`, so a half-open BLE connection can't block the next retry.

## Field testing

Debugged and verified live against a Nectar adjustable base with an OKIN CST receiver (`bed_type: okin_cst`) on HA with a BlueZ adapter:

- **Before:** every connection log showed the three reads hanging back-to-back; setup after a power cycle failed repeatedly with `initial connection timed out after 45s`.
- **After:** power-cycled the bed cold; attempt 1 timed out while the receiver was still waking, attempt 2 connected, the timeboxed reads capped the ceremony, and full setup (all 9 platforms) completed in ~19s. Reconnects after idle-disconnect reuse the cached device info and skip the known-dead probe, so the first button press acts immediately. Presets (zero-g / flat / anti-snore) verified moving the physical bed across multiple reconnect cycles.

## Tests

- `pytest`: full suite passes (2080 passed)
- `ruff@0.15.16 check custom_components tests`: clean
- `pyright@1.1.410`: clean
- 4 new tests: hung DIS reads are time-boxed (`test_adapter.py`), bond-probe timeout sets the session skip flag and later probes are skipped (`test_coordinator.py`), device info is read once and reused across reconnects (`test_coordinator.py`), setup timeout tears down the half-open connection (`test_init.py`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup reliability by allowing more time for startup connections and handling cleanup failures more gracefully.
  * Prevented device information reads from hanging during connection attempts.
  * Reduced repeated retry delays by skipping certain failed checks for the rest of a session.
  * Cached device information across reconnects, which can make reconnects faster and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->