### PR TITLE
Fix BOX25 detection and presets

### DIFF
--- a/custom_components/adjustable_bed/beds/sleepys_box25.py
+++ b/custom_components/adjustable_bed/beds/sleepys_box25.py
@@ -15,7 +15,8 @@ The BOX25 protocol uses a two-track initialization system:
 Both tracks require a wake command (0x5A 0x0B 0x00 0xA5) first.
 
 Command formats:
-- Motor/Preset: 05 02 [b2] [b3] [b4] [b5] [b6] (7 bytes)
+- Motor:        05 02 [b2] [b3] [b4] [b5] [b6] (7 bytes)
+- Preset:       5A 01 03 10 30 [key] A5 (7 bytes)
 - Position:     03 F0 [zone] [pos 0-100] 00 (5 bytes)
 - Lighting:     04 E0 [sub] [val] 00 00 (6 bytes)
 - Vibration:    04 E0 06 [head 0-8] [foot 0-8] 00 (6 bytes)
@@ -112,7 +113,17 @@ class Box25Commands:
     STAR_PRESET_ZERO_GRAVITY = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x13, 0xA5])
     STAR_PRESET_ANTI_SNORE = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x16, 0xA5])
     STAR_PRESET_LOUNGE = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x17, 0xA5])  # app "reading"
+    STAR_PRESET_MEMORY_1 = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x1A, 0xA5])
+    STAR_PRESET_MEMORY_2 = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x1B, 0xA5])
+    STAR_MEMORY_PRESETS = (STAR_PRESET_MEMORY_1, STAR_PRESET_MEMORY_2)
     STAR_PRESET_TERMINATOR = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x0F, 0xA5])
+
+    # Saving a position is a long-press operation in the M1X12 app. It repeats
+    # the selected key 110 times at the sender's 100 ms interval, without a
+    # trailing terminator.
+    STAR_STORE_MEMORY_1 = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x94, 0xA5])
+    STAR_STORE_MEMORY_2 = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x95, 0xA5])
+    STAR_MEMORY_STORE = (STAR_STORE_MEMORY_1, STAR_STORE_MEMORY_2)
 
     # ─── Lighting (04 E0 prefix, 6 bytes) ────────────────────────────────
     LIGHT_OFF = bytes([0x04, 0xE0, 0x01, 0x00, 0x00, 0x00])
@@ -136,11 +147,11 @@ _INIT_DELAY = 0.08
 # packets drained 100 ms apart by its periodic BLE sender: the preset key ×3,
 # then a terminator that *commits* the preset — the bed arms while it keeps
 # receiving the key and only drives to the target once the terminator arrives.
-# For Star* devices the terminator is the StarCode 0x0F packet; the legacy CB25
-# memory path still uses the 05 02 00…00 STOP. See _send_preset (#372).
+# The terminator is the StarCode 0x0F packet. See _send_preset (#372).
 _PRESET_REPEAT_COUNT = 3
 _PRESET_REPEAT_DELAY_MS = 100
 _PRESET_COMMIT_DELAY = 0.1
+_MEMORY_STORE_REPEAT_COUNT = 110
 
 
 class SleepysBox25Controller(BedController):
@@ -150,8 +161,8 @@ class SleepysBox25Controller(BedController):
     motor commands require 0xD0 init, massage/light commands require 0xB0 init.
     Both tracks need a wake command (5A 0B 00 A5) sent first.
 
