### PR TITLE
Fix KSBT03C (Ergomotion RIO 5.0) motor layout, massage-off button, and memory slots

### DIFF
--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -52,6 +52,19 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+def is_ksbt03c_name(name: str | None) -> bool:
+    """Return True if the device name identifies a KSBT03C control box.
+
+    KSBT03C beds (e.g. Ergomotion RIO 5.0) drive three motors: head/back
+    (0x1/0x2), feet/legs (0x4/0x8) and lumbar (0x40/0x80). The Ergomotion
+    Sync app's KSBT03C remote has no head-tilt (0x10/0x20) buttons at all,
+    so those beds have no tilt motor. KSBT03CR is a different control box
+    and is excluded.
+    """
+    normalized = (name or "").strip().lower()
+    return normalized.startswith("ksbt03c") and not normalized.startswith("ksbt03cr")
+
+
 class KeesonCommands:
     """Keeson command constants (32-bit values)."""
 
@@ -60,7 +73,7 @@ class KeesonCommands:
     PRESET_ZERO_G = 0x1000
 
     # KSBT-specific presets (not available on BaseI4/I5)
-    PRESET_MEMORY_1 = 0x2000  # KSBT "M" button
+    PRESET_MEMORY_1 = 0x2000  # KSBT "Read" button (Ergomotion Sync remotes A/B/C)
     PRESET_TV = 0x4000  # KSBT only
     PRESET_ANTI_SNORE = 0x8000  # KSBT only
 
@@ -70,10 +83,10 @@ class KeesonCommands:
 
     # Memory presets (availability varies by variant)
     PRESET_MEMORY_2 = 0x4000  # Same as TV on KSBT
-    PRESET_MEMORY_4 = 0x10000  # May work on some beds
+    PRESET_MEMORY_4 = 0x10000  # KSBT "M" button (Ergomotion Sync remotes A/B/C)
 
     # Aliases
-    PRESET_LOUNGE = 0x2000  # Same as Memory 1 / KSBT "M" button
+    PRESET_LOUNGE = 0x2000  # Same as Memory 1 / KSBT "Read" button
 
     # Motors
     MOTOR_HEAD_UP = 0x1
@@ -175,6 +188,7 @@ class KeesonController(BedController):
         *,
         betterliving_presets: bool = False,
         cb1322_presets: bool = False,
+        device_name: str | None = None,
     ) -> None:
         """Initialize the Keeson controller.
 
@@ -184,11 +198,18 @@ class KeesonController(BedController):
             char_uuid: The characteristic UUID to use for writing commands
             betterliving_presets: Use BetterLiving BED_DEFAULT preset values
             cb1322_presets: Use CB1322 sub-variant memory preset values
+            device_name: Raw BLE device name (used to detect KSBT03C motor layout)
         """
         super().__init__(coordinator)
         self._variant = variant
         self._betterliving_presets = betterliving_presets
         self._cb1322_presets = cb1322_presets
+        # KSBT03C control boxes have no head-tilt motor; their third motor is
+        # lumbar. Fall back to the configured name (defaults to the BLE name)
+        # when the raw device name is unavailable on this connection.
+        self._is_ksbt03c = is_ksbt03c_name(device_name) or is_ksbt03c_name(
+            getattr(coordinator, "name", None)
+        )
         self._notify_callback: Callable[[str, float], None] | None = None
         self._motor_state: dict[str, bool | None] = {}
         self._write_with_response = True
