### PR TITLE
Add Malouf/Lucid hold-to-save memory programming, verify L600 protocol

### DIFF
--- a/custom_components/adjustable_bed/beds/malouf.py
+++ b/custom_components/adjustable_bed/beds/malouf.py
@@ -1,6 +1,8 @@
 """Malouf bed controller implementations.
 
-Reverse-engineered from Malouf Base app v2.4.3.
+Reverse-engineered from Malouf Base app v2.4.3; verified against a fresh
+decompile of Lucid Base v1.3.3 (com.lucid.bedbase, shared
+com.malouf.adjustablebasebluetooth library) on 2026-07-10.
 
 Malouf beds use two distinct protocols:
 - NEW_OKIN: 8-byte commands via Nordic UART, advertises unique service UUID
@@ -57,6 +59,15 @@ class MaloufCommands:
     TV_READ = 0x4000
     MEMORY_1 = 0x10000
     MEMORY_2 = 0x40000
+
+    # Memory programming (hold-to-save). The app emulates holding the
+    # remote's memory button: it streams the save command at the protocol's
+    # repeat interval for the full repeat window, then sends STOP. Slot 1
+    # reuses the recall value (the sustained stream is what signals "save");
+    # beds named "Smartbed238" use a dedicated value with the save bit set.
+    SAVE_MEMORY_1 = 0x10000
+    SAVE_MEMORY_1_SMARTBED238 = 0x80010000
+    SAVE_MEMORY_2 = 0x80040000
 
     # Lights & Massage
     LIGHT_SWITCH = 0x20000
@@ -116,6 +127,25 @@ def _malouf_hilo_motor_control_specs() -> tuple[MotorControlSpec, ...]:
             stop_fn=lambda ctrl: ctrl.move_bed_height_stop(),
         ),
     )
+
+
+def _save_memory_command(memory_num: int, device_name: str | None) -> int | None:
+    """Return the hold-to-save command value for a memory slot.
+
+    Matches the app's setMemory1/setMemory2 handling: slot 1 uses the recall
+    value (or the save-bit variant on beds named "Smartbed238"), slot 2 always
+    carries the save bit.
+    """
+    smartbed238 = bool(device_name) and "smartbed238" in device_name.lower()
+    if memory_num == 1:
+        return (
+            MaloufCommands.SAVE_MEMORY_1_SMARTBED238
+            if smartbed238
+            else MaloufCommands.SAVE_MEMORY_1
+        )
+    if memory_num == 2:
+        return MaloufCommands.SAVE_MEMORY_2
+    return None
 
 
 class MaloufNewOkinController(BedController):
@@ -190,8 +220,8 @@ class MaloufNewOkinController(BedController):
 
     @property
     def supports_memory_programming(self) -> bool:
-        """Return False - Malouf beds don't support programming memory positions."""
-        return False
+        """Return True - saving is a sustained hold-to-save command stream."""
+        return True
 
     @property
     def motor_control_specs(self) -> tuple[MotorControlSpec, ...]:
@@ -383,10 +413,28 @@ class MaloufNewOkinController(BedController):
             _LOGGER.warning("Memory slot %d not supported on Malouf beds", memory_num)
 
     async def program_memory(self, memory_num: int) -> None:
-        """Program current position to memory (not supported)."""
-        _LOGGER.warning(
-            "Malouf beds don't support programming memory presets (requested: %d)", memory_num
-        )
+        """Program current position to memory.
+
+        The app emulates holding the remote's memory button: it streams the
+        save command every 100ms for up to 55 repeats (NEW_OKIN timing), then
+        sends STOP.
+        """
+        command_value = _save_memory_command(memory_num, self._coordinator.name)
+        if command_value is None:
+            _LOGGER.warning("Memory slot %d not supported on Malouf beds", memory_num)
+            return
+        try:
+            await self.write_command(
+                self._build_command(command_value), repeat_count=55, repeat_delay_ms=100
+            )
+        finally:
+            try:
+                await self.write_command(
+                    self._build_command(MaloufCommands.STOP),
+                    cancel_event=asyncio.Event(),
+                )
+            except (BleakError, ConnectionError):
+                _LOGGER.debug("Failed to send STOP after memory programming", exc_info=True)
 
     # Light control
     async def lights_toggle(self) -> None:
@@ -507,8 +555,8 @@ class MaloufLegacyOkinController(BedController):
 
     @property
     def supports_memory_programming(self) -> bool:
-        """Return False - Malouf beds don't support programming memory positions."""
-        return False
+        """Return True - saving is a sustained hold-to-save command stream."""
+        return True
 
     @property
     def motor_control_specs(self) -> tuple[MotorControlSpec, ...]:
@@ -703,10 +751,28 @@ class MaloufLegacyOkinController(BedController):
             _LOGGER.warning("Memory slot %d not supported on Malouf beds", memory_num)
 
     async def program_memory(self, memory_num: int) -> None:
-        """Program current position to memory (not supported)."""
-        _LOGGER.warning(
-            "Malouf beds don't support programming memory presets (requested: %d)", memory_num
-        )
+        """Program current position to memory.
+
+        The app emulates holding the remote's memory button: it streams the
+        save command every 150ms for up to 85 repeats (LEGACY_OKIN timing),
+        then sends STOP.
+        """
+        command_value = _save_memory_command(memory_num, self._coordinator.name)
+        if command_value is None:
+            _LOGGER.warning("Memory slot %d not supported on Malouf beds", memory_num)
+            return
+        try:
+            await self.write_command(
+                self._build_command(command_value), repeat_count=85, repeat_delay_ms=150
+            )
+        finally:
+            try:
+                await self.write_command(
+                    self._build_command(MaloufCommands.STOP),
+                    cancel_event=asyncio.Event(),
+                )
+            except (BleakError, ConnectionError):
+                _LOGGER.debug("Failed to send STOP after memory programming", exc_info=True)
 
     # Light control
     async def lights_toggle(self) -> None:

--- a/custom_components/adjustable_bed/beds/malouf.py
+++ b/custom_components/adjustable_bed/beds/malouf.py
@@ -62,9 +62,9 @@ class MaloufCommands:
 
     # Memory programming (hold-to-save). The app emulates holding the
     # remote's memory button: it streams the save command at the protocol's
-    # repeat interval for the full repeat window, then sends STOP. Slot 1
-    # reuses the recall value (the sustained stream is what signals "save");
-    # beds named "Smartbed238" use a dedicated value with the save bit set.
+    # repeat interval for the full repeat window. Slot 1 reuses the recall
+    # value (the sustained stream is what signals "save"); beds named
+    # "Smartbed238" use a dedicated value with the save bit set.
     SAVE_MEMORY_1 = 0x10000
     SAVE_MEMORY_1_SMARTBED238 = 0x80010000
     SAVE_MEMORY_2 = 0x80040000
@@ -416,25 +416,17 @@ class MaloufNewOkinController(BedController):
         """Program current position to memory.
 
         The app emulates holding the remote's memory button: it streams the
-        save command every 100ms for up to 55 repeats (NEW_OKIN timing), then
-        sends STOP.
+        save command every 100ms for 55 repeats (NEW_OKIN timing). The APK then
+        calls the unhandled command name ``stopCommand``, which performs no BLE
+        write, so saving completes by ending the command stream.
         """
         command_value = _save_memory_command(memory_num, self._coordinator.name)
         if command_value is None:
             _LOGGER.warning("Memory slot %d not supported on Malouf beds", memory_num)
             return
-        try:
-            await self.write_command(
-                self._build_command(command_value), repeat_count=55, repeat_delay_ms=100
-            )
-        finally:
-            try:
-                await self.write_command(
-                    self._build_command(MaloufCommands.STOP),
-                    cancel_event=asyncio.Event(),
-                )
-            except (BleakError, ConnectionError):
-                _LOGGER.debug("Failed to send STOP after memory programming", exc_info=True)
+        await self.write_command(
+            self._build_command(command_value), repeat_count=55, repeat_delay_ms=100
+        )
 
     # Light control
     async def lights_toggle(self) -> None:
@@ -754,25 +746,17 @@ class MaloufLegacyOkinController(BedController):
         """Program current position to memory.
 
         The app emulates holding the remote's memory button: it streams the
-        save command every 150ms for up to 85 repeats (LEGACY_OKIN timing),
-        then sends STOP.
+        save command every 150ms for 85 repeats (LEGACY_OKIN timing). The APK
+        then calls the unhandled command name ``stopCommand``, which performs
+        no BLE write, so saving completes by ending the command stream.
         """
         command_value = _save_memory_command(memory_num, self._coordinator.name)
         if command_value is None:
             _LOGGER.warning("Memory slot %d not supported on Malouf beds", memory_num)
             return
-        try:
-            await self.write_command(
-                self._build_command(command_value), repeat_count=85, repeat_delay_ms=150
-            )
-        finally:
-            try:
-                await self.write_command(
-                    self._build_command(MaloufCommands.STOP),
-                    cancel_event=asyncio.Event(),
-                )
-            except (BleakError, ConnectionError):
-                _LOGGER.debug("Failed to send STOP after memory programming", exc_info=True)
+        await self.write_command(
+            self._build_command(command_value), repeat_count=85, repeat_delay_ms=150
+        )
 
     # Light control
     async def lights_toggle(self) -> None:

--- a/docs/beds/malouf.md
+++ b/docs/beds/malouf.md
@@ -2,6 +2,10 @@
 
 **Status:** ✅ Tested
 
