### PR TITLE
Require a Richmat name to detect W4 (FFF0) WiLinke beds

### DIFF
--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -321,6 +321,15 @@ BEDTECH_MANUFACTURER_ID: Final = 0x4C57
 # The app supports 6 BLE variants (Nordic + W1-W5), we track the WiLinke ones here
 # W1 is the default fallback when no specific service is found
 RICHMAT_WILINKE_W1_SERVICE_UUID: Final = "0000fee9-0000-1000-8000-00805f9b34fb"
+# W4 uses the generic FFF0 short UUID, which countless non-bed BLE devices also
+# advertise (a "NO_DVR-*" camera system in issue #418, plus LED strips, scales,
+# etc.), so it is NOT bed-unique. All known W4 beds are Germany Motions units
+# named "DHN-*" (issue #163; confirmed against the GM Bed Control 4.6.0 APK,
+# whose scan is unfiltered and which identifies beds by name/remote code), so
+# detection must require a corroborating Richmat name signal before treating a
+# W4 advertisement as a bed. FFF0 stays in manifest.json because SUTA and the
+# Keeson Sino fallback also discover via it (both name-guarded too).
+RICHMAT_WILINKE_W4_SERVICE_UUID: Final = "0000fff0-0000-1000-8000-00805f9b34fb"
 # W5 uses a Telink-style custom 128-bit base (the "0xe0ff" is the little-endian
 # encoding of the generic 0xFFE0 short UUID). That base is shared by many non-bed
 # Telink-chip devices (e.g. a "Nokia-*" headset reported in issue #382), so this
