### PR TITLE
Fix BedTech QRRM under-bed lights

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -31,6 +31,7 @@ from .const import (
     BED_TYPE_SLEEPYS_BOX25,
     BED_TYPE_VIBRADORM,
     BEDS_WITH_POSITION_FEEDBACK,
+    BEDTECH_MANUFACTURER_ID,
     BEDTECH_SERVICE_UUID,
     CONF_BED_TYPE,
     CONF_DISABLE_ANGLE_SENSING,
@@ -49,12 +50,10 @@ from .const import (
     DOMAIN,
     KEESON_VARIANT_ERGOMOTION,
     OKIN_CST_POSITION_AXES,
-    RICHMAT_REMOTE_AUTO,
     VARIANT_AUTO,
     requires_pairing,
 )
 from .coordinator import AdjustableBedCoordinator
-from .detection import detect_richmat_remote_from_name
 from .kaidi_metadata import add_kaidi_entry_metadata, resolve_kaidi_advertisement
 from .unsupported import (
     async_clear_unsupported_device_issues,
@@ -290,7 +289,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     await _async_register_services(hass)
 
-    await _async_maybe_reclassify_legacy_bedtech_entry(hass, entry)
+    await _async_maybe_reclassify_bedtech_qrrm_entry(hass, entry)
     _maybe_cache_kaidi_metadata(hass, entry)
 
     _LOGGER.info(
@@ -399,18 +398,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
 
-async def _async_maybe_reclassify_legacy_bedtech_entry(
+async def _async_maybe_reclassify_bedtech_qrrm_entry(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> None:
-    """Correct legacy BedTech entries that were created for Richmat QRRM beds.
+    """Correct BedTech QRRM entries previously persisted as Richmat.
 
-    BedTech and Richmat WiLinke share the FEE9 service, and older versions of
-    the integration could persist QRRM devices as `bedtech`. That leaves the
-    entry sending BedTech preset/light bytes to a Richmat controller, which is
-    why issue #243 reported lounge and light commands either doing nothing or
-    triggering the wrong behavior.
+    QRRM is used by both BedTech white-light controllers and Richmat/Casper RGB
+    controllers. Older releases treated every QRRM name as Richmat. Confirmed
+    BedTech controllers additionally advertise manufacturer ID 0x4C57, so only
+    that positive signal is used for this one-way correction. Keeping the
+    correction one-way avoids oscillating if a later advertisement omits data.
     """
-    if entry.data.get(CONF_BED_TYPE) != BED_TYPE_BEDTECH:
+    if entry.data.get(CONF_BED_TYPE) != BED_TYPE_RICHMAT:
         return
 
     address = entry.data.get(CONF_ADDRESS)
@@ -428,26 +427,28 @@ async def _async_maybe_reclassify_legacy_bedtech_entry(
         return
 
     device_name = getattr(service_info, "name", None)
-    detected_remote = detect_richmat_remote_from_name(device_name)
-    if not detected_remote:
+    if not isinstance(device_name, str) or not device_name.lower().startswith("qrrm"):
+        return
+
+    manufacturer_data = getattr(service_info, "manufacturer_data", None) or {}
+    if BEDTECH_MANUFACTURER_ID not in manufacturer_data:
         return
 
     new_data = {
         **entry.data,
-        CONF_BED_TYPE: BED_TYPE_RICHMAT,
+        CONF_BED_TYPE: BED_TYPE_BEDTECH,
         CONF_PROTOCOL_VARIANT: VARIANT_AUTO,
     }
-    if entry.data.get(CONF_RICHMAT_REMOTE, RICHMAT_REMOTE_AUTO) == RICHMAT_REMOTE_AUTO:
-        new_data[CONF_RICHMAT_REMOTE] = detected_remote
+    new_data.pop(CONF_RICHMAT_REMOTE, None)
 
     hass.config_entries.async_update_entry(entry, data=new_data)
     _LOGGER.warning(
-        "Corrected config entry %s (%s) from BedTech to Richmat because BLE name %r "
-        "matches Richmat remote %r on the shared FEE9 service",
+        "Corrected config entry %s (%s) from Richmat to BedTech because BLE name %r "
+        "uses the shared FEE9 service and advertises BedTech manufacturer ID 0x%04X",
         entry.title,
         entry.entry_id,
         device_name,
-        detected_remote,
+        BEDTECH_MANUFACTURER_ID,
     )
 
 

--- a/custom_components/adjustable_bed/beds/bedtech.py
+++ b/custom_components/adjustable_bed/beds/bedtech.py
@@ -88,25 +88,25 @@ class BedTechCommands:
     MASSAGE_TIMER_20 = "c"  # 0x63
     MASSAGE_TIMER_30 = "a"  # 0x61
 
-    # Light control
-    LIGHT_GO = "."  # 0x2E
-    LIGHT_SAVE = "+"  # 0x2B
+    # Memory slots. The OEM APK names these memory.one and memory.two.
+    MEMORY_1_GO = "."  # 0x2E
+    MEMORY_1_SAVE = "+"  # 0x2B
+    MEMORY_2_GO = "/"  # 0x2F
+    MEMORY_2_SAVE = ","  # 0x2C
+
+    # Light control. The OEM app exposes OFF and TOGGLE, but no discrete ON.
     LIGHT_OFF = "u"  # 0x75
     LIGHT_TOGGLE = "<"  # 0x3C
 
-    # Light2 (dual base)
-    LIGHT2_GO = "_."
-    LIGHT2_SAVE = "_+"
+    # Secondary-base light control
     LIGHT2_OFF = "_u"
     LIGHT2_TOGGLE = "_<"
 
-    # Memory
-    MEMORY_GO = "/"  # 0x2F
-    MEMORY_SAVE = ","  # 0x2C
-
-    # Memory2 (dual base)
-    MEMORY2_GO = "_/"
-    MEMORY2_SAVE = "_,"
+    # Secondary-base memory slots
+    MEMORY2_1_GO = "_."
+    MEMORY2_1_SAVE = "_+"
+    MEMORY2_2_GO = "_/"
+    MEMORY2_2_SAVE = "_,"
 
 
 def build_bedtech_command(cmd_char: str) -> bytes:
@@ -192,8 +192,8 @@ class BedTechController(BedController):
 
     @property
     def supports_discrete_light_control(self) -> bool:
-        """Return True - BedTech supports discrete on/off control."""
-        return True
+        """Return False because the BedTech app has no discrete ON command."""
+        return False
 
     @property
     def has_pillow_support(self) -> bool:
@@ -348,8 +348,8 @@ class BedTechController(BedController):
     async def preset_memory(self, memory_num: int) -> None:
         """Go to memory preset."""
         commands = {
-            1: BedTechCommands.MEMORY_GO,
-            2: BedTechCommands.MEMORY2_GO if self._is_dual_base else BedTechCommands.MEMORY_GO,
+            1: BedTechCommands.MEMORY_1_GO,
+            2: BedTechCommands.MEMORY_2_GO,
         }
         if cmd_char := commands.get(memory_num):
             await self.write_command(self._build_command(cmd_char))
@@ -359,8 +359,8 @@ class BedTechController(BedController):
     async def program_memory(self, memory_num: int) -> None:
         """Program current position to memory."""
         commands = {
-            1: BedTechCommands.MEMORY_SAVE,
-            2: BedTechCommands.MEMORY2_SAVE if self._is_dual_base else BedTechCommands.MEMORY_SAVE,
+            1: BedTechCommands.MEMORY_1_SAVE,
+            2: BedTechCommands.MEMORY_2_SAVE,
         }
         if cmd_char := commands.get(memory_num):
             await self.write_command(self._build_command(cmd_char))
@@ -385,8 +385,12 @@ class BedTechController(BedController):
 
     # Light methods
     async def lights_on(self) -> None:
-        """Turn on under-bed lights."""
-        await self.write_command(self._build_command(BedTechCommands.LIGHT_GO))
+        """Toggle under-bed lights, matching the OEM app's light button.
+
+        The protocol has a discrete OFF command but no discrete ON command.
+        Command `.` was previously used here but is memory-slot-1 recall.
+        """
+        await self.lights_toggle()
 
     async def lights_off(self) -> None:
         """Turn off under-bed lights."""

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -308,9 +308,13 @@ RICHMAT_NORDIC_SERVICE_UUID: Final = NORDIC_UART_SERVICE_UUID
 RICHMAT_NORDIC_CHAR_UUID: Final = NORDIC_UART_WRITE_CHAR_UUID
 
 # BedTech specific UUIDs (FEE9 service with d44bc439 characteristic)
-# Note: Shares FEE9 service with Richmat WiLinke but uses different packet format
+# Note: Shares FEE9 service with Richmat WiLinke but uses different packet format.
+# Confirmed BedTech QRRM advertisements expose the controller MAC as manufacturer
+# data under company ID 0x4C57 (the little-endian form of the 57:4C MAC prefix).
+# Richmat/Casper QRRM captures using the RGB-strip protocol omit this field.
 BEDTECH_SERVICE_UUID: Final = "0000fee9-0000-1000-8000-00805f9b34fb"
 BEDTECH_WRITE_CHAR_UUID: Final = "d44bc439-abfd-45a2-b575-925416129600"
+BEDTECH_MANUFACTURER_ID: Final = 0x4C57
 
 # WiLinke variants (5-byte commands with checksum)
 # Source: com.desarketing.gmmotor (Germany Motions) APK blutter decompilation

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -76,6 +76,7 @@ from .const import (
     BED_TYPE_TIMOTION_AHF,
     BED_TYPE_VIBRADORM,
     # Detection constants
+    BEDTECH_MANUFACTURER_ID,
     BEDTECH_NAME_PATTERNS,
     BEDTECH_SERVICE_UUID,
     BEDTECH_WRITE_CHAR_UUID,
@@ -1490,8 +1491,37 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
             requires_characteristic_check=True,
         )
 
-    # Check for BedTech - name-based detection (before Richmat WiLinke since same UUID)
-    # BedTech shares FEE9 service UUID with Richmat WiLinke
+    # Check for BedTech before Richmat WiLinke since they share FEE9 and QRRM
+    # names. Confirmed BedTech QRRM controllers advertise their MAC suffix under
+    # manufacturer ID 0x4C57; confirmed Casper/Richmat QRRM RGB controllers do not.
+    has_bedtech_manufacturer = (
+        BEDTECH_MANUFACTURER_ID in (service_info.manufacturer_data or {})
+        and (
+            device_name.startswith("qrrm")
+            or any(pattern in device_name for pattern in BEDTECH_NAME_PATTERNS)
+        )
+    )
+    if has_bedtech_manufacturer and BEDTECH_SERVICE_UUID.lower() in service_uuids:
+        signals.extend(
+            [
+                f"uuid:{BEDTECH_SERVICE_UUID.lower()}",
+                f"manufacturer_id:{BEDTECH_MANUFACTURER_ID}",
+            ]
+        )
+        _LOGGER.info(
+            "Detected BedTech bed at %s (name: %s) by FEE9 UUID + manufacturer ID 0x%04X",
+            service_info.address,
+            service_info.name,
+            BEDTECH_MANUFACTURER_ID,
+        )
+        return DetectionResult(
+            bed_type=BED_TYPE_BEDTECH,
+            confidence=0.95,
+            signals=signals,
+            manufacturer_id=BEDTECH_MANUFACTURER_ID,
+        )
+
+    # BedTech-branded names remain a strong signal even without manufacturer data.
     if any(pattern in device_name for pattern in BEDTECH_NAME_PATTERNS):
         if BEDTECH_SERVICE_UUID.lower() in service_uuids:
             signals.append(f"uuid:{BEDTECH_SERVICE_UUID.lower()}")

--- a/docs/beds/bedtech.md
+++ b/docs/beds/bedtech.md
@@ -35,7 +35,10 @@
 > [!NOTE]
 > BedTech shares the FEE9 service UUID and characteristic with Richmat WiLinke.
 > Both use a similar 5-byte command format with `0x6E` prefix.
-> Manual bed type selection may be required if auto-detection selects the wrong type.
+> QRRM controllers that advertise manufacturer ID `0x4C57` are identified as
+> BedTech; QRRM controllers without that field remain Richmat (including the
+> confirmed Casper RGB-light controller). Manual selection may still be required
+> if an advertisement omits the manufacturer field.
 
 ### Packet Format
 
@@ -80,8 +83,10 @@ Commands use ASCII character codes. The last byte is a simple checksum.
 
 | Command | Char | Hex | Description |
 |---------|------|-----|-------------|
-| Memory Go | `/` | `0x2F` | Go to memory position |
-| Memory Save | `,` | `0x2C` | Save current position |
+| Memory 1 Go | `.` | `0x2E` | Go to memory position 1 |
+| Memory 1 Save | `+` | `0x2B` | Save memory position 1 |
+| Memory 2 Go | `/` | `0x2F` | Go to memory position 2 |
+| Memory 2 Save | `,` | `0x2C` | Save memory position 2 |
 
 ### Massage
 
@@ -117,10 +122,11 @@ Commands use ASCII character codes. The last byte is a simple checksum.
 
 | Command | Char | Hex | Description |
 |---------|------|-----|-------------|
-| Light On | `.` | `0x2E` | Turn light on |
-| Light Save | `+` | `0x2B` | Save light setting |
 | Light Off | `u` | `0x75` | Turn light off |
 | Light Toggle | `<` | `0x3C` | Toggle light |
+
+The official app exposes the light as a toggle button. There is no discrete
+light-on command; `.` and `+` belong to memory slot 1.
 
 ## Dual Base Commands
 

--- a/docs/beds/richmat.md
+++ b/docs/beds/richmat.md
@@ -72,6 +72,10 @@ Brands using Richmat actuators:
 **Format:** 5 bytes `[0x6E, 0x01, 0x00, command, checksum]`
 **Checksum:** `(command + 111) & 0xFF`
 
+FEE9/QRRM advertisements are shared with BedTech. A confirmed BedTech-specific
+manufacturer field (`0x4C57`) selects the BedTech protocol; QRRM devices without
+that field retain Richmat behavior, including the confirmed Casper RGB-light model.
+
 ### Prefix55 Variant
 **Format:** 5 bytes `[0x55, 0x01, 0x00, command, checksum]`
 **Checksum:** `(command + 0x56) & 0xFF`

--- a/tests/test_bedtech.py
+++ b/tests/test_bedtech.py
@@ -104,14 +104,15 @@ class TestBedTechCommands:
 
     def test_light_commands(self):
         """Light commands should be defined."""
-        assert BedTechCommands.LIGHT_GO == "."
         assert BedTechCommands.LIGHT_OFF == "u"
         assert BedTechCommands.LIGHT_TOGGLE == "<"
 
     def test_memory_commands(self):
         """Memory commands should be defined."""
-        assert BedTechCommands.MEMORY_GO == "/"
-        assert BedTechCommands.MEMORY_SAVE == ","
+        assert BedTechCommands.MEMORY_1_GO == "."
+        assert BedTechCommands.MEMORY_1_SAVE == "+"
+        assert BedTechCommands.MEMORY_2_GO == "/"
+        assert BedTechCommands.MEMORY_2_SAVE == ","
 
 
 # -----------------------------------------------------------------------------
@@ -277,11 +278,12 @@ class TestBedTechController:
         mock_bedtech_config_entry,
         mock_coordinator_connected,
     ):
-        """BedTech should support discrete light control."""
+        """BedTech should be toggle-only because it has no explicit ON command."""
         coordinator = AdjustableBedCoordinator(hass, mock_bedtech_config_entry)
         await coordinator.async_connect()
 
-        assert coordinator.controller.supports_discrete_light_control is True
+        assert coordinator.controller.supports_discrete_light_control is False
+        assert coordinator.controller.supports_light_toggle_control is True
 
     async def test_has_pillow_support(
         self,
@@ -419,6 +421,54 @@ class TestBedTechPresets:
         call_data = calls[0][0][1]
         assert call_data[3] == ord(BedTechCommands.PRESET_ANTI_SNORE)
 
+    @pytest.mark.parametrize(
+        ("memory_num", "expected_command"),
+        [
+            (1, BedTechCommands.MEMORY_1_GO),
+            (2, BedTechCommands.MEMORY_2_GO),
+        ],
+    )
+    async def test_memory_recall_uses_oem_slot_commands(
+        self,
+        hass: HomeAssistant,
+        mock_bedtech_config_entry,
+        mock_coordinator_connected,
+        memory_num: int,
+        expected_command: str,
+    ):
+        """Memory recall should use `.` for slot 1 and `/` for slot 2."""
+        coordinator = AdjustableBedCoordinator(hass, mock_bedtech_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.preset_memory(memory_num)
+
+        call_data = coordinator._client.write_gatt_char.call_args_list[0][0][1]
+        assert call_data[3] == ord(expected_command)
+
+    @pytest.mark.parametrize(
+        ("memory_num", "expected_command"),
+        [
+            (1, BedTechCommands.MEMORY_1_SAVE),
+            (2, BedTechCommands.MEMORY_2_SAVE),
+        ],
+    )
+    async def test_memory_programming_uses_oem_slot_commands(
+        self,
+        hass: HomeAssistant,
+        mock_bedtech_config_entry,
+        mock_coordinator_connected,
+        memory_num: int,
+        expected_command: str,
+    ):
+        """Memory save should use `+` for slot 1 and `,` for slot 2."""
+        coordinator = AdjustableBedCoordinator(hass, mock_bedtech_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.program_memory(memory_num)
+
+        call_data = coordinator._client.write_gatt_char.call_args_list[0][0][1]
+        assert call_data[3] == ord(expected_command)
+
 
 class TestBedTechLights:
     """Test BedTech light commands."""
@@ -429,7 +479,7 @@ class TestBedTechLights:
         mock_bedtech_config_entry,
         mock_coordinator_connected,
     ):
-        """lights_on should send LIGHT_GO command."""
+        """lights_on should use TOGGLE because the APK has no discrete ON command."""
         coordinator = AdjustableBedCoordinator(hass, mock_bedtech_config_entry)
         await coordinator.async_connect()
         mock_client = coordinator._client
@@ -438,7 +488,7 @@ class TestBedTechLights:
 
         calls = mock_client.write_gatt_char.call_args_list
         call_data = calls[0][0][1]
-        assert call_data[3] == ord(BedTechCommands.LIGHT_GO)
+        assert call_data[3] == ord(BedTechCommands.LIGHT_TOGGLE)
 
     async def test_lights_off_sends_correct_command(
         self,

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -53,6 +53,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_SVANE,
     BED_TYPE_TIMOTION_AHF,
     BED_TYPE_VIBRADORM,
+    BEDTECH_MANUFACTURER_ID,
     BEDTECH_SERVICE_UUID,
     COMFORT_MOTION_LIERDA3_SERVICE_UUID,
     DEVICE_INFO_SERVICE_UUID,
@@ -1582,6 +1583,19 @@ class TestFEE9UUIDDisambiguation:
         assert result.bed_type == BED_TYPE_RICHMAT
         assert result.confidence == 0.9
         assert result.detected_remote == "qrrm"
+
+    def test_fee9_qrrm_with_bedtech_manufacturer_prefers_bedtech(self):
+        """BedTech's manufacturer field disambiguates QRRM from Casper RGB beds."""
+        service_info = _make_service_info(
+            name="QRRM157738",
+            service_uuids=[BEDTECH_SERVICE_UUID],
+            manufacturer_data={BEDTECH_MANUFACTURER_ID: bytes.fromhex("54307651")},
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type == BED_TYPE_BEDTECH
+        assert result.confidence == 0.95
+        assert result.manufacturer_id == BEDTECH_MANUFACTURER_ID
+        assert f"manufacturer_id:{BEDTECH_MANUFACTURER_ID}" in result.signals
 
     def test_fee9_with_mlrm_name(self):
         """Test Leggett WiLinke detection with FEE9 UUID + MlRM prefix."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -32,6 +32,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_RICHMAT,
     BED_TYPE_SLEEPYS_BOX25,
     BED_TYPE_VIBRADORM,
+    BEDTECH_MANUFACTURER_ID,
     BEDTECH_SERVICE_UUID,
     CONF_BACK_MAX_ANGLE,
     CONF_BED_TYPE,
@@ -189,7 +190,7 @@ class TestIntegrationSetup:
         devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
         assert len(devices) == 1
 
-    async def test_setup_entry_reclassifies_legacy_bedtech_qrrm_entry(
+    async def test_setup_entry_reclassifies_bedtech_qrrm_richmat_entry(
         self,
         hass: HomeAssistant,
         mock_coordinator_connected,
@@ -197,30 +198,34 @@ class TestIntegrationSetup:
         mock_async_ble_device_from_address: MagicMock,
         enable_custom_integrations,
     ):
-        """Legacy BedTech entries should be corrected to Richmat for QRRM devices."""
+        """A BedTech manufacturer advert should correct a persisted Richmat QRRM entry."""
         entry = MockConfigEntry(
             domain=DOMAIN,
-            title="Legacy BedTech QRRM",
+            title="QRRM157738",
             data={
-                CONF_ADDRESS: "57:4C:54:30:77:FA",
-                CONF_NAME: "Legacy Bed",
-                CONF_BED_TYPE: BED_TYPE_BEDTECH,
+                CONF_ADDRESS: "57:4C:54:30:76:51",
+                CONF_NAME: "QRRM157738",
+                CONF_BED_TYPE: BED_TYPE_RICHMAT,
+                CONF_RICHMAT_REMOTE: "qrrm",
                 CONF_MOTOR_COUNT: 2,
                 CONF_HAS_MASSAGE: True,
                 CONF_DISABLE_ANGLE_SENSING: True,
                 CONF_PREFERRED_ADAPTER: "auto",
             },
-            unique_id="57:4C:54:30:77:FA",
-            entry_id="legacy_bedtech_qrrm",
+            unique_id="57:4C:54:30:76:51",
+            entry_id="bedtech_qrrm_as_richmat",
         )
         entry.add_to_hass(hass)
 
         service_info = MagicMock()
-        service_info.name = "QRRM138330"
-        service_info.address = "57:4C:54:30:77:FA"
+        service_info.name = "QRRM157738"
+        service_info.address = "57:4C:54:30:76:51"
         service_info.service_uuids = [BEDTECH_SERVICE_UUID]
+        service_info.manufacturer_data = {
+            BEDTECH_MANUFACTURER_ID: bytes.fromhex("54307651")
+        }
 
-        mock_async_ble_device_from_address.return_value.name = "QRRM138330"
+        mock_async_ble_device_from_address.return_value.name = "QRRM157738"
 
         with (
             patch(
@@ -236,10 +241,60 @@ class TestIntegrationSetup:
             await hass.async_block_till_done()
 
         assert entry.state == ConfigEntryState.LOADED
-        assert entry.data[CONF_BED_TYPE] == BED_TYPE_RICHMAT
-        assert entry.data[CONF_RICHMAT_REMOTE] == "qrrm"
+        assert entry.data[CONF_BED_TYPE] == BED_TYPE_BEDTECH
+        assert CONF_RICHMAT_REMOTE not in entry.data
         coordinator = hass.data[DOMAIN][entry.entry_id]
-        assert coordinator._bed_type == BED_TYPE_RICHMAT
+        assert coordinator._bed_type == BED_TYPE_BEDTECH
+        assert coordinator.controller.__class__.__name__ == "BedTechController"
+
+    async def test_setup_entry_keeps_casper_qrrm_as_richmat_without_bedtech_manufacturer(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        mock_async_ble_device_from_address: MagicMock,
+        enable_custom_integrations,
+    ):
+        """A QRRM entry without the BedTech field should retain Casper RGB behavior."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Casper Adjustable Base Max",
+            data={
+                CONF_ADDRESS: "57:4C:62:C3:39:05",
+                CONF_NAME: "Casper Adjustable Base Max",
+                CONF_BED_TYPE: BED_TYPE_RICHMAT,
+                CONF_RICHMAT_REMOTE: "qrrm",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: True,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="57:4C:62:C3:39:05",
+            entry_id="casper_qrrm",
+        )
+        entry.add_to_hass(hass)
+
+        service_info = MagicMock()
+        service_info.name = "QRRM105550"
+        service_info.address = "57:4C:62:C3:39:05"
+        service_info.service_uuids = [BEDTECH_SERVICE_UUID]
+        service_info.manufacturer_data = {}
+        mock_async_ble_device_from_address.return_value.name = "QRRM105550"
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.bluetooth.async_last_service_info",
+                return_value=service_info,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.bluetooth.async_last_service_info",
+                return_value=service_info,
+            ),
+        ):
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert entry.data[CONF_BED_TYPE] == BED_TYPE_RICHMAT
+        coordinator = hass.data[DOMAIN][entry.entry_id]
         assert coordinator.controller.__class__.__name__ == "RichmatController"
 
 


### PR DESCRIPTION
## Summary

- distinguish BedTech QRRM controllers from Casper/Richmat QRRM controllers using the confirmed `0x4C57` manufacturer field
- correct affected persisted Richmat entries to the BedTech controller without oscillating when later advertisements omit manufacturer data
- align BedTech light and memory commands with the BedTech 7.1.3 APK: light toggle is `<`, light off is `u`, and `.` / `+` belong to memory slot 1
- expose BedTech lighting as toggle-only because the OEM protocol has no discrete light-on command

## Root cause

QRRM names and the FEE9 GATT service are shared by BedTech and Richmat/Casper hardware. The integration classified all QRRM devices as Richmat, causing BedTech beds to receive Casper RGB frames. The BedTech controller also mislabeled memory-slot-1 commands as light commands.

## Impact

Affected BedTech beds now use the verified five-byte toggle packet with write-without-response, while confirmed Casper RGB-light behavior remains unchanged.

## Validation

- `589 passed` across BedTech, detection, setup, Richmat, entity, and controller-contract tests
- Ruff checks passed
- full workspace regression suite: `2087 passed`

Closes #410