+> Protocol re-verified 2026-07-10 against a fresh jadx decompile of Lucid Base
+> v1.3.3 (`com.lucid.bedbase`): frame formats, checksum, command values,
+> preset repeat behaviour, and timing all match the shipped controllers.
+
 **Credit:** Reverse engineering by [kristofferR](https://github.com/kristofferR/ha-adjustable-bed)
 
 ## Known Models
@@ -23,7 +27,7 @@
 |---------|-----------|
 | Motor Control | ✅ |
 | Position Feedback | ❌ |
-| Memory Presets | ✅ (2 slots) |
+| Memory Presets | ✅ (2 slots, save + recall) |
 | Massage | ✅ |
 | Under-bed Lights | ✅ |
 | Zero-G / Anti-Snore / TV / Lounge | ✅ |
@@ -105,6 +109,18 @@ Both protocols use the same command values (32-bit integers):
 | Memory 1 | `0x10000` |
 | Memory 2 | `0x40000` |
 
+### Memory Programming (hold-to-save)
+
+The app saves the current position by emulating a held memory button: it
+streams the save command at the protocol's repeat interval for the full
+repeat window (85×150ms legacy, 55×100ms new OKIN), then sends STOP.
+
+| Command | Value |
+|---------|-------|
+| Save Memory 1 | `0x10000` (same as recall; the sustained stream signals "save") |
+| Save Memory 1 (`Smartbed238` names) | `0x80010000` |
+| Save Memory 2 | `0x80040000` |
+
 ### Other Commands
 
 | Command | Value |
@@ -116,6 +132,32 @@ Both protocols use the same command values (32-bit integers):
 | Massage Foot - | `0x1000000` |
 | Massage Timer | `0x200` |
 | Massage Off | `0x2000000` |
+
+### Observed But Not Implemented
+
+Additional commands found in the app (fresh Lucid Base 1.3.3 decompile,
+2026-07-10) that the integration does not currently expose:
+
+| App command | Value | Notes |
+|-------------|-------|-------|
+| `massageAllOnOff` | `0x4000000` | Toggle all massage on/off |
+| `massageAll` (+) | `0x100` | Step all-massage intensity |
+| `massageWave` | `0x10000000` | Massage wave/type (also sent for `massageWaistMinus`) |
+| `massageWaist` | `0x400000` | Waist massage + |
+| `intensityOne/Two/Three` | `0x80000` / `0x100000` / `0x200000` | Direct intensity levels |
+| Set alarm | 16-byte frame `ED 80 03 hh mm repeats type … ~sum` (legacy/custom) | Sent 3× on legacy |
+| Set current time | 10-byte frame `E7 80 01 yy mm dd hh mm ss ~sum` (legacy/custom) | Sent 3× on legacy |
+| Status query | `[0x00, 0xB0]` | New OKIN only; light/massage status |
+
+Legacy beds also push status notifications on FFE4 (frame lengths 10/16/20)
+carrying massage time remaining and under-bed light state — unparsed by the
+integration today.
+
+### L600 Model Notes
+
+The app's L600 model definition: manual controls HEAD/FOOT only, presets
+Zero-G / Anti-Snore / Lounge / TV-Read, **1 memory position**, massage
+(head/foot/type/timer), light, alarm. No tilt, lumbar, or Hi-Lo hardware.
 
 ## Command Timing
 

--- a/docs/beds/malouf.md
+++ b/docs/beds/malouf.md
@@ -111,6 +111,9 @@ Both protocols use the same command values (32-bit integers):
 
 ### Memory Programming (hold-to-save)
 
+> ⚠️ Verified against app decompilation only; not yet confirmed on physical
+> hardware.
+
 The app saves the current position by emulating a held memory button: it
 streams the save command at the protocol's repeat interval for the full
 repeat window (85×150ms legacy, 55×100ms new OKIN). The APK then calls
@@ -160,6 +163,14 @@ integration today.
 The app's L600 model definition: manual controls HEAD/FOOT only, presets
 Zero-G / Anti-Snore / Lounge / TV-Read, **1 memory position**, massage
 (head/foot/type/timer), light, alarm. No tilt, lumbar, or Hi-Lo hardware.
+
+Note: this describes what the vendor app exposes for the L600 model only. The
+integration's `MaloufLegacyOkinController` applies the generic LEGACY_OKIN
+capability set to every LEGACY_OKIN device (2 memory slots, plus tilt, lumbar,
+and bed-height controls), which is a superset of what an L600 physically has.
+Extra entities on an L600 are harmless (the hardware ignores unsupported
+commands); gating capabilities per model would require model detection the
+protocol does not currently provide.
 
 ## Command Timing
 

--- a/docs/beds/malouf.md
+++ b/docs/beds/malouf.md
@@ -113,7 +113,9 @@ Both protocols use the same command values (32-bit integers):
 
 The app saves the current position by emulating a held memory button: it
 streams the save command at the protocol's repeat interval for the full
-repeat window (85×150ms legacy, 55×100ms new OKIN), then sends STOP.
+repeat window (85×150ms legacy, 55×100ms new OKIN). The APK then calls
+`stopCommand`, but `OkinConnection.sendCommand()` does not handle that name,
+so no final BLE packet is written; saving completes when the stream ends.
 
 | Command | Value |
 |---------|-------|

--- a/tests/test_malouf.py
+++ b/tests/test_malouf.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
@@ -11,6 +11,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adjustable_bed.beds.malouf import (
     MaloufCommands,
+    _save_memory_command,
 )
 from custom_components.adjustable_bed.const import (
     BED_TYPE_MALOUF_LEGACY_OKIN,
@@ -549,17 +550,90 @@ class TestMaloufCapabilities:
         assert specs[2].translation_key == "head_end_tilt"
         assert specs[3].translation_key == "foot_end_tilt"
 
-    async def test_does_not_support_memory_programming(
+    async def test_supports_memory_programming(
         self,
         hass: HomeAssistant,
         mock_malouf_new_config_entry,
         mock_coordinator_connected,
     ):
-        """Test Malouf does not support programming memory positions."""
+        """Test Malouf supports programming memory positions (hold-to-save)."""
         coordinator = AdjustableBedCoordinator(hass, mock_malouf_new_config_entry)
         await coordinator.async_connect()
 
-        assert coordinator.controller.supports_memory_programming is False
+        assert coordinator.controller.supports_memory_programming is True
+
+
+class TestMaloufMemoryProgramming:
+    """Test Malouf hold-to-save memory programming."""
+
+    async def test_new_okin_program_memory_streams_save_then_stop(
+        self,
+        hass: HomeAssistant,
+        mock_malouf_new_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test NEW_OKIN programming streams the save command at 55x100ms, then STOP."""
+        coordinator = AdjustableBedCoordinator(hass, mock_malouf_new_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        with patch.object(controller, "write_command", new=AsyncMock()) as mock_write:
+            await controller.program_memory(1)
+
+        assert mock_write.call_count == 2
+        save_call = mock_write.call_args_list[0]
+        assert save_call.args[0] == controller._build_command(MaloufCommands.SAVE_MEMORY_1)
+        assert save_call.kwargs["repeat_count"] == 55
+        assert save_call.kwargs["repeat_delay_ms"] == 100
+        stop_call = mock_write.call_args_list[1]
+        assert stop_call.args[0] == controller._build_command(MaloufCommands.STOP)
+
+    async def test_legacy_okin_program_memory_streams_save_then_stop(
+        self,
+        hass: HomeAssistant,
+        mock_malouf_legacy_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test LEGACY_OKIN programming streams the save command at 85x150ms, then STOP."""
+        coordinator = AdjustableBedCoordinator(hass, mock_malouf_legacy_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        with patch.object(controller, "write_command", new=AsyncMock()) as mock_write:
+            await controller.program_memory(2)
+
+        assert mock_write.call_count == 2
+        save_call = mock_write.call_args_list[0]
+        assert save_call.args[0] == controller._build_command(MaloufCommands.SAVE_MEMORY_2)
+        assert save_call.kwargs["repeat_count"] == 85
+        assert save_call.kwargs["repeat_delay_ms"] == 150
+        stop_call = mock_write.call_args_list[1]
+        assert stop_call.args[0] == controller._build_command(MaloufCommands.STOP)
+
+    async def test_program_memory_invalid_slot_writes_nothing(
+        self,
+        hass: HomeAssistant,
+        mock_malouf_legacy_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test invalid memory slots are rejected without any BLE writes."""
+        coordinator = AdjustableBedCoordinator(hass, mock_malouf_legacy_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        with patch.object(controller, "write_command", new=AsyncMock()) as mock_write:
+            await controller.program_memory(3)
+
+        mock_write.assert_not_called()
+
+    def test_save_memory_command_values(self):
+        """Test save values match the app (slot 1 recall value, slot 2 save bit)."""
+        assert _save_memory_command(1, "OKIN-BLE00017786") == 0x10000
+        assert _save_memory_command(1, "Smartbed238-0042") == 0x80010000
+        assert _save_memory_command(2, "OKIN-BLE00017786") == 0x80040000
+        assert _save_memory_command(2, "Smartbed238-0042") == 0x80040000
+        assert _save_memory_command(3, "OKIN-BLE00017786") is None
+        assert _save_memory_command(1, None) == 0x10000
 
 
 class TestMaloufLumbarAndTilt:

--- a/tests/test_malouf.py
+++ b/tests/test_malouf.py
@@ -566,13 +566,13 @@ class TestMaloufCapabilities:
 class TestMaloufMemoryProgramming:
     """Test Malouf hold-to-save memory programming."""
 
-    async def test_new_okin_program_memory_streams_save_then_stop(
+    async def test_new_okin_program_memory_streams_save(
         self,
         hass: HomeAssistant,
         mock_malouf_new_config_entry,
         mock_coordinator_connected,
     ):
-        """Test NEW_OKIN programming streams the save command at 55x100ms, then STOP."""
+        """Test NEW_OKIN programming streams the save command at 55x100ms."""
         coordinator = AdjustableBedCoordinator(hass, mock_malouf_new_config_entry)
         await coordinator.async_connect()
         controller = coordinator.controller
@@ -580,21 +580,19 @@ class TestMaloufMemoryProgramming:
         with patch.object(controller, "write_command", new=AsyncMock()) as mock_write:
             await controller.program_memory(1)
 
-        assert mock_write.call_count == 2
-        save_call = mock_write.call_args_list[0]
+        mock_write.assert_called_once()
+        save_call = mock_write.call_args
         assert save_call.args[0] == controller._build_command(MaloufCommands.SAVE_MEMORY_1)
         assert save_call.kwargs["repeat_count"] == 55
         assert save_call.kwargs["repeat_delay_ms"] == 100
-        stop_call = mock_write.call_args_list[1]
-        assert stop_call.args[0] == controller._build_command(MaloufCommands.STOP)
 
-    async def test_legacy_okin_program_memory_streams_save_then_stop(
+    async def test_legacy_okin_program_memory_streams_save(
         self,
         hass: HomeAssistant,
         mock_malouf_legacy_config_entry,
         mock_coordinator_connected,
     ):
-        """Test LEGACY_OKIN programming streams the save command at 85x150ms, then STOP."""
+        """Test LEGACY_OKIN programming streams the save command at 85x150ms."""
         coordinator = AdjustableBedCoordinator(hass, mock_malouf_legacy_config_entry)
         await coordinator.async_connect()
         controller = coordinator.controller
@@ -602,13 +600,11 @@ class TestMaloufMemoryProgramming:
         with patch.object(controller, "write_command", new=AsyncMock()) as mock_write:
             await controller.program_memory(2)
 
-        assert mock_write.call_count == 2
-        save_call = mock_write.call_args_list[0]
+        mock_write.assert_called_once()
+        save_call = mock_write.call_args
         assert save_call.args[0] == controller._build_command(MaloufCommands.SAVE_MEMORY_2)
         assert save_call.kwargs["repeat_count"] == 85
         assert save_call.kwargs["repeat_delay_ms"] == 150
-        stop_call = mock_write.call_args_list[1]
-        assert stop_call.args[0] == controller._build_command(MaloufCommands.STOP)
 
     async def test_program_memory_invalid_slot_writes_nothing(
         self,


### PR DESCRIPTION
## Summary

Fresh jadx decompile of **Lucid Base 1.3.3** (`com.lucid.bedbase`, shared `com.malouf.adjustablebasebluetooth` library) done for the Lucid L600 request (Ref #358).

**Verification result:** the shipped `malouf_legacy_okin` / `malouf_new_okin` controllers are byte-exact with the app: frame formats (`E6 FE 16` + LE u32 + `~sum` for FFE9; `05 02` + BE u32 for Nordic), checksum, all command values, preset repeat behaviour (3× no-STOP legacy / 1× + STOP new OKIN), and timing all match. Detection of `OKIN-BLE`/`BTCB` beacons to the legacy FFE5 path (shipped in 2.9.13) is consistent with the app's service-based binding.

**Feature gap closed:** the app supports saving memory positions; our controllers reported programming as unsupported. The app emulates a held remote memory button: it streams the save command at the protocol repeat interval (85×150ms legacy, 55×100ms new OKIN). The APK then calls the unhandled `stopCommand` name, so no final GATT write occurs. Save values from the app: M1 `0x10000` (`0x80010000` on `Smartbed238` names), M2 `0x80040000`. Implemented for both controllers; **untested on hardware**.

## Changes
- `beds/malouf.py`: save-memory command constants, `_save_memory_command()` helper, `program_memory()` on both controllers, `supports_memory_programming` → True
- `tests/test_malouf.py`: hold-to-save stream tests, save-value tests (incl. Smartbed238 variant), invalid-slot guard
- `docs/beds/malouf.md`: verification note, memory-programming section, observed-but-unimplemented app commands (massage all/wave/waist, intensity levels, alarm/clock frames, status query, FFE4 status frames), L600 model feature table

## Testing
- Full suite: 2104 passed
- `ruff check`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added memory preset programming for Malouf adjustable beds.
  * Supports saving presets to two memory slots using hold-to-save behavior.
  * Added compatibility for Smartbed238 device variants.

* **Documentation**
  * Updated Malouf protocol details, timing information, command values, and model limitations.

* **Tests**
  * Added coverage for memory programming, protocol-specific behavior, invalid slots, and protocol-specific stream handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->