### PR TITLE
Enable SUTA notify channel before commands (WLT8016 / SUTA-B202B)

### DIFF
--- a/custom_components/adjustable_bed/beds/suta.py
+++ b/custom_components/adjustable_bed/beds/suta.py
@@ -13,13 +13,22 @@ Characteristic UUIDs are discovered dynamically based on GATT properties.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from ..const import SUTA_DEFAULT_WRITE_CHAR_UUID, SUTA_SERVICE_UUID
+from bleak.exc import BleakError
+
+from ..const import (
+    SUTA_DEFAULT_NOTIFY_CHAR_UUID,
+    SUTA_DEFAULT_WRITE_CHAR_UUID,
+    SUTA_SERVICE_UUID,
+)
 from .base import BedController
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ..coordinator import AdjustableBedCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -82,14 +91,30 @@ class SutaController(BedController):
         """Initialize the SUTA controller."""
         super().__init__(coordinator)
         self._write_char_uuid = SUTA_DEFAULT_WRITE_CHAR_UUID
-        self._write_with_response = True
-        self._write_mode_initialized = False
+        self._notify_char_uuid = SUTA_DEFAULT_NOTIFY_CHAR_UUID
+        self._write_with_response = False
+        self._chars_initialized = False
+        self._notify_started = False
         self._light_state = False
 
     @property
     def control_characteristic_uuid(self) -> str:
         """Return the command characteristic UUID."""
         return self._write_char_uuid
+
+    @property
+    def requires_notification_channel(self) -> bool:
+        """Return True - SUTA firmware needs an active notify subscription.
+
+        The SUTA app enables notifications on the FFF0 notify characteristic
+        (FFF1) immediately after connecting, before it sends any command. On
+        some transparent-UART controllers (e.g. the WLT8016 module in the
+        Dreams Sleepmotion / SUTA-B202B, issue #345) the bed connects and beeps
+        but silently ignores motor commands until that subscription is active,
+        so the coordinator must call start_notify() even when angle sensing is
+        disabled.
+        """
+        return True
 
     # Capability properties
     @property
@@ -137,9 +162,16 @@ class SutaController(BedController):
         """Build a CRLF-terminated AT command packet."""
         return f"{command}\r\n".encode()
 
-    def _refresh_write_characteristic(self) -> None:
-        """Resolve write characteristic and write mode from discovered services."""
-        if self._write_mode_initialized:
+    def _refresh_characteristics(self) -> None:
+        """Resolve write and notify characteristics from discovered services.
+
+        SUTA devices expose their command and notify characteristics
+        dynamically under SUTA_SERVICE_UUID, so we mirror the app: pick the
+        first char with WRITE/WRITE_NO_RESPONSE as the command channel (FFF2)
+        and the first char with NOTIFY/INDICATE as the notify channel (FFF1),
+        instead of matching fixed UUIDs.
+        """
+        if self._chars_initialized:
             return
 
         client = self.client
@@ -149,38 +181,92 @@ class SutaController(BedController):
         service = client.services.get_service(SUTA_SERVICE_UUID)
         if service is None:
             _LOGGER.debug(
-                "SUTA service %s not found, using fallback characteristic %s",
+                "SUTA service %s not found, using fallback write=%s notify=%s",
                 SUTA_SERVICE_UUID,
                 self._write_char_uuid,
+                self._notify_char_uuid,
             )
-            self._write_mode_initialized = True
+            self._chars_initialized = True
             return
 
-        # SUTA devices expose writable characteristics dynamically under
-        # SUTA_SERVICE_UUID, so we intentionally select the first writable char
-        # we find and store it in _write_char_uuid instead of matching a fixed UUID.
+        write_found = False
+        notify_found = False
         for char in service.characteristics:
             props = {prop.lower() for prop in char.properties}
-            if "write" in props or "write-without-response" in props:
+            if not write_found and ("write" in props or "write-without-response" in props):
                 self._write_char_uuid = str(char.uuid)
                 # Prefer write-with-response when available for acknowledgements;
                 # otherwise fall back to write-without-response.
                 self._write_with_response = "write" in props
