### PR TITLE
fix: preserve BLE timeout recovery paths

### DIFF
--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -117,6 +117,7 @@ from .const import (
     DEVICE_INFO_READ_TIMEOUT,
     DOMAIN,
     LEGGETT_VARIANT_GEN2,
+    LEGGETT_VARIANT_OKIN,
     OKIMAT_SERVICE_UUID,
     OKIN_CST_POSITION_AXES,
     OKIN_FOOT_MAX_ANGLE,
@@ -139,6 +140,7 @@ from .const import (
 )
 from .controller_factory import create_controller
 from .detection import (
+    OKIN_SHARED_UUID_GATT_REFINABLE_TYPES,
     detect_richmat_remote_from_name,
     refine_dewertokin_star_protocol_from_name,
     refine_malouf_protocol_from_gatt,
@@ -945,6 +947,22 @@ class AdjustableBedCoordinator:
         }
         return normalized not in chipset_manufacturers
 
+    def _bed_type_needs_ble_model(self) -> bool:
+        """Whether the current protocol refinement depends on the DIS model value.
+
+        Shared-UUID OKIN profiles use the Device Information model to tell a
+        multi-motor OKIMAT bed apart from a single-actuator RF ECO BT stair that
+        exposes the same GATT signature (issue #406). If that model read times
+        out transiently we must not latch a partial read as complete, or the
+        bed would be misrouted to the stair profile on every future reconnect.
+        """
+        if self._bed_type in OKIN_SHARED_UUID_GATT_REFINABLE_TYPES:
+            return True
+        return (
+            self._bed_type == BED_TYPE_LEGGETT_PLATT
+            and self._protocol_variant == LEGGETT_VARIANT_OKIN
+        )
+
     def _store_ble_device_info(
         self,
         manufacturer: str | None,
@@ -954,21 +972,46 @@ class AdjustableBedCoordinator:
         self._ble_manufacturer = manufacturer
         self._ble_model = model
 
-        has_useful_value = self._is_useful_ble_value(
-            manufacturer
-        ) or self._is_useful_ble_value(model)
+        manufacturer_useful = self._is_useful_ble_value(manufacturer)
+        model_useful = self._is_useful_ble_value(model)
+        has_useful_value = manufacturer_useful or model_useful
+
+        # A protocol whose per-reconnect refinement needs the DIS model must not
+        # cache a read where the model timed out (manufacturer answered, model
+        # did not). Latching that partial read would freeze model=None forever
+        # and demote an OKIMAT bed to the single-actuator RF ECO BT profile on
+        # every reconnect. Require the model before we stop retrying; a genuinely
+        # model-less bed re-reads cheaply (an absent characteristic errors fast,
+        # only a transient timeout costs the read budget, which is what we want
+        # to retry). OKIN CST is exempted below via the negative cache.
+        required_fields_present = (
+            not self._bed_type_needs_ble_model() or model_useful
+        )
+
         # Certain OKIN CST receivers consistently never answer DIS reads. Their
         # protocol is already explicit and does not depend on Device Information,
         # so a negative session cache is safe and avoids 10s on every reconnect.
         negative_cache_is_safe = self._bed_type == BED_TYPE_OKIN_CST
-        self._device_info_read_done = has_useful_value or negative_cache_is_safe
+        self._device_info_read_done = (
+            has_useful_value and required_fields_present
+        ) or negative_cache_is_safe
 
         if not self._device_info_read_done:
-            _LOGGER.debug(
-                "Device Information read for %s returned no useful values; "
-                "retrying on the next connection.",
-                self._address,
-            )
+            if has_useful_value and not required_fields_present:
+                _LOGGER.debug(
+                    "Device Information read for %s is missing the model this "
+                    "protocol needs (manufacturer=%r, model=%r); retrying on the "
+                    "next connection.",
+                    self._address,
+                    manufacturer,
+                    model,
+                )
+            else:
+                _LOGGER.debug(
+                    "Device Information read for %s returned no useful values; "
+                    "retrying on the next connection.",
+                    self._address,
+                )
 
     def remember_cb24_continuous_presets(self) -> None:
         """Persist the learned CB24 continuous preset mode across reconnects."""

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -696,6 +696,10 @@ class AdjustableBedCoordinator:
             self._address,
             err,
         )
+        # A definitive authentication failure invalidates any earlier decision
+        # to skip a probe that timed out. The next paired connection should
+        # verify the fresh bond again.
+        self._bond_probe_timed_out = False
         self._clear_ble_bond_established()
 
         try:
@@ -760,13 +764,25 @@ class AdjustableBedCoordinator:
             )
             return True
         except (TimeoutError, OSError) as err:
-            self._bond_probe_timed_out = True
-            _LOGGER.debug(
-                "Bond verification read for %s failed (%s); proceeding and "
-                "skipping future probes for this session.",
-                self._address,
-                err,
-            )
+            # The field-proven OKIN CST receiver never answers this DIS read,
+            # so repeated probes only add latency. Other pairing-required beds
+            # can time out transiently while waking and must retry on a later
+            # connection so stale bond state can still be detected.
+            self._bond_probe_timed_out = self._bed_type == BED_TYPE_OKIN_CST
+            if self._bond_probe_timed_out:
+                _LOGGER.debug(
+                    "Bond verification read for OKIN CST %s failed (%s); "
+                    "skipping future probes for this session.",
+                    self._address,
+                    err,
+                )
+            else:
+                _LOGGER.debug(
+                    "Bond verification read for %s failed (%s); proceeding and "
+                    "retrying on the next connection.",
+                    self._address,
+                    err,
+                )
             return True
 
         # Read succeeded → the encrypted link works → we are bonded.
@@ -928,6 +944,31 @@ class AdjustableBedCoordinator:
             "stmicroelectronics",
         }
         return normalized not in chipset_manufacturers
+
+    def _store_ble_device_info(
+        self,
+        manufacturer: str | None,
+        model: str | None,
+    ) -> None:
+        """Store Device Information and decide whether reconnects should retry it."""
+        self._ble_manufacturer = manufacturer
+        self._ble_model = model
+
+        has_useful_value = self._is_useful_ble_value(
+            manufacturer
+        ) or self._is_useful_ble_value(model)
+        # Certain OKIN CST receivers consistently never answer DIS reads. Their
+        # protocol is already explicit and does not depend on Device Information,
+        # so a negative session cache is safe and avoids 10s on every reconnect.
+        negative_cache_is_safe = self._bed_type == BED_TYPE_OKIN_CST
+        self._device_info_read_done = has_useful_value or negative_cache_is_safe
+
+        if not self._device_info_read_done:
+            _LOGGER.debug(
+                "Device Information read for %s returned no useful values; "
+                "retrying on the next connection.",
+                self._address,
+            )
 
     def remember_cb24_continuous_presets(self) -> None:
         """Persist the learned CB24 continuous preset mode across reconnects."""
@@ -1595,9 +1636,7 @@ class AdjustableBedCoordinator:
                         ble_manufacturer, ble_model = await read_ble_device_info(
                             self._client, self._address
                         )
