### PR TITLE
Fix SUTA WLT8016 command initialization

### DIFF
--- a/custom_components/adjustable_bed/beds/suta.py
+++ b/custom_components/adjustable_bed/beds/suta.py
@@ -17,8 +17,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable
-from typing import TYPE_CHECKING
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, cast
 
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.exc import BleakError
@@ -254,7 +254,7 @@ class SutaController(BedController):
         if callable(acquire_mtu):
             try:
                 async with self._ble_lock:
-                    await acquire_mtu()
+                    await cast(Callable[[], Awaitable[object]], acquire_mtu)()
             except (AssertionError, BleakError, OSError, TimeoutError) as err:
                 _LOGGER.warning(
                     "Could not acquire SUTA command MTU (OEM app requests %d): %s",

--- a/custom_components/adjustable_bed/beds/suta.py
+++ b/custom_components/adjustable_bed/beds/suta.py
@@ -4,25 +4,40 @@ Protocol reverse-engineered from com.shuta.smart_home.
 
 Bed-frame controllers use an ASCII AT command protocol over BLE:
 - Service UUID: 0000fff0-0000-1000-8000-00805f9b34fb
+- Notify characteristic: 0000fff1-0000-1000-8000-00805f9b34fb
+- Write characteristic: 0000fff2-0000-1000-8000-00805f9b34fb
 - Command format: b"AT+...\\r\\n" (UTF-8, CRLF-terminated)
 - No checksum
 
-Characteristic UUIDs are discovered dynamically based on GATT properties.
+The official app subscribes to notifications and requests MTU 250 before sending
+commands.  Several motor commands exceed the default 20-byte ATT payload.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from ..const import SUTA_DEFAULT_WRITE_CHAR_UUID, SUTA_SERVICE_UUID
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.exc import BleakError
+
+from ..const import (
+    SUTA_DEFAULT_WRITE_CHAR_UUID,
+    SUTA_NOTIFY_CHAR_UUID,
+    SUTA_SERVICE_UUID,
+)
 from .base import BedController
 
 if TYPE_CHECKING:
     from ..coordinator import AdjustableBedCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+_SUTA_APP_REQUESTED_MTU = 250
+# The longest currently implemented B202 command is 24 bytes including CRLF.
+_SUTA_MIN_COMMAND_MTU = 27
 
 
 class SutaCommands:
@@ -82,14 +97,21 @@ class SutaController(BedController):
         """Initialize the SUTA controller."""
         super().__init__(coordinator)
         self._write_char_uuid = SUTA_DEFAULT_WRITE_CHAR_UUID
-        self._write_with_response = True
-        self._write_mode_initialized = False
+        self._notify_char_uuid = SUTA_NOTIFY_CHAR_UUID
+        self._write_with_response = False
+        self._gatt_characteristics_initialized = False
+        self._notifications_started = False
         self._light_state = False
 
     @property
     def control_characteristic_uuid(self) -> str:
         """Return the command characteristic UUID."""
         return self._write_char_uuid
+
+    @property
+    def requires_notification_channel(self) -> bool:
+        """Return True because the OEM app enables notifications before commands."""
+        return True
 
     # Capability properties
     @property
@@ -137,9 +159,9 @@ class SutaController(BedController):
         """Build a CRLF-terminated AT command packet."""
         return f"{command}\r\n".encode()
 
-    def _refresh_write_characteristic(self) -> None:
-        """Resolve write characteristic and write mode from discovered services."""
-        if self._write_mode_initialized:
+    def _refresh_gatt_characteristics(self) -> None:
+        """Resolve the bed-frame write/notify characteristics from FFF0."""
+        if self._gatt_characteristics_initialized:
             return
 
         client = self.client
@@ -149,38 +171,159 @@ class SutaController(BedController):
         service = client.services.get_service(SUTA_SERVICE_UUID)
         if service is None:
             _LOGGER.debug(
-                "SUTA service %s not found, using fallback characteristic %s",
+                "SUTA bed-frame service %s not found; using fallback chars write=%s notify=%s",
                 SUTA_SERVICE_UUID,
                 self._write_char_uuid,
+                self._notify_char_uuid,
             )
-            self._write_mode_initialized = True
+            self._gatt_characteristics_initialized = True
             return
 
-        # SUTA devices expose writable characteristics dynamically under
-        # SUTA_SERVICE_UUID, so we intentionally select the first writable char
-        # we find and store it in _write_char_uuid instead of matching a fixed UUID.
+        write_candidate = None
+        notify_candidate = None
         for char in service.characteristics:
             props = {prop.lower() for prop in char.properties}
             if "write" in props or "write-without-response" in props:
-                self._write_char_uuid = str(char.uuid)
-                # Prefer write-with-response when available for acknowledgements;
-                # otherwise fall back to write-without-response.
-                self._write_with_response = "write" in props
-                self._write_mode_initialized = True
-                _LOGGER.debug(
-                    "SUTA write characteristic resolved to %s (response=%s, props=%s)",
-                    self._write_char_uuid,
-                    self._write_with_response,
-                    char.properties,
-                )
-                return
+                if (
+                    write_candidate is None
+                    or str(char.uuid).lower() == SUTA_DEFAULT_WRITE_CHAR_UUID
+                ):
+                    write_candidate = char
+            if "notify" in props or "indicate" in props:
+                if notify_candidate is None or str(char.uuid).lower() == SUTA_NOTIFY_CHAR_UUID:
+                    notify_candidate = char
 
+        if write_candidate is not None:
+            write_props = {prop.lower() for prop in write_candidate.properties}
+            self._write_char_uuid = str(write_candidate.uuid)
+            # Android uses the characteristic's advertised default write type.
+            self._write_with_response = "write" in write_props
+        else:
+            _LOGGER.warning(
+                "No writable characteristic found in SUTA service %s; using fallback %s",
+                SUTA_SERVICE_UUID,
+                self._write_char_uuid,
+            )
+
+        if notify_candidate is not None:
+            self._notify_char_uuid = str(notify_candidate.uuid)
+        else:
+            _LOGGER.warning(
+                "No notifiable characteristic found in SUTA service %s; using fallback %s",
+                SUTA_SERVICE_UUID,
+                self._notify_char_uuid,
+            )
+
+        self._gatt_characteristics_initialized = True
         _LOGGER.debug(
-            "No writable characteristic found in SUTA service %s, using fallback %s",
+            "SUTA GATT resolved: service=%s write=%s response=%s notify=%s",
             SUTA_SERVICE_UUID,
             self._write_char_uuid,
+            self._write_with_response,
+            self._notify_char_uuid,
         )
-        self._write_mode_initialized = True
+
+    def _handle_notification(
+        self,
+        characteristic: BleakGATTCharacteristic,
+        data: bytearray,
+    ) -> None:
+        """Forward and log SUTA AT responses received on FFF1."""
+        payload = bytes(data)
+        characteristic_uuid = str(getattr(characteristic, "uuid", characteristic))
+        self.forward_raw_notification(characteristic_uuid, payload)
+        _LOGGER.debug(
+            "SUTA response on %s: %r",
+            characteristic_uuid,
+            payload.decode("utf-8", errors="replace"),
+        )
+
+    async def _acquire_command_mtu(self) -> None:
+        """Acquire the negotiated MTU on backends that require an explicit request.
+
+        Android requests MTU 250 after subscribing.  Bleak's BlueZ backend exposes
+        MTU negotiation through a guarded private coroutine; other backends usually
+        negotiate automatically and report their MTU through ``mtu_size``.
+        """
+        client = self.client
+        if client is None or not client.is_connected:
+            return
+
+        backend = getattr(client, "_backend", None)
+        acquire_mtu = getattr(backend, "_acquire_mtu", None)
+        if callable(acquire_mtu):
+            try:
+                async with self._ble_lock:
+                    await acquire_mtu()
+            except (AssertionError, BleakError, OSError, TimeoutError) as err:
+                _LOGGER.warning(
+                    "Could not acquire SUTA command MTU (OEM app requests %d): %s",
+                    _SUTA_APP_REQUESTED_MTU,
+                    err,
+                )
+
+        mtu_size = getattr(client, "mtu_size", 23)
+        if isinstance(mtu_size, int) and mtu_size < _SUTA_MIN_COMMAND_MTU:
+            _LOGGER.warning(
+                "SUTA negotiated MTU is %d; motor commands need at least %d. "
+                "Writes longer than %d bytes may fail on this Bluetooth backend.",
+                mtu_size,
+                _SUTA_MIN_COMMAND_MTU,
+                mtu_size - 3,
+            )
+        else:
+            _LOGGER.debug(
+                "SUTA command MTU ready: %s (OEM app requests %d)",
+                mtu_size,
+                _SUTA_APP_REQUESTED_MTU,
+            )
+
+    async def start_notify(self, callback: Callable[[str, float], None] | None = None) -> None:
+        """Enable the FFF1 response channel and negotiate MTU before commands."""
+        self._notify_callback = callback
+        client = self.client
+        if client is None or not client.is_connected:
+            raise ConnectionError("Cannot start SUTA notifications: not connected")
+
+        self._refresh_gatt_characteristics()
+        if self._notifications_started:
+            return
+
+        try:
+            async with self._ble_lock:
+                await client.start_notify(self._notify_char_uuid, self._handle_notification)
+        except BleakError:
+            _LOGGER.warning(
+                "Failed to enable required SUTA notification characteristic %s",
+                self._notify_char_uuid,
+                exc_info=True,
+            )
+            self.log_discovered_services(level=logging.INFO)
+            raise
+
+        self._notifications_started = True
+        _LOGGER.debug("Enabled required SUTA notifications on %s", self._notify_char_uuid)
+        await self._acquire_command_mtu()
+
+    async def stop_notify(self) -> None:
+        """Stop the SUTA response notification channel."""
+        client = self.client
+        if client is None or not client.is_connected:
+            self._notifications_started = False
+            self._notify_callback = None
+            return
+        if not self._notifications_started:
+            self._notify_callback = None
+            return
+
+        try:
+            async with self._ble_lock:
+                await client.stop_notify(self._notify_char_uuid)
+        except BleakError:
+            _LOGGER.debug("Failed to stop SUTA notifications", exc_info=True)
+        finally:
+            self._notifications_started = False
+            self._notify_callback = None
 
     async def write_command(
         self,
@@ -190,7 +333,7 @@ class SutaController(BedController):
         cancel_event: asyncio.Event | None = None,
     ) -> None:
         """Write a SUTA command packet."""
-        self._refresh_write_characteristic()
+        self._refresh_gatt_characteristics()
         await self._write_gatt_with_retry(
             self._write_char_uuid,
             command,

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -423,11 +423,13 @@ SOLACE_CHAR_UUID: Final = "0000ffe1-0000-1000-8000-00805f9b34fb"
 MOTOSLEEP_SERVICE_UUID: Final = "0000ffe0-0000-1000-8000-00805f9b34fb"
 MOTOSLEEP_CHAR_UUID: Final = "0000ffe1-0000-1000-8000-00805f9b34fb"
 
-# SUTA Smart Home specific UUIDs (AT command protocol)
-# The app discovers writable/notifiable characteristics dynamically by properties.
-# FFF1 is used as a fallback write characteristic when dynamic discovery is unavailable.
+# SUTA Smart Home bed-frame UUIDs (AT command protocol).
+# The official app selects FFF0 for non-accessory SUTA devices, enables FFF1
+# notifications, requests MTU 250, and writes commands to FFF2. The separate
+# FFE0 service is selected for SUTA smart-mattress/accessory families.
 SUTA_SERVICE_UUID: Final = "0000fff0-0000-1000-8000-00805f9b34fb"
-SUTA_DEFAULT_WRITE_CHAR_UUID: Final = "0000fff1-0000-1000-8000-00805f9b34fb"
+SUTA_NOTIFY_CHAR_UUID: Final = "0000fff1-0000-1000-8000-00805f9b34fb"
+SUTA_DEFAULT_WRITE_CHAR_UUID: Final = "0000fff2-0000-1000-8000-00805f9b34fb"
 
 # TiMOTION AHF protocol UUIDs (Nordic UART Service)
 TIMOTION_AHF_SERVICE_UUID: Final = NORDIC_UART_SERVICE_UUID

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -1117,7 +1117,7 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
             signals=signals,
         )
 
-    # Check for SUTA Smart Home (AT command protocol over FFF0).
+    # Check for SUTA Smart Home bed frames (AT command protocol over FFF0).
     # Excludes known accessory-only subtypes that use a separate binary protocol.
     if any(device_name.startswith(pattern) for pattern in SUTA_NAME_PATTERNS):
         if any(device_name.startswith(prefix) for prefix in SUTA_UNSUPPORTED_NAME_PREFIXES):

--- a/docs/beds/suta.md
+++ b/docs/beds/suta.md
@@ -8,6 +8,7 @@
 
 - SUTA bed-frame controllers with names like `SUTA-B*`, `SUTA-M*`, `SUTA-S*`
 - Confirmed app model families include B803/B804/B805, B207/B202, and M-series variants
+- Dreams Sleepmotion / SUTA-B202B with WLT8016_S106 BLE module
 
 ## Apps
 
@@ -30,9 +31,32 @@
 
 ## Protocol Details
 
-**Service UUID:** `0000fff0-0000-1000-8000-00805f9b34fb`  
-**Write Characteristic:** Dynamic discovery by GATT properties (fallback: `0000fff1-0000-1000-8000-00805f9b34fb`)  
-**Format:** ASCII AT commands terminated with `\r\n` (no checksum)
+- **Service UUID:** `0000fff0-0000-1000-8000-00805f9b34fb`
+- **Notify Characteristic:** `0000fff1-0000-1000-8000-00805f9b34fb`
+- **Write Characteristic:** `0000fff2-0000-1000-8000-00805f9b34fb` (write without response on WLT8016_S106)
+- **Format:** ASCII AT commands terminated with `\r\n` (no checksum)
+
+### Connection Setup
+
+The official SUTA 3.15.0 app performs these steps for bed-frame devices before
+sending a command:
+
+1. Connect and select service `FFF0`.
+2. Subscribe to the notifiable characteristic (`FFF1` on WLT8016_S106).
+3. Request MTU 250.
+4. Write the CRLF-terminated AT command to the writable characteristic (`FFF2`).
+
+Notification setup is required even though SUTA does not provide position feedback.
+The MTU request matters because B202 motor commands are 22-24 bytes including CRLF,
+while the default ATT payload is only 20 bytes.
+
+BlueZ may label the generic FFF0 UUID as “PKOC / ICCE Digital Key / Aliro”, but
+the SUTA app explicitly selects FFF0 for bed frames; that label does not describe
+this vendor-specific use. The app selects `FFE0` instead for accessory/smart-mattress
+families such as `SUTA-MOON`, `SUTA-TEMP`, and `SUTA-RBHC`.
+The WLT vendor service `02f00000-0000-0000-0000-00000000fe00` is not referenced by
+the app's bed-control path. The app performs no BLE pairing, PIN, or application-level
+authentication before B202 commands.
 
 ## Detection
 
@@ -137,7 +161,10 @@ Duty cycle cycles: `00` -> `20` -> `33` -> `50` -> `00`. Level cycles: `00` -> `
 
 1. The app includes many extra AT commands (massage, lock, beep, calibration, scheduling). Current integration support is focused on core bed control and presets.
 2. The SUTA accessory family uses a different binary protocol and is intentionally excluded from SUTA bed-frame detection.
-3. Characteristic UUIDs are discovered at runtime from service properties, not hardcoded in the app.
+3. The app discovers the FFF0 write/notify characteristics by their GATT properties;
+   WLT8016_S106 exposes the canonical FFF2/FFF1 pair.
+4. Fresh protocol verification used SUTA 3.15.0 (`com.shuta.smart_home`, version code 75),
+   XAPK SHA-256 `deba1167bbd61b1440f039a29384f44033ac65afadb59cb5c1566ea0be8caa52`.
 
 ## References
 

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -494,6 +494,7 @@ class TestDetectBedTypeByServiceUUID:
         result = detect_bed_type_detailed(service_info)
         assert result.bed_type == BED_TYPE_SUTA
         assert result.confidence == 0.9
+        assert "uuid:suta_fff0" in result.signals
 
     def test_detect_comfort_motion_lierda3_by_uuid(self):
         """Test Comfort Motion detection by Lierda3 FE60 service UUID."""

--- a/tests/test_suta.py
+++ b/tests/test_suta.py
@@ -165,6 +165,24 @@ class TestSutaController:
         assert first_payload == _to_packet(SutaCommands.BACK_UP)
         assert last_payload == _to_packet(SutaCommands.STOP_ALL)
 
+    async def test_wlt8016_stop_notify_unsubscribes_once(
+        self,
+        suta_coordinator,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """Stopping WLT8016 notifications should unsubscribe idempotently."""
+        _configure_wlt8016_gatt(mock_bleak_client, [])
+        coordinator = await suta_coordinator(
+            address="AA:BB:CC:DD:EE:B3",
+            name="SUTA-B202B",
+            entry_id="suta_wlt8016_stop_entry",
+        )
+
+        await coordinator.controller.stop_notify()
+        await coordinator.controller.stop_notify()
+
+        mock_bleak_client.stop_notify.assert_awaited_once_with(SUTA_NOTIFY_CHAR_UUID)
+
     async def test_lights_on_and_off(
         self,
         suta_coordinator,

--- a/tests/test_suta.py
+++ b/tests/test_suta.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
@@ -19,12 +19,50 @@ from custom_components.adjustable_bed.const import (
     CONF_PREFERRED_ADAPTER,
     DOMAIN,
     SUTA_DEFAULT_WRITE_CHAR_UUID,
+    SUTA_NOTIFY_CHAR_UUID,
+    SUTA_SERVICE_UUID,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
 
 
 def _to_packet(command: str) -> bytes:
     return f"{command}\r\n".encode()
+
+
+def _configure_wlt8016_gatt(client: MagicMock, events: list[str]) -> AsyncMock:
+    """Configure the FFF0/FFF1/FFF2 GATT shape reported by WLT8016_S106."""
+    notify_char = MagicMock()
+    notify_char.uuid = SUTA_NOTIFY_CHAR_UUID
+    notify_char.properties = ["notify"]
+
+    write_char = MagicMock()
+    write_char.uuid = SUTA_DEFAULT_WRITE_CHAR_UUID
+    write_char.properties = ["write-without-response"]
+
+    service = MagicMock()
+    service.uuid = SUTA_SERVICE_UUID
+    service.characteristics = [notify_char, write_char]
+    client.services.get_service.side_effect = lambda uuid: (
+        service if str(uuid).lower() == SUTA_SERVICE_UUID else None
+    )
+    client.services.__iter__ = lambda _: iter([service])
+    client.services.__len__ = lambda _: 1
+
+    async def _start_notify(char_uuid: str, callback: object) -> None:
+        del callback
+        assert char_uuid == SUTA_NOTIFY_CHAR_UUID
+        events.append("notify")
+
+    async def _acquire_mtu() -> None:
+        events.append("mtu")
+
+    client.start_notify = AsyncMock(side_effect=_start_notify)
+    backend = MagicMock()
+    acquire_mtu = AsyncMock(side_effect=_acquire_mtu)
+    backend._acquire_mtu = acquire_mtu
+    client._backend = backend
+    client.mtu_size = 250
+    return acquire_mtu
 
 
 @pytest.fixture
@@ -73,6 +111,38 @@ class TestSutaController:
         )
 
         assert coordinator.controller.control_characteristic_uuid == SUTA_DEFAULT_WRITE_CHAR_UUID
+
+    async def test_wlt8016_initializes_notify_and_mtu_before_no_response_write(
+        self,
+        suta_coordinator,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """WLT8016 must subscribe FFF1 and acquire MTU before writing FFF2."""
+        events: list[str] = []
+        acquire_mtu = _configure_wlt8016_gatt(mock_bleak_client, events)
+
+        coordinator = await suta_coordinator(
+            address="AA:BB:CC:DD:EE:B2",
+            name="SUTA-B202B",
+            entry_id="suta_wlt8016_entry",
+        )
+
+        assert coordinator.controller.requires_notification_channel is True
+        assert events == ["notify", "mtu"]
+        mock_bleak_client.start_notify.assert_awaited_once()
+        acquire_mtu.assert_awaited_once()
+
+        # Diagnostics may ask to start notifications again on an already-connected
+        # controller; the subscription must remain idempotent.
+        await coordinator.async_start_notify_for_diagnostics()
+        mock_bleak_client.start_notify.assert_awaited_once()
+
+        await coordinator.controller.move_back_down()
+
+        first_write = mock_bleak_client.write_gatt_char.call_args_list[0]
+        assert first_write.args[0] == SUTA_DEFAULT_WRITE_CHAR_UUID
+        assert first_write.args[1] == _to_packet(SutaCommands.BACK_DOWN)
+        assert first_write.kwargs["response"] is False
 
     async def test_move_back_up_sends_back_and_stop(
         self,


### PR DESCRIPTION
## Summary

- initialize SUTA bed-frame connections in the OEM app's order: subscribe to FFF1, acquire the negotiated MTU, then write commands to FFF2
- use FFF2/write-without-response as the WLT8016 fallback while retaining GATT-property discovery for variants
- keep the required notification channel active even when angle sensing is disabled, with idempotent diagnostics setup and raw response forwarding
- document the freshly re-derived B202B protocol and add an exact WLT8016_S106 GATT regression test

## Root cause

A fresh decompilation of SUTA 3.15.0 (`com.shuta.smart_home`, version code 75), followed by smali verification of JADX's failed/ambiguous paths, shows that non-accessory SUTA beds such as SUTA-B202B use service FFF0. The generic BlueZ “PKOC / ICCE Digital Key / Aliro” label is misleading here; the app performs no pairing, PIN, or application-level authentication for B202 commands.

After connecting, the app subscribes to the notifiable characteristic (FFF1), requests MTU 250, and writes CRLF-terminated AT commands to the writable characteristic (FFF2). The integration previously used FFF1 as its fallback write target, skipped notifications when angle sensing was disabled, and did not acquire the BlueZ MTU. B202 motor packets are 22–24 bytes, exceeding the default 20-byte ATT payload.

## Validation

- `uv run pytest` — 2,125 passed
- `uvx ruff check ...` — passed
- `uvx ruff format --check ...` — passed
- `uv run mypy --explicit-package-bases custom_components/adjustable_bed/beds/suta.py` — passed

Fixes #345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved SUTA bed connectivity through dynamic Bluetooth characteristic discovery.
  - Added notification support and automatic MTU negotiation for longer commands.
  - Added support for Dreams Sleepmotion / SUTA-B202B beds.

- **Bug Fixes**
  - Improved reliability when starting and stopping Bluetooth notifications.
  - Corrected characteristic selection for commands and responses.

- **Documentation**
  - Expanded SUTA model support details and Bluetooth communication guidance.

- **Tests**
  - Added coverage for notification setup, MTU negotiation, detection, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->