### PR TITLE
Require a Kaidi signal to corroborate PairLink manufacturer data

### DIFF
--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -873,9 +873,18 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
 
     # Priority 2: Kaidi detection - manufacturer data is the primary signal.
     # The bed advertises FFC0 UUID, name "Mouselet", AND manufacturer data with
-    # Company ID 0xFFFF / marker 0xC0FF. Manufacturer data alone is sufficient
-    # for detection (matches the OEM app's discovery), but the other signals
-    # boost confidence when present.
+    # Company ID 0xFFFF / marker 0xC0FF.
+    #
+    # The 0xFFFF/0xC0FF blob is the PairLink mesh SDK transport
+    # (com.pairlink.mesh_lib in the OEM APKs), which non-bed products - notably
+    # BLE mesh LED controllers - also emit. An ESPHome ESP32-C6 LED controller
+    # advertising a structurally valid PairLink payload was misdetected as a
+    # Kaidi bed at 90% confidence (issue #417); even the OEM app's own scan
+    # validation accepts that exact payload (length, sofaType 0x82 = product ID
+    # 130, sane seat counts) and relies on mesh room-ID membership to filter,
+    # which we cannot replicate. So the payload alone is not sufficient: require
+    # a Kaidi-specific signal (Mouselet name, FFC0/mesh UUID, or Kaidi MAC OUI)
+    # to corroborate before detecting.
     has_kaidi_uuid = (
         KAIDI_DISCOVERY_SERVICE_UUID.lower() in service_uuids
         or KAIDI_MESH_SERVICE_UUID.lower() in service_uuids
@@ -884,7 +893,14 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
     has_kaidi_mac = any(
         service_info.address.upper().startswith(prefix) for prefix in KAIDI_MAC_PREFIXES
     )
-    if kaidi_adv:
+    if kaidi_adv and not (has_kaidi_uuid or has_kaidi_name or has_kaidi_mac):
+        _LOGGER.debug(
+            "Ignoring PairLink-format manufacturer data for %s (name: %s): "
+            "no Kaidi name, UUID, or MAC OUI to corroborate",
+            service_info.address,
+            service_info.name,
+        )
+    elif kaidi_adv:
         signals.append(f"manufacturer_payload:kaidi_type_{kaidi_adv.adv_type}")
         if has_kaidi_uuid:
             signals.append("uuid:kaidi")

--- a/docs/beds/kaidi.md
+++ b/docs/beds/kaidi.md
@@ -17,6 +17,16 @@ These apps share the same Kaidi OEM transport and command family.
 Kaidi beds are identified primarily by manufacturer data, not by advertised
 service UUIDs.
 
+> **PairLink caveat:** the `0xFFFF`/`0xC0FF` manufacturer blob is the PairLink
+> mesh SDK transport (`com.pairlink.mesh_lib` in the OEM APKs), which non-bed
+> products — notably BLE mesh LED controllers — also emit. An ESPHome ESP32-C6
+> LED controller advertising a structurally valid PairLink payload was
+> misdetected as a Kaidi bed (issue #417); the OEM app's own scan validation
+> accepts that payload too and filters on mesh room-ID membership, which the
+> integration cannot replicate. Detection therefore requires a corroborating
+> Kaidi signal — the `Mouselet` name, the FFC0/mesh service UUID, or a known
+> Kaidi MAC OUI — alongside a parseable payload.
+
 | Signal | Value |
 |--------|-------|
 | Manufacturer data company ID | `0xFFFF` in Home Assistant advertisements |

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -190,10 +190,44 @@ class TestDetectBedTypeByServiceUUID:
             == "Sleep Number 360 / i8 FlexFit (BAM/MCR)"
         )
 
-    def test_detect_kaidi_by_manufacturer_data_only(self):
-        """Test Kaidi detection by manufacturer data alone (no UUID/name needed)."""
+    def test_kaidi_manufacturer_data_alone_is_not_sufficient(self):
+        """A bare PairLink payload with no Kaidi name/UUID/OUI must not detect as Kaidi.
+
+        The 0xFFFF/0xC0FF blob is the generic PairLink mesh SDK transport that
+        non-bed products also emit (issue #417).
+        """
         service_info = _make_service_info(
             name="Unknown",
+            service_uuids=[],
+            manufacturer_data={
+                0xFFFF: bytes.fromhex("c0ff0278563412ffeeddccbbaa0000810100a004030201")
+            },
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type != BED_TYPE_KAIDI
+
+    def test_kaidi_esphome_led_controller_is_not_a_bed(self):
+        """Regression for #417: an ESPHome ESP32-C6 LED controller was misdetected.
+
+        Its PairLink-format payload is structurally valid (even the OEM app's
+        scan validation accepts it), so only corroborating Kaidi signals may
+        promote it to a detection.
+        """
+        service_info = _make_service_info(
+            name="EC:C5:7F:6A:67:11",
+            address="EC:C5:7F:6A:67:11",
+            service_uuids=[],
+            manufacturer_data={
+                0xFFFF: bytes.fromhex("c0ff011e27000082020211676a7fc5ec")
+            },
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type is None
+
+    def test_detect_kaidi_by_manufacturer_data_with_mouselet_name(self):
+        """A Mouselet-named device with a PairLink payload detects as Kaidi."""
+        service_info = _make_service_info(
+            name="Mouselet",
             service_uuids=[],
             manufacturer_data={
                 0xFFFF: bytes.fromhex("c0ff0278563412ffeeddccbbaa0000810100a004030201")
@@ -203,6 +237,22 @@ class TestDetectBedTypeByServiceUUID:
         assert result.bed_type == BED_TYPE_KAIDI
         assert result.confidence == 0.9
         assert "manufacturer_payload:kaidi_type_2" in result.signals
+        assert "name:kaidi" in result.signals
+
+    def test_detect_kaidi_by_manufacturer_data_with_kaidi_oui(self):
+        """A device with a known Kaidi MAC OUI and a PairLink payload detects as Kaidi."""
+        service_info = _make_service_info(
+            name="Unknown",
+            address="F0:AC:D7:12:34:56",
+            service_uuids=[],
+            manufacturer_data={
+                0xFFFF: bytes.fromhex("c0ff0278563412ffeeddccbbaa0000810100a004030201")
+            },
+        )
+        result = detect_bed_type_detailed(service_info)
+        assert result.bed_type == BED_TYPE_KAIDI
+        assert result.confidence == 0.9
+        assert "mac:kaidi_oui" in result.signals
 
     def test_detect_kaidi_with_ffc0_uuid(self):
         """Test Kaidi detection with FFC0 UUID gives higher confidence."""


### PR DESCRIPTION
## Summary

An ESPHome ESP32-C6 LED controller was auto-detected as a **kaidi** bed at 90% confidence from its manufacturer data alone (Ref #417). The `0xFFFF`/`0xC0FF` blob Kaidi detection keyed on turns out to be the **PairLink mesh SDK** transport (`com.pairlink.mesh_lib` in the OEM APKs) — a generic BLE-mesh layer that non-bed products, notably LED mesh controllers, also emit.

## APK verification

Fresh jadx decompilation of **Rize Beds 1.3.0** (`com.kaidi_test4.rize`):

- `MeshService.isMeshDevice`/`isMeshConnectable` match only on the `FF FF C0 FF` prefix + adv type \{1, 2, 9\} — no bed-specific check.
- `MainActivity.on_scan_list` adds structural validation (AD length, sofaType range, seat-count sanity) — and the reporter's exact payload **passes all of it**: correct type-1 length, sofaType `0x82` = valid Kaidi product ID 130, seat counts decode as sane values.
- The OEM app's real gate is mesh **room-ID membership** (`isMeshConnectable` compares `join_mesh_roomId`), which an integration cannot replicate.

So payload-shape validation cannot exclude PairLink non-beds, no matter how strict. The only sound policy is corroboration.

## Changes

- `detection.py`: a parseable PairLink payload alone no longer detects as kaidi. Detection now requires a corroborating Kaidi signal — `Mouselet` name, FFC0/mesh service UUID, or a known Kaidi MAC OUI — and otherwise falls through silently (discovery aborts, no card). Confirmed real Kaidi beds advertise the `Mouselet` name (Ref #247), so genuine beds keep detecting at 0.9/0.95.
- `manifest.json` unchanged: the `0xFFFF` + `C0 FF` matcher stays for passive discovery of real beds; uncorroborated devices abort silently.
- `docs/beds/kaidi.md`: PairLink caveat documented.
- Tests: exact #417 ESP32 advertisement locked in as a regression (returns no detection); payload-only detection test updated to the new policy; new corroboration tests for Mouselet-name and Kaidi-OUI paths.

Full suite: 2095 passed.

https://claude.ai/code/session_01Spex5CjPJhLXx8r3gbNr8K