### PR TITLE
Require BLE bonding for Leggett & Platt Gen2 (LP Comfort Connect)

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -34,6 +34,7 @@ from .const import (
     BEDTECH_MANUFACTURER_ID,
     BEDTECH_SERVICE_UUID,
     CONF_BED_TYPE,
+    CONF_BLE_BOND_ESTABLISHED,
     CONF_DISABLE_ANGLE_SENSING,
     CONF_HAS_MASSAGE,
     CONF_KAIDI_ADV_TYPE,
@@ -52,6 +53,7 @@ from .const import (
     OKIN_CST_POSITION_AXES,
     RICHMAT_REMOTE_AUTO,
     VARIANT_AUTO,
+    connection_gated_by_bond,
     requires_pairing,
 )
 from .coordinator import AdjustableBedCoordinator
@@ -345,6 +347,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
             return
 
+        # Beds that refuse *connections* from unbonded peers (LP Comfort
+        # Connect / Leggett & Platt Gen2): a connect timeout on an unbonded
+        # entry is itself the pairing symptom — the box ignores connection
+        # requests outside its pairing window, so waiting on HA's setup
+        # retries can never succeed. Guide the user through the repair flow
+        # (power-cycle into pairing mode, then pair) instead (issue #385).
+        if connection_gated_by_bond(bed_type, protocol_variant) and not entry.data.get(
+            CONF_BLE_BOND_ESTABLISHED
+        ):
+            await create_pairing_required_issue(
+                hass,
+                address or "Unknown",
+                entry.data.get("name", entry.title),
+                entry.entry_id,
+            )
+            return
+
         # Connection failed before pairing was even attempted (device not found,
         # timeout, etc.). Don't create repair — HA will retry automatically and
         # pairing will be attempted on the next successful connection.
@@ -353,6 +372,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "attempted — not creating pairing repair (will retry automatically)",
             address,
         )
+
+    # Beds that ignore connection requests from unbonded peers (LP Comfort
+    # Connect / Leggett & Platt Gen2) can only ever connect through the guided
+    # pairing repair, so plain retry messaging would mislead (issue #385).
+    _bond_gated_unbonded = connection_gated_by_bond(
+        entry.data.get(CONF_BED_TYPE, ""), entry.data.get(CONF_PROTOCOL_VARIANT)
+    ) and not entry.data.get(CONF_BLE_BOND_ESTABLISHED)
+    _bond_gated_hint = (
+        " This bed only accepts Bluetooth connections from devices it has "
+        "paired with. Open Settings → Repairs and follow the pairing steps "
+        "(power-cycle the bed to enter its ~2 minute pairing mode)."
+        if _bond_gated_unbonded
+        else " The integration will retry automatically."
+    )
 
     # Connect to the bed with a timeout to avoid blocking startup forever
     _LOGGER.debug("Attempting initial connection to bed (timeout: %.0fs)...", SETUP_TIMEOUT)
@@ -369,8 +402,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 reason=f"initial connection timed out after {SETUP_TIMEOUT:.0f}s",
             )
         raise ConfigEntryNotReady(
-            f"Connection to bed at {entry.data.get(CONF_ADDRESS)} timed out after {SETUP_TIMEOUT:.0f}s. "
-            "The integration will retry automatically."
+            f"Connection to bed at {entry.data.get(CONF_ADDRESS)} timed out after "
+            f"{SETUP_TIMEOUT:.0f}s.{_bond_gated_hint}"
         ) from None
 
     if not connected:
@@ -381,6 +414,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 entry,
                 coordinator,
                 reason="device was not reachable during initial setup",
