### PR TITLE
Address post-merge review feedback on PR #423

### DIFF
--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -205,11 +205,14 @@ class KeesonController(BedController):
         self._betterliving_presets = betterliving_presets
         self._cb1322_presets = cb1322_presets
         # KSBT03C control boxes have no head-tilt motor; their third motor is
-        # lumbar. Fall back to the configured name (defaults to the BLE name)
-        # when the raw device name is unavailable on this connection.
-        self._is_ksbt03c = is_ksbt03c_name(device_name) or is_ksbt03c_name(
-            getattr(coordinator, "name", None)
-        )
+        # lumbar. The raw BLE name is authoritative when present; only fall
+        # back to the configured name (defaults to the BLE name) when this
+        # connection didn't surface a device name, so a stale or user-edited
+        # configured name can never override the real hardware name.
+        if device_name:
+            self._is_ksbt03c = is_ksbt03c_name(device_name)
+        else:
+            self._is_ksbt03c = is_ksbt03c_name(getattr(coordinator, "name", None))
         self._notify_callback: Callable[[str, float], None] | None = None
         self._motor_state: dict[str, bool | None] = {}
         self._write_with_response = True
@@ -1252,7 +1255,7 @@ class KeesonController(BedController):
             await self.write_command(self._build_command(KeesonCommands.PRESET_ZERO_G), repeat_count=self._single_shot_count)
 
     async def preset_lounge(self) -> None:
-        """Go to lounge position (KSBT/Ergomotion/Purple 'M' button / Memory 1)."""
+        """Go to lounge position (KSBT 'Read' button / Memory 1, Lounge on Purple)."""
         if (
             not self._is_ksbt
             and not self._is_json_variant

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -104,9 +104,11 @@ The integration treats `0000a00a` as a distinct Keeson variant and uses the shar
 Some Ergomotion-branded beds also use this variant. A confirmed Rio 6.0 support bundle advertises as `KSBT04...` and works correctly with the standard KSBT 6-byte protocol.
 Juna's `LVrestore` and `LVrelax` remotes also use this direct 6-byte framing rather than the JSON/A00A path.
 
-**Ergomotion Sync remotes (from `cn.com.mancini` APK):** the app has three remote layouts — A and C target `KSBT04C` devices, B targets `KSBT03C` (e.g. Rio 5.0). All three share the same preset buttons: Read = `0x2000`, TV = `0x4000`, M = `0x10000`, Zero-G = `0x1000`, Flat = `0x8000000`, Anti-Snore = `0x8000` (B/C only), light toggle = `0x20000`, and massage steps head `0x800` / foot `0x400` / timer `0x200` (no all-off command). The integration exposes Read/TV/M as memory slots 1-3 on KSBT variants.
+**Ergomotion Sync remotes (from `cn.com.mancini` APK):** the app has three remote layouts — A and C target `KSBT04C` devices, B targets `KSBT03C` (e.g. Rio 5.0). All three share the same preset buttons: Read = `0x2000`, TV = `0x4000`, M = `0x10000`, Zero-G = `0x1000`, Flat = `0x8000000`, light toggle = `0x20000`, and massage steps head `0x800` / foot `0x400` / timer `0x200` (no all-off command). The Anti-Snore button (`0x8000`) appears on layouts B/C only; that describes the remote UIs, not command support — the integration exposes anti-snore on all KSBT variants. Read/TV/M are exposed as memory slots 1-3 on KSBT variants.
 
 **KSBT03C motor layout:** the KSBT03C remote (layout B) drives only three motors — head/back (`0x1`/`0x2`), feet/legs (`0x4`/`0x8`) and lumbar (`0x40`/`0x80`). There are no head-tilt (`0x10`/`0x20`) buttons, so KSBT03C beds have no tilt motor and the integration maps the third configured motor to lumbar. KSBT04C remotes (layouts A/C) additionally have the head-tilt buttons.
+
+**Status:** the KSBT03C command values and 3-motor layout are APK-derived (Ergomotion Sync 1.0.2) and not yet confirmed on hardware; the Rio 5.0 report in issue #408 confirms the lumbar motor responds to `0x40`/`0x80` and that no tilt motor exists.
 
 **Fallback Service UUIDs:** Some KSBT devices use different service UUIDs. The integration automatically tries these if the primary isn't found:
 - `6e400020-b5a3-f393-e0a9-e50e24dcca9e` (characteristic: `6e400021`) - Extended Nordic UART, used by some Ergomotion/SFD beds

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -1052,7 +1052,10 @@ class TestKsbt03cMotorLayout:
         mock_keeson_config_entry_data: dict,
         mock_coordinator_connected,
     ):