-                self._write_mode_initialized = True
-                _LOGGER.debug(
-                    "SUTA write characteristic resolved to %s (response=%s, props=%s)",
-                    self._write_char_uuid,
-                    self._write_with_response,
-                    char.properties,
-                )
-                return
+                write_found = True
+            if not notify_found and ("notify" in props or "indicate" in props):
+                self._notify_char_uuid = str(char.uuid)
+                notify_found = True
 
+        if not write_found:
+            _LOGGER.debug(
+                "No writable characteristic found in SUTA service %s, using fallback %s",
+                SUTA_SERVICE_UUID,
+                self._write_char_uuid,
+            )
+        self._chars_initialized = True
         _LOGGER.debug(
-            "No writable characteristic found in SUTA service %s, using fallback %s",
-            SUTA_SERVICE_UUID,
+            "SUTA characteristics resolved: write=%s (response=%s) notify=%s",
             self._write_char_uuid,
+            self._write_with_response,
+            self._notify_char_uuid,
         )
-        self._write_mode_initialized = True
+
+    async def start_notify(self, callback: Callable[[str, float], None] | None = None) -> None:
+        """Subscribe to the FFF0 notify characteristic (FFF1).
+
+        SUTA firmware requires an active notify subscription before it accepts
+        commands (see requires_notification_channel). The position callback is
+        unused - SUTA reports no motor angle - but the subscription itself is
+        what unblocks command handling on the WLT8016 and similar modules.
+        """
+        self._notify_callback = callback
+
+        client = self.client
+        if client is None or not client.is_connected:
+            _LOGGER.warning("Cannot start SUTA notifications: not connected")
+            return
+
+        self._refresh_characteristics()
+        if self._notify_started:
+            return
+
+        try:
+            async with self._ble_lock:
+                await client.start_notify(self._notify_char_uuid, self._handle_notification)
+            self._notify_started = True
+            _LOGGER.debug(
+                "Started SUTA notifications on %s for %s",
+                self._notify_char_uuid,
+                self._coordinator.address,
+            )
+        except BleakError as err:
+            _LOGGER.warning("Failed to start SUTA notifications: %s", err)
+            self.log_discovered_services(level=logging.INFO)
+
+    async def stop_notify(self) -> None:
+        """Unsubscribe from the FFF0 notify characteristic."""
+        self._notify_callback = None
+        client = self.client
+        if client is not None and client.is_connected and self._notify_started:
+            with contextlib.suppress(BleakError):
+                async with self._ble_lock:
+                    await client.stop_notify(self._notify_char_uuid)
+        self._notify_started = False
+
+    def _handle_notification(self, _sender: Any, data: bytearray) -> None:
+        """Forward raw SUTA notifications for diagnostics capture.
+
+        SUTA exposes no motor-position feedback, so there is nothing to parse
+        into an angle - the notification channel exists only to unblock command
+        handling and to surface +OK/+ERR responses in diagnostic captures.
+        """
+        self.forward_raw_notification(self._notify_char_uuid, bytes(data))
 
     async def write_command(
         self,
@@ -190,7 +276,7 @@ class SutaController(BedController):
         cancel_event: asyncio.Event | None = None,
     ) -> None:
         """Write a SUTA command packet."""