@@ -425,7 +446,9 @@ class KeesonController(BedController):
     def memory_slot_count(self) -> int:
         """Return memory slot count based on variant.
 
-        KSBT: Slots 1-2 (M button = slot 1, TV = slot 2)
+        KSBT/KSBT04C: Slots 1-3 (Read = slot 1, TV = slot 2, M = slot 3, from
+            Ergomotion Sync APK remotes A/B/C)
+        KSBT03CR: Slots 1-2 (not covered by Ergomotion Sync, keep legacy)
         BetterLiving/CB1322: Slots 1-2 (from APK analysis)
         BaseI4/I5: Slot 3 only (from APK analysis)
         Ergomotion: 4 slots (needs verification)
@@ -436,8 +459,10 @@ class KeesonController(BedController):
             return 4
         if self._betterliving_presets or self._cb1322_presets:
             return 2  # BetterLiving and CB1322 both have Memory 1 and Memory 2
+        if self._variant in {"ksbt", KEESON_VARIANT_KSBT04C}:
+            return 3  # Read (0x2000), TV (0x4000), M (0x10000) buttons
         if self._is_ksbt:
-            return 2  # Memory 1 (M button) and Memory 2 (TV button)
+            return 2  # KSBT03CR: Memory 1 and Memory 2 only (unverified beyond that)
         elif self._variant == KEESON_VARIANT_PURPLE:
             return 2  # Purple Premium has 2. Plus model bed supports 3, but we don't know what path it uses
         elif self._variant == "ergomotion":
@@ -481,8 +506,13 @@ class KeesonController(BedController):
 
     @property
     def has_tilt_support(self) -> bool:
-        """Return True - Keeson beds have tilt motor control."""
-        return True
+        """Return True if the bed has a head-tilt motor.
+
+        KSBT03C control boxes (e.g. Ergomotion RIO 5.0) have no tilt motor:
+        the Ergomotion Sync app's KSBT03C remote exposes only head, feet and
+        lumbar movement. Other Keeson variants keep tilt control.
+        """
+        return not self._is_ksbt03c
 
     @property
     def has_lumbar_support(self) -> bool:
@@ -543,8 +573,12 @@ class KeesonController(BedController):
             ),
         ]
 
-        if self._coordinator.motor_count >= 3 and self.has_tilt_support:
-            specs.append(
+        # Allocate the extra motor slots (motor_count beyond the standard 2)
+        # in remote order: tilt first where the bed has one, then lumbar.
+        # KSBT03C beds have no tilt motor, so their third motor is lumbar.
+        optional_specs = []
+        if self.has_tilt_support:
+            optional_specs.append(
                 MotorControlSpec(
                     key="tilt",
                     translation_key=translation_overrides.get("tilt", "tilt"),
@@ -554,9 +588,8 @@ class KeesonController(BedController):
                     max_angle=45,
                 )
             )
-
-        if self._coordinator.motor_count >= 4 and self.has_lumbar_support:
-            specs.append(
+        if self.has_lumbar_support:
+            optional_specs.append(
                 MotorControlSpec(
                     key="lumbar",
                     translation_key=translation_overrides.get("lumbar", "lumbar"),
@@ -567,7 +600,20 @@ class KeesonController(BedController):
                 )
             )
 
+        extra_slots = max(0, self._coordinator.motor_count - 2)
+        specs.extend(optional_specs[:extra_slots])
+
         return tuple(specs)
+
+    @property
+    def stale_motor_entity_keys(self) -> frozenset[str]:
+        """Clean up optional motor covers that no longer apply.
+
+        Removes the phantom tilt cover on KSBT03C beds (no tilt motor) and
+        covers left behind when the configured motor count is reduced.
+        Active keys are skipped by the cleanup.
+        """
+        return frozenset({"tilt", "lumbar"})
 
     # Massage timer - Keeson only has step command, no direct timer set
     # We cannot reliably emulate stepping without knowing current state
@@ -575,6 +621,15 @@ class KeesonController(BedController):
     def supports_massage_timer(self) -> bool:
         """Return False - Keeson can only step through timer, not set directly."""
         return False
+
+    @property
+    def supports_massage_off_control(self) -> bool:
+        """Return True only for Sino, the sole variant with a real off command.
+
+        Other Keeson variants (KSBT, BaseI4/I5, Ergomotion) can only step
+        massage intensity; massage_off() would raise, so hide the button.
+        """
+        return self._variant == KEESON_VARIANT_SINO
 
     @property
     def supports_massage_intensity_control(self) -> bool:
@@ -1053,7 +1108,8 @@ class KeesonController(BedController):
         """Go to memory preset.
 
         Note: Command values vary by protocol variant:
-        - KSBT: Memory 1 (0x2000) = M button, Memory 2 (0x4000) = TV button
+        - KSBT/KSBT04C (Ergomotion Sync APK): Memory 1 (0x2000) = Read button,
+          Memory 2 (0x4000) = TV button, Memory 3 (0x10000) = M button
         - BaseI4/I5: Memory 3 (0x8000) is the only confirmed memory preset
         - Memory 3 (0x8000) on KSBT is actually anti-snore, not memory
         - BetterLiving: Memory 1 (0x01000008), Memory 2 (0x01000009)