-        """Test KSBT03C layout falls back to the configured name."""
+        """Test KSBT03C layout falls back to the configured name via the factory."""
+        from custom_components.adjustable_bed.const import KEESON_VARIANT_KSBT
+        from custom_components.adjustable_bed.controller_factory import create_controller
+
         mock_keeson_config_entry_data[CONF_NAME] = "KSBT03C300039050"
         entry = MockConfigEntry(
             domain=DOMAIN,
@@ -1064,10 +1067,79 @@ class TestKsbt03cMotorLayout:
         entry.add_to_hass(hass)
         coordinator = AdjustableBedCoordinator(hass, entry)
         await coordinator.async_connect()
+        coordinator._motor_count = 3
 
-        controller = KeesonController(coordinator, variant="ksbt")
+        controller = await create_controller(
+            coordinator=coordinator,
+            bed_type=BED_TYPE_KEESON,
+            protocol_variant=KEESON_VARIANT_KSBT,
+            client=coordinator.client,
+            device_name=None,
+        )
 
+        assert isinstance(controller, KeesonController)
+        assert controller._variant == "ksbt"
         assert not controller.has_tilt_support
+        assert [spec.key for spec in controller.motor_control_specs] == [
+            "head",
+            "feet",
+            "lumbar",
+        ]
+
+    async def test_ksbt03c_detected_from_ble_name_via_factory(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test the factory auto-detects the ksbt variant and KSBT03C layout from the BLE name."""
+        from custom_components.adjustable_bed.controller_factory import create_controller
+
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        coordinator._motor_count = 3
+
+        controller = await create_controller(
+            coordinator=coordinator,
+            bed_type=BED_TYPE_KEESON,
+            protocol_variant="auto",
+            client=coordinator.client,
+            device_name="KSBT03C300039050",
+        )
+
+        assert isinstance(controller, KeesonController)
+        assert controller._variant == "ksbt"
+        assert not controller.has_tilt_support
+        assert [spec.key for spec in controller.motor_control_specs] == [
+            "head",
+            "feet",
+            "lumbar",
+        ]
+
+    async def test_present_device_name_overrides_configured_name(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry_data: dict,
+        mock_coordinator_connected,
+    ):
+        """Test a non-KSBT03C raw BLE name wins over a stale KSBT03C configured name."""
+        mock_keeson_config_entry_data[CONF_NAME] = "KSBT03C300039050"
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="KSBT03C300039050",
+            data=mock_keeson_config_entry_data,
+            unique_id="AA:BB:CC:DD:EE:F1",
+            entry_id="keeson_stale_name_entry",
+        )
+        entry.add_to_hass(hass)
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        await coordinator.async_connect()
+
+        controller = KeesonController(
+            coordinator, variant="ksbt_cr", device_name="KSBT03CR12345"
+        )
+
+        assert controller.has_tilt_support
 
     async def test_standard_keeson_motor_layout_unchanged(
         self,
@@ -1165,12 +1237,15 @@ class TestKsbtMemoryPresets:
 
         assert controller.memory_slot_count == slots
 
+    @pytest.mark.parametrize("variant", ["ksbt", "ksbt04c"])
     @pytest.mark.parametrize(
         "memory_num,expected_value",
         [
-            (1, KeesonCommands.PRESET_MEMORY_1),  # Read button (0x2000)
-            (2, KeesonCommands.PRESET_MEMORY_2),  # TV button (0x4000)
-            (3, KeesonCommands.PRESET_MEMORY_4),  # M button (0x10000)
+            # Literal protocol values from the Ergomotion Sync APK, pinned so a
+            # bad edit to the KeesonCommands constants cannot self-verify.
+            (1, 0x2000),  # Read button
+            (2, 0x4000),  # TV button
+            (3, 0x10000),  # M button
         ],
     )
     async def test_ksbt_preset_memory_mapping(
@@ -1179,13 +1254,14 @@ class TestKsbtMemoryPresets:
         mock_keeson_config_entry,
         mock_coordinator_connected,
         mock_bleak_client: MagicMock,
+        variant: str,
         memory_num: int,
         expected_value: int,
     ):
-        """Test KSBT memory slots map to the Read/TV/M remote buttons."""
+        """Test KSBT/KSBT04C memory slots map to the Read/TV/M remote buttons."""
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         await coordinator.async_connect()
-        controller = KeesonController(coordinator, variant="ksbt")
+        controller = KeesonController(coordinator, variant=variant)
         coordinator._controller = controller
         mock_bleak_client.write_gatt_char.reset_mock()
 


### PR DESCRIPTION
## Summary

CodeRabbit's full review of #423 landed after the merge (the review-completion race is fixed separately in crq: kristofferR/coderabbit-queue@17dc681). This addresses those findings on master.

### Fixed

- **Raw BLE name precedence** (major): `KeesonController` now bases KSBT03C detection exclusively on the raw `device_name` when one is present, falling back to the configured name only when the connection surfaced no device name. Previously a stale/user-edited configured name like `KSBT03C...` could disable tilt on a bed whose real name says otherwise. New test: a `KSBT03CR` raw name wins over a `KSBT03C` configured name.
- **`preset_lounge()` docstring**: 0x2000 is the KSBT "Read" button, not "M".
- **Docs**: explicit status note that KSBT03C command values are APK-derived with lumbar/no-tilt confirmed by the issue #408 report; clarified that the anti-snore B/C-only note describes the remote UIs, not the integration's command gating.
- **Tests**: the configured-name fallback test now constructs via `create_controller()` and asserts variant + motor layout; added a factory auto-detection test for the KSBT03C BLE name; the memory-slot mapping test now covers both `ksbt` and `ksbt04c` and pins the literal `0x2000`/`0x4000`/`0x10000` values so a bad constant edit can't self-verify.

### Skipped

- "Route motor entity callbacks through coordinator command serialization" — false positive: the `motor_control_specs` callbacks are consumed by cover entities exclusively through `coordinator.async_execute_controller_command()` (`cover.py:378`), identical to the base-class specs every other controller uses.

## Testing

Full suite: 2123 passed.

Ref #408, see #423