-    Presets are armed by repeating the preset key, then committed by a trailing
-    MOTOR_STOP — see _send_preset (#372).
+    Presets are armed by repeating the StarCode key, then committed by a trailing
+    StarCode 0x0F frame — see _send_preset (#372).
     """
 
     # Position feedback: head/feet/lumbar at 0-100 percentage
@@ -198,7 +209,7 @@ class SleepysBox25Controller(BedController):
 
     @property
     def memory_slot_count(self) -> int:
-        return 4
+        return 2
 
     @property
     def supports_memory_programming(self) -> bool:
@@ -409,9 +420,7 @@ class SleepysBox25Controller(BedController):
 
     # ─── Notification Handling ───────────────────────────────────────────
 
-    def _on_notification(
-        self, characteristic: BleakGATTCharacteristic, data: bytearray
-    ) -> None:
+    def _on_notification(self, characteristic: BleakGATTCharacteristic, data: bytearray) -> None:
         """Handle BLE notification data from the bed."""
         raw = bytes(data)
         self.forward_raw_notification(characteristic.uuid, raw)
@@ -445,9 +454,7 @@ class SleepysBox25Controller(BedController):
             if mode_byte in _MASSAGE_MODES:
                 self._massage_mode_index = _MASSAGE_MODES.index(mode_byte)
 
-    async def start_notify(
-        self, callback: Callable[[str, float], None] | None = None
-    ) -> None:
+    async def start_notify(self, callback: Callable[[str, float], None] | None = None) -> None:
         """Start listening for position notifications via Nordic UART RX."""
         from ..const import NORDIC_UART_READ_CHAR_UUID
 
@@ -582,8 +589,8 @@ class SleepysBox25Controller(BedController):
 
     # ─── Presets ─────────────────────────────────────────────────────────
 
-    async def _send_preset(self, preset_cmd: bytes, terminator: bytes) -> None:
-        """Send a preset (key ×3 at 100 ms), then commit it with `terminator`.
+    async def _send_preset(self, preset_cmd: bytes) -> None:
+        """Send a preset (key ×3 at 100 ms), then commit it with StarCode 0x0F.
 
         The decompiled "Adjustable Comfort M1X12" app (StarCode/DewertOkin CB25
         protocol, e.g. Star252201 / Ashley/Nectar M1X1232) sends every preset as
@@ -597,9 +604,8 @@ class SleepysBox25Controller(BedController):
         soon (the old 50 ms confirm) lands before the bed arms and cancels the
         preset — hence the key is repeated first to hold it long enough.
 
-        Star* devices use StarCode framing (5A 01 03 10 30 KK A5) and the 0x0F
-        StarCode terminator; the legacy CB25 memory path passes the 05 02 00…00
-        MOTOR_STOP. The terminator's framing must match its preset key's framing.
+        Star* devices use StarCode framing (5A 01 03 10 30 KK A5), including
+        Memory 1/2. The terminator's framing must match its preset key's framing.
         """
         try:
             await self.write_command(
@@ -612,53 +618,43 @@ class SleepysBox25Controller(BedController):
             try:
                 # Fresh cancel event so a pending Stop All can't suppress the
                 # commit packet — without it the preset never executes.
-                await self.write_command(terminator, cancel_event=asyncio.Event())
-            except (BleakError, ConnectionError):
+                await self.write_command(
+                    Box25Commands.STAR_PRESET_TERMINATOR,
+                    cancel_event=asyncio.Event(),
+                )
+            except BleakError, ConnectionError:
                 _LOGGER.debug(
                     "Failed to send committing terminator after preset",
                     exc_info=True,
                 )
 
     async def preset_flat(self) -> None:
-        await self._send_preset(
-            Box25Commands.STAR_PRESET_FLAT, Box25Commands.STAR_PRESET_TERMINATOR
-        )
+        await self._send_preset(Box25Commands.STAR_PRESET_FLAT)
 
     async def preset_zero_g(self) -> None:
-        await self._send_preset(
-            Box25Commands.STAR_PRESET_ZERO_GRAVITY, Box25Commands.STAR_PRESET_TERMINATOR
-        )
+        await self._send_preset(Box25Commands.STAR_PRESET_ZERO_GRAVITY)
 
     async def preset_anti_snore(self) -> None:
-        await self._send_preset(
-            Box25Commands.STAR_PRESET_ANTI_SNORE, Box25Commands.STAR_PRESET_TERMINATOR
-        )
+        await self._send_preset(Box25Commands.STAR_PRESET_ANTI_SNORE)
 
     async def preset_lounge(self) -> None:
         """Move bed to lounge or relax position."""
-        await self._send_preset(
-            Box25Commands.STAR_PRESET_LOUNGE, Box25Commands.STAR_PRESET_TERMINATOR
-        )
+        await self._send_preset(Box25Commands.STAR_PRESET_LOUNGE)
 
     async def preset_memory(self, memory_num: int) -> None:
-        if memory_num < 1 or memory_num > len(Box25Commands.MEMORY_RECALL):
-            _LOGGER.warning("Invalid memory slot %d (valid: 1-4)", memory_num)
+        if memory_num < 1 or memory_num > len(Box25Commands.STAR_MEMORY_PRESETS):
+            _LOGGER.warning("Invalid memory slot %d (valid: 1-2)", memory_num)
             return
-        # Memory recall/store still use the unverified CB25 keys + CB25 STOP
-        # terminator (#372 follow-up): the correct StarCode memory keys aren't
-        # pinned down yet, so this path is unchanged from the legacy behaviour.
-        await self._send_preset(
-            Box25Commands.MEMORY_RECALL[memory_num - 1], Box25Commands.MOTOR_STOP
-        )
+        await self._send_preset(Box25Commands.STAR_MEMORY_PRESETS[memory_num - 1])
 
     async def program_memory(self, memory_num: int) -> None:
-        if memory_num < 1 or memory_num > len(Box25Commands.MEMORY_STORE):
-            _LOGGER.warning("Invalid memory slot %d (valid: 1-4)", memory_num)
+        if memory_num < 1 or memory_num > len(Box25Commands.STAR_MEMORY_STORE):
+            _LOGGER.warning("Invalid memory slot %d (valid: 1-2)", memory_num)
             return
-        # Memory store uses the same arm-then-commit sequence as recall; see
-        # _send_preset for why a trailing terminator is required.
-        await self._send_preset(
-            Box25Commands.MEMORY_STORE[memory_num - 1], Box25Commands.MOTOR_STOP
+        await self.write_command(
+            Box25Commands.STAR_MEMORY_STORE[memory_num - 1],
+            repeat_count=_MEMORY_STORE_REPEAT_COUNT,
+            repeat_delay_ms=_PRESET_REPEAT_DELAY_MS,
         )
 
     # ─── Lights ──────────────────────────────────────────────────────────

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -65,7 +65,6 @@ from .const import (
     BED_TYPE_OCTO,
     BED_TYPE_OKIMAT,
     BED_TYPE_OKIN_7BYTE,
-    BED_TYPE_OKIN_CB35,
     BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_FFE,
     BED_TYPE_OKIN_HANDLE,
@@ -77,7 +76,6 @@ from .const import (
     BED_TYPE_SERTA,
     BED_TYPE_SLEEP_NUMBER,
     BED_TYPE_SLEEP_NUMBER_MCR,
-    BED_TYPE_SLEEPYS_BOX25,
     BED_TYPE_SOLACE,
     BED_TYPE_VIBRADORM,
     BEDS_WITH_ANGLE_SENSING,
@@ -142,6 +140,7 @@ from .const import (
 from .controller_factory import create_controller
 from .detection import (
     detect_richmat_remote_from_name,
+    refine_dewertokin_star_protocol_from_name,
     refine_malouf_protocol_from_gatt,
     refine_nordic_uart_protocol_from_device_info,
     refine_okin_dot_protocol_from_gatt,
@@ -1582,6 +1581,10 @@ class AdjustableBedCoordinator:
                     self._protocol_variant,
                     ble_model,
                 )
+                corrected_bed_type = refine_dewertokin_star_protocol_from_name(
+                    corrected_bed_type,
+                    device.name,
+                )
                 corrected_bed_type = refine_nordic_uart_protocol_from_device_info(
                     corrected_bed_type,
                     device.name,
@@ -1618,34 +1621,6 @@ class AdjustableBedCoordinator:
                         protocol_correction_pairing_retry_reserved = True
                         attempt_limit += 1
                     continue
-
-                # Post-connection protocol verification for DewertOkin Star devices.
-                # The adjustbed app (com.okin.bedding.adjustbed) reads BLE characteristic
-                # 2A29 (Manufacturer Name) after connecting: exactly "STAR" = CB35 protocol
-                # (35_22_01), anything else = BOX25 protocol (25_42_02).
-                if self._bed_type in (BED_TYPE_OKIN_CB35, BED_TYPE_SLEEPYS_BOX25):
-                    is_star_manufacturer = (
-                        ble_manufacturer is not None and ble_manufacturer.strip().upper() == "STAR"
-                    )
-                    if is_star_manufacturer and self._bed_type == BED_TYPE_SLEEPYS_BOX25:
-                        _LOGGER.warning(
-                            "BLE Manufacturer Name is 'STAR' for %s - this indicates a "
-                            "CB35 protocol device, but configured as BOX25. Auto-correcting "
-                            "to CB35. Source: com.okin.bedding.adjustbed 2A29 detection",
-                            self._address,
-                        )
-                        self._bed_type = BED_TYPE_OKIN_CB35
-                    elif not is_star_manufacturer and self._bed_type == BED_TYPE_OKIN_CB35:
-                        if ble_manufacturer is not None:
-                            _LOGGER.warning(
-                                "BLE Manufacturer Name is '%s' (not 'STAR') for %s - this "
-                                "indicates a BOX25 protocol device, but configured as CB35. "
-                                "Auto-correcting to BOX25. Source: com.okin.bedding.adjustbed "
-                                "2A29 detection",
-                                ble_manufacturer,
-                                self._address,
-                            )
-                            self._bed_type = BED_TYPE_SLEEPYS_BOX25
 
                 # If remote is set to auto, infer Richmat remote code from BLE name at runtime.
                 # This preserves compatibility for existing entries created before auto-code storage.

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -733,6 +733,29 @@ def refine_okin_dot_protocol_from_gatt(bed_type: str, gatt_services: Any) -> str
     return bed_type
 
 
+def refine_dewertokin_star_protocol_from_name(
+    bed_type: str,
+    device_name: str | None,
+) -> str:
+    """Correct CB35/BOX25 entries from the protocol digits in a Star name.
+
+    ``Star35...`` identifies CB35 while ``Star25...`` identifies BOX25.  Both
+    families can report ``STAR`` in Device Information characteristic 0x2A29;
+    the M1X12 app uses that value to select StarCode framing, not to distinguish
+    CB35 from BOX25.  Treating it as a CB35 discriminator caused a correctly
+    discovered Star25 entry to be overwritten on every connection (issue #413).
+    """
+    if bed_type not in {BED_TYPE_OKIN_CB35, BED_TYPE_SLEEPYS_BOX25}:
+        return bed_type
+
+    normalized_name = (device_name or "").strip().lower()
+    if normalized_name.startswith("star25"):
+        return BED_TYPE_SLEEPYS_BOX25
+    if normalized_name.startswith("star35"):
+        return BED_TYPE_OKIN_CB35
+    return bed_type
+
+
 def refine_nordic_uart_protocol_from_device_info(
     bed_type: str,
     device_name: str | None,

--- a/docs/beds/okin-cb35.md
+++ b/docs/beds/okin-cb35.md
@@ -16,7 +16,7 @@
 | Name digits 4-5 | `35` distinguishes CB35 from BOX25 (`25`) |
 | Service UUID | Nordic UART `6E400001-B5A3-F393-E0A9-E50E24DCCA9E` |
 | Manufacturer ID | 89 (OKIN) |
-| Manufacturer Name (2A29) | Exactly `STAR` (post-connection confirmation) |
+| Manufacturer Name (2A29) | `STAR` selects StarCode framing but is shared with BOX25 |
 
 ### Name Encoding
 
@@ -27,9 +27,14 @@ DewertOkin Star device names encode the protocol version: `Star` + `[protocol di
 | `Star352201011800` | `35` | CB.35.22.01 | CB35 (this protocol) |
 | `Star254202079996` | `25` | 25_42_02 | BOX25 (Sleepy's Elite) |
 
-### Post-Connection Verification
+### Manufacturer Name Is Not a Protocol Discriminator
 
-The `com.okin.bedding.adjustbed` app (which supports both CB35 and BOX25) reads BLE characteristic `2A29` (Manufacturer Name) from the Device Information Service (`180A`) after connecting. If it returns exactly `STAR` (4 bytes: 0x53 0x54 0x41 0x52), the device uses CB35. Otherwise it uses BOX25. The integration performs the same check to auto-correct if the name-based detection was wrong.
+Both confirmed `Star25...` BOX25 devices from issues #372 and #413 return
+`STAR` from Device Information characteristic `2A29`. The Adjustable Comfort
+M1X12 app uses this value to choose StarCode command framing within its CB25
+device implementation; it does not prove the device is CB35. The integration
+therefore uses the `25`/`35` digits in the advertised name and never rewrites a
+high-confidence `Star25...` detection from the manufacturer string alone.
 
 ## Protocol
 

--- a/docs/beds/sleepys.md
+++ b/docs/beds/sleepys.md
@@ -43,7 +43,7 @@ The Sleepy's Elite app supports multiple control box types. This integration imp
 | Neck Tilt Motor | ❌ | ❌ | ✅ |
 | Position Feedback | ❌ | ❌ | ✅ (0-100%) |
 | Direct Position Control | ❌ | ❌ | ✅ (protocol: head/feet/lumbar) |
-| Memory Presets | ❌ | ❌ | ✅ (4 slots) |
+| Memory Presets | ❌ | ❌ | ✅ (2 slots) |
 | Memory Programming | ❌ | ❌ | ✅ |
 | Flat Preset | ✅ | ✅ | ✅ |
 | Zero-G Preset | ✅ | ✅ | ✅ |
@@ -149,7 +149,7 @@ A5 5A 00 00 00 40 02
 
 **Notify Characteristic (RX):** `6E400003-B5A3-F393-E0A9-E50E24DCCA9E`
 
-**BLE Device Name:** Starts with `Star` (e.g., `Star1234`)
+**BLE Device Name:** Starts with `Star25` (e.g., `Star252201154718`)
 
 **Integration motor surface:** `head`, `feet`, `lumbar`, `tilt`
 
@@ -165,10 +165,9 @@ The BOX25 Star uses a multi-subsystem protocol with a two-track initialization:
 
 ```text
 [0-1]  Header: 05 02
-[2]    Flags (preset/exit)
+[2]    Flags
 [3]    Motor bitmask (directional)
-[4]    Preset/Memory store bitmask
-[5]    Memory recall bitmask
+[4-5]  Reserved for motor commands
 [6]    Reserved: 0x00
 ```
 
@@ -185,30 +184,30 @@ The BOX25 Star uses a multi-subsystem protocol with a two-track initialization:
 | 0x40 | Neck Tilt | Up |
 | 0x80 | Neck Tilt | Down |
 
-**Preset Commands (byte 2 or byte 4):**
+#### Preset and Memory Recall Commands (StarCode, 7 bytes)
 
-| Preset | Byte 2 | Byte 4 |
-|--------|--------|--------|
-| Flat | 0x08 | — |
-| Zero Gravity | — | 0x10 |
-| Lounge/Relax | — | 0x20 |
-| Ascent | — | 0x40 |
-| Anti-Snore | — | 0x80 |
+The Adjustable Comfort M1X12 app uses StarCode framing for presets:
 
-Presets require a confirmation: send the preset command, then send `MOTOR_STOP` (`05 02 00 00 00 00 00`).
+```text
+5A 01 03 10 30 [command] A5
+```
 
-**Memory Commands:**
+| Preset | Command |
+|--------|---------|
+| Flat | 0x10 |
+| Zero Gravity | 0x13 |
+| Anti-Snore | 0x16 |
+| Lounge/Reading | 0x17 |
+| Memory 1 | 0x1A |
+| Memory 2 | 0x1B |
 
-| Action | Slot | Byte 4 (store) | Byte 5 (recall) |
-|--------|------|-----------------|------------------|
-| Store | 1 | 0x01 | — |
-| Store | 2 | 0x02 | — |
-| Store | 3 | 0x04 | — |
-| Store | 4 | 0x08 | — |
-| Recall | 1 | — | 0x01 |
-| Recall | 2 | — | 0x02 |
-| Recall | 3 | — | 0x04 |
-| Recall | 4 | — | 0x08 |
+Each preset frame is sent three times at 100 ms intervals, followed 100 ms
+later by the StarCode commit frame `5A 01 03 10 30 0F A5`. Without that final
+frame the bed remains armed until STOP or BLE disconnect (issue #372).
+
+Saving Memory 1/2 uses command `0x94`/`0x95`, respectively. The app models this
+as a long press: it repeats the save frame 110 times at 100 ms intervals and
+does not append the preset commit frame.
 
 #### Position Commands (5 bytes, `03 F0` prefix)
 

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -104,6 +104,7 @@ from custom_components.adjustable_bed.detection import (
     detect_bed_type_detailed,
     detect_bed_type_from_gatt_services,
     detect_richmat_remote_from_name,
+    refine_dewertokin_star_protocol_from_name,
     refine_malouf_protocol_from_gatt,
     refine_nordic_uart_protocol_from_device_info,
     refine_okin_shared_uuid_protocol_from_gatt,
@@ -381,6 +382,46 @@ class TestDetectBedTypeByServiceUUID:
         assert "uuid:nordic_uart" in result.signals
         assert "star_digits:25" in result.signals
         assert not result.ambiguous_types
+
+    def test_runtime_refinement_keeps_star25_on_box25(self):
+        """A Star25 name remains BOX25 even though Device Info may say STAR (#413)."""
+        assert (
+            refine_dewertokin_star_protocol_from_name(
+                BED_TYPE_SLEEPYS_BOX25,
+                "Star252201053516",
+            )
+            == BED_TYPE_SLEEPYS_BOX25
+        )
+
+    def test_runtime_refinement_repairs_stale_star25_cb35_entry(self):
+        """A config entry poisoned by the former 2A29 override recovers to BOX25."""
+        assert (
+            refine_dewertokin_star_protocol_from_name(
+                BED_TYPE_OKIN_CB35,
+                "Star252201154718",
+            )
+            == BED_TYPE_SLEEPYS_BOX25
+        )
+
+    def test_runtime_refinement_repairs_star35_box25_entry(self):
+        """The name-based correction works in both directions."""
+        assert (
+            refine_dewertokin_star_protocol_from_name(
+                BED_TYPE_SLEEPYS_BOX25,
+                "Star352201011800",
+            )
+            == BED_TYPE_OKIN_CB35
+        )
+
+    def test_runtime_refinement_does_not_guess_from_ambiguous_star_name(self):
+        """Unknown Star digits preserve the user's selected protocol."""
+        assert (
+            refine_dewertokin_star_protocol_from_name(
+                BED_TYPE_SLEEPYS_BOX25,
+                "Star991234567890",
+            )
+            == BED_TYPE_SLEEPYS_BOX25
+        )
 
     def test_detect_star_unknown_digits_is_ambiguous(self):
         """Star with unknown digits plus Nordic UART should be ambiguous."""

--- a/tests/test_sleepys.py
+++ b/tests/test_sleepys.py
@@ -1093,12 +1093,8 @@ class TestSleepysProtocolDifferences:
         box24_coordinator = AdjustableBedCoordinator(hass, mock_sleepys_box24_config_entry)
         await box24_coordinator.async_connect()
 
-        box15_cmd = box15_coordinator.controller._build_motor_command(
-            SleepysBox15Commands.HEAD_UP
-        )
-        box24_cmd = box24_coordinator.controller._build_command(
-            SleepysBox24Commands.HEAD_UP
-        )
+        box15_cmd = box15_coordinator.controller._build_motor_command(SleepysBox15Commands.HEAD_UP)
+        box24_cmd = box24_coordinator.controller._build_command(SleepysBox24Commands.HEAD_UP)
         assert len(box15_cmd) == 9
         assert len(box24_cmd) == 7
 
@@ -1116,17 +1112,13 @@ class TestSleepysProtocolDifferences:
         box24_coordinator = AdjustableBedCoordinator(hass, mock_sleepys_box24_config_entry)
         await box24_coordinator.async_connect()
 
-        box15_cmd = box15_coordinator.controller._build_motor_command(
-            SleepysBox15Commands.HEAD_UP
-        )
+        box15_cmd = box15_coordinator.controller._build_motor_command(SleepysBox15Commands.HEAD_UP)
         # BOX15 checksum is in last byte
         expected_checksum = _calculate_box15_checksum(box15_cmd[0:8])
         assert box15_cmd[8] == expected_checksum
 
         # BOX24 has no checksum - last byte is the command itself
-        box24_cmd = box24_coordinator.controller._build_command(
-            SleepysBox24Commands.HEAD_UP
-        )
+        box24_cmd = box24_coordinator.controller._build_command(SleepysBox24Commands.HEAD_UP)
         assert box24_cmd[6] == SleepysBox24Commands.HEAD_UP
 
     async def test_different_characteristic_uuids(
@@ -1144,8 +1136,7 @@ class TestSleepysProtocolDifferences:
         await box24_coordinator.async_connect()
 
         assert (
-            box15_coordinator.controller.control_characteristic_uuid
-            == KEESON_BASE_WRITE_CHAR_UUID
+            box15_coordinator.controller.control_characteristic_uuid == KEESON_BASE_WRITE_CHAR_UUID
         )
         assert (
             box24_coordinator.controller.control_characteristic_uuid
@@ -1282,13 +1273,13 @@ class TestSleepysBox25Controller:
         assert commit_call.args[0] == Box25Commands.STAR_PRESET_TERMINATOR
         assert isinstance(commit_call.kwargs["cancel_event"], asyncio.Event)
 
-    async def test_named_presets_use_starcode_frames(
+    async def test_named_and_memory_presets_use_starcode_frames(
         self,
         hass: HomeAssistant,
         mock_sleepys_box25_config_entry,
         mock_coordinator_connected,
     ):
-        """Each named preset sends its StarCode arm frame, then the terminator."""
+        """Every M1X12 preset sends its StarCode arm frame, then the terminator."""
         coordinator = AdjustableBedCoordinator(hass, mock_sleepys_box25_config_entry)
         await coordinator.async_connect()
         controller = coordinator.controller
@@ -1298,6 +1289,8 @@ class TestSleepysBox25Controller:
             (controller.preset_zero_g, Box25Commands.STAR_PRESET_ZERO_GRAVITY),
             (controller.preset_anti_snore, Box25Commands.STAR_PRESET_ANTI_SNORE),
             (controller.preset_lounge, Box25Commands.STAR_PRESET_LOUNGE),
+            (lambda: controller.preset_memory(1), Box25Commands.STAR_PRESET_MEMORY_1),
+            (lambda: controller.preset_memory(2), Box25Commands.STAR_PRESET_MEMORY_2),
         )
         for method, arm_frame in cases:
             # StarCode framing: 5A 01 … A5, 7 bytes.
@@ -1317,34 +1310,47 @@ class TestSleepysBox25Controller:
             assert mock_write.call_args_list[0].args[0] == arm_frame
             assert mock_write.call_args_list[1].args[0] == Box25Commands.STAR_PRESET_TERMINATOR
 
-    async def test_program_memory_arms_then_commits_with_stop(
+    async def test_program_memory_uses_starcode_long_press_sequence(
         self,
         hass: HomeAssistant,
         mock_sleepys_box25_config_entry,
         mock_coordinator_connected,
     ):
-        """Memory store still uses the legacy CB25 key + CB25 MOTOR_STOP (#372 follow-up).
-
-        The correct StarCode memory keys aren't pinned down yet, so the memory
-        path is intentionally left on the unverified CB25 framing.
-        """
+        """Memory store repeats the StarCode save key like the M1X12 app."""
         coordinator = AdjustableBedCoordinator(hass, mock_sleepys_box25_config_entry)
         await coordinator.async_connect()
         controller = coordinator.controller
 
-        with (
-            patch.object(controller, "write_command", AsyncMock()) as mock_write,
-            patch("custom_components.adjustable_bed.beds.sleepys_box25.asyncio.sleep", AsyncMock()),
+        for slot, command in (
+            (1, Box25Commands.STAR_STORE_MEMORY_1),
+            (2, Box25Commands.STAR_STORE_MEMORY_2),
         ):
-            await controller.program_memory(1)
+            with patch.object(controller, "write_command", AsyncMock()) as mock_write:
+                await controller.program_memory(slot)
 
-        assert mock_write.await_count == 2
-        arm_call = mock_write.call_args_list[0]
-        assert arm_call.args[0] == Box25Commands.MEMORY_STORE[0]
-        assert arm_call.kwargs == {"repeat_count": 3, "repeat_delay_ms": 100}
-        commit_call = mock_write.call_args_list[1]
-        assert commit_call.args[0] == Box25Commands.MOTOR_STOP
-        assert isinstance(commit_call.kwargs["cancel_event"], asyncio.Event)
+            mock_write.assert_awaited_once_with(
+                command,
+                repeat_count=110,
+                repeat_delay_ms=100,
+            )
+
+    async def test_box25_exposes_only_the_two_app_memory_slots(
+        self,
+        hass: HomeAssistant,
+        mock_sleepys_box25_config_entry,
+        mock_coordinator_connected,
+    ):
+        """M1X12 has Memory 1/2; stale guessed slots 3/4 must stay hidden."""
+        coordinator = AdjustableBedCoordinator(hass, mock_sleepys_box25_config_entry)
+        await coordinator.async_connect()
+
+        assert coordinator.controller.memory_slot_count == 2
+
+        with patch.object(coordinator.controller, "write_command", AsyncMock()) as mock_write:
+            await coordinator.controller.preset_memory(3)
+            await coordinator.controller.program_memory(3)
+
+        mock_write.assert_not_awaited()
 
     async def test_set_motor_position_supports_lumbar(
         self,


### PR DESCRIPTION
## Summary

- keep `Star25...` devices on the BOX25 protocol and repair entries previously rewritten to CB35
- send BOX25 presets and Memory 1/2 using the M1X12 app's verified StarCode arm/commit sequence
- expose only the two supported memory slots and use the verified long-press save commands
- update protocol documentation and regression coverage

## Root cause

Both BOX25 and CB35 devices can report `STAR` from Device Information characteristic `0x2A29`. The integration incorrectly treated that shared value as proof of CB35 and overrode the stronger `Star25...` name signal. BOX25 memory recalls were also still using legacy CB25 frames instead of the StarCode sequence used by the official M1X12 app.

## Validation

- Ruff checks passed
- `tests/test_detection.py tests/test_sleepys.py`: 309 passed
- `tests/test_coordinator.py tests/test_entities.py`: 142 passed

Closes #413
Closes #372