### PR TITLE
Align BedTech writes with the OEM app and log QRRM reclassification skips

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This is a Home Assistant custom integration for controlling smart adjustable bed
 
 - Never post GitHub comments (issues, pull requests, discussions, releases, etc.) without explicit and specific user approval for that exact comment action.
 - If approval is missing or ambiguous, ask before posting.
+- Never use em dashes (—) in drafted/suggested GitHub replies. Rephrase with commas, colons, parentheses, or separate sentences instead.
 
 ## Architecture
 

--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -431,6 +431,13 @@ async def _async_maybe_reclassify_bedtech_qrrm_entry(
 
     service_info = bluetooth.async_last_service_info(hass, address, connectable=True)
     if service_info is None:
+        _LOGGER.debug(
+            "Skipping BedTech/Richmat QRRM reclassification for %s (%s): no "
+            "advertisement seen yet for %s",
+            entry.title,
+            entry.entry_id,
+            address,
+        )
         return
 
     service_uuids = {
@@ -447,6 +454,14 @@ async def _async_maybe_reclassify_bedtech_qrrm_entry(
         if not isinstance(device_name, str) or not device_name.lower().startswith("qrrm"):
             return
         if not has_bedtech_manufacturer:
+            _LOGGER.info(
+                "QRRM entry %s (%s) stays Richmat: advertisement carries no BedTech "
+                "manufacturer ID 0x%04X (manufacturer IDs seen: %s)",
+                entry.title,
+                entry.entry_id,
+                BEDTECH_MANUFACTURER_ID,
+                sorted(manufacturer_data) or "none",
+            )
             return
 
         new_data = {

--- a/custom_components/adjustable_bed/beds/bedtech.py
+++ b/custom_components/adjustable_bed/beds/bedtech.py
@@ -209,29 +209,6 @@ class BedTechController(BedController):
         """Build command bytes for the given command character."""
         return build_bedtech_command(cmd_char)
 
-    async def write_command(
-        self,
-        command: bytes,
-        repeat_count: int = 1,
-        repeat_delay_ms: int = 100,
-        cancel_event: asyncio.Event | None = None,
-    ) -> None:
-        """Write a command using write-without-response.
-
-        The BedTech Android app (react-native-ble-plx) uses writeWithoutResponse
-        (WRITE_TYPE_NO_RESPONSE = 1) for all BLE writes. Using write-with-response
-        causes some commands (lights, lounge preset) to be silently ignored by the
-        bed firmware.
-        """
-        await self._write_gatt_with_retry(
-            self._char_uuid,
-            command,
-            repeat_count=repeat_count,
-            repeat_delay_ms=repeat_delay_ms,
-            cancel_event=cancel_event,
-            response=False,
-        )
-
     async def _send_command(self, cmd_char: str, repeat: int | None = None) -> None:
         """Send a command to the bed."""
         command = self._build_command(cmd_char)

--- a/docs/beds/bedtech.md
+++ b/docs/beds/bedtech.md
@@ -47,6 +47,24 @@
 
 Commands use ASCII character codes. The last byte is a simple checksum.
 
+### Write Mode
+
+The official app (react-native-ble-manager) uses **write-with-response**
+(`BleManager.write`) for every command; its `writeWithoutResponse` wrapper is
+never called. An earlier claim that the app used write-without-response (and
+that write-with-response made lights/lounge fail) traced back to issue #243,
+whose device turned out to be a misclassified Richmat QRRM — it never applied
+to real BedTech hardware. Verified against BedTech 7.1.3 Hermes bytecode
+(2026-07-10, issue #410).
+
+### Command Repeats
+
+The app repeats only motor position commands (`repeat: 1` in its command
+table), re-sending every `repeat_ms` while the button is held. Presets,
+memory, massage, and light commands are sent once. The app sends no stop
+command on button release (BT6500 field reports still show `^` acting as
+stop, so the integration keeps sending it).
+
 ## Commands
 
 ### Motor Control
@@ -57,27 +75,50 @@ Commands use ASCII character codes. The last byte is a simple checksum.
 | Head Down | `%` | `0x25` | Lower head |
 | Foot Up | `&` | `0x26` | Raise foot |
 | Foot Down | `'` | `0x27` | Lower foot |
-| Leg Up | `)` | `0x29` | Raise leg/pillow |
-| Leg Down | `*` | `0x2A` | Lower leg/pillow |
+| Both Heads Up | `)` | `0x29` | Raise both heads (app group `bothHeads`) |
+| Both Heads Down | `*` | `0x2A` | Lower both heads |
+| Pillow Up | `?` | `0x3F` | Raise pillow (BT6500; app group `pillow`) |
+| Pillow Down | `@` | `0x40` | Lower pillow |
+| Lumbar Up | `A` | `0x41` | Raise lumbar (BT6500; app group `lumbar`) |
+| Lumbar Down | `B` | `0x42` | Lower lumbar |
 
-### Sync Commands (Both Sides)
-
-| Command | Char | Hex | Description |
-|---------|------|-----|-------------|
-| Both Heads Up | `?` | `0x3F` | Raise both heads |
-| Both Heads Down | `@` | `0x40` | Lower both heads |
-| Both Feet Up | `A` | `0x41` | Raise both feet |
-| Both Feet Down | `B` | `0x42` | Lower both feet |
+> [!WARNING]
+> Earlier versions of this document labeled `)`/`*` as "leg/pillow" and
+> `?`/`@`/`A`/`B` as "both heads"/"both feet". The BedTech 7.1.3 command
+> table maps `)`/`*` to `bothHeads`, `?`/`@` to `pillow`, and `A`/`B` to
+> `lumbar` (pillow/lumbar exist only on BT6500). The integration's entity
+> mapping still follows the old labels and needs a separate verification
+> pass before being changed.
 
 ### Presets
 
 | Command | Char | Hex | Description |
 |---------|------|-----|-------------|
 | Flat | `1` | `0x31` | Flat position |
+| Flat (alt) | `l` | `0x6C` | Secondary flat command (app `flat2`) |
 | Zero-G | `E` | `0x45` | Zero gravity |
 | Anti-Snore | `F` | `0x46` | Anti-snore |
 | TV | `X` | `0x58` | TV position |
 | Lounge | `e` | `0x65` | Lounge position |
+
+### Model Capabilities (per BedTech 7.1.3)
+
+The app gates features per user-selected model; command bytes are shared.
+
+| Model | Light | Massage | Pillow/Lumbar | Dual (head2) | Presets |
+|-------|-------|---------|---------------|--------------|---------|
+| BT2000 | ❌ | ❌ | ❌ | ❌ | flat, zero-g, anti-snore |
+| BT2500 | ❌ | head only | ❌ | ❌ | flat, zero-g, anti-snore |
+| BT3000 | ✅ | head+foot | ❌ | ❌ | + TV |
+| BT3000FH | ✅ | head+foot | ❌ | ✅ | + TV |
+| BT6500 | ✅ | head+foot | ✅ | ❌ | flat, zero-g, anti-snore |
+| BTX4 | ❌ | ❌ | ❌ | ❌ | flat, zero-g |
+| BTX4FH | ❌ | ❌ | ❌ | ✅ | flat, zero-g |
+| BTX5 | ✅ | head+foot | ❌ | ❌ | flat, zero-g, anti-snore |
+| BTX5FH | ✅ | head+foot | ❌ | ✅ | flat, zero-g, anti-snore |
+
+BT2000/BT2500/BTX4/BTX4FH owners have no BLE light command at all — the
+app hides the button. `light2` (`_u`/`_<`) is only offered on BT3000FH.
 
 ### Memory
 


### PR DESCRIPTION
## Summary

- Drop the BedTech write-without-response override: a fresh Hermes decompile of BedTech 7.1.3 shows the app uses react-native-ble-manager and sends every command via `BleManager.write` (write with response). The `writeWithoutResponse` wrapper in the app is never called. The override came from d456798, whose evidence device (issue #243) was later identified as a misclassified Richmat QRRM, so it never described real BedTech hardware.
- Make the richmat/bedtech QRRM reclassification observable: log at INFO when a QRRM Richmat entry stays Richmat because the advertisement lacks manufacturer ID 0x4C57 (including the manufacturer IDs actually seen), and at DEBUG when no advertisement is available yet. Until now these paths skipped silently, so a support bundle could not show why an entry was not corrected.
- Correct `docs/beds/bedtech.md` against the 7.1.3 command table: write mode, repeat semantics, per-model capability gating (BT2000/BT2500/BTX4/BTX4FH have no BLE light at all), the `flat2` preset, and the app's actual motor groups (`)`/`*` = bothHeads, `?`/`@` = pillow, `A`/`B` = lumbar). The integration's entity mapping still uses the old labels; realigning it needs a separate verification pass.
- AGENTS.md: no em dashes in drafted GitHub replies.

## Context

Follow-up to PR #420 after the reporter of issue #410 confirmed lights still do not work on 3.1.0. The 3.1.0 light bytes (`<` toggle, `u` off) are confirmed correct against the APK; this PR aligns the write mode with the app and adds the diagnostics needed to determine from the next support bundle whether the reporter's entry actually reclassified. It does not claim to fix #410.

## Validation

- `tests/test_bedtech.py + tests/test_init.py + tests/test_detection.py`: 318 passed
- `ruff check` clean on changed files

Ref #410