-        self._refresh_write_characteristic()
+        self._refresh_characteristics()
         await self._write_gatt_with_retry(
             self._write_char_uuid,
             command,

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -424,10 +424,13 @@ MOTOSLEEP_SERVICE_UUID: Final = "0000ffe0-0000-1000-8000-00805f9b34fb"
 MOTOSLEEP_CHAR_UUID: Final = "0000ffe1-0000-1000-8000-00805f9b34fb"
 
 # SUTA Smart Home specific UUIDs (AT command protocol)
-# The app discovers writable/notifiable characteristics dynamically by properties.
-# FFF1 is used as a fallback write characteristic when dynamic discovery is unavailable.
+# The app discovers writable/notifiable characteristics dynamically by properties
+# under FFF0: it picks the char with WRITE/WRITE_NO_RESPONSE as the command channel
+# (FFF2) and the char with NOTIFY/INDICATE as the notify channel (FFF1). These
+# constants are only fallbacks used when dynamic discovery is unavailable.
 SUTA_SERVICE_UUID: Final = "0000fff0-0000-1000-8000-00805f9b34fb"
-SUTA_DEFAULT_WRITE_CHAR_UUID: Final = "0000fff1-0000-1000-8000-00805f9b34fb"
+SUTA_DEFAULT_WRITE_CHAR_UUID: Final = "0000fff2-0000-1000-8000-00805f9b34fb"
+SUTA_DEFAULT_NOTIFY_CHAR_UUID: Final = "0000fff1-0000-1000-8000-00805f9b34fb"
 
 # TiMOTION AHF protocol UUIDs (Nordic UART Service)
 TIMOTION_AHF_SERVICE_UUID: Final = NORDIC_UART_SERVICE_UUID

--- a/docs/beds/suta.md
+++ b/docs/beds/suta.md
@@ -8,6 +8,9 @@
 
 - SUTA bed-frame controllers with names like `SUTA-B*`, `SUTA-M*`, `SUTA-S*`
 - Confirmed app model families include B803/B804/B805, B207/B202, and M-series variants
+- Rebranded frames using the same protocol, e.g. **Dreams Sleepmotion** (`SUTA-B202B`,
+  WLT8016 module). The app maps by the first 9 chars of the BLE name, so `SUTA-B202B`
+  is handled as `SUTA-B202`.
 
 ## Apps
 
@@ -31,8 +34,27 @@
 ## Protocol Details
 
 **Service UUID:** `0000fff0-0000-1000-8000-00805f9b34fb`  
-**Write Characteristic:** Dynamic discovery by GATT properties (fallback: `0000fff1-0000-1000-8000-00805f9b34fb`)  
+**Write Characteristic:** Dynamic discovery by GATT properties — the `WRITE`/`WRITE_NO_RESPONSE` char under FFF0 (fallback: `0000fff2-0000-1000-8000-00805f9b34fb`)  
+**Notify Characteristic:** Dynamic discovery by GATT properties — the `NOTIFY`/`INDICATE` char under FFF0 (fallback: `0000fff1-0000-1000-8000-00805f9b34fb`)  
 **Format:** ASCII AT commands terminated with `\r\n` (no checksum)
+
+### Notification channel is required before commands work
+
+The SUTA app enables notifications on the FFF0 notify characteristic (FFF1)
+**immediately after connecting, before it sends any command**. On some
+transparent-UART controllers — notably the **WLT8016** module used in the Dreams
+Sleepmotion / `SUTA-B202B` (issue #345) — the bed connects and beeps but silently
+ignores motor commands until that subscription is active. The controller
+therefore sets `requires_notification_channel = True` so the coordinator opens
+the notify subscription even when angle sensing is disabled. SUTA reports no
+motor position, so the subscription carries no position data; it exists purely to
+unblock command handling (and to surface `+OK`/`+ERR` responses in diagnostics).
+
+The app also requests an MTU of 250 on connect. Commands such as
+`AT+CTRL=BOTH BACK UP\r\n` are 22 bytes, which exceeds the 20-byte default ATT
+payload, so a full-size MTU is needed for the command to arrive intact. Home
+Assistant's BlueZ/ESPHome transport negotiates a large MTU automatically, but a
+proxy stuck at the 23-byte default can truncate longer commands.
 
 ## Detection
 

--- a/tests/test_suta.py
+++ b/tests/test_suta.py
@@ -18,6 +18,7 @@ from custom_components.adjustable_bed.const import (
     CONF_MOTOR_COUNT,
     CONF_PREFERRED_ADAPTER,
     DOMAIN,
+    SUTA_DEFAULT_NOTIFY_CHAR_UUID,
     SUTA_DEFAULT_WRITE_CHAR_UUID,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
@@ -168,6 +169,59 @@ class TestSutaController:
         calls = mock_bleak_client.write_gatt_char.call_args_list
         assert len(calls) == 1
         assert calls[0][0][1] == _to_packet(SutaCommands.PRESET_TV)
+
+
+class TestSutaNotifications:
+    """Test SUTA notification-channel behavior (issue #345)."""
+
+    async def test_requires_notification_channel(self, suta_coordinator) -> None:
+        """SUTA must declare it needs the notify channel active for commands."""
+        coordinator = await suta_coordinator(
+            address="AA:BB:CC:DD:EE:0A",
+            name="SUTA-B202B",
+            entry_id="suta_test_entry_notify",
+        )
+
+        assert coordinator.controller.requires_notification_channel is True
+
+    async def test_connect_subscribes_to_notify_char(
+        self,
+        suta_coordinator,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """Connecting subscribes to FFF1 even with angle sensing disabled.
+
+        The SUTA app enables notifications before any command works; without an
+        active subscription the WLT8016 firmware connects but ignores motor
+        commands (issue #345).
+        """
+        coordinator = await suta_coordinator(
+            address="AA:BB:CC:DD:EE:0B",
+            name="SUTA-B202B",
+            entry_id="suta_test_entry_notify_2",
+        )
+
+        chars = [c.args[0] for c in mock_bleak_client.start_notify.call_args_list]
+        assert SUTA_DEFAULT_NOTIFY_CHAR_UUID in chars
+        assert coordinator.controller._notify_started is True
+
+    async def test_stop_notify_unsubscribes(
+        self,
+        suta_coordinator,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """stop_notify unsubscribes from the notify characteristic."""
+        coordinator = await suta_coordinator(
+            address="AA:BB:CC:DD:EE:0C",
+            name="SUTA-B202B",
+            entry_id="suta_test_entry_notify_3",
+        )
+
+        await coordinator.controller.stop_notify()
+
+        stopped = [c.args[0] for c in mock_bleak_client.stop_notify.call_args_list]
+        assert SUTA_DEFAULT_NOTIFY_CHAR_UUID in stopped
+        assert coordinator.controller._notify_started is False
 
 
 class TestSutaSync:


### PR DESCRIPTION
> [!WARNING]
> **UNVERIFIED - Treat the reverse-engineering
> and code here as bad Opus 4.8-authored, not Fable 5.

Ref #345

## Symptom

`SUTA-B202B` (Dreams Sleepmotion, WLT8016 module, firmware V380.00.09) connects
and beeps but silently ignores all AT motor commands. Reporter confirmed the
physical remote works and that raw writes to `fff2`/`ffe2` do nothing.

## Root cause (from re-decompiling `com.shuta.smart_home` 3.15.0)

The bed uses the **standard SUTA AT protocol we already implement** — the app
maps `SUTA-B202B` via `name.substring(0,9)` -> `SUTA-B202`, which sends the same
`AT+CTRL=BOTH BACK UP/FOOT UP/...`, `AT+MODE=BOTH M1/M2`, `AT+CTRL=BOTH STOP`
commands as `beds/suta.py`.

The difference is the **connect sequence**. `DeviceControlVM.U()` always, before
sending any command:

1. Enables **notifications on the FFF0 notify characteristic (FFF1)**, then
2. Requests **MTU 250**.

There is **no PIN/auth/handshake** command. On the WLT8016 transparent-UART
firmware the notify subscription is what unblocks command handling — which
matches the "connects, beeps, but won't move; notifications hang" symptom. Our
SUTA controller never subscribed to notifications, so it hit the same wall the
reporter hit with raw `gatttool` writes. (The reporter also tried `ffe1` for
notify — the correct notify char is `fff1`.)

## Change

Mirrors the app and the existing **Jensen / Leggett-Gen2** `requires_notification_channel` pattern:

- `beds/suta.py`: `requires_notification_channel = True`; dynamic notify-char
  discovery (NOTIFY/INDICATE -> FFF1); `start_notify`/`stop_notify` overrides that
  subscribe to FFF1 on connect even when angle sensing is disabled. SUTA reports
  no motor position, so the channel carries no angle data — it exists only to
  unblock commands (and surface `+OK`/`+ERR` in diagnostics).
- `const.py`: corrected the write fallback to **FFF2** (FFF1 is the notify char,
  not writable — latent bug) and added `SUTA_DEFAULT_NOTIFY_CHAR_UUID`.
- `docs/beds/suta.md`: documents the notify requirement + MTU note.
- `tests/test_suta.py`: 3 new tests (declares notify channel, subscribes to FFF1
  on connect, unsubscribes on stop).

## Validation

- Full suite: **2103 passed** (3 new), pyright clean, ruff clean on changed lines.
- **Not tested on a physical bed.** Needs a reporter with a SUTA-B202B / WLT8016
  to confirm. If it still fails, the next step is an nRF Connect / btsnoop capture
  of the working app's connect to compare MTU + notify behavior directly.