@@ -1085,6 +1141,26 @@ class KeesonController(BedController):
             else:
                 _LOGGER.warning(
                     "CB1322 memory %d not supported (valid: %s)",
+                    memory_num,
+                    sorted(commands.keys()),
+                )
+            return
+
+        # KSBT/KSBT04C remotes (Ergomotion Sync APK): memory slot 3 is the
+        # "M" button (0x10000), not 0x8000 which triggers anti-snore there.
+        if self._variant in {"ksbt", KEESON_VARIANT_KSBT04C}:
+            commands = {
+                1: KeesonCommands.PRESET_MEMORY_1,
+                2: KeesonCommands.PRESET_MEMORY_2,
+                3: KeesonCommands.PRESET_MEMORY_4,
+            }
+            if command := commands.get(memory_num):
+                await self.write_command(
+                    self._build_command(command), repeat_count=self._single_shot_count
+                )
+            else:
+                _LOGGER.warning(
+                    "KSBT memory %d not supported (valid: %s)",
                     memory_num,
                     sorted(commands.keys()),
                 )

--- a/custom_components/adjustable_bed/controller_factory.py
+++ b/custom_components/adjustable_bed/controller_factory.py
@@ -631,13 +631,13 @@ async def create_controller(
             return KeesonController(coordinator, variant=KEESON_VARIANT_JSON)
         if keeson_variant == KEESON_VARIANT_KSBT:
             _LOGGER.debug("Using KSBT Keeson variant (configured)")
-            return KeesonController(coordinator, variant="ksbt")
+            return KeesonController(coordinator, variant="ksbt", device_name=device_name)
         elif keeson_variant == KEESON_VARIANT_KSBT_CR:
             _LOGGER.debug("Using KSBT03CR Keeson variant (7-byte, 0x05 prefix)")
-            return KeesonController(coordinator, variant="ksbt_cr")
+            return KeesonController(coordinator, variant="ksbt_cr", device_name=device_name)
         elif keeson_variant == KEESON_VARIANT_KSBT04C:
             _LOGGER.debug("Using KSBT04C Keeson variant (7-byte with checksum)")
-            return KeesonController(coordinator, variant="ksbt04c")
+            return KeesonController(coordinator, variant="ksbt04c", device_name=device_name)
         elif keeson_variant == KEESON_VARIANT_ERGOMOTION:
             _LOGGER.debug("Using Ergomotion Keeson variant (with position feedback)")
             return KeesonController(coordinator, variant="ergomotion")

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -10,6 +10,7 @@ Brands using Keeson/Ergomotion actuators:
 
 - Serta
 - Ergomotion
+- Ergomotion Rio 5.0 / Denver Mattress Hibernation Platinum (advertises as `KSBT03C...`; 3 motors: back, legs, lumbar — no head tilt)
 - Ergomotion Rio 6.0 (advertises as `KSBT04...`, works with KSBT protocol)
 - Tempur Zero G / Tempur Curve
 - Beautyrest Black
@@ -39,6 +40,7 @@ Brands using Keeson/Ergomotion actuators:
 | ✅ | [Ergomotion](https://play.google.com/store/apps/details?id=com.sfd.ergomotion) | `com.sfd.ergomotion` |
 | ✅ | [Tempur Zero G Bed Base](https://play.google.com/store/apps/details?id=com.sfd.row) | `com.sfd.row` |
 | ✅ | [Member's Mark Base Remote](https://play.google.com/store/apps/details?id=com.sfd.mm) | `com.sfd.mm` |
+| ✅ | Ergomotion Sync | `cn.com.mancini` |
 | ✅ | Linx | `com.keeson.connectedbed` |
 | ✅ | Juna Sleep | `com.keeson.junasleep` |
 | ✅ | [Purple Smart Base](https://play.google.com/store/apps/details?id=com.keeson.purpleBase) | `com.keeson.purpleBase` |
@@ -49,7 +51,7 @@ Brands using Keeson/Ergomotion actuators:
 |---------|-----------|------------|------|------------|------|-------|------|------------------|-----------------------|
 | Motor Control | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❓ |
 | Position Feedback | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❓ |
-| Memory Presets | ✅ (slots 3-4) | ✅ (remote-dependent 0x2000/0x4000/0x8000/0x10000) | ✅ (slots 1-2) | ✅ (4 slots) | ✅ | ✅ | ✅ | ✅ | ❓ |
+| Memory Presets | ✅ (slots 3-4) | ✅ (remote-dependent 0x2000/0x4000/0x8000/0x10000) | ✅ (slots 1-3: Read/TV/M) | ✅ (4 slots) | ✅ | ✅ | ✅ | ✅ | ❓ |
 | TV Preset | ❌ | ✅ (remote-dependent) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❓ |
 | Anti-Snore Preset | ❌ | ✅ (remote-dependent) | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ❓ |
 | Lounge Preset | ❌ | ✅ (remote-dependent) | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❓ |
@@ -101,6 +103,10 @@ The integration treats `0000a00a` as a distinct Keeson variant and uses the shar
 
 Some Ergomotion-branded beds also use this variant. A confirmed Rio 6.0 support bundle advertises as `KSBT04...` and works correctly with the standard KSBT 6-byte protocol.
 Juna's `LVrestore` and `LVrelax` remotes also use this direct 6-byte framing rather than the JSON/A00A path.
+
+**Ergomotion Sync remotes (from `cn.com.mancini` APK):** the app has three remote layouts — A and C target `KSBT04C` devices, B targets `KSBT03C` (e.g. Rio 5.0). All three share the same preset buttons: Read = `0x2000`, TV = `0x4000`, M = `0x10000`, Zero-G = `0x1000`, Flat = `0x8000000`, Anti-Snore = `0x8000` (B/C only), light toggle = `0x20000`, and massage steps head `0x800` / foot `0x400` / timer `0x200` (no all-off command). The integration exposes Read/TV/M as memory slots 1-3 on KSBT variants.
+
+**KSBT03C motor layout:** the KSBT03C remote (layout B) drives only three motors — head/back (`0x1`/`0x2`), feet/legs (`0x4`/`0x8`) and lumbar (`0x40`/`0x80`). There are no head-tilt (`0x10`/`0x20`) buttons, so KSBT03C beds have no tilt motor and the integration maps the third configured motor to lumbar. KSBT04C remotes (layouts A/C) additionally have the head-tilt buttons.
 
 **Fallback Service UUIDs:** Some KSBT devices use different service UUIDs. The integration automatically tries these if the primary isn't found:
 - `6e400020-b5a3-f393-e0a9-e50e24dcca9e` (characteristic: `6e400021`) - Extended Nordic UART, used by some Ergomotion/SFD beds
@@ -160,10 +166,10 @@ Position data includes:
 | Massage Foot Up | `0x00000400` | Increase foot massage |
 | Massage Head Up | `0x00000800` | Increase head massage |
 | Zero-G | `0x00001000` | Zero-G preset |
-| Memory 1 / Lounge | `0x00002000` | KSBT "M" button, Lounge on Purple, not available on BaseI4/I5 |
+| Memory 1 / Lounge | `0x00002000` | KSBT "Read" button, Lounge on Purple, not available on BaseI4/I5 |
 | Memory 2 / TV | `0x00004000` | KSBT TV button, Purple Memory 2, not available on BaseI4/I5  |
 | Memory 3 / Anti-Snore | `0x00008000` | Memory 3 on BaseI4/I5, Anti-Snore on KSBT and Purple |
-| Memory 4 | `0x00010000` | Go to memory 4, Maps to Memory 1 on Purple |
+| Memory 4 / M | `0x00010000` | KSBT "M" button (memory slot 3), Maps to Memory 1 on Purple |
 | Toggle Lights | `0x00020000` | Toggle safety lights |
 | Massage Head Down | `0x00800000` | Decrease head massage |
 | Massage Foot Down | `0x01000000` | Decrease foot massage |
@@ -213,7 +219,7 @@ Unique service UUID auto-detection:
 | Device Name Prefix | Protocol |
 |-------------------|----------|
 | `base` | Standard FFE5/FFE9 (8-byte) |
-| `KSBT03C` | Nordic UART with 6-byte packets |
+| `KSBT03C` | Nordic UART with 6-byte packets (3 motors: no head tilt; e.g. Ergomotion Rio 5.0) |
 | `KSBT04C` | Nordic UART with 6-byte packets (used by some Ergomotion Sync beds, including Rio 6.0) |
 | `ksbt03cr` | Nordic UART with 7-byte packets (KSBT03CR variant) |
 | `EH` | Mattress variant (E0FF service) |

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -992,3 +992,225 @@ class TestKeesonPositionNotifications:
         await coordinator.controller.start_notify(callback)
 
         assert coordinator.controller._notify_callback is callback
+
+
+class TestKsbt03cMotorLayout:
+    """Test KSBT03C (Ergomotion RIO 5.0) motor layout handling (issue #408)."""
+
+    def test_is_ksbt03c_name(self):
+        """Test KSBT03C name detection."""
+        from custom_components.adjustable_bed.beds.keeson import is_ksbt03c_name
+
+        assert is_ksbt03c_name("KSBT03C300039050")
+        assert is_ksbt03c_name("ksbt03c123")
+        assert not is_ksbt03c_name("KSBT03CR12345")
+        assert not is_ksbt03c_name("KSBT04C300039050")
+        assert not is_ksbt03c_name("KSBT123456")
+        assert not is_ksbt03c_name(None)
+        assert not is_ksbt03c_name("")
+
+    async def test_ksbt03c_three_motors_third_is_lumbar(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test KSBT03C with 3 motors exposes lumbar (not tilt) as third motor."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        coordinator._motor_count = 3
+
+        controller = KeesonController(
+            coordinator, variant="ksbt", device_name="KSBT03C300039050"
+        )
+
+        assert not controller.has_tilt_support
+        keys = [spec.key for spec in controller.motor_control_specs]
+        assert keys == ["head", "feet", "lumbar"]
+
+    async def test_ksbt03c_four_motors_has_no_phantom_tilt(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test KSBT03C with 4 configured motors still has no tilt motor."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        coordinator._motor_count = 4
+
+        controller = KeesonController(
+            coordinator, variant="ksbt", device_name="KSBT03C300039050"
+        )
+
+        keys = [spec.key for spec in controller.motor_control_specs]
+        assert keys == ["head", "feet", "lumbar"]
+
+    async def test_ksbt03c_detected_from_configured_name(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry_data: dict,
+        mock_coordinator_connected,
+    ):
+        """Test KSBT03C layout falls back to the configured name."""
+        mock_keeson_config_entry_data[CONF_NAME] = "KSBT03C300039050"
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="KSBT03C300039050",
+            data=mock_keeson_config_entry_data,
+            unique_id="AA:BB:CC:DD:EE:F0",
+            entry_id="keeson_ksbt03c_entry",
+        )
+        entry.add_to_hass(hass)
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        await coordinator.async_connect()
+
+        controller = KeesonController(coordinator, variant="ksbt")
+
+        assert not controller.has_tilt_support
+
+    async def test_standard_keeson_motor_layout_unchanged(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test non-KSBT03C beds keep tilt as third and lumbar as fourth motor."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+        assert controller.has_tilt_support
+
+        coordinator._motor_count = 3
+        assert [spec.key for spec in controller.motor_control_specs] == [
+            "head",
+            "feet",
+            "tilt",
+        ]
+
+        coordinator._motor_count = 4
+        assert [spec.key for spec in controller.motor_control_specs] == [
+            "head",
+            "feet",
+            "tilt",
+            "lumbar",
+        ]
+
+    async def test_stale_motor_entity_keys(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test stale keys cover the optional tilt/lumbar motors."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+
+        assert coordinator.controller.stale_motor_entity_keys == frozenset(
+            {"tilt", "lumbar"}
+        )
+
+
+class TestKeesonMassageOffGating:
+    """Test massage-off capability gating (issue #408)."""
+
+    @pytest.mark.parametrize("variant", ["base", "ksbt", "ksbt04c", "ergomotion"])
+    async def test_non_sino_variants_hide_massage_off(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        variant: str,
+    ):
+        """Test variants without a real off command don't expose the button."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+
+        controller = KeesonController(coordinator, variant=variant)
+
+        assert not controller.supports_massage_off_control
+
+    async def test_sino_variant_supports_massage_off(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test the Sino variant keeps its working massage-off control."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+
+        controller = KeesonController(coordinator, variant="sino")
+
+        assert controller.supports_massage_off_control
+
+
+class TestKsbtMemoryPresets:
+    """Test KSBT memory presets from Ergomotion Sync APK (issue #408)."""
+
+    @pytest.mark.parametrize("variant,slots", [("ksbt", 3), ("ksbt04c", 3), ("ksbt_cr", 2)])
+    async def test_memory_slot_count(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        variant: str,
+        slots: int,
+    ):
+        """Test KSBT variants expose the remotes' three preset buttons."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+
+        controller = KeesonController(coordinator, variant=variant)
+
+        assert controller.memory_slot_count == slots
+
+    @pytest.mark.parametrize(
+        "memory_num,expected_value",
+        [
+            (1, KeesonCommands.PRESET_MEMORY_1),  # Read button (0x2000)
+            (2, KeesonCommands.PRESET_MEMORY_2),  # TV button (0x4000)
+            (3, KeesonCommands.PRESET_MEMORY_4),  # M button (0x10000)
+        ],
+    )
+    async def test_ksbt_preset_memory_mapping(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+        memory_num: int,
+        expected_value: int,
+    ):
+        """Test KSBT memory slots map to the Read/TV/M remote buttons."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        controller = KeesonController(coordinator, variant="ksbt")
+        coordinator._controller = controller
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        await controller.preset_memory(memory_num)
+
+        expected_cmd = controller._build_command(expected_value)
+        first_call = mock_bleak_client.write_gatt_char.call_args_list[0]
+        assert first_call[0][1] == expected_cmd
+
+    async def test_ksbt_preset_memory_invalid_slot_warns(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+        caplog,
+    ):
+        """Test out-of-range KSBT memory slot warns and sends nothing."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        controller = KeesonController(coordinator, variant="ksbt")
+        coordinator._controller = controller
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        await controller.preset_memory(4)
+
+        assert "KSBT memory 4 not supported" in caplog.text
+        mock_bleak_client.write_gatt_char.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes the three problems reported in #408 for the Ergomotion RIO 5.0 / Denver Mattress Hibernation Platinum (Keeson KSBT03C), based on a fresh decompile of the **Ergomotion Sync** APK (`cn.com.mancini`) — the official app for exactly these control boxes (its remote layout B scans for the `KSBT03C` name prefix).

### 1. Motor count mismatch (main bug)

The KSBT03C remote has **no head-tilt buttons** (`0x10`/`0x20`); it drives only head/back (`0x1`/`0x2`), feet/legs (`0x4`/`0x8`) and lumbar (`0x40`/`0x80`). Previously a 3-motor config exposed a dead tilt ("Head") cover, and the working lumbar motor only appeared when configuring 4 motors — with the dead Head entity still present.

- `KSBT03C*` device names now disable tilt support, so the third motor slot is allocated to lumbar (`motor_control_specs` now fills extra slots in remote order: tilt where it exists, then lumbar).
- The phantom tilt cover left behind on existing installs is removed via `stale_motor_entity_keys`.
- Other Keeson variants keep their existing 3=tilt / 4=tilt+lumbar layout (covered by a regression test).

### 2. "Massage: Off" button raised "not supported"

`KeesonController` overrides `massage_off()` (for the Sino variant), so the capability check exposed the button on all Keeson beds — but every non-Sino variant fell through to the base implementation and raised. No Ergomotion Sync remote has a massage-off command (only head/foot/timer step), so the button is now gated to the Sino variant only.

### 3. Remote has 3 memory buttons, integration only offered 2

All three Ergomotion Sync remote layouts (A/B/C) have the same three preset buttons: **Read = `0x2000`, TV = `0x4000`, M = `0x10000`**. KSBT/KSBT04C variants now expose 3 memory slots mapped accordingly. Slots 1–2 keep their existing values; slot 3 previously sent `0x8000`, which triggers **anti-snore** on these beds, and now correctly sends the M-button value. (The old "M button = 0x2000" lore from smartbed-mqtt was wrong — that address is the Read button.)

## APK evidence

`disassembly/output/cn.com.mancini/ANALYSIS.md` (untracked, local) documents the full command map from `RemoteAFragment`/`RemoteBFragment`/`RemoteCFragment`: packet `[0x04, 0x02, <32-bit BE command>]` on Nordic UART `6e400002`, held motion resent at 300 ms. Matches the user's support bundle GATT layout (Nordic UART service, name `KSBT03C300039050`).

## Testing

- 18 new tests: KSBT03C name detection, 3/4-motor spec layouts, configured-name fallback, standard-Keeson regression, stale keys, massage-off gating per variant, memory slot counts, and the Read/TV/M slot mapping (including out-of-range warning).
- Full suite: **2118 passed**.

Ref #408


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for KSBT03C beds, including accurate three-motor layouts and lumbar control.
  * Improved detection of KSBT03C devices from their advertised names.
  * Updated memory preset handling for KSBT and KSBT04C variants.

* **Bug Fixes**
  * Corrected motor controls when optional tilt or lumbar motors are unavailable.
  * Removed stale optional motor controls after device changes.

* **Documentation**
  * Expanded Keeson model, app, preset, command, and device-detection documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->