@@ -333,7 +342,7 @@ RICHMAT_WILINKE_SERVICE_UUIDS: Final = [
     "0000fee9-0000-1000-8000-00805f9b34fb",  # W1 (index 1) - default fallback
     "0000fee9-0000-1000-8000-00805f9b34bb",  # W2 (index 2) - note different base UUID suffix
     "0000ffe0-0000-1000-8000-00805f9b34fb",  # W3 (index 3)
-    "0000fff0-0000-1000-8000-00805f9b34fb",  # W4 (index 4) - Germany Motions DHN-* beds
+    RICHMAT_WILINKE_W4_SERVICE_UUID,  # W4 (index 4) - Germany Motions DHN-*, name-guarded
     RICHMAT_WILINKE_W5_SERVICE_UUID,  # W5 (index 5) - shared Telink base, name-guarded
 ]
 RICHMAT_WILINKE_CHAR_UUIDS: Final = [

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -179,6 +179,17 @@ KEESON_FALLBACK_SERVICE_UUIDS: frozenset[str] = frozenset(
     service_uuid.lower() for service_uuid, _ in KEESON_FALLBACK_GATT_PAIRS
 )
 
+# WiLinke service UUIDs that non-bed devices also advertise, mapped to the
+# reason they are not bed-unique. These only detect as Richmat when a Richmat
+# name corroborates the match (see const.py for the full rationale).
+NAME_GUARDED_WILINKE_UUIDS: dict[str, str] = {
+    # W4: fully generic FFF0 short UUID - a "NO_DVR-*" camera system (#418)
+    # and a FIXD OBD scanner (#415); all known W4 beds are "DHN-*" units.
+    RICHMAT_WILINKE_W4_SERVICE_UUID.lower(): "generic FFF0 service",
+    # W5: Telink-style custom base - a "Nokia-*" headset (#382).
+    RICHMAT_WILINKE_W5_SERVICE_UUID.lower(): "shared Telink base",
+}
+
 OKIN_SHARED_UUID_GATT_REFINABLE_TYPES: frozenset[str] = frozenset(
     {
         BED_TYPE_LEGGETT_OKIN,
@@ -1669,34 +1680,18 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
     # Check for Richmat WiLinke variants (includes FEE9 which is also used by BedTech)
     for wilinke_uuid in RICHMAT_WILINKE_SERVICE_UUIDS:
         if wilinke_uuid.lower() in service_uuids:
-            # W5 (E0FF) uses a Telink-style custom base that non-bed devices also
-            # advertise (e.g. a "Nokia-*" headset, issue #382). It is not
-            # bed-unique, so only trust it when a Richmat name corroborates the
-            # match; otherwise keep scanning and let detection fall through.
-            if (
-                wilinke_uuid.lower() == RICHMAT_WILINKE_W5_SERVICE_UUID.lower()
-                and not is_richmat_named
-            ):
+            # Some WiLinke UUIDs are shared with non-bed devices, so they are
+            # only trusted when a Richmat name corroborates the match;
+            # otherwise keep scanning and let detection fall through.
+            guard_reason = NAME_GUARDED_WILINKE_UUIDS.get(wilinke_uuid.lower())
+            if guard_reason and not is_richmat_named:
                 _LOGGER.debug(
-                    "Ignoring W5 WiLinke UUID for %s (name: %s): shared Telink "
-                    "base with no Richmat name to corroborate",
+                    "Ignoring WiLinke UUID %s for %s (name: %s): %s with no "
+                    "Richmat name to corroborate",
+                    wilinke_uuid,
                     service_info.address,
                     service_info.name,
-                )
-                continue
-            # W4 (FFF0) is a fully generic short UUID advertised by countless
-            # non-bed devices (e.g. a "NO_DVR-*" camera system, issue #418).
-            # All known W4 beds are Germany Motions "DHN-*" units, so require
-            # a Richmat name to corroborate; otherwise keep scanning.
-            if (
-                wilinke_uuid.lower() == RICHMAT_WILINKE_W4_SERVICE_UUID.lower()
-                and not is_richmat_named
-            ):
-                _LOGGER.debug(
-                    "Ignoring W4 WiLinke UUID for %s (name: %s): generic FFF0 "
-                    "service with no Richmat name to corroborate",
-                    service_info.address,
-                    service_info.name,
+                    guard_reason,
                 )
                 continue
             signals.append("uuid:wilinke")

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -140,6 +140,7 @@ from .const import (
     RICHMAT_NAME_PATTERNS,
     RICHMAT_NORDIC_SERVICE_UUID,
     RICHMAT_WILINKE_SERVICE_UUIDS,
+    RICHMAT_WILINKE_W4_SERVICE_UUID,
     RICHMAT_WILINKE_W5_SERVICE_UUID,
     SERTA_NAME_PATTERNS,
     SLEEP_NUMBER_MCR_SERVICE_UUID,
@@ -1679,6 +1680,21 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
                 _LOGGER.debug(
                     "Ignoring W5 WiLinke UUID for %s (name: %s): shared Telink "
                     "base with no Richmat name to corroborate",
+                    service_info.address,
+                    service_info.name,
+                )
+                continue
+            # W4 (FFF0) is a fully generic short UUID advertised by countless
+            # non-bed devices (e.g. a "NO_DVR-*" camera system, issue #418).
+            # All known W4 beds are Germany Motions "DHN-*" units, so require
+            # a Richmat name to corroborate; otherwise keep scanning.
+            if (
+                wilinke_uuid.lower() == RICHMAT_WILINKE_W4_SERVICE_UUID.lower()
+                and not is_richmat_named
+            ):
+                _LOGGER.debug(
+                    "Ignoring W4 WiLinke UUID for %s (name: %s): generic FFF0 "
+                    "service with no Richmat name to corroborate",
                     service_info.address,
                     service_info.name,
                 )

--- a/docs/beds/richmat.md
+++ b/docs/beds/richmat.md
@@ -263,6 +263,15 @@ The app tries BLE services in this order:
 > bed (issue #382). W5 is therefore **not** used for passive discovery and only
 > detects as a bed when the device name also matches a Richmat pattern.
 
+> **W4 (`0000FFF0-...`) caveat:** FFF0 is a fully generic short UUID that many
+> non-bed devices advertise — a "NO_DVR-*" camera system was misdetected as a
+> Richmat bed (issue #418). All known W4 beds are Germany Motions units named
+> `DHN-*` (the GM Bed Control app scans unfiltered and identifies beds by
+> name/remote code, never by bare FFF0), so W4 likewise only detects as a bed
+> when the device name also matches a Richmat pattern. FFF0 stays in
+> `manifest.json` for passive discovery because SUTA and the Keeson Sino
+> fallback also rely on it (both name-guarded as well).
+
 ## Device Detection
 
 | Device Name Prefix | Features |

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -88,6 +88,7 @@ from custom_components.adjustable_bed.const import (
     REVERIE_SERVICE_UUID,
     RICHMAT_NORDIC_SERVICE_UUID,
     RICHMAT_WILINKE_SERVICE_UUIDS,
+    RICHMAT_WILINKE_W4_SERVICE_UUID,
     RICHMAT_WILINKE_W5_SERVICE_UUID,
     SLEEP_NUMBER_MCR_SERVICE_UUID,
     SLEEP_NUMBER_SERVICE_UUID,
@@ -1710,6 +1711,51 @@ class TestW5WiLinkeNameGuard:
             entry.get("service_uuid", "").lower() for entry in manifest["bluetooth"]
         }
         assert RICHMAT_WILINKE_W5_SERVICE_UUID.lower() not in service_uuids
+
+
+class TestW4WiLinkeNameGuard:
+    """W4 (FFF0) is a generic short UUID, so it needs a Richmat name (issue #418)."""
+
+    def test_w4_uuid_without_richmat_name_is_not_a_bed(self):
+        """A non-bed device advertising only the generic FFF0 UUID must not detect as Richmat.
+
+        Regression for #418: a "NO_DVR-*" camera system advertised FFF0 and was
+        misidentified as a Richmat bed at 80% confidence.
+        """
+        service_info = _make_service_info(
+            name="NO_DVR-FTD4-8",
+            address="50:E4:78:14:28:EE",
+            service_uuids=[RICHMAT_WILINKE_W4_SERVICE_UUID],
+            manufacturer_data={
+                0x3035: bytes.fromhex(
+                    "453437383134323845455f4652433334335253503838445f30"
+                )
+            },
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type != BED_TYPE_RICHMAT
+        assert "uuid:wilinke" not in result.signals
+
+    def test_w4_uuid_with_dhn_name_still_detects(self):
+        """A genuine Germany Motions DHN-* bed still detects as Richmat (issue #163)."""
+        service_info = _make_service_info(
+            name="DHN-FC9E27",
+            service_uuids=[RICHMAT_WILINKE_W4_SERVICE_UUID],
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type == BED_TYPE_RICHMAT
+        assert result.confidence == 0.8
+        assert "uuid:wilinke" in result.signals
+
+    def test_w4_uuid_with_richmat_remote_code_name_still_detects(self):
+        """A Richmat remote-code name corroborates a W4 advertisement."""
+        service_info = _make_service_info(
+            name="QRRM141291",
+            service_uuids=[RICHMAT_WILINKE_W4_SERVICE_UUID],
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type == BED_TYPE_RICHMAT
+        assert "uuid:wilinke" in result.signals
 
 
 class TestNordicUARTDisambiguation:

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1768,6 +1768,27 @@ class TestW4WiLinkeNameGuard:
         assert result.bed_type == BED_TYPE_RICHMAT
         assert "uuid:wilinke" in result.signals
 
+    def test_w4_uuid_kept_in_manifest_discovery(self):
+        """FFF0 must stay a passive discovery matcher (unlike W5).
+
+        SUTA and the Keeson Sino fallback also discover via FFF0; non-bed
+        FFF0 devices abort silently now that detection is name-guarded.
+        """
+        import json
+        from pathlib import Path
+
+        manifest_path = (
+            Path(__file__).parents[1]
+            / "custom_components"
+            / "adjustable_bed"
+            / "manifest.json"
+        )
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        service_uuids = {
+            entry.get("service_uuid", "").lower() for entry in manifest["bluetooth"]
+        }
+        assert RICHMAT_WILINKE_W4_SERVICE_UUID.lower() in service_uuids
+
 
 class TestNordicUARTDisambiguation:
     """Test disambiguation of beds sharing Nordic UART service UUID."""

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1736,6 +1736,17 @@ class TestW4WiLinkeNameGuard:
         assert result.bed_type != BED_TYPE_RICHMAT
         assert "uuid:wilinke" not in result.signals
 
+    def test_w4_uuid_fixd_obd_tool_is_not_a_bed(self):
+        """A FIXD car OBD scanner advertising FFF0 must not detect as Richmat (issue #415)."""
+        service_info = _make_service_info(
+            name="FIXD",
+            address="66:1B:11:72:F5:8C",
+            service_uuids=[RICHMAT_WILINKE_W4_SERVICE_UUID],
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type != BED_TYPE_RICHMAT
+        assert "uuid:wilinke" not in result.signals
+
     def test_w4_uuid_with_dhn_name_still_detects(self):
         """A genuine Germany Motions DHN-* bed still detects as Richmat (issue #163)."""
         service_info = _make_service_info(


### PR DESCRIPTION
## Summary

Also fixes the FIXD car OBD scanner false positive (Ref #415) — same root cause, covered by a dedicated regression test.

A camera system (`NO_DVR-FTD4-8`) advertising the generic `0000fff0` service UUID was auto-detected as a **richmat** bed at 80% confidence (Ref #418). FFF0 is the W4 WiLinke service, but it's a fully generic short UUID used by countless non-bed devices, so a bare FFF0 advertisement is not bed-identifying.

This applies the same policy as the W5 Telink-base fix (Ref #382): W4/FFF0 only detects as Richmat when the device name corroborates it (a `RICHMAT_NAME_PATTERNS` prefix such as `DHN-`, or a Richmat remote-code name like `QRRM…`). Non-bed FFF0 devices now fall through detection and the discovery flow silently aborts — no more false discovery cards.

## APK verification

Re-decompiled **Germany Motions GM Bed Control 4.6.0** (fresh blutter pass on the arm64 `libapp.so`, Dart 3.7.0) rather than trusting the legacy analysis:

- `BleServiceUUID` enum confirms W4 = service `0000FFF0`, write `0000FFF2`, notify `0000FFF1` — matches `const.py` exactly.
- `RMBlueToothUtil::startScanBleDevice` calls `FlutterBluePlus.startScan` with only a timeout — **no service filter**. The app identifies beds by name/remote code downstream (explicit `FWRM`/`WFRM` string checks), never by bare FFF0.
- All known real-world W4 beds are Germany Motions `DHN-*` units (Ref #163), already covered by `RICHMAT_NAME_PATTERNS`.

## Changes

- `const.py`: new `RICHMAT_WILINKE_W4_SERVICE_UUID` constant with rationale comment.
- `detection.py`: name-guard for W4 in the WiLinke UUID loop, mirroring the existing W5 guard.
- `manifest.json` unchanged: FFF0 stays as a passive discovery matcher because SUTA and the Keeson Sino fallback also discover through it (both already name-guarded), and undetected devices abort silently.
- `docs/beds/richmat.md`: W4 caveat documented next to the W5 one.
- Tests: `TestW4WiLinkeNameGuard` — the exact #418 camera advertisement no longer detects; `DHN-*` and remote-code-named beds on FFF0 still detect at 0.8.

Full suite: 2095 passed.

https://claude.ai/code/session_01Spex5CjPJhLXx8r3gbNr8K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Also fixes the FIXD car OBD scanner false positive (Ref #415) — same root cause, covered by a dedicated regression test. by CodeRabbit

* **Bug Fixes**
  * Improved Richmat bed detection for devices using the generic W4 Bluetooth service.
  * Reduced false-positive detections from unrelated devices advertising the same service.
  * Continued recognizing genuine Richmat and Germany Motions beds based on identifying device names.

* **Documentation**
  * Added guidance explaining W4 service detection limitations and supported device naming patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->