-                        self._ble_manufacturer = ble_manufacturer
-                        self._ble_model = ble_model
-                        self._device_info_read_done = True
+                        self._store_ble_device_info(ble_manufacturer, ble_model)
 
                 previous_bed_type = self._bed_type
                 corrected_bed_type = refine_malouf_protocol_from_gatt(
@@ -1784,9 +1823,7 @@ class AdjustableBedCoordinator:
                         ble_manufacturer, ble_model = await read_ble_device_info(
                             self._client, self._address
                         )
-                        self._ble_manufacturer = ble_manufacturer
-                        self._ble_model = ble_model
-                        self._device_info_read_done = True
+                        self._store_ble_device_info(ble_manufacturer, ble_model)
 
                 if (
                     self._bed_type != BED_TYPE_SLEEP_NUMBER_MCR
@@ -1833,6 +1870,11 @@ class AdjustableBedCoordinator:
                 return True
 
             except (BleakError, TimeoutError, OSError) as err:
+                if isinstance(err, BleakError) and _is_ble_authentication_error(err):
+                    # Authentication can first fail during controller startup,
+                    # after a slow DIS probe was treated as inconclusive. Clear
+                    # the stale marker here so the next retry requests pairing.
+                    await self._async_handle_ble_authentication_error(err, holding_lock=True)
                 attempt_elapsed = time.monotonic() - attempt_start
                 attempt_details["total_elapsed_seconds"] = round(attempt_elapsed, 3)
                 attempt_details["result"] = "failed"

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -1917,7 +1917,21 @@ class AdjustableBedCoordinator:
                     # Authentication can first fail during controller startup,
                     # after a slow DIS probe was treated as inconclusive. Clear
                     # the stale marker here so the next retry requests pairing.
-                    await self._async_handle_ble_authentication_error(err, holding_lock=True)
+                    # Keep this best-effort: the handler disconnects the client,
+                    # and disconnect cleanup can itself raise. Letting that escape
+                    # would replace the original authentication error and abort
+                    # the remaining retries. CancelledError is a BaseException, so
+                    # cancellation still propagates.
+                    try:
+                        await self._async_handle_ble_authentication_error(
+                            err, holding_lock=True
+                        )
+                    except Exception:
+                        _LOGGER.debug(
+                            "Authentication recovery cleanup failed for %s",
+                            self._address,
+                            exc_info=True,
+                        )
                 attempt_elapsed = time.monotonic() - attempt_start
                 attempt_details["total_elapsed_seconds"] = round(attempt_elapsed, 3)
                 attempt_details["result"] = "failed"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1746,6 +1746,7 @@ class TestCoordinatorWriteCommand:
 
         coordinator = AdjustableBedCoordinator(hass, entry)
         await coordinator.async_connect()
+        coordinator._bond_probe_timed_out = True
 
         async def _auth_failure_command(_controller):
             raise BleakError(
@@ -1771,11 +1772,100 @@ class TestCoordinatorWriteCommand:
             )
 
         assert coordinator._ble_bond_established is False
+        assert coordinator._bond_probe_timed_out is False
         assert entry.data[CONF_BLE_BOND_ESTABLISHED] is False
         mock_create_issue.assert_awaited_once_with(
             hass, TEST_ADDRESS, TEST_NAME, "okimat_auth_failure_test"
         )
         mock_disconnect.assert_awaited_once_with(reason="authentication_failed")
+
+    async def test_controller_startup_auth_failure_clears_bond_marker(
+        self,
+        hass: HomeAssistant,
+        mock_bleak_client: MagicMock,
+        mock_bluetooth_adapters,
+    ):
+        """Startup auth failures must recover even after a cached probe timeout."""
+        del mock_bluetooth_adapters
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=TEST_NAME,
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: TEST_NAME,
+                CONF_BED_TYPE: BED_TYPE_OKIMAT,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+                CONF_BLE_BOND_ESTABLISHED: True,
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id="okimat_startup_auth_failure_test",
+        )
+        entry.add_to_hass(hass)
+
+        adapter_result = MagicMock()
+        adapter_result.device = MagicMock()
+        adapter_result.device.address = TEST_ADDRESS
+        adapter_result.device.name = TEST_NAME
+        adapter_result.device.details = {"source": "local"}
+        adapter_result.source = "local"
+        adapter_result.rssi = -60
+        adapter_result.connectable = True
+        adapter_result.available_sources = ["local"]
+
+        auth_error = BleakError(
+            "Bluetooth GATT Error address=AA:BB:CC:DD:EE:FF "
+            "handle=19 error=5 description=Insufficient authentication"
+        )
+        with (
+            patch(
+                "custom_components.adjustable_bed.coordinator.select_adapter",
+                new_callable=AsyncMock,
+                return_value=adapter_result,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.establish_connection",
+                new_callable=AsyncMock,
+                return_value=mock_bleak_client,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.discover_services",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.read_ble_device_info",
+                new_callable=AsyncMock,
+                return_value=("OKIN", "Model X"),
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.create_controller",
+                new_callable=AsyncMock,
+                side_effect=auth_error,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.create_pairing_required_issue",
+                new_callable=AsyncMock,
+            ) as mock_create_issue,
+            patch(
+                "custom_components.adjustable_bed.coordinator.asyncio.sleep",
+                new=AsyncMock(),
+            ),
+        ):
+            coordinator = AdjustableBedCoordinator(hass, entry)
+            coordinator._max_retries = 1
+            coordinator._bond_probe_timed_out = True
+            result = await coordinator.async_connect()
+
+        assert result is False
+        assert coordinator._ble_bond_established is False
+        assert coordinator._bond_probe_timed_out is False
+        assert entry.data[CONF_BLE_BOND_ESTABLISHED] is False
+        mock_create_issue.assert_awaited_once_with(
+            hass, TEST_ADDRESS, TEST_NAME, "okimat_startup_auth_failure_test"
+        )
 
     async def test_failed_pairing_does_not_persist_bond_marker(
         self,
@@ -1943,11 +2033,11 @@ class TestCoordinatorWriteCommand:
         mock_delete_issue.assert_awaited_once_with(hass, TEST_ADDRESS)
 
 
-    async def test_verify_bonded_timeout_sets_flag_and_skips_future_probes(
+    async def test_verify_bonded_timeout_is_retryable_for_other_beds(
         self,
         hass: HomeAssistant,
     ):
-        """A probe that times out is skipped for the rest of the session."""
+        """A transient timeout must not suppress probes on later connections."""
         entry = MockConfigEntry(
             domain=DOMAIN,
             title=TEST_NAME,
@@ -1962,6 +2052,56 @@ class TestCoordinatorWriteCommand:
             },
             unique_id=TEST_ADDRESS,
             entry_id="okimat_verify_bonded_timeout_test",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        client = MagicMock()
+        client.is_connected = True
+
+        async def _never_answers(*args, **kwargs):
+            await asyncio.Event().wait()
+
+        client.read_gatt_char = AsyncMock(side_effect=_never_answers)
+        coordinator._client = client
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator.DEVICE_INFO_READ_TIMEOUT",
+            0.05,
+        ):
+            async with asyncio.timeout(5):
+                bonded = await coordinator._async_verify_bonded()
+
+            assert bonded is True
+            assert coordinator._bond_probe_timed_out is False
+            assert client.read_gatt_char.await_count == 1
+
+            async with asyncio.timeout(5):
+                bonded = await coordinator._async_verify_bonded()
+
+        assert bonded is True
+        assert coordinator._bond_probe_timed_out is False
+        assert client.read_gatt_char.await_count == 2
+
+    async def test_verify_bonded_timeout_is_negative_cached_for_okin_cst(
+        self,
+        hass: HomeAssistant,
+    ):
+        """Known-unresponsive OKIN CST probes remain skipped after a timeout."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=TEST_NAME,
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: TEST_NAME,
+                CONF_BED_TYPE: BED_TYPE_OKIN_CST,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id="okin_cst_verify_bonded_timeout_test",
         )
         entry.add_to_hass(hass)
 
@@ -2587,12 +2727,12 @@ class TestRuntimeBedTypeCorrection:
 class TestDeviceInfoCache:
     """Device Information Service results are cached across reconnects."""
 
-    async def test_device_info_read_once_across_reconnects(
+    async def test_failed_device_info_read_retries_then_caches_success(
         self,
         hass: HomeAssistant,
         mock_bleak_client: MagicMock,
     ):
-        """The DIS read runs on the first connect only; reconnects reuse it."""
+        """A failed DIS read retries once connected again, then caches success."""
         entry = MockConfigEntry(
             domain=DOMAIN,
             title=TEST_NAME,
@@ -2649,7 +2789,7 @@ class TestDeviceInfoCache:
             patch(
                 "custom_components.adjustable_bed.coordinator.read_ble_device_info",
                 new_callable=AsyncMock,
-                return_value=("OKIN", "Model X"),
+                side_effect=[(None, None), ("OKIN", "Model X")],
             ) as mock_read_device_info,
             patch.object(
                 AdjustableBedCoordinator,
@@ -2672,16 +2812,93 @@ class TestDeviceInfoCache:
 
             assert await coordinator.async_connect() is True
             assert mock_read_device_info.await_count == 1
+            assert coordinator._device_info_read_done is False
+            assert coordinator._ble_manufacturer is None
+            assert coordinator._ble_model is None
+
+            await coordinator.async_disconnect()
+
+            assert await coordinator.async_connect() is True
+            assert mock_read_device_info.await_count == 2
+            assert coordinator._device_info_read_done is True
             assert coordinator._ble_manufacturer == "OKIN"
             assert coordinator._ble_model == "Model X"
 
             await coordinator.async_disconnect()
 
             assert await coordinator.async_connect() is True
-            # Reconnect must reuse the cached values instead of re-reading.
-            assert mock_read_device_info.await_count == 1
+            # Once a useful read succeeds, later reconnects reuse it.
+            assert mock_read_device_info.await_count == 2
             assert coordinator._ble_manufacturer == "OKIN"
             assert coordinator._ble_model == "Model X"
+
+    @pytest.mark.parametrize(
+        ("bed_type", "expected_read_done"),
+        [
+            (BED_TYPE_OKIMAT, False),
+            (BED_TYPE_OKIN_CST, True),
+        ],
+    )
+    def test_missing_device_info_cache_policy(
+        self,
+        hass: HomeAssistant,
+        bed_type: str,
+        expected_read_done: bool,
+    ):
+        """Only the known-unresponsive explicit protocol uses a negative cache."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=TEST_NAME,
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: TEST_NAME,
+                CONF_BED_TYPE: bed_type,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id=f"{bed_type}_device_info_cache_policy_test",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        coordinator._store_ble_device_info(None, None)
+
+        assert coordinator._device_info_read_done is expected_read_done
+
+    def test_useful_device_info_is_cached_for_refinable_bed(
+        self,
+        hass: HomeAssistant,
+    ):
+        """A later successful read should stop retries for refinable protocols."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=TEST_NAME,
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: TEST_NAME,
+                CONF_BED_TYPE: BED_TYPE_OKIMAT,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id="okimat_useful_device_info_cache_test",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        coordinator._store_ble_device_info(None, None)
+        assert coordinator._device_info_read_done is False
+
+        coordinator._store_ble_device_info("OKIN", "OKIMAT 4 IPS/M")
+
+        assert coordinator._device_info_read_done is True
+        assert coordinator._ble_manufacturer == "OKIN"
+        assert coordinator._ble_model == "OKIMAT 4 IPS/M"
 
     async def test_deferred_device_info_read_once_across_reconnects(
         self,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1867,6 +1867,98 @@ class TestCoordinatorWriteCommand:
             hass, TEST_ADDRESS, TEST_NAME, "okimat_startup_auth_failure_test"
         )
 
+    async def test_startup_auth_recovery_survives_failing_disconnect(
+        self,
+        hass: HomeAssistant,
+        mock_bleak_client: MagicMock,
+        mock_bluetooth_adapters,
+    ):
+        """A disconnect that raises during auth recovery must not abort the retry path."""
+        del mock_bluetooth_adapters
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=TEST_NAME,
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: TEST_NAME,
+                CONF_BED_TYPE: BED_TYPE_OKIMAT,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+                CONF_BLE_BOND_ESTABLISHED: True,
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id="okimat_startup_auth_failing_disconnect_test",
+        )
+        entry.add_to_hass(hass)
+
+        adapter_result = MagicMock()
+        adapter_result.device = MagicMock()
+        adapter_result.device.address = TEST_ADDRESS
+        adapter_result.device.name = TEST_NAME
+        adapter_result.device.details = {"source": "local"}
+        adapter_result.source = "local"
+        adapter_result.rssi = -60
+        adapter_result.connectable = True
+        adapter_result.available_sources = ["local"]
+
+        auth_error = BleakError(
+            "Bluetooth GATT Error address=AA:BB:CC:DD:EE:FF "
+            "handle=19 error=5 description=Insufficient authentication"
+        )
+        # Disconnect cleanup raises a non-BleakError so it escapes the disconnect
+        # helper's own guard and would otherwise replace the auth error.
+        mock_bleak_client.is_connected = True
+        mock_bleak_client.disconnect = AsyncMock(side_effect=OSError("cleanup boom"))
+        with (
+            patch(
+                "custom_components.adjustable_bed.coordinator.select_adapter",
+                new_callable=AsyncMock,
+                return_value=adapter_result,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.establish_connection",
+                new_callable=AsyncMock,
+                return_value=mock_bleak_client,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.discover_services",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.read_ble_device_info",
+                new_callable=AsyncMock,
+                return_value=("OKIN", "Model X"),
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.create_controller",
+                new_callable=AsyncMock,
+                side_effect=auth_error,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.create_pairing_required_issue",
+                new_callable=AsyncMock,
+            ) as mock_create_issue,
+            patch(
+                "custom_components.adjustable_bed.coordinator.asyncio.sleep",
+                new=AsyncMock(),
+            ),
+        ):
+            coordinator = AdjustableBedCoordinator(hass, entry)
+            coordinator._max_retries = 1
+            # Must not raise the OSError from the failing disconnect.
+            result = await coordinator.async_connect()
+
+        assert result is False
+        # The recovery still ran despite the failing disconnect.
+        assert coordinator._ble_bond_established is False
+        assert entry.data[CONF_BLE_BOND_ESTABLISHED] is False
+        mock_create_issue.assert_awaited_once_with(
+            hass, TEST_ADDRESS, TEST_NAME, "okimat_startup_auth_failing_disconnect_test"
+        )
+
     async def test_failed_pairing_does_not_persist_bond_marker(
         self,
         hass: HomeAssistant,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2900,6 +2900,74 @@ class TestDeviceInfoCache:
         assert coordinator._ble_manufacturer == "OKIN"
         assert coordinator._ble_model == "OKIMAT 4 IPS/M"
 
+    def test_partial_device_info_does_not_latch_for_model_dependent_bed(
+        self,
+        hass: HomeAssistant,
+    ):
+        """A model that timed out must not freeze an OKIMAT bed's identity.
+
+        An OKIMAT bed shares the RF ECO BT GATT signature, so its Device Info
+        model is what keeps it from being demoted to the single-actuator stair
+        profile. If the manufacturer read succeeds but the model times out, the
+        cache must not latch complete, or model=None would persist across every
+        reconnect and misroute the bed (issue #430 follow-up).
+        """
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=TEST_NAME,
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: TEST_NAME,
+                CONF_BED_TYPE: BED_TYPE_OKIMAT,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id="okimat_partial_device_info_test",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+
+        # Manufacturer answered, model timed out (returned None).
+        coordinator._store_ble_device_info("OKIN", None)
+        assert coordinator._device_info_read_done is False
+
+        # A later reconnect recovers the model and stops retrying.
+        coordinator._store_ble_device_info("OKIN", "OKIMAT 4 IPS/M")
+        assert coordinator._device_info_read_done is True
+        assert coordinator._ble_model == "OKIMAT 4 IPS/M"
+
+    def test_partial_device_info_latches_for_model_independent_bed(
+        self,
+        hass: HomeAssistant,
+    ):
+        """A protocol that never consults the DIS model still caches partial reads."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=TEST_NAME,
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: TEST_NAME,
+                CONF_BED_TYPE: BED_TYPE_KEESON,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id="keeson_partial_device_info_test",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+
+        # Manufacturer alone is enough for a bed whose protocol never needs model.
+        coordinator._store_ble_device_info("Keeson", None)
+        assert coordinator._device_info_read_done is True
+
     async def test_deferred_device_info_read_once_across_reconnects(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## Summary

- Keep failed Device Information reads retryable for protocols whose runtime correction depends on manufacturer or model data.
- Retain the negative session cache only for explicit OKIN CST devices, the field-proven receivers that consistently never answer these reads.
- Retry transient bond-probe timeouts for other pairing-required beds.
- Clear stale bond state and reset the probe skip when authentication fails during controller startup or a later command.

## Why

Follow-up review on #416 identified two recovery paths that were too broadly cached:

- [Failed Device Information reads could suppress later protocol correction](https://github.com/kristofferR/ha-adjustable-bed/pull/416#discussion_r3556332054).
- [A transient bond-probe timeout could suppress later startup verification](https://github.com/kristofferR/ha-adjustable-bed/pull/416#discussion_r3556332058).

The original fix correctly avoids repeated 10-second reconnect delays on affected OKIN CST hardware. This follow-up scopes that behavior to the proven protocol while allowing other beds to recover from transient discovery or authentication failures.

## Impact

Beds that temporarily fail a Device Information read can correct their protocol on a later reconnect. Pairing-required beds can recover stale bond state during controller startup without requiring an integration reload. Known-unresponsive OKIN CST receivers keep the fast reconnect behavior from #416.

## Validation

- `pytest -q tests/test_coordinator.py`: 104 passed
- `pytest -q`: 2,136 passed
- `ruff@0.15.16 check custom_components tests`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from Bluetooth authentication failures during startup and reconnection.
  * Pairing status is now refreshed correctly after authentication errors, allowing repair flows to run without stale connection state.
  * Temporary bond-verification timeouts can be retried on supported devices.
  * Device information reads now retry after failures and cache results appropriately, including devices that do not provide useful information.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->