+            )
+        if _bond_gated_unbonded:
+            raise ConfigEntryNotReady(
+                f"Failed to connect to bed at {entry.data.get(CONF_ADDRESS)}."
+                f"{_bond_gated_hint}"
             )
         raise ConfigEntryNotReady(
             f"Failed to connect to bed at {entry.data.get(CONF_ADDRESS)}. "

--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -308,6 +308,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = AdjustableBedCoordinator(hass, entry)
     _async_ensure_device_registry_entry(hass, entry, coordinator)
 
+    # Beds that ignore connection requests from unbonded peers (LP Comfort
+    # Connect / Leggett & Platt Gen2) can only ever connect through the guided
+    # pairing repair, so plain retry messaging would mislead (issue #385).
+    bond_gated_unbonded = connection_gated_by_bond(
+        entry.data.get(CONF_BED_TYPE, ""), entry.data.get(CONF_PROTOCOL_VARIANT)
+    ) and not entry.data.get(CONF_BLE_BOND_ESTABLISHED)
+
     # Helper to create pairing issue — only when there's actual evidence of a pairing
     # problem. Generic connection failures (timeout, device not found) should NOT
     # trigger this, since the bed may just be temporarily unreachable after a restart.
@@ -353,9 +360,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # requests outside its pairing window, so waiting on HA's setup
         # retries can never succeed. Guide the user through the repair flow
         # (power-cycle into pairing mode, then pair) instead (issue #385).
-        if connection_gated_by_bond(bed_type, protocol_variant) and not entry.data.get(
-            CONF_BLE_BOND_ESTABLISHED
-        ):
+        if bond_gated_unbonded:
             await create_pairing_required_issue(
                 hass,
                 address or "Unknown",
@@ -373,17 +378,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             address,
         )
 
-    # Beds that ignore connection requests from unbonded peers (LP Comfort
-    # Connect / Leggett & Platt Gen2) can only ever connect through the guided
-    # pairing repair, so plain retry messaging would mislead (issue #385).
-    _bond_gated_unbonded = connection_gated_by_bond(
-        entry.data.get(CONF_BED_TYPE, ""), entry.data.get(CONF_PROTOCOL_VARIANT)
-    ) and not entry.data.get(CONF_BLE_BOND_ESTABLISHED)
-    _bond_gated_hint = (
+    bond_gated_hint = (
         " This bed only accepts Bluetooth connections from devices it has "
         "paired with. Open Settings → Repairs and follow the pairing steps "
         "(power-cycle the bed to enter its ~2 minute pairing mode)."
-        if _bond_gated_unbonded
+        if bond_gated_unbonded
         else " The integration will retry automatically."
     )
 
@@ -403,7 +402,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
         raise ConfigEntryNotReady(
             f"Connection to bed at {entry.data.get(CONF_ADDRESS)} timed out after "
-            f"{SETUP_TIMEOUT:.0f}s.{_bond_gated_hint}"
+            f"{SETUP_TIMEOUT:.0f}s.{bond_gated_hint}"
         ) from None
 
     if not connected:
@@ -415,10 +414,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 coordinator,
                 reason="device was not reachable during initial setup",
             )
-        if _bond_gated_unbonded:
+        if bond_gated_unbonded:
             raise ConfigEntryNotReady(
                 f"Failed to connect to bed at {entry.data.get(CONF_ADDRESS)}."
-                f"{_bond_gated_hint}"
+                f"{bond_gated_hint}"
             )
         raise ConfigEntryNotReady(
             f"Failed to connect to bed at {entry.data.get(CONF_ADDRESS)}. "

--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -308,12 +308,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = AdjustableBedCoordinator(hass, entry)
     _async_ensure_device_registry_entry(hass, entry, coordinator)
 
-    # Beds that ignore connection requests from unbonded peers (LP Comfort
-    # Connect / Leggett & Platt Gen2) can only ever connect through the guided
-    # pairing repair, so plain retry messaging would mislead (issue #385).
-    bond_gated_unbonded = connection_gated_by_bond(
-        entry.data.get(CONF_BED_TYPE, ""), entry.data.get(CONF_PROTOCOL_VARIANT)
-    ) and not entry.data.get(CONF_BLE_BOND_ESTABLISHED)
+    def _bond_gated_unbonded() -> bool:
+        """Return whether this entry still needs the bond-gated repair path.
+
+        Evaluate this after each connection attempt rather than caching it at
+        setup start: the coordinator can establish and persist the bond before
+        a later setup step fails for an unrelated reason.
+        """
+        return connection_gated_by_bond(
+            entry.data.get(CONF_BED_TYPE, ""), entry.data.get(CONF_PROTOCOL_VARIANT)
+        ) and not entry.data.get(CONF_BLE_BOND_ESTABLISHED)
 
     # Helper to create pairing issue — only when there's actual evidence of a pairing
     # problem. Generic connection failures (timeout, device not found) should NOT
@@ -354,13 +358,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
             return
 
-        # Beds that refuse *connections* from unbonded peers (LP Comfort
-        # Connect / Leggett & Platt Gen2): a connect timeout on an unbonded
-        # entry is itself the pairing symptom — the box ignores connection
-        # requests outside its pairing window, so waiting on HA's setup
-        # retries can never succeed. Guide the user through the repair flow
-        # (power-cycle into pairing mode, then pair) instead (issue #385).
-        if bond_gated_unbonded:
+        # LP Comfort Connect / Leggett & Platt Gen2 shows a distinct unbonded
+        # failure signature in issue #385: reconnects time out outside the
+        # pairing window while advertisements continue. Guide the user through
+        # the repair flow (power-cycle into pairing mode, then pair) instead of
+        # leaving the entry on retries that cannot establish the required bond.
+        if _bond_gated_unbonded():
             await create_pairing_required_issue(
                 hass,
                 address or "Unknown",
@@ -378,13 +381,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             address,
         )
 
-    bond_gated_hint = (
-        " This bed only accepts Bluetooth connections from devices it has "
-        "paired with. Open Settings → Repairs and follow the pairing steps "
-        "(power-cycle the bed to enter its ~2 minute pairing mode)."
-        if bond_gated_unbonded
-        else " The integration will retry automatically."
-    )
+    def _connection_failure_hint() -> str:
+        """Return pairing guidance only while the entry remains unbonded."""
+        if _bond_gated_unbonded():
+            return (
+                " This bed requires a Bluetooth bond. Open Settings → Repairs and "
+                "follow the pairing steps (power-cycle the bed to enter its ~2 minute "
+                "pairing mode)."
+            )
+        return " The integration will retry automatically."
 
     # Connect to the bed with a timeout to avoid blocking startup forever
     _LOGGER.debug("Attempting initial connection to bed (timeout: %.0fs)...", SETUP_TIMEOUT)
@@ -402,7 +407,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
         raise ConfigEntryNotReady(
             f"Connection to bed at {entry.data.get(CONF_ADDRESS)} timed out after "
-            f"{SETUP_TIMEOUT:.0f}s.{bond_gated_hint}"
+            f"{SETUP_TIMEOUT:.0f}s.{_connection_failure_hint()}"
         ) from None
 
     if not connected:
@@ -414,10 +419,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 coordinator,
                 reason="device was not reachable during initial setup",
             )
-        if bond_gated_unbonded:
+        if _bond_gated_unbonded():
             raise ConfigEntryNotReady(
                 f"Failed to connect to bed at {entry.data.get(CONF_ADDRESS)}."
-                f"{bond_gated_hint}"
+                f"{_connection_failure_hint()}"
             )
         raise ConfigEntryNotReady(
             f"Failed to connect to bed at {entry.data.get(CONF_ADDRESS)}. "

--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -150,12 +150,12 @@ class BedController(ABC):
     def requires_persistent_connection(self) -> bool:
         """Return True if the BLE link must be held open for the entry's lifetime.
 
-        Controllers whose hardware refuses reconnection once disconnected (e.g.
-        Leggett & Platt Gen2 / LP Comfort Connect, which only accepts a connection
-        while in pairing mode) override this to return True so the coordinator
-        never idle-disconnects them. Because this is a property of the resolved
-        controller, it is authoritative even when the bed type/variant resolves to
-        different protocols at connect time.
+        Controllers that must or should conservatively retain the link (e.g.
+        Leggett & Platt Gen2 / LP Comfort Connect pending bonded-reconnect hardware
+        confirmation) override this to return True so the coordinator never
+        idle-disconnects them. Because this is a property of the resolved controller,
+        it is authoritative even when the bed type/variant resolves to different
+        protocols at connect time.
         """
         return False
 

--- a/custom_components/adjustable_bed/beds/leggett_gen2.py
+++ b/custom_components/adjustable_bed/beds/leggett_gen2.py
@@ -16,9 +16,9 @@ Protocol details:
         "M {down}:{up}:{stop}").
 
 Connection note:
-    The ESP32 controller only accepts a BLE connection while the bed is in
-    pairing mode and refuses reconnection afterwards, so this bed type uses a
-    persistent connection (it is never idle-disconnected). See
+    The ESP32 controller requires an OS-level BLE bond. This bed type continues
+    to use a persistent connection (it is never idle-disconnected) until bonded
+    reconnect behavior is confirmed on hardware. See
     coordinator._uses_persistent_connection().
 
 Features (gated per model by the bundled capability profile — see
@@ -199,13 +199,12 @@ class LeggettGen2Controller(BedController):
 
     @property
     def requires_persistent_connection(self) -> bool:
-        """LP Comfort Connect's ESP32 only accepts a connection while in pairing
-        mode and refuses reconnection afterwards, so the link must be held open."""
+        """Keep the Gen2 link open pending hardware confirmation of reconnects."""
         return True
 
     @property
     def manual_disconnect_strands_connection(self) -> bool:
-        """A manual disconnect can't be recovered without re-entering pairing mode."""
+        """Hide manual disconnect until bonded reconnects are hardware-confirmed."""
         return True
 
     @property

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -282,13 +282,27 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         )
         return translations.get(f"component.{DOMAIN}.config.{key}", default)
 
-    async def _get_pairing_instructions(self, bed_type: str | None) -> str:
+    async def _get_pairing_instructions(
+        self, bed_type: str | None, protocol_variant: str | None = None
+    ) -> str:
         """Return pairing instructions tailored to the selected bed type."""
         if bed_type == BED_TYPE_SLEEP_NUMBER:
             return await self._get_config_translation(
                 "step.bluetooth_pairing.data_description.pairing_instructions_sleep_number",
                 "1. Put your bed in pairing mode (hold the side pairing button until the blue light blinks)\n"
                 "2. Click 'Pair Now'",
+            )
+        if bed_type == BED_TYPE_LEGGETT_GEN2 or (
+            bed_type == BED_TYPE_LEGGETT_PLATT and protocol_variant == LEGGETT_VARIANT_GEN2
+        ):
+            # LP Comfort Connect pairing steps, from the LP Control app's
+            # pairing_mode_instructions_gen2 / settings_pair_another_phone_msg.
+            return await self._get_config_translation(
+                "step.bluetooth_pairing.data_description.pairing_instructions_leggett_gen2",
+                "1. Unplug your bed's power cord and remove any batteries from the power supply.\n"
+                "2. Plug the bed back in. You'll hear a small chime and see a pulsing blue light "
+                "under the bed - the bed stays in pairing mode for about 2 minutes.\n"
+                "3. While the light is pulsing, click 'Pair Now'.",
             )
         if bed_type in {
             BED_TYPE_OKIMAT,
@@ -1837,7 +1851,8 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         description_placeholders = {
             "name": self._manual_data.get(CONF_NAME, "Unknown"),
             "pairing_instructions": await self._get_pairing_instructions(
-                self._manual_data.get(CONF_BED_TYPE)
+                self._manual_data.get(CONF_BED_TYPE),
+                self._manual_data.get(CONF_PROTOCOL_VARIANT),
             ),
         }
 
@@ -1903,7 +1918,8 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         description_placeholders = {
             "name": self._manual_data.get(CONF_NAME, "Unknown"),
             "pairing_instructions": await self._get_pairing_instructions(
-                self._manual_data.get(CONF_BED_TYPE)
+                self._manual_data.get(CONF_BED_TYPE),
+                self._manual_data.get(CONF_PROTOCOL_VARIANT),
             ),
         }
 

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -182,13 +182,11 @@ _PROBE_TIMEOUT_SECONDS = 15.0
 
 
 def _skips_setup_connection_probe(bed_type: str | None, variant: str | None) -> bool:
-    """Return True for beds whose single connection must not be spent on the probe.
+    """Return True when setup should avoid a redundant Gen2 connection cycle.
 
-    The setup verify probe connects read-only and always disconnects afterwards.
-    LP Comfort Connect (Leggett & Platt Gen2) only accepts a BLE connection while
-    in pairing mode and refuses reconnection afterwards, so probing would consume
-    the pairing-window connection and leave ``async_setup_entry`` unable to
-    reconnect (issue #385). Skip the probe and create the entry directly for those.
+    LP Comfort Connect must establish its first bond during the short pairing
+    window. After the explicit pairing attempt, skip the optional read-only probe
+    and let ``async_setup_entry`` make the meaningful bonded connection directly.
     """
     if bed_type == BED_TYPE_LEGGETT_GEN2:
         return True

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -1771,13 +1771,21 @@ BEDS_REQUIRING_PAIRING: Final[set[str]] = {
     BED_TYPE_OKIMAT,
     BED_TYPE_VIBRADORM,
     BED_TYPE_LOGICDATA,
+    # Leggett & Platt Gen2 (LP Comfort Connect, 209-M001): the LP Control app
+    # calls createBond() after service discovery ("Bond Needed...Bonding" in
+    # BLEConnectionViewModel), and the ESP32 box only accepts connections from
+    # bonded peers outside its ~2-minute pairing window (fresh power-up or the
+    # "PAIR ENABLE" serial command). Without a bond every reconnect is refused
+    # at the link layer (CONNECT_IND ignored -> TimeoutError) even though the
+    # box keeps advertising (issue #385).
+    BED_TYPE_LEGGETT_GEN2,
 }
 
 # Bed type + variant combinations that require BLE pairing
 # Maps bed type to set of variants that require pairing for that specific bed type
 # Note: Keeson's "okin" variant (OKIN FFE) does NOT require pairing - it's a different protocol
 BED_TYPE_VARIANTS_REQUIRING_PAIRING: Final[dict[str, set[str]]] = {
-    BED_TYPE_LEGGETT_PLATT: {LEGGETT_VARIANT_OKIN},
+    BED_TYPE_LEGGETT_PLATT: {LEGGETT_VARIANT_OKIN, LEGGETT_VARIANT_GEN2},
 }
 
 
@@ -1799,6 +1807,20 @@ def requires_pairing(bed_type: str, protocol_variant: str | None = None) -> bool
         if protocol_variant in BED_TYPE_VARIANTS_REQUIRING_PAIRING[bed_type]:
             return True
     return False
+
+
+def connection_gated_by_bond(bed_type: str, protocol_variant: str | None = None) -> bool:
+    """Return True when a bed refuses *connections* from unbonded peers.
+
+    Most pairing-required beds accept the BLE connection and only gate GATT
+    access on the bond. LP Comfort Connect (Leggett & Platt Gen2) instead
+    ignores connection requests from unbonded peers entirely outside its
+    pairing window, so a plain connect timeout on an unbonded entry is itself
+    evidence of a pairing problem (issue #385).
+    """
+    if bed_type == BED_TYPE_LEGGETT_GEN2:
+        return True
+    return bed_type == BED_TYPE_LEGGETT_PLATT and protocol_variant == LEGGETT_VARIANT_GEN2
 
 # Bed types that support angle sensing (position feedback)
 BEDS_WITH_ANGLE_SENSING: Final = frozenset(

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -1773,11 +1773,10 @@ BEDS_REQUIRING_PAIRING: Final[set[str]] = {
     BED_TYPE_LOGICDATA,
     # Leggett & Platt Gen2 (LP Comfort Connect, 209-M001): the LP Control app
     # calls createBond() after service discovery ("Bond Needed...Bonding" in
-    # BLEConnectionViewModel), and the ESP32 box only accepts connections from
-    # bonded peers outside its ~2-minute pairing window (fresh power-up or the
-    # "PAIR ENABLE" serial command). Without a bond every reconnect is refused
-    # at the link layer (CONNECT_IND ignored -> TimeoutError) even though the
-    # box keeps advertising (issue #385).
+    # BLEConnectionViewModel). Issue #385 shows the corresponding hardware
+    # symptom outside its ~2-minute pairing window: unbonded reconnects time out
+    # while the box keeps advertising. The app can re-open that window with its
+    # "PAIR ENABLE" serial command.
     BED_TYPE_LEGGETT_GEN2,
 }
 
@@ -1810,13 +1809,14 @@ def requires_pairing(bed_type: str, protocol_variant: str | None = None) -> bool
 
 
 def connection_gated_by_bond(bed_type: str, protocol_variant: str | None = None) -> bool:
-    """Return True when a bed refuses *connections* from unbonded peers.
+    """Return True for the observed bond-gated connection-failure signature.
 
     Most pairing-required beds accept the BLE connection and only gate GATT
-    access on the bond. LP Comfort Connect (Leggett & Platt Gen2) instead
-    ignores connection requests from unbonded peers entirely outside its
-    pairing window, so a plain connect timeout on an unbonded entry is itself
-    evidence of a pairing problem (issue #385).
+    access on the bond. With LP Comfort Connect (Leggett & Platt Gen2), issue
+    #385 shows that an unbonded peer times out while the box keeps advertising
+    outside its pairing window. Treat that observed signature as the pairing
+    symptom; the controller firmware's exact link-layer filtering is not
+    visible in the Android APK.
     """
     if bed_type == BED_TYPE_LEGGETT_GEN2:
         return True

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -961,12 +961,11 @@ class AdjustableBedCoordinator:
     def _uses_persistent_connection(self) -> bool:
         """Return True when this controller should stay connected indefinitely.
 
-        Leggett & Platt Gen2 (LP Comfort Connect, 209-M001) is included because
-        its ESP32 controller only accepts a BLE connection while in pairing mode
-        and refuses reconnection afterwards. Idle-disconnecting it leaves the bed
-        unreachable until it is power-cycled / re-paired, so we hold the link open
-        for the lifetime of the entry instead (issue #385). Trade-off: the physical
-        remote cannot be used while Home Assistant is connected.
+        Leggett & Platt Gen2 (LP Comfort Connect, 209-M001) is included
+        conservatively until bonded reconnects are confirmed on hardware. We hold
+        the link open for the lifetime of the entry in the meantime (issue #385).
+        Trade-off: the physical remote cannot be used while Home Assistant is
+        connected.
 
         Resolution order:
         1. The live controller's ``requires_persistent_connection`` (authoritative).
@@ -1003,14 +1002,22 @@ class AdjustableBedCoordinator:
         # entirely until power-cycled (#369). The next user command reconnects on
         # demand, so no reconnect timer is needed for these beds.
         #
-        # Persistent-connection beds are the opposite: they are supposed to stay
-        # connected indefinitely, so an unexpected drop should be repaired
-        # immediately rather than waiting for the next command. For LP Comfort
-        # Connect (Leggett & Platt Gen2) the bonded link is what makes the box
-        # reachable at all, and a drop often means the bed was power-cycled —
-        # reconnecting promptly re-establishes the link while it is accepting
-        # connections (issue #385).
-        return not self._disconnect_after_operation_enabled()
+        if self._disconnect_after_operation_enabled():
+            return False
+
+        # LP Comfort Connect is kept connected conservatively, and the new bond
+        # makes an unexpected drop recoverable. Reconnect promptly while leaving
+        # the established lifecycle behavior of other persistent protocols (such
+        # as Sleep Number MCR) unchanged by this Gen2-specific fix.
+        if self._bed_type == BED_TYPE_LEGGETT_GEN2:
+            return True
+        if self._bed_type == BED_TYPE_LEGGETT_PLATT and self._protocol_variant in (
+            VARIANT_AUTO,
+            LEGGETT_VARIANT_GEN2,
+        ):
+            return self._uses_persistent_connection()
+
+        return not self._uses_persistent_connection()
 
     async def _async_connect_locked(self, reset_timer: bool = True) -> bool:
         """Connect to the bed (must hold lock)."""
@@ -1998,7 +2005,8 @@ class AdjustableBedCoordinator:
 
         if not self._auto_reconnect_enabled():
             _LOGGER.debug(
-                "Skipping auto-reconnect timer for %s (disconnect_after_command); "
+                "Skipping auto-reconnect timer for %s (persistent connection or "
+                "disconnect_after_command); "
                 "next command reconnects on demand",
                 self._bed_type,
             )

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -1002,9 +1002,15 @@ class AdjustableBedCoordinator:
         # few reconnect cycles enter a protection mode where they stop advertising
         # entirely until power-cycled (#369). The next user command reconnects on
         # demand, so no reconnect timer is needed for these beds.
-        if self._disconnect_after_operation_enabled():
-            return False
-        return not self._uses_persistent_connection()
+        #
+        # Persistent-connection beds are the opposite: they are supposed to stay
+        # connected indefinitely, so an unexpected drop should be repaired
+        # immediately rather than waiting for the next command. For LP Comfort
+        # Connect (Leggett & Platt Gen2) the bonded link is what makes the box
+        # reachable at all, and a drop often means the bed was power-cycled —
+        # reconnecting promptly re-establishes the link while it is accepting
+        # connections (issue #385).
+        return not self._disconnect_after_operation_enabled()
 
     async def _async_connect_locked(self, reset_timer: bool = True) -> bool:
         """Connect to the bed (must hold lock)."""
@@ -1992,8 +1998,8 @@ class AdjustableBedCoordinator:
 
         if not self._auto_reconnect_enabled():
             _LOGGER.debug(
-                "Skipping auto-reconnect timer for %s (persistent connection or "
-                "disconnect_after_command); next command reconnects on demand",
+                "Skipping auto-reconnect timer for %s (disconnect_after_command); "
+                "next command reconnects on demand",
                 self._bed_type,
             )
             if self._reconnect_timer is not None:

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -184,12 +184,14 @@
           "action": "Action",
           "pairing_instructions_generic": "Pairing instructions (generic)",
           "pairing_instructions_okin": "Pairing instructions (Okin)",
-          "pairing_instructions_sleep_number": "Pairing instructions (Sleep Number)"
+          "pairing_instructions_sleep_number": "Pairing instructions (Sleep Number)",
+          "pairing_instructions_leggett_gen2": "Pairing instructions (Leggett & Platt Gen2)"
         },
         "data_description": {
           "pairing_instructions_generic": "1. Put your bed in pairing mode (hold lamp button until blue light blinks, or unplug for 30+ seconds)\n2. Click 'Pair Now'",
           "pairing_instructions_okin": "1. Put the OKIN base into Bluetooth pairing mode by power-cycling the control box: unplug it for ~30 seconds, then plug it back in. The status light blinks blue, then turns green after ~20 seconds. (Some models instead use the under-bed lamp/light button - hold it until the light blinks blue.) There is no separate Bluetooth pairing button; any Pair/Learn button on the box only syncs the RF remote.\n2. While the light is active, click 'Pair Now'.",
-          "pairing_instructions_sleep_number": "1. Put your bed in pairing mode (hold the side pairing button until the blue light blinks)\n2. Click 'Pair Now'"
+          "pairing_instructions_sleep_number": "1. Put your bed in pairing mode (hold the side pairing button until the blue light blinks)\n2. Click 'Pair Now'",
+          "pairing_instructions_leggett_gen2": "1. Unplug your bed's power cord and remove any batteries from the power supply.\n2. Plug the bed back in. You'll hear a small chime and see a pulsing blue light under the bed - the bed stays in pairing mode for about 2 minutes.\n3. While the light is pulsing, click 'Pair Now'."
         }
       },
       "manual_pairing": {
@@ -774,11 +776,11 @@
         "step": {
           "confirm": {
             "title": "Pair your adjustable bed",
-            "description": "**{name}** ({address}) connected but its Bluetooth link is not bonded, so it cannot be controlled yet.\n\n1. Put the bed into pairing mode. **OKIN bases** (Okimat, Okin CST, Nectar OKIN-*, Mattress Firm 900-O): power-cycle the control box — unplug it for ~30 seconds, then plug it back in (the light blinks blue, then turns green); they have no Bluetooth pairing button. **Other beds**: hold the pairing button on the control box or remote until its light blinks.\n2. While the bed is discoverable, press **Submit** to pair.\n\nPairing happens on your Home Assistant host or Bluetooth proxy — not your phone. ESPHome proxies must run ESPHome 2024.3.0 or newer."
+            "description": "**{name}** ({address}) requires a Bluetooth bond before it can be controlled.\n\n1. Put the bed into pairing mode. **OKIN bases** (Okimat, Okin CST, Nectar OKIN-*, Mattress Firm 900-O): power-cycle the control box — unplug it for ~30 seconds, then plug it back in (the light blinks blue, then turns green); they have no Bluetooth pairing button. **Leggett & Platt Smart Bed (LP Comfort Connect)**: unplug the bed's power cord, remove any batteries from the power supply, then plug it back in — you'll hear a chime and see a pulsing blue light under the bed, and the bed stays in pairing mode for about 2 minutes. **Other beds**: hold the pairing button on the control box or remote until its light blinks.\n2. While the bed is in pairing mode, press **Submit** to pair.\n\nPairing happens on your Home Assistant host or Bluetooth proxy — not your phone. ESPHome proxies must run ESPHome 2024.3.0 or newer."
           }
         },
         "abort": {
-          "pairing_failed": "Pairing didn't complete. Put the bed back into pairing mode (OKIN bases: unplug the control box ~30s, then plug it back in; other beds: hold the pairing button), make sure it is in range of your Home Assistant adapter or an ESPHome proxy on 2024.3.0+, then run this repair again."
+          "pairing_failed": "Pairing didn't complete. Put the bed back into pairing mode (OKIN bases: unplug the control box ~30s, then plug it back in; Leggett & Platt Smart Bed: unplug the bed and remove the power-supply batteries, then plug it back in and wait for the chime and pulsing blue light; other beds: hold the pairing button), make sure it is in range of your Home Assistant adapter or an ESPHome proxy on 2024.3.0+, then run this repair again."
         }
       }
     }

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -184,12 +184,14 @@
           "action": "Action",
           "pairing_instructions_generic": "Pairing instructions (generic)",
           "pairing_instructions_okin": "Pairing instructions (Okin)",
-          "pairing_instructions_sleep_number": "Pairing instructions (Sleep Number)"
+          "pairing_instructions_sleep_number": "Pairing instructions (Sleep Number)",
+          "pairing_instructions_leggett_gen2": "Pairing instructions (Leggett & Platt Gen2)"
         },
         "data_description": {
           "pairing_instructions_generic": "1. Put your bed in pairing mode (hold lamp button until blue light blinks, or unplug for 30+ seconds)\n2. Click 'Pair Now'",
           "pairing_instructions_okin": "1. Put the OKIN base into Bluetooth pairing mode by power-cycling the control box: unplug it for ~30 seconds, then plug it back in. The status light blinks blue, then turns green after ~20 seconds. (Some models instead use the under-bed lamp/light button - hold it until the light blinks blue.) There is no separate Bluetooth pairing button; any Pair/Learn button on the box only syncs the RF remote.\n2. While the light is active, click 'Pair Now'.",
-          "pairing_instructions_sleep_number": "1. Put your bed in pairing mode (hold the side pairing button until the blue light blinks)\n2. Click 'Pair Now'"
+          "pairing_instructions_sleep_number": "1. Put your bed in pairing mode (hold the side pairing button until the blue light blinks)\n2. Click 'Pair Now'",
+          "pairing_instructions_leggett_gen2": "1. Unplug your bed's power cord and remove any batteries from the power supply.\n2. Plug the bed back in. You'll hear a small chime and see a pulsing blue light under the bed - the bed stays in pairing mode for about 2 minutes.\n3. While the light is pulsing, click 'Pair Now'."
         }
       },
       "manual_pairing": {
@@ -777,11 +779,11 @@
         "step": {
           "confirm": {
             "title": "Pair your adjustable bed",
-            "description": "**{name}** ({address}) connected but its Bluetooth link is not bonded, so it cannot be controlled yet.\n\n1. Put the bed into pairing mode. **OKIN bases** (Okimat, Okin CST, Nectar OKIN-*, Mattress Firm 900-O): power-cycle the control box — unplug it for ~30 seconds, then plug it back in (the light blinks blue, then turns green); they have no Bluetooth pairing button. **Other beds**: hold the pairing button on the control box or remote until its light blinks.\n2. While the bed is discoverable, press **Submit** to pair.\n\nPairing happens on your Home Assistant host or Bluetooth proxy — not your phone. ESPHome proxies must run ESPHome 2024.3.0 or newer."
+            "description": "**{name}** ({address}) requires a Bluetooth bond before it can be controlled.\n\n1. Put the bed into pairing mode. **OKIN bases** (Okimat, Okin CST, Nectar OKIN-*, Mattress Firm 900-O): power-cycle the control box — unplug it for ~30 seconds, then plug it back in (the light blinks blue, then turns green); they have no Bluetooth pairing button. **Leggett & Platt Smart Bed (LP Comfort Connect)**: unplug the bed's power cord, remove any batteries from the power supply, then plug it back in — you'll hear a chime and see a pulsing blue light under the bed, and the bed stays in pairing mode for about 2 minutes. **Other beds**: hold the pairing button on the control box or remote until its light blinks.\n2. While the bed is in pairing mode, press **Submit** to pair.\n\nPairing happens on your Home Assistant host or Bluetooth proxy — not your phone. ESPHome proxies must run ESPHome 2024.3.0 or newer."
           }
         },
         "abort": {
-          "pairing_failed": "Pairing didn't complete. Put the bed back into pairing mode (OKIN bases: unplug the control box ~30s, then plug it back in; other beds: hold the pairing button), make sure it is in range of your Home Assistant adapter or an ESPHome proxy on 2024.3.0+, then run this repair again."
+          "pairing_failed": "Pairing didn't complete. Put the bed back into pairing mode (OKIN bases: unplug the control box ~30s, then plug it back in; Leggett & Platt Smart Bed: unplug the bed and remove the power-supply batteries, then plug it back in and wait for the chime and pulsing blue light; other beds: hold the pairing button), make sure it is in range of your Home Assistant adapter or an ESPHome proxy on 2024.3.0+, then run this repair again."
         }
       }
     }

--- a/docs/beds/leggett-platt.md
+++ b/docs/beds/leggett-platt.md
@@ -43,13 +43,27 @@ Leggett & Platt beds have three protocol variants with different detection metho
   from that prefix, matching the LP Control app's `isGen2Box()` check.
 - Detection: automatic by service UUID **or** the `XP`/`CP` manufacturer prefix.
 
-> **Connection note (LP Comfort Connect):** the ESP32 controller only accepts a
-> BLE connection while the bed is **in pairing mode**, and refuses reconnection
-> afterwards. The integration therefore keeps the link open for this bed type
-> (no idle disconnect). If Home Assistant loses the connection (e.g. a restart),
-> put the bed back into pairing mode (pull the remote's batteries / re-enable
-> pairing) before it can reconnect. While Home Assistant is connected the
-> physical remote cannot be used.
+> **Connection & bonding (LP Comfort Connect):** the ESP32 controller requires a
+> **BLE bond** (issue #385). Outside its pairing window it ignores connection
+> requests from unbonded peers entirely — connects time out while the box keeps
+> advertising. The LP Control app bonds after service discovery
+> (`BLEConnectionViewModel`: bond state `BOND_NONE` + Gen2 → `createBond()`),
+> which is why the app can reconnect at any time.
+>
+> The integration therefore pairs (`pair=True`) on the first connection, which
+> must happen during the pairing window:
+>
+> - **Entering pairing mode** (per the LP Control app): unplug the bed, remove
+>   any batteries from the power supply, plug it back in — a small chime plays
+>   and a pulsing blue light shows under the bed. The window lasts ~2 minutes.
+>   A connected client can also re-open the window with the `PAIR ENABLE`
+>   serial command (the app's "pair another phone" feature).
+> - Factory reset (`DWIPE`) clears the box's stored Bluetooth pairings.
+>
+> Once bonded, reconnects are accepted outside the pairing window. The
+> integration still holds the link open for this bed type (no idle disconnect).
+> While Home Assistant is connected the physical remote cannot be used (same
+> limitation as the app: the box allows one active client).
 
 ### Okin Variant
 - **Service UUID:** `62741523-...` (shared with Okimat and Nectar)

--- a/docs/beds/leggett-platt.md
+++ b/docs/beds/leggett-platt.md
@@ -44,11 +44,15 @@ Leggett & Platt beds have three protocol variants with different detection metho
 - Detection: automatic by service UUID **or** the `XP`/`CP` manufacturer prefix.
 
 > **Connection & bonding (LP Comfort Connect):** the ESP32 controller requires a
-> **BLE bond** (issue #385). Outside its pairing window it ignores connection
-> requests from unbonded peers entirely — connects time out while the box keeps
-> advertising. The LP Control app bonds after service discovery
+> **BLE bond** (issue #385). Outside its pairing window, the reported unbonded
+> connection attempts time out while the box keeps advertising. The LP Control
+> app bonds after service discovery
 > (`BLEConnectionViewModel`: bond state `BOND_NONE` + Gen2 → `createBond()`),
 > which is why the app can reconnect at any time.
+>
+> The APK proves that the app requires a bond; the controller firmware is not
+> present in the APK, so the exact link-layer filtering mechanism is inferred
+> from the observed timeout-while-advertising behavior.
 >
 > The integration therefore pairs (`pair=True`) on the first connection, which
 > must happen during the pairing window:
@@ -58,7 +62,9 @@ Leggett & Platt beds have three protocol variants with different detection metho
 >   and a pulsing blue light shows under the bed. The window lasts ~2 minutes.
 >   A connected client can also re-open the window with the `PAIR ENABLE`
 >   serial command (the app's "pair another phone" feature).
-> - Factory reset (`DWIPE`) clears the box's stored Bluetooth pairings.
+> - `DWIPE` is the app's Gen2 factory-reset command. Whether it specifically
+>   clears the controller's bond table is firmware behavior and is not required
+>   by this integration flow.
 >
 > Once bonded, reconnects are accepted outside the pairing window. The
 > integration still holds the link open for this bed type (no idle disconnect).

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1506,13 +1506,15 @@ class TestSleepNumberMcrCoordinatorLifecycle:
         coordinator.async_disconnect.assert_not_awaited()
         assert coordinator._disconnect_timer is None
 
-    async def test_sleep_number_mcr_unexpected_disconnect_skips_auto_reconnect(
+    async def test_sleep_number_mcr_unexpected_disconnect_schedules_auto_reconnect(
         self,
         hass: HomeAssistant,
         mock_coordinator_connected,
         mock_bleak_client: MagicMock,
     ):
-        """Sleep Number MCR should not schedule timer-based auto-reconnect."""
+        """Persistent-connection beds repair unexpected drops via the reconnect
+        timer — they are supposed to stay connected indefinitely, so waiting for
+        the next user command would leave them offline (issue #385)."""
         del mock_coordinator_connected
         entry = MockConfigEntry(
             domain=DOMAIN,
@@ -1537,9 +1539,11 @@ class TestSleepNumberMcrCoordinatorLifecycle:
 
         coordinator._on_disconnect(mock_bleak_client)
 
-        assert coordinator._reconnect_timer is None
+        assert coordinator._reconnect_timer is not None
         assert coordinator.client is None
         assert coordinator.controller is None
+        coordinator._reconnect_timer.cancel()
+        coordinator._reconnect_timer = None
 
     async def test_disconnect_after_command_skips_auto_reconnect(
         self,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1506,15 +1506,13 @@ class TestSleepNumberMcrCoordinatorLifecycle:
         coordinator.async_disconnect.assert_not_awaited()
         assert coordinator._disconnect_timer is None
 
-    async def test_sleep_number_mcr_unexpected_disconnect_schedules_auto_reconnect(
+    async def test_sleep_number_mcr_unexpected_disconnect_skips_auto_reconnect(
         self,
         hass: HomeAssistant,
         mock_coordinator_connected,
         mock_bleak_client: MagicMock,
     ):
-        """Persistent-connection beds repair unexpected drops via the reconnect
-        timer — they are supposed to stay connected indefinitely, so waiting for
-        the next user command would leave them offline (issue #385)."""
+        """The Gen2 fix must not change Sleep Number MCR reconnect behavior."""
         del mock_coordinator_connected
         entry = MockConfigEntry(
             domain=DOMAIN,
@@ -1539,11 +1537,9 @@ class TestSleepNumberMcrCoordinatorLifecycle:
 
         coordinator._on_disconnect(mock_bleak_client)
 
-        assert coordinator._reconnect_timer is not None
+        assert coordinator._reconnect_timer is None
         assert coordinator.client is None
         assert coordinator.controller is None
-        coordinator._reconnect_timer.cancel()
-        coordinator._reconnect_timer = None
 
     async def test_disconnect_after_command_skips_auto_reconnect(
         self,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -156,9 +156,7 @@ class TestIntegrationSetup:
         mock_bluetooth_adapters,
         enable_custom_integrations,
     ):
-        """An unbonded LP Comfort Connect (Gen2) that cannot connect gets the
-        guided pairing repair — the box ignores connection requests from
-        unbonded peers, so waiting on setup retries can never succeed (#385)."""
+        """An unbonded Gen2 timeout gets the guided pairing repair from #385."""
         from homeassistant.helpers import issue_registry as ir
 
         entry = MockConfigEntry(
@@ -230,6 +228,61 @@ class TestIntegrationSetup:
         issue_registry = ir.async_get(hass)
         assert (
             issue_registry.async_get_issue(DOMAIN, "pairing_required_08_3a_f2_1e_4b_7f") is None
+        )
+
+    async def test_setup_gen2_failure_after_bond_skips_pairing_repair(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_adapters,
+        enable_custom_integrations,
+    ):
+        """A bond established during this setup attempt must be observed dynamically."""
+        from homeassistant.helpers import issue_registry as ir
+
+        address = "08:3A:F2:1E:4B:80"
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Smart Bed 22D8",
+            data={
+                CONF_ADDRESS: address,
+                CONF_NAME: "Smart Bed 22D8",
+                CONF_BED_TYPE: BED_TYPE_LEGGETT_GEN2,
+                CONF_MOTOR_COUNT: 4,
+                CONF_HAS_MASSAGE: True,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=address,
+            entry_id="leggett_gen2_bonded_during_setup_entry",
+        )
+        entry.add_to_hass(hass)
+
+        async def _connect_then_fail(_coordinator) -> bool:
+            hass.config_entries.async_update_entry(
+                entry,
+                data={**entry.data, CONF_BLE_BOND_ESTABLISHED: True},
+            )
+            return False
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.AdjustableBedCoordinator.async_connect",
+                autospec=True,
+                side_effect=_connect_then_fail,
+            ),
+            patch(
+                "custom_components.adjustable_bed.bluetooth.async_ble_device_from_address",
+                return_value=None,
+            ),
+        ):
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert entry.state == ConfigEntryState.SETUP_RETRY
+        assert entry.data[CONF_BLE_BOND_ESTABLISHED] is True
+        issue_registry = ir.async_get(hass)
+        assert (
+            issue_registry.async_get_issue(DOMAIN, "pairing_required_08_3a_f2_1e_4b_80") is None
         )
 
     async def test_setup_non_gated_pairing_bed_connect_failure_skips_repair(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -24,6 +24,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_BEDTECH,
     BED_TYPE_DIAGNOSTIC,
     BED_TYPE_KAIDI,
+    BED_TYPE_LEGGETT_GEN2,
     BED_TYPE_LINAK,
     BED_TYPE_MALOUF_LEGACY_OKIN,
     BED_TYPE_OKIN_CST,
@@ -36,6 +37,7 @@ from custom_components.adjustable_bed.const import (
     BEDTECH_SERVICE_UUID,
     CONF_BACK_MAX_ANGLE,
     CONF_BED_TYPE,
+    CONF_BLE_BOND_ESTABLISHED,
     CONF_DISABLE_ANGLE_SENSING,
     CONF_HAS_MASSAGE,
     CONF_KAIDI_PRODUCT_ID,
@@ -147,6 +149,128 @@ class TestIntegrationSetup:
         devices = dr.async_entries_for_config_entry(device_registry, mock_config_entry.entry_id)
         assert len(devices) == 1
         assert devices[0].name == mock_config_entry.title
+
+    async def test_setup_gen2_connect_failure_creates_pairing_repair(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_adapters,
+        enable_custom_integrations,
+    ):
+        """An unbonded LP Comfort Connect (Gen2) that cannot connect gets the
+        guided pairing repair — the box ignores connection requests from
+        unbonded peers, so waiting on setup retries can never succeed (#385)."""
+        from homeassistant.helpers import issue_registry as ir
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Smart Bed 22D8",
+            data={
+                CONF_ADDRESS: "08:3A:F2:1E:4B:7E",
+                CONF_NAME: "Smart Bed 22D8",
+                CONF_BED_TYPE: BED_TYPE_LEGGETT_GEN2,
+                CONF_MOTOR_COUNT: 4,
+                CONF_HAS_MASSAGE: True,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="08:3A:F2:1E:4B:7E",
+            entry_id="leggett_gen2_pairing_repair_entry",
+        )
+        entry.add_to_hass(hass)
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator.bluetooth.async_ble_device_from_address",
+            return_value=None,
+        ):
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert entry.state == ConfigEntryState.SETUP_RETRY
+        issue_registry = ir.async_get(hass)
+        issue = issue_registry.async_get_issue(DOMAIN, "pairing_required_08_3a_f2_1e_4b_7e")
+        assert issue is not None
+        assert issue.translation_key == "pairing_required"
+
+    async def test_setup_gen2_connect_failure_with_bond_skips_pairing_repair(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_adapters,
+        enable_custom_integrations,
+    ):
+        """A bonded Gen2 entry that cannot connect is a transient failure, not
+        a pairing problem — no repair issue."""
+        from homeassistant.helpers import issue_registry as ir
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Smart Bed 22D8",
+            data={
+                CONF_ADDRESS: "08:3A:F2:1E:4B:7F",
+                CONF_NAME: "Smart Bed 22D8",
+                CONF_BED_TYPE: BED_TYPE_LEGGETT_GEN2,
+                CONF_MOTOR_COUNT: 4,
+                CONF_HAS_MASSAGE: True,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+                CONF_BLE_BOND_ESTABLISHED: True,
+            },
+            unique_id="08:3A:F2:1E:4B:7F",
+            entry_id="leggett_gen2_bonded_no_repair_entry",
+        )
+        entry.add_to_hass(hass)
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator.bluetooth.async_ble_device_from_address",
+            return_value=None,
+        ):
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert entry.state == ConfigEntryState.SETUP_RETRY
+        issue_registry = ir.async_get(hass)
+        assert (
+            issue_registry.async_get_issue(DOMAIN, "pairing_required_08_3a_f2_1e_4b_7f") is None
+        )
+
+    async def test_setup_non_gated_pairing_bed_connect_failure_skips_repair(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_adapters,
+        enable_custom_integrations,
+    ):
+        """Ordinary pairing-required beds (e.g. Okin CST) keep the existing
+        behaviour: a plain connect failure before pairing creates no repair."""
+        from homeassistant.helpers import issue_registry as ir
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Okin CST Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:20",
+                CONF_NAME: "Okin CST Bed",
+                CONF_BED_TYPE: BED_TYPE_OKIN_CST,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:20",
+            entry_id="okin_cst_no_repair_entry",
+        )
+        entry.add_to_hass(hass)
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator.bluetooth.async_ble_device_from_address",
+            return_value=None,
+        ):
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        assert entry.state == ConfigEntryState.SETUP_RETRY
+        issue_registry = ir.async_get(hass)
+        assert (
+            issue_registry.async_get_issue(DOMAIN, "pairing_required_aa_bb_cc_dd_ee_20") is None
+        )
 
     async def test_setup_entry_loads_diagnostic_device_without_connection(
         self,

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -20,6 +20,7 @@ from custom_components.adjustable_bed.beds.leggett_okin import (
 from custom_components.adjustable_bed.const import (
     BED_TYPE_LEGGETT_GEN2,
     BED_TYPE_LEGGETT_PLATT,
+    BED_TYPE_OKIMAT,
     CONF_BED_TYPE,
     CONF_DISABLE_ANGLE_SENSING,
     CONF_HAS_MASSAGE,
@@ -32,6 +33,8 @@ from custom_components.adjustable_bed.const import (
     LEGGETT_VARIANT_MLRM,
     LEGGETT_VARIANT_OKIN,
     VARIANT_AUTO,
+    connection_gated_by_bond,
+    requires_pairing,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
 
@@ -236,6 +239,81 @@ class TestLeggettGen2Connection:
         # Resolved to a persistent (Gen2) controller, then cleared.
         coordinator._persistent_connection_resolved = True
         assert coordinator._uses_persistent_connection() is True
+
+    @pytest.mark.parametrize(
+        ("bed_type", "variant", "expected"),
+        [
+            (BED_TYPE_LEGGETT_GEN2, None, True),
+            (BED_TYPE_LEGGETT_GEN2, VARIANT_AUTO, True),
+            (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_GEN2, True),
+            (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_OKIN, True),
+            (BED_TYPE_LEGGETT_PLATT, VARIANT_AUTO, False),
+            (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_MLRM, False),
+        ],
+    )
+    async def test_gen2_requires_pairing(
+        self, bed_type: str, variant: str | None, expected: bool
+    ):
+        """LP Comfort Connect requires a BLE bond: the LP Control app calls
+        createBond() after service discovery, and the box refuses connections
+        from unbonded peers outside its pairing window (issue #385)."""
+        assert requires_pairing(bed_type, variant) is expected
+
+    @pytest.mark.parametrize(
+        ("bed_type", "variant", "expected"),
+        [
+            (BED_TYPE_LEGGETT_GEN2, None, True),
+            (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_GEN2, True),
+            # Okin-style pairing beds accept the connection and only gate GATT
+            # access, so a connect timeout there is not a pairing symptom.
+            (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_OKIN, False),
+            (BED_TYPE_LEGGETT_PLATT, VARIANT_AUTO, False),
+            (BED_TYPE_OKIMAT, None, False),
+        ],
+    )
+    async def test_connection_gated_by_bond(
+        self, bed_type: str, variant: str | None, expected: bool
+    ):
+        """Only Gen2 refuses *connections* from unbonded peers."""
+        assert connection_gated_by_bond(bed_type, variant) is expected
+
+    async def test_gen2_unexpected_disconnect_schedules_auto_reconnect(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """A persistent-connection Gen2 bed must repair unexpected drops itself:
+        the bonded link is what keeps the box reachable, and a drop often means
+        the bed was power-cycled, so reconnect promptly (issue #385)."""
+        del mock_coordinator_connected
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="LP Comfort Connect Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:85",
+                CONF_NAME: "Smart Bed 22D8",
+                CONF_BED_TYPE: BED_TYPE_LEGGETT_GEN2,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:85",
+            entry_id="leggett_gen2_auto_reconnect_test",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        assert coordinator._auto_reconnect_enabled() is True
+        await coordinator.async_connect()
+        mock_bleak_client.is_connected = False
+
+        coordinator._on_disconnect(mock_bleak_client)
+
+        assert coordinator._reconnect_timer is not None
+        coordinator._reconnect_timer.cancel()
+        coordinator._reconnect_timer = None
 
 
 class TestLeggettGen2Capabilities:

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -254,9 +254,7 @@ class TestLeggettGen2Connection:
     async def test_gen2_requires_pairing(
         self, bed_type: str, variant: str | None, expected: bool
     ):
-        """LP Comfort Connect requires a BLE bond: the LP Control app calls
-        createBond() after service discovery, and the box refuses connections
-        from unbonded peers outside its pairing window (issue #385)."""
+        """LP Control calls createBond() for Gen2 after service discovery."""
         assert requires_pairing(bed_type, variant) is expected
 
     @pytest.mark.parametrize(
@@ -274,7 +272,7 @@ class TestLeggettGen2Connection:
     async def test_connection_gated_by_bond(
         self, bed_type: str, variant: str | None, expected: bool
     ):
-        """Only Gen2 refuses *connections* from unbonded peers."""
+        """Only Gen2 showed the bond-gated timeout signature in issue #385."""
         assert connection_gated_by_bond(bed_type, variant) is expected
 
     async def test_gen2_unexpected_disconnect_schedules_auto_reconnect(
@@ -283,9 +281,7 @@ class TestLeggettGen2Connection:
         mock_coordinator_connected,
         mock_bleak_client: MagicMock,
     ):
-        """A persistent-connection Gen2 bed must repair unexpected drops itself:
-        the bonded link is what keeps the box reachable, and a drop often means
-        the bed was power-cycled, so reconnect promptly (issue #385)."""
+        """A persistent Gen2 bed should promptly repair an unexpected drop."""
         del mock_coordinator_connected
         entry = MockConfigEntry(
             domain=DOMAIN,
@@ -392,7 +388,7 @@ class TestLeggettGen2Capabilities:
     async def test_manual_disconnect_strands_connection(
         self, hass: HomeAssistant, mock_leggett_gen2_config_entry
     ):
-        # Gen2 can only reconnect in pairing mode -> manual disconnect strands it.
+        # Keep this hidden until bonded reconnects are confirmed on hardware.
         assert self._controller(
             hass, mock_leggett_gen2_config_entry, 5
         ).manual_disconnect_strands_connection is True


### PR DESCRIPTION
## Problem

Ref #385. A Leggett & Platt **Smart Bed** (LP Comfort Connect, ESP32 box 209-M001) connects exactly once — right after the bed is power-cycled — and then every reconnect times out (`BleakNotFoundError: TimeoutError` after 20s) while the box keeps advertising. On 3.0.1 that means setup never completes and no entities are created; the support bundles show two clean connect timeouts each.

## Root cause

Fresh jadx decompile of **LP Control 2.9.x** (`com.leggett.android.universal`):

- `BLEConnectionViewModel.setBleStatus`: on `SERVICES_DISCOVERED` with bond state `BOND_NONE` on a Gen2 box, the app logs "Bond Needed...Bonding" and calls **`createBond()`**.
- The box only accepts connections from **bonded** peers outside its pairing window — unbonded CONNECT_INDs are ignored at the link layer (whitelist-filtered advertising), which is exactly the observed timeout-while-advertising signature.
- Pairing window (app strings `pairing_mode_instructions_gen2` / `settings_pair_another_phone_msg`): unplug the bed, remove any batteries from the power supply, plug back in → chime + pulsing blue light, **~2 minutes**. A connected client can re-open the window with the `PAIR ENABLE` serial command; `DWIPE` (factory reset) clears stored pairings.

The app bonds once during the window and can then reconnect forever. Home Assistant never bonded, so it got one pairing-window connection and was locked out afterwards — the previous "persistent connection" treatment addressed the symptom, not the cause.

## Fix

- **`const.py`**: `leggett_gen2` (and the `leggett_platt` + `gen2` variant) added to the pairing requirements, so the coordinator's existing pair-on-connect path (`pair=True`, bond verification, persisted bond marker) applies. New `connection_gated_by_bond()` helper marks Gen2 as a bed where a plain connect timeout on an unbonded entry is itself the pairing symptom.
- **`__init__.py`**: an unbonded Gen2 entry that cannot connect now creates the **guided pairing repair** (previously explicitly skipped for connect-before-pairing failures, which could never resolve for this box) and the `ConfigEntryNotReady` message explains the pairing window instead of promising retries that cannot succeed. Bonded entries keep the transient-failure behaviour.
- **`config_flow.py`**: Gen2-specific pairing instructions (from the app's own strings) shown in the pairing step for both discovery and manual setup; the repair-issue text gains the same steps.
- **`coordinator.py`**: persistent-connection beds now schedule the standard auto-reconnect after an unexpected disconnect (previously skipped). For Gen2 the bonded link is what keeps the box reachable, and a drop often *is* the power-cycle moment; MCR benefits equally. `disconnect_after_command` beds keep skipping it (#369 reconnect-storm guard unchanged).
- **`docs/beds/leggett-platt.md`**: connection note rewritten around the bonding model.

## Expected user flow (reporter's case)

1. Update → entry retries setup → repair issue appears with the power-cycle steps.
2. User power-cycles the bed and presses Submit within the 2-minute window → repair pairs (`pair=True`), verifies the bond, persists `ble_bond_established`, reloads the entry.
3. Setup connects (now bonded), entities appear; reconnects survive HA restarts.

> Follow-up question for hardware testing: if bonded reconnects are confirmed across restarts, Gen2 may no longer need the persistent connection at all — idle-disconnect would give the physical remote back between HA commands.

## Testing

- New: `requires_pairing`/`connection_gated_by_bond` matrices for all leggett variants; unbonded-Gen2 setup failure creates the pairing repair (bonded and Okin-CST cases don't); Gen2 unexpected disconnect schedules auto-reconnect.
- Updated: MCR disconnect test now asserts the reconnect timer is scheduled.
- Full suite: **2115 passed**; ruff + pyright clean.

⚠️ Needs on-device confirmation from the reporter — protocol behaviour is APK-verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BLE bonding support for Leggett & Platt Gen2 beds.
  * Added guided pairing and repair prompts when an unbonded bed cannot connect.
  * Updated pairing instructions for Bluetooth and manual setup flows.

* **Bug Fixes**
  * Improved automatic reconnection after unexpected disconnects, including persistent-connection beds.
  * Preserved automatic retry behavior when bonding is not required.

* **Documentation**
  * Clarified bonding, pairing mode, and reconnection behavior for LP Comfort Connect Gen2 beds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->