### PR TITLE
Fix Lucid L600 protocol and setup handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,8 @@ The supported-protocol list lives in the README's "Supported Beds" table — tha
 | Option | Description | Default |
 |--------|-------------|---------|
 | `motor_count` | 2, 3, or 4 motors | 2 |
+| `malouf_layout` | Malouf/Lucid physical actuator layout, independent of protocol | auto |
+| `malouf_memory_slots` | Malouf/Lucid remote memory capacity (auto, 1, or 2) | auto |
 | `has_massage` | Enable massage entities | false |
 | `protocol_variant` | Protocol variant (bed-specific) | auto |
 | `disable_angle_sensing` | Disable position feedback | true |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The names below refer to motor/actuator manufacturers. Your bed might use one of
 | ✅ [Solace](docs/beds/solace.md) | Solace, Sealy, Woosa Sleep, QMS |
 | ✅ [Leggett & Platt](docs/beds/leggett-platt.md) | Leggett & Platt |
 | ✅ [Reverie](docs/beds/reverie.md) | Reverie |
-| ✅ [Okimat/Okin](docs/beds/okimat.md) | Lucid, CVB, Smartbed |
+| ✅ [Okimat/Okin](docs/beds/okimat.md) | Lucid (including some Smartbed/L600 bases), CVB, Smartbed |
 | ✅ [Okin 64-Bit](docs/beds/okin-64bit.md) | NORA_CON / NORACON Mattress Firm controllers |
 | ✅ [Jiecang](docs/beds/jiecang.md) | Glideaway, Dream Motion, LOGICDATA |
 | ✅ [Kaidi](docs/beds/kaidi.md) | Rize Remedy III / newer Mouselet-based Rize beds, Floyd Home, ISleep |
@@ -87,7 +87,7 @@ The names below refer to motor/actuator manufacturers. Your bed might use one of
 | ✅ [Serta](docs/beds/serta.md) | Serta Motion Perfect |
 | ✅ [Mattress Firm 900](docs/beds/mattressfirm.md) | iFlex / older Nordic UART bases |
 | ✅ [Nectar](docs/beds/nectar.md) | Nectar |
-| ✅ [Malouf](docs/beds/malouf.md) | Malouf, Structures |
+| ✅ [Malouf/Lucid](docs/beds/malouf.md) | Malouf, Lucid (including some L600 bases), Structures |
 | ✅ [BedTech](docs/beds/bedtech.md) | BedTech |
 | ✅ [Sleep Number](docs/beds/sleep_number.md) | Climate 360, FlexFit, FlexFit Smart, i8 / 360 FlexFit 2 |
 | ✅ [Sleepy's Elite](docs/beds/sleepys.md) | Sleepy's |
@@ -104,6 +104,12 @@ The names below refer to motor/actuator manufacturers. Your bed might use one of
 | ✅ [Okin CST](docs/beds/okin-cst.md) | Mattress Firm 900-O / MFirm 900-O, Rize MF900, Nectar Motion, LP Prodigy CE |
 | ✅ [OKIN Smart Remote / RF ECO BT](docs/beds/okin-rf-eco-bt.md) | Elda BTH / MEGAMAT staircase actuator |
 | ⚠️ [Okin DOT](docs/beds/okin-dot.md) | DewertOkin RF1058/RF34/RF6707 handset beds |
+
+Retail model names do not identify a BLE protocol. In particular, **Lucid
+L600 is not one protocol**: confirmed L600 units include both 7-byte OKIN CB24
+(`Smartbed237...`) and 9-byte legacy Malouf/OKIN (`OKIN-BLE...` with `BTCB`)
+controllers. Auto-detection uses advertising data and connected GATT services,
+not the L600 label.
 
 **Have one of these?** [Let us know](https://github.com/kristofferR/ha-adjustable-bed/issues) how well it works!
 

--- a/custom_components/adjustable_bed/beds/malouf.py
+++ b/custom_components/adjustable_bed/beds/malouf.py
@@ -1,6 +1,7 @@
 """Malouf bed controller implementations.
 
-Reverse-engineered from Malouf Base app v2.4.3.
+Reverse-engineered from the shared Malouf/Lucid Android SDK, including Lucid
+Base 1.3.3.
 
 Malouf beds use two distinct protocols:
 - NEW_OKIN: 8-byte commands via Nordic UART, advertises unique service UUID
@@ -18,7 +19,14 @@ from typing import TYPE_CHECKING
 from bleak.exc import BleakError
 
 from ..const import (
+    MALOUF_LAYOUT_AUTO,
+    MALOUF_LAYOUT_FOUR_MOTOR,
+    MALOUF_LAYOUT_HEAD_TILT,
+    MALOUF_LAYOUT_HILO,
+    MALOUF_LAYOUT_LUMBAR,
+    MALOUF_LAYOUT_TWO_MOTOR,
     MALOUF_LEGACY_OKIN_WRITE_CHAR_UUID,
+    MALOUF_MEMORY_SLOTS_AUTO,
     MALOUF_NEW_OKIN_WRITE_CHAR_UUID,
 )
 from .base import BedController, MotorControlSpec
@@ -57,6 +65,8 @@ class MaloufCommands:
     TV_READ = 0x4000
     MEMORY_1 = 0x10000
     MEMORY_2 = 0x40000
+    SET_MEMORY_1_SMARTBED238 = 0x80010000
+    SET_MEMORY_2 = 0x80040000
 
     # Lights & Massage
     LIGHT_SWITCH = 0x20000
@@ -74,9 +84,9 @@ class MaloufCommands:
     BED_HEIGHT_DOWN = HEAD_TILT_DOWN | LUMBAR_DOWN
 
 
-def _malouf_hilo_motor_control_specs() -> tuple[MotorControlSpec, ...]:
-    """Return the Hi-Lo motor layout exposed by Malouf/OKIN protocol beds."""
-    return (
+def _malouf_motor_control_specs(layout: str) -> tuple[MotorControlSpec, ...]:
+    """Return entities for the configured physical actuator layout."""
+    specs = [
         MotorControlSpec(
             key="back",
             translation_key="back",
@@ -92,30 +102,78 @@ def _malouf_hilo_motor_control_specs() -> tuple[MotorControlSpec, ...]:
             stop_fn=lambda ctrl: ctrl.move_legs_stop(),
             max_angle=45,
         ),
-        MotorControlSpec(
-            key="tilt",
-            translation_key="head_end_tilt",
-            open_fn=lambda ctrl: ctrl.move_tilt_up(),
-            close_fn=lambda ctrl: ctrl.move_tilt_down(),
-            stop_fn=lambda ctrl: ctrl.move_tilt_stop(),
-            max_angle=45,
-        ),
-        MotorControlSpec(
-            key="lumbar",
-            translation_key="foot_end_tilt",
-            open_fn=lambda ctrl: ctrl.move_lumbar_up(),
-            close_fn=lambda ctrl: ctrl.move_lumbar_down(),
-            stop_fn=lambda ctrl: ctrl.move_lumbar_stop(),
-            max_angle=30,
-        ),
-        MotorControlSpec(
-            key="bed_height",
-            translation_key="bed_height",
-            open_fn=lambda ctrl: ctrl.move_bed_height_up(),
-            close_fn=lambda ctrl: ctrl.move_bed_height_down(),
-            stop_fn=lambda ctrl: ctrl.move_bed_height_stop(),
-        ),
-    )
+    ]
+    if layout in {MALOUF_LAYOUT_HEAD_TILT, MALOUF_LAYOUT_FOUR_MOTOR}:
+        specs.append(
+            MotorControlSpec(
+                key="tilt",
+                translation_key="tilt",
+                open_fn=lambda ctrl: ctrl.move_tilt_up(),
+                close_fn=lambda ctrl: ctrl.move_tilt_down(),
+                stop_fn=lambda ctrl: ctrl.move_tilt_stop(),
+                max_angle=45,
+            )
+        )
+    if layout in {MALOUF_LAYOUT_LUMBAR, MALOUF_LAYOUT_FOUR_MOTOR}:
+        specs.append(
+            MotorControlSpec(
+                key="lumbar",
+                translation_key="lumbar",
+                open_fn=lambda ctrl: ctrl.move_lumbar_up(),
+                close_fn=lambda ctrl: ctrl.move_lumbar_down(),
+                stop_fn=lambda ctrl: ctrl.move_lumbar_stop(),
+                max_angle=30,
+            )
+        )
+    if layout == MALOUF_LAYOUT_HILO:
+        specs.extend(
+            (
+                MotorControlSpec(
+                    key="tilt",
+                    translation_key="head_end_tilt",
+                    open_fn=lambda ctrl: ctrl.move_tilt_up(),
+                    close_fn=lambda ctrl: ctrl.move_tilt_down(),
+                    stop_fn=lambda ctrl: ctrl.move_tilt_stop(),
+                    max_angle=45,
+                ),
+                MotorControlSpec(
+                    key="lumbar",
+                    translation_key="foot_end_tilt",
+                    open_fn=lambda ctrl: ctrl.move_lumbar_up(),
+                    close_fn=lambda ctrl: ctrl.move_lumbar_down(),
+                    stop_fn=lambda ctrl: ctrl.move_lumbar_stop(),
+                    max_angle=30,
+                ),
+                MotorControlSpec(
+                    key="bed_height",
+                    translation_key="bed_height",
+                    open_fn=lambda ctrl: ctrl.move_bed_height_up(),
+                    close_fn=lambda ctrl: ctrl.move_bed_height_down(),
+                    stop_fn=lambda ctrl: ctrl.move_bed_height_stop(),
+                ),
+            )
+        )
+    return tuple(specs)
+
+
+def _resolve_malouf_layout(coordinator: AdjustableBedCoordinator) -> str:
+    """Resolve an actuator layout without using a retail model as a protocol."""
+    configured = coordinator.malouf_layout
+    if configured != MALOUF_LAYOUT_AUTO:
+        return configured
+    if coordinator.motor_count <= 2:
+        return MALOUF_LAYOUT_TWO_MOTOR
+    if coordinator.motor_count == 3:
+        return MALOUF_LAYOUT_HEAD_TILT
+    return MALOUF_LAYOUT_FOUR_MOTOR
+
+
+def _resolve_malouf_memory_slots(coordinator: AdjustableBedCoordinator, layout: str) -> int:
+    """Resolve memory capacity independently from command protocol."""
+    configured = coordinator.malouf_memory_slots
+    if configured != MALOUF_MEMORY_SLOTS_AUTO:
+        return configured
+    return 1 if layout == MALOUF_LAYOUT_TWO_MOTOR else 2
 
 
 class MaloufNewOkinController(BedController):
@@ -158,15 +216,19 @@ class MaloufNewOkinController(BedController):
 
     @property
     def has_lumbar_support(self) -> bool:
-        return True
+        return self._layout in {MALOUF_LAYOUT_LUMBAR, MALOUF_LAYOUT_FOUR_MOTOR, MALOUF_LAYOUT_HILO}
 
     @property
     def has_tilt_support(self) -> bool:
-        return True
+        return self._layout in {
+            MALOUF_LAYOUT_HEAD_TILT,
+            MALOUF_LAYOUT_FOUR_MOTOR,
+            MALOUF_LAYOUT_HILO,
+        }
 
     @property
     def has_bed_height_support(self) -> bool:
-        return True
+        return self._layout == MALOUF_LAYOUT_HILO
 
     @property
     def supports_lights(self) -> bool:
@@ -180,44 +242,52 @@ class MaloufNewOkinController(BedController):
 
     @property
     def supports_memory_presets(self) -> bool:
-        """Return True - Malouf beds support memory presets (slots 1-2)."""
-        return True
+        """Return whether at least one memory position is configured."""
+        return self.memory_slot_count > 0
 
     @property
     def memory_slot_count(self) -> int:
-        """Return 2 - Malouf beds support memory slots 1-2."""
-        return 2
+        """Return the configured physical remote's memory capacity."""
+        return _resolve_malouf_memory_slots(self._coordinator, self._layout)
 
     @property
     def supports_memory_programming(self) -> bool:
-        """Return False - Malouf beds don't support programming memory positions."""
-        return False
+        """Return True; the official app programs memory by a timed long press."""
+        return self.memory_slot_count > 0
+
+    @property
+    def _layout(self) -> str:
+        """Return the resolved physical actuator layout."""
+        return _resolve_malouf_layout(self._coordinator)
 
     @property
     def motor_control_specs(self) -> tuple[MotorControlSpec, ...]:
-        """Return the exposed Hi-Lo motor layout."""
-        return _malouf_hilo_motor_control_specs()
+        """Return controls for the selected physical actuator layout."""
+        return _malouf_motor_control_specs(self._layout)
 
     @property
     def stale_motor_entity_keys(self) -> frozenset[str]:
-        """Remove duplicate legacy aliases that should no longer be exposed."""
-        return frozenset({"head", "feet"})
+        """Remove legacy aliases and controls absent from the selected layout."""
+        active = {spec.key for spec in self.motor_control_specs}
+        return frozenset({"head", "feet", "tilt", "lumbar", "bed_height"} - active)
 
     def _build_command(self, command_value: int) -> bytes:
         """Build an 8-byte NEW_OKIN command.
 
         Format: [0x05, 0x02, (cmd>>24)&0xFF, (cmd>>16)&0xFF, (cmd>>8)&0xFF, cmd&0xFF, 0x00, 0x00]
         """
-        return bytes([
-            0x05,
-            0x02,
-            (command_value >> 24) & 0xFF,
-            (command_value >> 16) & 0xFF,
-            (command_value >> 8) & 0xFF,
-            command_value & 0xFF,
-            0x00,
-            0x00,
-        ])
+        return bytes(
+            [
+                0x05,
+                0x02,
+                (command_value >> 24) & 0xFF,
+                (command_value >> 16) & 0xFF,
+                (command_value >> 8) & 0xFF,
+                command_value & 0xFF,
+                0x00,
+                0x00,
+            ]
+        )
 
     async def _move_with_stop(self, command_value: int) -> None:  # pyright: ignore[reportIncompatibleMethodOverride]
         """Execute a movement command and always send STOP at the end."""
@@ -232,7 +302,7 @@ class MaloufNewOkinController(BedController):
                     self._build_command(MaloufCommands.STOP),
                     cancel_event=asyncio.Event(),
                 )
-            except (BleakError, ConnectionError):
+            except BleakError, ConnectionError:
                 _LOGGER.debug("Failed to send STOP command during cleanup", exc_info=True)
 
     # Motor control methods
@@ -348,7 +418,7 @@ class MaloufNewOkinController(BedController):
                 self._build_command(MaloufCommands.STOP),
                 cancel_event=asyncio.Event(),
             )
-        except (BleakError, ConnectionError):
+        except BleakError, ConnectionError:
             _LOGGER.debug("Failed to send STOP after preset", exc_info=True)
 
     async def preset_flat(self) -> None:
@@ -373,6 +443,9 @@ class MaloufNewOkinController(BedController):
 
     async def preset_memory(self, memory_num: int) -> None:
         """Go to memory preset."""
+        if memory_num < 1 or memory_num > self.memory_slot_count:
+            _LOGGER.warning("Memory slot %d not supported on this Malouf layout", memory_num)
+            return
         commands = {
             1: MaloufCommands.MEMORY_1,
             2: MaloufCommands.MEMORY_2,
@@ -383,9 +456,23 @@ class MaloufNewOkinController(BedController):
             _LOGGER.warning("Memory slot %d not supported on Malouf beds", memory_num)
 
     async def program_memory(self, memory_num: int) -> None:
-        """Program current position to memory (not supported)."""
-        _LOGGER.warning(
-            "Malouf beds don't support programming memory presets (requested: %d)", memory_num
+        """Program memory using the official app's 55 x 100 ms hold sequence."""
+        if memory_num < 1 or memory_num > self.memory_slot_count:
+            _LOGGER.warning("Memory slot %d not supported on this Malouf layout", memory_num)
+            return
+        command_value = (
+            MaloufCommands.SET_MEMORY_1_SMARTBED238
+            if memory_num == 1 and "smartbed238" in self._coordinator.ble_device_name.lower()
+            else MaloufCommands.MEMORY_1
+            if memory_num == 1
+            else MaloufCommands.SET_MEMORY_2
+        )
+        # The APK schedules the first write after one interval, then performs
+        # exactly 55 acknowledged writes. Its final "stopCommand" string is not
+        # recognized by the dispatcher, so no STOP packet is actually emitted.
+        await asyncio.sleep(0.1)
+        await self.write_command(
+            self._build_command(command_value), repeat_count=55, repeat_delay_ms=100
         )
 
     # Light control
@@ -475,15 +562,19 @@ class MaloufLegacyOkinController(BedController):
 
     @property
     def has_lumbar_support(self) -> bool:
-        return True
+        return self._layout in {MALOUF_LAYOUT_LUMBAR, MALOUF_LAYOUT_FOUR_MOTOR, MALOUF_LAYOUT_HILO}
 
     @property
     def has_tilt_support(self) -> bool:
-        return True
+        return self._layout in {
+            MALOUF_LAYOUT_HEAD_TILT,
+            MALOUF_LAYOUT_FOUR_MOTOR,
+            MALOUF_LAYOUT_HILO,
+        }
 
     @property
     def has_bed_height_support(self) -> bool:
-        return True
+        return self._layout == MALOUF_LAYOUT_HILO
 
     @property
     def supports_lights(self) -> bool:
@@ -497,28 +588,34 @@ class MaloufLegacyOkinController(BedController):
 
     @property
     def supports_memory_presets(self) -> bool:
-        """Return True - Malouf beds support memory presets (slots 1-2)."""
-        return True
+        """Return whether at least one memory position is configured."""
+        return self.memory_slot_count > 0
 
     @property
     def memory_slot_count(self) -> int:
-        """Return 2 - Malouf beds support memory slots 1-2."""
-        return 2
+        """Return the configured physical remote's memory capacity."""
+        return _resolve_malouf_memory_slots(self._coordinator, self._layout)
 
     @property
     def supports_memory_programming(self) -> bool:
-        """Return False - Malouf beds don't support programming memory positions."""
-        return False
+        """Return True; the official app programs memory by a timed long press."""
+        return self.memory_slot_count > 0
+
+    @property
+    def _layout(self) -> str:
+        """Return the resolved physical actuator layout."""
+        return _resolve_malouf_layout(self._coordinator)
 
     @property
     def motor_control_specs(self) -> tuple[MotorControlSpec, ...]:
-        """Return the exposed Hi-Lo motor layout."""
-        return _malouf_hilo_motor_control_specs()
+        """Return controls for the selected physical actuator layout."""
+        return _malouf_motor_control_specs(self._layout)
 
     @property
     def stale_motor_entity_keys(self) -> frozenset[str]:
-        """Remove duplicate legacy aliases that should no longer be exposed."""
-        return frozenset({"head", "feet"})
+        """Remove legacy aliases and controls absent from the selected layout."""
+        active = {spec.key for spec in self.motor_control_specs}
+        return frozenset({"head", "feet", "tilt", "lumbar", "bed_height"} - active)
 
     def _build_command(self, command_value: int) -> bytes:
         """Build a 9-byte LEGACY_OKIN command with checksum.
@@ -553,7 +650,7 @@ class MaloufLegacyOkinController(BedController):
                     self._build_command(MaloufCommands.STOP),
                     cancel_event=asyncio.Event(),
                 )
-            except (BleakError, ConnectionError):
+            except BleakError, ConnectionError:
                 _LOGGER.debug("Failed to send STOP command during cleanup", exc_info=True)
 
     # Motor control methods
@@ -662,13 +759,13 @@ class MaloufLegacyOkinController(BedController):
 
     # Preset methods
     async def _send_preset(self, command_value: int) -> None:
-        """Send a preset command 3x with 200ms delays.
+        """Queue the same preset command three times.
 
         LEGACY_OKIN requires triple-send for reliable preset reception.
         No STOP is sent after presets (APK sets shouldSendStopAfterPreset=false).
         """
         await self.write_command(
-            self._build_command(command_value), repeat_count=3, repeat_delay_ms=200
+            self._build_command(command_value), repeat_count=3, repeat_delay_ms=0
         )
 
     async def preset_flat(self) -> None:
@@ -693,6 +790,9 @@ class MaloufLegacyOkinController(BedController):
 
     async def preset_memory(self, memory_num: int) -> None:
         """Go to memory preset."""
+        if memory_num < 1 or memory_num > self.memory_slot_count:
+            _LOGGER.warning("Memory slot %d not supported on this Malouf layout", memory_num)
+            return
         commands = {
             1: MaloufCommands.MEMORY_1,
             2: MaloufCommands.MEMORY_2,
@@ -703,9 +803,22 @@ class MaloufLegacyOkinController(BedController):
             _LOGGER.warning("Memory slot %d not supported on Malouf beds", memory_num)
 
     async def program_memory(self, memory_num: int) -> None:
-        """Program current position to memory (not supported)."""
-        _LOGGER.warning(
-            "Malouf beds don't support programming memory presets (requested: %d)", memory_num
+        """Program memory using the official app's 85 x 150 ms hold sequence."""
+        if memory_num < 1 or memory_num > self.memory_slot_count:
+            _LOGGER.warning("Memory slot %d not supported on this Malouf layout", memory_num)
+            return
+        command_value = (
+            MaloufCommands.SET_MEMORY_1_SMARTBED238
+            if memory_num == 1 and "smartbed238" in self._coordinator.ble_device_name.lower()
+            else MaloufCommands.MEMORY_1
+            if memory_num == 1
+            else MaloufCommands.SET_MEMORY_2
+        )
+        # Match the APK's delayed first write and exact repeat count. The APK's
+        # trailing "stopCommand" is a dead string, not a STOP transmission.
+        await asyncio.sleep(0.15)
+        await self.write_command(
+            self._build_command(command_value), repeat_count=85, repeat_delay_ms=150
         )
 
     # Light control

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,
 )
 from homeassistant.config_entries import (
+    SOURCE_IGNORE,
     ConfigEntry,
     ConfigEntryState,
     ConfigFlow,
@@ -52,6 +53,8 @@ from .const import (
     BED_TYPE_LEGGETT_GEN2,
     BED_TYPE_LEGGETT_OKIN,
     BED_TYPE_LEGGETT_PLATT,
+    BED_TYPE_MALOUF_LEGACY_OKIN,
+    BED_TYPE_MALOUF_NEW_OKIN,
     BED_TYPE_OCTO,
     BED_TYPE_OKIMAT,
     BED_TYPE_OKIN_CST,
@@ -72,6 +75,8 @@ from .const import (
     CONF_IDLE_DISCONNECT_SECONDS,
     CONF_JENSEN_PIN,
     CONF_LEGS_MAX_ANGLE,
+    CONF_MALOUF_LAYOUT,
+    CONF_MALOUF_MEMORY_SLOTS,
     CONF_MOTOR_COUNT,
     CONF_MOTOR_PULSE_COUNT,
     CONF_MOTOR_PULSE_DELAY_MS,
@@ -100,6 +105,10 @@ from .const import (
     DOMAIN,
     KEESON_VARIANT_ERGOMOTION,
     LEGGETT_VARIANT_GEN2,
+    MALOUF_LAYOUT_AUTO,
+    MALOUF_LAYOUTS,
+    MALOUF_MEMORY_SLOT_OPTIONS,
+    MALOUF_MEMORY_SLOTS_AUTO,
     POSITION_MODE_ACCURACY,
     POSITION_MODE_SPEED,
     RICHMAT_REMOTE_AUTO,
@@ -171,10 +180,34 @@ def _confident_auto_detect(result: DetectionResult) -> str | None:
         return result.bed_type
     return None
 
+
 CONNECTION_PROFILE_OPTIONS: dict[str, str] = {
     CONNECTION_PROFILE_BALANCED: "Balanced (recommended)",
     CONNECTION_PROFILE_RELIABLE: "Reliable (slower connect)",
 }
+
+MALOUF_BED_TYPES = frozenset({BED_TYPE_MALOUF_NEW_OKIN, BED_TYPE_MALOUF_LEGACY_OKIN})
+
+
+def _add_malouf_schema_fields(schema: dict[vol.Marker, Any]) -> None:
+    """Add physical-layout fields, kept deliberately separate from protocol."""
+    schema[vol.Optional(CONF_MALOUF_LAYOUT, default=MALOUF_LAYOUT_AUTO)] = vol.In(MALOUF_LAYOUTS)
+    schema[vol.Optional(CONF_MALOUF_MEMORY_SLOTS, default=MALOUF_MEMORY_SLOTS_AUTO)] = vol.All(
+        vol.Coerce(int), vol.In(MALOUF_MEMORY_SLOT_OPTIONS)
+    )
+
+
+def _add_malouf_entry_data(
+    entry_data: dict[str, Any], user_input: dict[str, Any], bed_type: str | None
+) -> None:
+    """Persist Malouf physical capabilities without deriving them from a model name."""
+    if bed_type not in MALOUF_BED_TYPES:
+        return
+    entry_data[CONF_MALOUF_LAYOUT] = user_input.get(CONF_MALOUF_LAYOUT, MALOUF_LAYOUT_AUTO)
+    entry_data[CONF_MALOUF_MEMORY_SLOTS] = int(
+        user_input.get(CONF_MALOUF_MEMORY_SLOTS, MALOUF_MEMORY_SLOTS_AUTO)
+    )
+
 
 # Short, single-attempt timeout for the optional setup-time connection probe.
 # Keep this small so a failing probe (e.g. the phone app holding the bed's single
@@ -414,9 +447,17 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     def _configured_entries_by_address(self) -> dict[str, ConfigEntry]:
-        """Return configured entries keyed by normalized Bluetooth address."""
+        """Return active entries keyed by normalized Bluetooth address.
+
+        Ignored discovery placeholders must remain selectable in a user-started
+        flow. Home Assistant replaces the ignored entry when that flow creates
+        the real entry; treating it as configured here made the bed disappear
+        from both device pickers and led users to an unhelpful duplicate error.
+        """
         configured: dict[str, ConfigEntry] = {}
         for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if entry.source == SOURCE_IGNORE:
+                continue
             candidate = entry.unique_id or entry.data.get(CONF_ADDRESS)
             if isinstance(candidate, str):
                 configured[candidate.upper()] = entry
@@ -646,9 +687,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             # otherwise re-show the form with a clear error instead of committing
             # to a low-confidence/ambiguous guess.
             if selected_bed_type == BED_TYPE_AUTO_DETECT:
-                resolved = self._disambiguated_bed_type or _confident_auto_detect(
-                    detection_result
-                )
+                resolved = self._disambiguated_bed_type or _confident_auto_detect(detection_result)
                 if resolved:
                     _LOGGER.info(
                         "Auto-detect resolved bed type to %s for %s",
@@ -685,7 +724,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             if pulse_count_input is not None and pulse_count_input != "":
                 try:
                     motor_pulse_count = int(pulse_count_input)
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     errors[CONF_MOTOR_PULSE_COUNT] = "invalid_number"
                     motor_pulse_count = pulse_defaults[0]
             else:
@@ -695,7 +734,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             if pulse_delay_input is not None and pulse_delay_input != "":
                 try:
                     motor_pulse_delay_ms = int(pulse_delay_input)
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     errors[CONF_MOTOR_PULSE_DELAY_MS] = "invalid_number"
                     motor_pulse_delay_ms = pulse_defaults[1]
             else:
@@ -735,6 +774,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_IDLE_DISCONNECT_SECONDS, DEFAULT_IDLE_DISCONNECT_SECONDS
                     ),
                 }
+                _add_malouf_entry_data(entry_data, user_input, selected_bed_type)
                 # Handle bed-type-specific configuration when user overrides detected type
                 # If user selected Octo but detection wasn't Octo, collect PIN in follow-up step
                 if selected_bed_type == BED_TYPE_OCTO and detected_bed_type != BED_TYPE_OCTO:
@@ -869,6 +909,9 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         schema_dict[vol.Optional(CONF_PROTOCOL_VARIANT, default=VARIANT_AUTO)] = vol.In(
             ALL_PROTOCOL_VARIANTS
         )
+
+        if bed_type in MALOUF_BED_TYPES:
+            _add_malouf_schema_fields(schema_dict)
 
         # Add PIN field for Octo beds
         if bed_type == BED_TYPE_OCTO:
@@ -1322,13 +1365,9 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             # otherwise it re-shows the form with a clear error instead of silently
             # configuring a guessed protocol (issue #385).
             if bed_type == BED_TYPE_AUTO_DETECT:
-                resolved = _confident_auto_detect(
-                    detect_bed_type_detailed(self._discovery_info)
-                )
+                resolved = _confident_auto_detect(detect_bed_type_detailed(self._discovery_info))
                 if resolved:
-                    _LOGGER.info(
-                        "Auto-detect resolved bed type to %s for %s", resolved, address
-                    )
+                    _LOGGER.info("Auto-detect resolved bed type to %s for %s", resolved, address)
                     bed_type = resolved
                 else:
                     errors["base"] = "auto_detect_failed"
@@ -1353,7 +1392,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 motor_pulse_delay_ms = int(
                     user_input.get(CONF_MOTOR_PULSE_DELAY_MS) or pulse_defaults[1]
                 )
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 errors["base"] = "invalid_number"
 
             if not errors:
@@ -1391,6 +1430,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_IDLE_DISCONNECT_SECONDS, DEFAULT_IDLE_DISCONNECT_SECONDS
                     ),
                 }
+                _add_malouf_entry_data(entry_data, user_input, bed_type)
                 # For Octo beds, collect PIN in a separate step
                 if bed_type == BED_TYPE_OCTO:
                     self._manual_data = entry_data
@@ -1427,9 +1467,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         detected_bed_type = detect_bed_type(self._discovery_info)
         # Only a high-confidence, unambiguous detection becomes the Auto-detect
         # default; ambiguous/low-confidence guesses keep "Auto-detect" selected.
-        confident_bed_type = _confident_auto_detect(
-            detect_bed_type_detailed(self._discovery_info)
-        )
+        confident_bed_type = _confident_auto_detect(detect_bed_type_detailed(self._discovery_info))
 
         # Build base schema with bed type selector (alphabetically sorted)
         if preselected_bed_type:
@@ -1526,6 +1564,8 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 ): vol.All(vol.Coerce(int), vol.Range(min=10, max=300)),
             }
         )
+        if defaults_bed_type in MALOUF_BED_TYPES:
+            _add_malouf_schema_fields(schema_dict)
 
         return self.async_show_form(
             step_id="manual_config",
@@ -1572,12 +1612,15 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                     motor_pulse_delay_ms = int(
                         user_input.get(CONF_MOTOR_PULSE_DELAY_MS) or pulse_defaults[1]
                     )
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     errors["base"] = "invalid_number"
 
                 if not errors:
                     retrying_entry = self._configured_entries_by_address().get(address)
-                    if retrying_entry is not None and retrying_entry.state == ConfigEntryState.SETUP_RETRY:
+                    if (
+                        retrying_entry is not None
+                        and retrying_entry.state == ConfigEntryState.SETUP_RETRY
+                    ):
                         self._retrying_devices[address] = (retrying_entry, None)
                         return self._async_abort_retrying_entry(address)
 
@@ -1618,6 +1661,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                             CONF_IDLE_DISCONNECT_SECONDS, DEFAULT_IDLE_DISCONNECT_SECONDS
                         ),
                     }
+                    _add_malouf_entry_data(entry_data, user_input, bed_type)
                     # For Octo beds, collect PIN in a separate step
                     if bed_type == BED_TYPE_OCTO:
                         self._manual_data = entry_data
@@ -1715,6 +1759,8 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 ): vol.All(vol.Coerce(int), vol.Range(min=10, max=300)),
             }
         )
+        if preselected_bed_type in MALOUF_BED_TYPES:
+            _add_malouf_schema_fields(schema_dict)
 
         return self.async_show_form(
             step_id="manual_entry",
@@ -2063,9 +2109,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         except Exception:  # noqa: BLE001 - absence of scanners must not break setup
             return False
 
-    async def _finish_with_verify(
-        self, entry_data: dict[str, Any], title: str
-    ) -> ConfigFlowResult:
+    async def _finish_with_verify(self, entry_data: dict[str, Any], title: str) -> ConfigFlowResult:
         """Stash the finalized entry and route through the verify_connection step.
 
         Skips the verify step (creating the entry directly) when no connectable
@@ -2103,10 +2147,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         # mirror the same special-case the confirm step uses for angle sensing.
         has_position_feedback = bool(bed_type) and (
             bed_type in BEDS_WITH_POSITION_FEEDBACK
-            or (
-                bed_type == BED_TYPE_KEESON
-                and protocol_variant == KEESON_VARIANT_ERGOMOTION
-            )
+            or (bed_type == BED_TYPE_KEESON and protocol_variant == KEESON_VARIANT_ERGOMOTION)
         )
         report = CapabilityReport(position_feedback=has_position_feedback)
 
@@ -2142,10 +2183,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             writable = 0
             for service in services:
                 for char in service.characteristics:
-                    if (
-                        "write" in char.properties
-                        or "write-without-response" in char.properties
-                    ):
+                    if "write" in char.properties or "write-without-response" in char.properties:
                         writable += 1
             report.writable_count = writable
             report.manufacturer, report.model = await read_ble_device_info(client, address)
@@ -2168,9 +2206,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if not report.device_found:
             lines.append("❌ Device not found - it may be out of range or not advertising.")
-            lines.append(
-                "You can still finish setup; the integration will keep trying to connect."
-            )
+            lines.append("You can still finish setup; the integration will keep trying to connect.")
             return "\n".join(lines)
 
         lines.append("✅ Device found via Bluetooth")
@@ -2247,8 +2283,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             return self.async_create_entry(
-                title=self._pending_title
-                or self._pending_entry.get(CONF_NAME, "Adjustable Bed"),
+                title=self._pending_title or self._pending_entry.get(CONF_NAME, "Adjustable Bed"),
                 data=self._pending_entry,
             )
 
@@ -2263,8 +2298,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="verify_connection",
             data_schema=vol.Schema({}),
             description_placeholders={
-                "name": self._pending_entry.get(CONF_NAME)
-                or self._pending_entry[CONF_ADDRESS],
+                "name": self._pending_entry.get(CONF_NAME) or self._pending_entry[CONF_ADDRESS],
                 "capabilities": self._format_capabilities(report),
             },
         )
@@ -2509,6 +2543,20 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
                 )
             ] = vol.In(RICHMAT_REMOTES)
 
+        if bed_type in MALOUF_BED_TYPES:
+            schema_dict[
+                vol.Optional(
+                    CONF_MALOUF_LAYOUT,
+                    default=current_data.get(CONF_MALOUF_LAYOUT, MALOUF_LAYOUT_AUTO),
+                )
+            ] = vol.In(MALOUF_LAYOUTS)
+            schema_dict[
+                vol.Optional(
+                    CONF_MALOUF_MEMORY_SLOTS,
+                    default=current_data.get(CONF_MALOUF_MEMORY_SLOTS, MALOUF_MEMORY_SLOTS_AUTO),
+                )
+            ] = vol.All(vol.Coerce(int), vol.In(MALOUF_MEMORY_SLOT_OPTIONS))
+
         # Add angle limit fields for beds that use angle-based positions
         # (not percentage-based beds like Keeson/Ergomotion/Serta/Jensen)
         # Only show for beds that actually support position feedback
@@ -2565,7 +2613,7 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
                     user_input[CONF_MOTOR_PULSE_DELAY_MS] = int(
                         user_input[CONF_MOTOR_PULSE_DELAY_MS] or pulse_defaults[1]
                     )
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 return self.async_show_form(
                     step_id="init",
                     data_schema=vol.Schema(schema_dict),
@@ -2582,7 +2630,7 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
                             errors={CONF_BACK_MAX_ANGLE: "invalid_angle"},
                         )
                     user_input[CONF_BACK_MAX_ANGLE] = value
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     return self.async_show_form(
                         step_id="init",
                         data_schema=vol.Schema(schema_dict),
@@ -2598,7 +2646,7 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
                             errors={CONF_LEGS_MAX_ANGLE: "invalid_angle"},
                         )
                     user_input[CONF_LEGS_MAX_ANGLE] = value
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     return self.async_show_form(
                         step_id="init",
                         data_schema=vol.Schema(schema_dict),

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -263,6 +263,42 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         }
 
     @staticmethod
+    def _needs_malouf_step(bed_type: str | None, user_input: dict[str, Any]) -> bool:
+        """Return True when the Malouf layout/memory fields still need collecting.
+
+        The layout and memory-slot fields are only shown inline when the form was
+        built already knowing the bed is Malouf (pre-selected brand or a confident
+        detection). When the user instead picks a Malouf protocol from the bed-type
+        dropdown, the inline fields were never rendered, so ``user_input`` lacks
+        them and we must collect them in a dedicated follow-up step. Otherwise the
+        entry silently persists the default layout, dropping Hi-Lo / four-motor
+        controls until the user discovers the options flow.
+        """
+        return bed_type in MALOUF_BED_TYPES and CONF_MALOUF_LAYOUT not in user_input
+
+    async def _async_malouf_step(
+        self, step_id: str, user_input: dict[str, Any] | None
+    ) -> ConfigFlowResult:
+        """Collect Malouf layout/memory fields, then finish setup."""
+        assert self._manual_data is not None
+
+        if user_input is not None:
+            _add_malouf_entry_data(
+                self._manual_data, user_input, self._manual_data.get(CONF_BED_TYPE)
+            )
+            return await self._finish_with_verify(
+                self._manual_data,
+                self._manual_data.get(CONF_NAME, "Adjustable Bed"),
+            )
+
+        schema_dict: dict[vol.Marker, Any] = {}
+        _add_malouf_schema_fields(schema_dict)
+        return self.async_show_form(
+            step_id=step_id,
+            data_schema=vol.Schema(schema_dict),
+        )
+
+    @staticmethod
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
         """Get the options flow for this handler."""
         return AdjustableBedOptionsFlow(config_entry)
@@ -775,6 +811,11 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                     ),
                 }
                 _add_malouf_entry_data(entry_data, user_input, selected_bed_type)
+                # Malouf layout/memory fields weren't shown inline (user overrode the
+                # detected type to Malouf), so collect them in a follow-up step.
+                if self._needs_malouf_step(selected_bed_type, user_input):
+                    self._manual_data = entry_data
+                    return await self.async_step_bluetooth_malouf()
                 # Handle bed-type-specific configuration when user overrides detected type
                 # If user selected Octo but detection wasn't Octo, collect PIN in follow-up step
                 if selected_bed_type == BED_TYPE_OCTO and detected_bed_type != BED_TYPE_OCTO:
@@ -1431,6 +1472,11 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                     ),
                 }
                 _add_malouf_entry_data(entry_data, user_input, bed_type)
+                # Malouf layout/memory fields weren't shown inline (bed type was
+                # chosen from the dropdown), so collect them in a follow-up step.
+                if self._needs_malouf_step(bed_type, user_input):
+                    self._manual_data = entry_data
+                    return await self.async_step_manual_malouf()
                 # For Octo beds, collect PIN in a separate step
                 if bed_type == BED_TYPE_OCTO:
                     self._manual_data = entry_data
@@ -1662,6 +1708,11 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                         ),
                     }
                     _add_malouf_entry_data(entry_data, user_input, bed_type)
+                    # Malouf layout/memory fields weren't shown inline (bed type was
+                    # chosen from the dropdown), so collect them in a follow-up step.
+                    if self._needs_malouf_step(bed_type, user_input):
+                        self._manual_data = entry_data
+                        return await self.async_step_manual_malouf()
                     # For Octo beds, collect PIN in a separate step
                     if bed_type == BED_TYPE_OCTO:
                         self._manual_data = entry_data
@@ -1825,6 +1876,12 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
         )
 
+    async def async_step_manual_malouf(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Collect Malouf layout/memory fields for the manual-entry paths."""
+        return await self._async_malouf_step("manual_malouf", user_input)
+
     async def async_step_bluetooth_octo(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -1881,6 +1938,12 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 }
             ),
         )
+
+    async def async_step_bluetooth_malouf(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Collect Malouf layout/memory fields after a Bluetooth-discovery override."""
+        return await self._async_malouf_step("bluetooth_malouf", user_input)
 
     async def async_step_bluetooth_pairing(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -46,10 +46,13 @@ class ConnectionProfileSettings:
     connection_timeout: float
     post_connect_delay: float
 
+
 # Configuration keys
 CONF_BED_TYPE: Final = "bed_type"
 CONF_PROTOCOL_VARIANT: Final = "protocol_variant"
 CONF_MOTOR_COUNT: Final = "motor_count"
+CONF_MALOUF_LAYOUT: Final = "malouf_layout"
+CONF_MALOUF_MEMORY_SLOTS: Final = "malouf_memory_slots"
 CONF_HAS_MASSAGE: Final = "has_massage"
 CONF_DISABLE_ANGLE_SENSING: Final = "disable_angle_sensing"
 CONF_PREFERRED_ADAPTER: Final = "preferred_adapter"
@@ -95,6 +98,30 @@ CONNECTION_PROFILE_RELIABLE: Final = "reliable"
 # Special value for auto adapter selection
 ADAPTER_AUTO: Final = "auto"
 
+# Malouf/Lucid retail models are sold with several unrelated BLE protocols and
+# actuator arrangements. Keep the physical layout separate from protocol
+# detection so a retail name such as "L600" never implies command framing.
+MALOUF_LAYOUT_AUTO: Final = "auto"
+MALOUF_LAYOUT_TWO_MOTOR: Final = "two_motor"
+MALOUF_LAYOUT_HEAD_TILT: Final = "head_tilt"
+MALOUF_LAYOUT_LUMBAR: Final = "lumbar"
+MALOUF_LAYOUT_FOUR_MOTOR: Final = "four_motor"
+MALOUF_LAYOUT_HILO: Final = "hilo"
+MALOUF_LAYOUTS: Final = {
+    MALOUF_LAYOUT_AUTO: "Auto (motor count; select Hi-Lo explicitly)",
+    MALOUF_LAYOUT_TWO_MOTOR: "Back and legs (2 motor, including Lucid L600)",
+    MALOUF_LAYOUT_HEAD_TILT: "Back, legs, and head tilt",
+    MALOUF_LAYOUT_LUMBAR: "Back, legs, and lumbar",
+    MALOUF_LAYOUT_FOUR_MOTOR: "Back, legs, head tilt, and lumbar",
+    MALOUF_LAYOUT_HILO: "Hi-Lo (back, legs, two lift columns, and bed height)",
+}
+MALOUF_MEMORY_SLOTS_AUTO: Final = 0
+MALOUF_MEMORY_SLOT_OPTIONS: Final = {
+    MALOUF_MEMORY_SLOTS_AUTO: "Auto (1 for 2-motor layout, otherwise 2)",
+    1: "1 memory position",
+    2: "2 memory positions",
+}
+
 # Bed types - Protocol-based naming (new)
 # These are the canonical names organized by protocol characteristics
 BED_TYPE_OKIN_HANDLE: Final = "okin_handle"  # Okin 6-byte via BLE handle
@@ -130,6 +157,8 @@ def supports_passive_position_reconciliation(bed_type: str | None) -> bool:
 def passive_position_reconciliation_default_enabled(bed_type: str | None) -> bool:
     """Return whether passive position reconciliation should default to enabled."""
     return supports_passive_position_reconciliation(bed_type)
+
+
 BED_TYPE_REVERIE: Final = "reverie"
 BED_TYPE_LEGGETT_PLATT: Final = "leggett_platt"  # -> leggett_gen2 or leggett_okin
 BED_TYPE_OKIMAT: Final = "okimat"  # -> okin_uuid
@@ -153,13 +182,17 @@ BED_TYPE_SLEEP_NUMBER: Final = "sleep_number"  # Sleep Number Climate 360 / Fuzi
 BED_TYPE_SLEEP_NUMBER_MCR: Final = "sleep_number_mcr"  # Sleep Number BAM/MCR BLE
 BED_TYPE_OKIN_CB35: Final = "okin_cb35"  # DewertOkin CB35 Star (Sealy Posturematic, NUS 7-byte)
 BED_TYPE_OKIN_64BIT: Final = "okin_64bit"  # OKIN 64-bit protocol (10-byte commands)
-BED_TYPE_SLEEPYS_BOX15: Final = "sleepys_box15"  # Sleepy's Elite BOX15 protocol (9-byte with checksum)
+BED_TYPE_SLEEPYS_BOX15: Final = (
+    "sleepys_box15"  # Sleepy's Elite BOX15 protocol (9-byte with checksum)
+)
 BED_TYPE_SLEEPYS_BOX24: Final = "sleepys_box24"  # Sleepy's Elite BOX24 protocol (7-byte)
 BED_TYPE_SLEEPYS_BOX25: Final = "sleepys_box25"  # Sleepy's Elite BOX25 Star (NUS multi-subsystem)
 BED_TYPE_SVANE: Final = "svane"  # Svane LinonPI multi-service protocol
 BED_TYPE_VIBRADORM: Final = "vibradorm"  # Vibradorm VMAT protocol
 BED_TYPE_RONDURE: Final = "rondure"  # 1500 Tilt Base / Rondure Hump (8/9-byte FurniBus protocol)
-BED_TYPE_REMACRO: Final = "remacro"  # Remacro protocol (CheersSleep/Jeromes/Slumberland/The Brick, 8-byte SynData)
+BED_TYPE_REMACRO: Final = (
+    "remacro"  # Remacro protocol (CheersSleep/Jeromes/Slumberland/The Brick, 8-byte SynData)
+)
 BED_TYPE_COOLBASE: Final = "coolbase"  # Cool Base (Keeson BaseI5 with fan control)
 BED_TYPE_SCOTT_LIVING: Final = "scott_living"  # Scott Living 9-byte protocol
 BED_TYPE_SBI: Final = "sbi"  # SBI/Q-Plus (Costco) with position feedback
@@ -402,10 +435,12 @@ KEESON_FALLBACK_GATT_PAIRS: Final = [
 ]
 
 # BetterLiving-style OKIN-BLE beds advertise both fallback service UUIDs
-KEESON_BETTERLIVING_SERVICE_UUIDS: Final = frozenset({
-    "0000fff0-0000-1000-8000-00805f9b34fb",
-    "0000ffb0-0000-1000-8000-00805f9b34fb",
-})
+KEESON_BETTERLIVING_SERVICE_UUIDS: Final = frozenset(
+    {
+        "0000fff0-0000-1000-8000-00805f9b34fb",
+        "0000ffb0-0000-1000-8000-00805f9b34fb",
+    }
+)
 
 # CB1322 sub-variant manufacturer name markers (lowercase for comparison)
 CB1322_MANUFACTURER_MARKERS: Final = ("ble-4.0 module", "dewertokin")
@@ -579,9 +614,7 @@ DEWERTOKIN_SERVICE_UUID: Final = "00001523-0000-1000-8000-00805f9b34fb"
 # signal to wrap normal Okin commands in 8-byte RF frames.
 DEWERTOKIN_RF_GATEWAY_MODEL: Final = "Bluetooth RF-Gateway"
 DEWERTOKIN_RF_GATEWAY_SERVICE_UUID: Final = "92111420-72ab-4564-62ef-2a881286a6b0"
-DEWERTOKIN_RF_GATEWAY_DEVICE_NAME_CHAR_UUID: Final = (
-    "92111422-72ab-4564-62ef-2a881286a6b0"
-)
+DEWERTOKIN_RF_GATEWAY_DEVICE_NAME_CHAR_UUID: Final = "92111422-72ab-4564-62ef-2a881286a6b0"
 
 # Serta Motion Perfect III specific
 # Uses handle-based writes rather than UUID
@@ -998,7 +1031,7 @@ KEESON_VARIANTS: Final = {
     KEESON_VARIANT_SERTA: "Serta (Serta MP Remote)",
     KEESON_VARIANT_SINO: "Sino (Dynasty, INNOVA, BetterLiving - big-endian)",
     "ore": "ORE (deprecated alias for Sino)",
-    KEESON_VARIANT_PURPLE: "Purple Premium Smart Base"
+    KEESON_VARIANT_PURPLE: "Purple Premium Smart Base",
 }
 
 # Leggett & Platt variants
@@ -1089,9 +1122,7 @@ RICHMAT_REMOTE_BT6500: Final = "BT6500"
 # Richmat WiLinke stop-byte compatibility.
 # Most Richmat remotes use END=0x6E, but some devices require 0x5E to stop
 # movement: QRRM remotes and BedTech BT6500 beds (issue #194).
-RICHMAT_WILINKE_STOP_COMPAT_REMOTE_CODES: Final[frozenset[str]] = frozenset(
-    {"qrrm", "bt6500"}
-)
+RICHMAT_WILINKE_STOP_COMPAT_REMOTE_CODES: Final[frozenset[str]] = frozenset({"qrrm", "bt6500"})
 
 # Display names for remote selection
 RICHMAT_REMOTES: Final = {
@@ -1374,9 +1405,7 @@ def resolve_richmat_remote_code(
         return normalized
 
     haystack = " ".join(
-        part.lower()
-        for part in (entry_title, configured_name, device_name)
-        if part
+        part.lower() for part in (entry_title, configured_name, device_name) if part
     )
     if not haystack:
         return normalized or RICHMAT_REMOTE_AUTO
@@ -1804,6 +1833,7 @@ def requires_pairing(bed_type: str, protocol_variant: str | None = None) -> bool
         if protocol_variant in BED_TYPE_VARIANTS_REQUIRING_PAIRING[bed_type]:
             return True
     return False
+
 
 # Bed types that support angle sensing (position feedback)
 BEDS_WITH_ANGLE_SENSING: Final = frozenset(

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -90,6 +90,8 @@ from .const import (
     CONF_IDLE_DISCONNECT_SECONDS,
     CONF_JENSEN_PIN,
     CONF_LEGS_MAX_ANGLE,
+    CONF_MALOUF_LAYOUT,
+    CONF_MALOUF_MEMORY_SLOTS,
     CONF_MOTOR_COUNT,
     CONF_MOTOR_PULSE_COUNT,
     CONF_MOTOR_PULSE_DELAY_MS,
@@ -117,6 +119,8 @@ from .const import (
     DEVICE_INFO_READ_TIMEOUT,
     DOMAIN,
     LEGGETT_VARIANT_GEN2,
+    MALOUF_LAYOUT_AUTO,
+    MALOUF_MEMORY_SLOTS_AUTO,
     OKIMAT_SERVICE_UUID,
     OKIN_CST_POSITION_AXES,
     OKIN_FOOT_MAX_ANGLE,
@@ -195,6 +199,14 @@ class AdjustableBedCoordinator:
             CONF_PROTOCOL_VARIANT, DEFAULT_PROTOCOL_VARIANT
         )
         self._name: str = entry.data.get(CONF_NAME, "Adjustable Bed")
+        # Keep the advertised BLE name separate from the editable entry name.
+        # Malouf's APK has one command exception keyed to Smartbed238, so using
+        # a user-facing rename here would silently select the wrong command.
+        self._ble_device_name: str = self._name
+        self._malouf_layout: str = entry.data.get(CONF_MALOUF_LAYOUT, MALOUF_LAYOUT_AUTO)
+        self._malouf_memory_slots: int = int(
+            entry.data.get(CONF_MALOUF_MEMORY_SLOTS, MALOUF_MEMORY_SLOTS_AUTO)
+        )
         self._richmat_remote: str = entry.data.get(CONF_RICHMAT_REMOTE, RICHMAT_REMOTE_AUTO)
         if self._bed_type == BED_TYPE_RICHMAT:
             self._richmat_remote = resolve_richmat_remote_code(
@@ -455,6 +467,21 @@ class AdjustableBedCoordinator:
     def name(self) -> str:
         """Return the bed name."""
         return self._name
+
+    @property
+    def ble_device_name(self) -> str:
+        """Return the most recently observed BLE advertising name."""
+        return self._ble_device_name
+
+    @property
+    def malouf_layout(self) -> str:
+        """Return the configured Malouf actuator layout."""
+        return self._malouf_layout
+
+    @property
+    def malouf_memory_slots(self) -> int:
+        """Return the configured Malouf memory-slot override (0 means auto)."""
+        return self._malouf_memory_slots
 
     @property
     def bed_type(self) -> str:
@@ -1196,6 +1223,8 @@ class AdjustableBedCoordinator:
                     device.name,
                     getattr(device, "details", "N/A"),
                 )
+                if device.name:
+                    self._ble_device_name = device.name
 
                 if self._preferred_adapter and self._preferred_adapter != ADAPTER_AUTO:
                     if device_source == self._preferred_adapter:
@@ -1266,6 +1295,8 @@ class AdjustableBedCoordinator:
                             continue
                         svc_source = getattr(svc_info, "source", None)
                         if selected_source is None or svc_source == selected_source:
+                            if svc_info.device.name:
+                                self._ble_device_name = svc_info.device.name
                             _LOGGER.debug(
                                 "ble_device_callback returning device from %s (RSSI: %s, connectable=%s)",
                                 svc_source or "unknown",
@@ -1288,6 +1319,8 @@ class AdjustableBedCoordinator:
                     )
                     if fallback is None:
                         raise BleakError(f"Device {self._address} not found")
+                    if fallback.name:
+                        self._ble_device_name = fallback.name
                     if connectable is False:
                         _LOGGER.debug(
                             "ble_device_callback falling back to non-connectable record for %s",
@@ -2310,9 +2343,7 @@ class AdjustableBedCoordinator:
             # Intentional disconnects (manual, idle timeout, disconnect-after-command)
             # are routine for non-persistent beds; keep them at DEBUG so normal use
             # doesn't spam the log. The reason is preserved in _last_disconnect_reason.
-            _LOGGER.debug(
-                "Disconnecting from bed at %s (reason: %s)", self._address, reason
-            )
+            _LOGGER.debug("Disconnecting from bed at %s (reason: %s)", self._address, reason)
             # Mark as intentional so _on_disconnect doesn't trigger auto-reconnect
             self._intentional_disconnect = True
             # Track disconnect reason for diagnostics (issue #168)

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -46,6 +46,8 @@
           "bed_type": "Bed type",
           "name": "Name",
           "motor_count": "Number of motors",
+          "malouf_layout": "Malouf/Lucid actuator layout",
+          "malouf_memory_slots": "Malouf/Lucid memory positions",
           "has_massage": "Has massage feature",
           "disable_angle_sensing": "Disable angle sensing",
           "preferred_adapter": "Bluetooth adapter",
@@ -61,7 +63,9 @@
         },
         "data_description": {
           "bed_type": "Auto-detected bed type. Change if detection was incorrect.",
-          "motor_count": "2 motors: back and legs. 3 motors: adds head. 4 motors: adds feet.",
+          "motor_count": "Number of physical actuators. Malouf/Lucid beds use the separate actuator-layout setting below.",
+          "malouf_layout": "Physical controls on the remote. This is independent of BLE protocol: Lucid L600 beds have shipped with multiple protocols.",
+          "malouf_memory_slots": "Number of memory buttons on the physical remote. Auto exposes one for a two-motor L600-style layout and two for other layouts.",
           "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "preferred_adapter": "Select a specific Bluetooth adapter or proxy, or let Home Assistant choose automatically.",
           "protocol_variant": "Some beds have multiple protocol variants. Auto-detect usually works, but you can override if needed.",
@@ -89,6 +93,8 @@
           "protocol_variant": "Protocol variant",
           "name": "Name",
           "motor_count": "Number of motors",
+          "malouf_layout": "Malouf/Lucid actuator layout",
+          "malouf_memory_slots": "Malouf/Lucid memory positions",
           "has_massage": "Has massage feature",
           "disable_angle_sensing": "Disable angle sensing",
           "preferred_adapter": "Bluetooth adapter",
@@ -99,7 +105,9 @@
         },
         "data_description": {
           "protocol_variant": "Leave as 'auto' unless you know the specific protocol. Keeson: base (Member's Mark/Purple) or ksbt (KSBT03/KSBT04, including some Ergomotion Sync beds). Leggett: gen2 (most common) or okin. Richmat: auto-detected.",
-          "motor_count": "2 motors: back and legs. 3 motors: adds head. 4 motors: adds feet.",
+          "motor_count": "Number of physical actuators. Malouf/Lucid beds use the separate actuator-layout setting below.",
+          "malouf_layout": "Physical controls on the remote. This is independent of BLE protocol: Lucid L600 beds have shipped with multiple protocols.",
+          "malouf_memory_slots": "Number of memory buttons on the physical remote.",
           "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "preferred_adapter": "Select a specific Bluetooth adapter or proxy, or let Home Assistant choose automatically.",
           "motor_pulse_count": "Number of command pulses sent for motor movement (1-100). Higher = longer movement.",
@@ -117,6 +125,8 @@
           "protocol_variant": "Protocol variant",
           "name": "Name",
           "motor_count": "Number of motors",
+          "malouf_layout": "Malouf/Lucid actuator layout",
+          "malouf_memory_slots": "Malouf/Lucid memory positions",
           "has_massage": "Has massage feature",
           "disable_angle_sensing": "Disable angle sensing",
           "preferred_adapter": "Bluetooth adapter",
@@ -128,7 +138,9 @@
         "data_description": {
           "address": "MAC address in format XX:XX:XX:XX:XX:XX (found in the bed's Bluetooth settings or on a label).",
           "protocol_variant": "Leave as 'auto' unless you know the specific protocol. Keeson: base (Member's Mark/Purple) or ksbt (KSBT03/KSBT04, including some Ergomotion Sync beds). Leggett: gen2 (most common) or okin. Richmat: auto-detected.",
-          "motor_count": "2 motors: back and legs. 3 motors: adds head. 4 motors: adds feet.",
+          "motor_count": "Number of physical actuators. Malouf/Lucid beds use the separate actuator-layout setting below.",
+          "malouf_layout": "Physical controls on the remote. This is independent of BLE protocol: Lucid L600 beds have shipped with multiple protocols.",
+          "malouf_memory_slots": "Number of memory buttons on the physical remote.",
           "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "preferred_adapter": "Select a specific Bluetooth adapter or proxy, or let Home Assistant choose automatically.",
           "motor_pulse_count": "Number of command pulses sent for motor movement (1-100). Higher = longer movement.",
@@ -231,7 +243,7 @@
       }
     },
     "abort": {
-      "already_configured": "Device is already configured",
+      "already_configured": "This Bluetooth address already belongs to an Adjustable Bed entry. Check both active and ignored Adjustable Bed entries under Settings > Devices & services, then reload or reconfigure that entry instead of adding it again.",
       "configured_retrying_suffix": "[already configured, setup retry]",
       "configured_retrying": "**{name}** is already configured at `{address}`, but Home Assistant is still retrying its previous setup.\n\nUse **Generate Support Bundle** for the existing device entry, or run `adjustable_bed.generate_support_bundle` with `target_address: {address}`. Then reload or reconfigure the existing entry instead of adding it again.",
       "not_supported": "Device is not supported. The required Bluetooth service was not found.",
@@ -261,6 +273,8 @@
         "description": "Adjust the configuration for your adjustable bed.",
         "data": {
           "motor_count": "Number of motors",
+          "malouf_layout": "Malouf/Lucid actuator layout",
+          "malouf_memory_slots": "Malouf/Lucid memory positions",
           "has_massage": "Has massage feature",
           "disable_angle_sensing": "Disable angle sensing",
           "passive_position_reconciliation": "Refresh positions while idle",
@@ -280,7 +294,9 @@
           "legs_max_angle": "Maximum legs angle (degrees)"
         },
         "data_description": {
-          "motor_count": "2 motors: back and legs. 3 motors: adds head. 4 motors: adds feet.",
+          "motor_count": "Number of physical actuators. Malouf/Lucid beds use the separate actuator-layout setting below.",
+          "malouf_layout": "Choose the controls present on the physical remote. Protocol detection does not identify the actuator layout or retail model.",
+          "malouf_memory_slots": "Choose the number of memory buttons on the physical remote. Auto uses one for the two-motor layout and two otherwise.",
           "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "passive_position_reconciliation": "Periodically reconnect and read positions while idle so Home Assistant catches up with moves made using the physical remote. This is enabled by default for Linak beds and may briefly use the BLE connection in the background.",
           "position_mode": "Speed: faster button response. Accuracy: extra position read after each command.",

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -169,6 +169,18 @@
           "richmat_remote": "Use 'auto' unless you know your remote code."
         }
       },
+      "manual_malouf": {
+        "title": "Malouf/Lucid Actuator Configuration",
+        "description": "Select the physical controls on your Malouf/Lucid remote.",
+        "data": {
+          "malouf_layout": "Malouf/Lucid actuator layout",
+          "malouf_memory_slots": "Malouf/Lucid memory positions"
+        },
+        "data_description": {
+          "malouf_layout": "Physical controls on the remote. This is independent of BLE protocol: Lucid L600 beds have shipped with multiple protocols.",
+          "malouf_memory_slots": "Number of memory buttons on the physical remote. Auto exposes one for a two-motor L600-style layout and two for other layouts."
+        }
+      },
       "bluetooth_octo": {
         "title": "Octo PIN Configuration",
         "description": "Enter the PIN for your Octo bed. Leave empty if your bed doesn't require a PIN.",
@@ -187,6 +199,18 @@
         },
         "data_description": {
           "richmat_remote": "Use 'auto' unless you know your remote code."
+        }
+      },
+      "bluetooth_malouf": {
+        "title": "Malouf/Lucid Actuator Configuration",
+        "description": "Select the physical controls on your Malouf/Lucid remote.",
+        "data": {
+          "malouf_layout": "Malouf/Lucid actuator layout",
+          "malouf_memory_slots": "Malouf/Lucid memory positions"
+        },
+        "data_description": {
+          "malouf_layout": "Physical controls on the remote. This is independent of BLE protocol: Lucid L600 beds have shipped with multiple protocols.",
+          "malouf_memory_slots": "Number of memory buttons on the physical remote. Auto exposes one for a two-motor L600-style layout and two for other layouts."
         }
       },
       "bluetooth_pairing": {

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -46,6 +46,8 @@
           "bed_type": "Bed type",
           "name": "Name",
           "motor_count": "Number of motors",
+          "malouf_layout": "Malouf/Lucid actuator layout",
+          "malouf_memory_slots": "Malouf/Lucid memory positions",
           "has_massage": "Has massage feature",
           "disable_angle_sensing": "Disable angle sensing",
           "preferred_adapter": "Bluetooth adapter",
@@ -61,7 +63,9 @@
         },
         "data_description": {
           "bed_type": "Auto-detected bed type. Change if detection was incorrect.",
-          "motor_count": "2 motors: back and legs. 3 motors: adds head. 4 motors: adds feet.",
+          "motor_count": "Number of physical actuators. Malouf/Lucid beds use the separate actuator-layout setting below.",
+          "malouf_layout": "Physical controls on the remote. This is independent of BLE protocol: Lucid L600 beds have shipped with multiple protocols.",
+          "malouf_memory_slots": "Number of memory buttons on the physical remote. Auto exposes one for a two-motor L600-style layout and two for other layouts.",
           "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "preferred_adapter": "Select a specific Bluetooth adapter or proxy, or let Home Assistant choose automatically.",
           "protocol_variant": "Some beds have multiple protocol variants. Auto-detect usually works, but you can override if needed.",
@@ -89,6 +93,8 @@
           "protocol_variant": "Protocol variant",
           "name": "Name",
           "motor_count": "Number of motors",
+          "malouf_layout": "Malouf/Lucid actuator layout",
+          "malouf_memory_slots": "Malouf/Lucid memory positions",
           "has_massage": "Has massage feature",
           "disable_angle_sensing": "Disable angle sensing",
           "preferred_adapter": "Bluetooth adapter",
@@ -99,7 +105,9 @@
         },
         "data_description": {
           "protocol_variant": "Leave as 'auto' unless you know the specific protocol. Keeson: base (Member's Mark/Purple) or ksbt (KSBT03/KSBT04, including some Ergomotion Sync beds). Leggett: gen2 (most common) or okin. Richmat: auto-detected.",
-          "motor_count": "2 motors: back and legs. 3 motors: adds head. 4 motors: adds feet.",
+          "motor_count": "Number of physical actuators. Malouf/Lucid beds use the separate actuator-layout setting below.",
+          "malouf_layout": "Physical controls on the remote. This is independent of BLE protocol: Lucid L600 beds have shipped with multiple protocols.",
+          "malouf_memory_slots": "Number of memory buttons on the physical remote.",
           "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "preferred_adapter": "Select a specific Bluetooth adapter or proxy, or let Home Assistant choose automatically.",
           "motor_pulse_count": "Number of command pulses sent for motor movement (1-100). Higher = longer movement.",
@@ -117,6 +125,8 @@
           "protocol_variant": "Protocol variant",
           "name": "Name",
           "motor_count": "Number of motors",
+          "malouf_layout": "Malouf/Lucid actuator layout",
+          "malouf_memory_slots": "Malouf/Lucid memory positions",
           "has_massage": "Has massage feature",
           "disable_angle_sensing": "Disable angle sensing",
           "preferred_adapter": "Bluetooth adapter",
@@ -128,7 +138,9 @@
         "data_description": {
           "address": "MAC address in format XX:XX:XX:XX:XX:XX (found in the bed's Bluetooth settings or on a label).",
           "protocol_variant": "Leave as 'auto' unless you know the specific protocol. Keeson: base (Member's Mark/Purple) or ksbt (KSBT03/KSBT04, including some Ergomotion Sync beds). Leggett: gen2 (most common) or okin. Richmat: auto-detected.",
-          "motor_count": "2 motors: back and legs. 3 motors: adds head. 4 motors: adds feet.",
+          "motor_count": "Number of physical actuators. Malouf/Lucid beds use the separate actuator-layout setting below.",
+          "malouf_layout": "Physical controls on the remote. This is independent of BLE protocol: Lucid L600 beds have shipped with multiple protocols.",
+          "malouf_memory_slots": "Number of memory buttons on the physical remote.",
           "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "preferred_adapter": "Select a specific Bluetooth adapter or proxy, or let Home Assistant choose automatically.",
           "motor_pulse_count": "Number of command pulses sent for motor movement (1-100). Higher = longer movement.",
@@ -231,7 +243,7 @@
       }
     },
     "abort": {
-      "already_configured": "Device is already configured",
+      "already_configured": "This Bluetooth address already belongs to an Adjustable Bed entry. Check both active and ignored Adjustable Bed entries under Settings > Devices & services, then reload or reconfigure that entry instead of adding it again.",
       "configured_retrying_suffix": "[already configured, setup retry]",
       "configured_retrying": "**{name}** is already configured at `{address}`, but Home Assistant is still retrying its previous setup.\n\nUse **Generate Support Bundle** for the existing device entry, or run `adjustable_bed.generate_support_bundle` with `target_address: {address}`. Then reload or reconfigure the existing entry instead of adding it again.",
       "not_supported": "Device is not supported. The required Bluetooth service was not found.",
@@ -261,6 +273,8 @@
         "description": "Adjust the configuration for your adjustable bed.",
         "data": {
           "motor_count": "Number of motors",
+          "malouf_layout": "Malouf/Lucid actuator layout",
+          "malouf_memory_slots": "Malouf/Lucid memory positions",
           "has_massage": "Has massage feature",
           "disable_angle_sensing": "Disable angle sensing",
           "passive_position_reconciliation": "Refresh positions while idle",
@@ -280,7 +294,9 @@
           "legs_max_angle": "Maximum legs angle (degrees)"
         },
         "data_description": {
-          "motor_count": "2 motors: back and legs. 3 motors: adds head. 4 motors: adds feet.",
+          "motor_count": "Number of physical actuators. Malouf/Lucid beds use the separate actuator-layout setting below.",
+          "malouf_layout": "Choose the controls present on the physical remote. Protocol detection does not identify the actuator layout or retail model.",
+          "malouf_memory_slots": "Choose the number of memory buttons on the physical remote. Auto uses one for the two-motor layout and two otherwise.",
           "disable_angle_sensing": "When enabled, position sensors and position controls are disabled but the physical remote will continue working. Uncheck to enable position sliders for beds that support them.",
           "passive_position_reconciliation": "Periodically reconnect and read positions while idle so Home Assistant catches up with moves made using the physical remote. This is enabled by default for Linak beds and may briefly use the BLE connection in the background.",
           "position_mode": "Speed: faster button response. Accuracy: extra position read after each command.",

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -169,6 +169,18 @@
           "richmat_remote": "Use 'auto' unless you know your remote code."
         }
       },
+      "manual_malouf": {
+        "title": "Malouf/Lucid Actuator Configuration",
+        "description": "Select the physical controls on your Malouf/Lucid remote.",
+        "data": {
+          "malouf_layout": "Malouf/Lucid actuator layout",
+          "malouf_memory_slots": "Malouf/Lucid memory positions"
+        },
+        "data_description": {
+          "malouf_layout": "Physical controls on the remote. This is independent of BLE protocol: Lucid L600 beds have shipped with multiple protocols.",
+          "malouf_memory_slots": "Number of memory buttons on the physical remote. Auto exposes one for a two-motor L600-style layout and two for other layouts."
+        }
+      },
       "bluetooth_octo": {
         "title": "Octo PIN Configuration",
         "description": "Enter the PIN for your Octo bed. Leave empty if your bed doesn't require a PIN.",
@@ -187,6 +199,18 @@
         },
         "data_description": {
           "richmat_remote": "Use 'auto' unless you know your remote code."
+        }
+      },
+      "bluetooth_malouf": {
+        "title": "Malouf/Lucid Actuator Configuration",
+        "description": "Select the physical controls on your Malouf/Lucid remote.",
+        "data": {
+          "malouf_layout": "Malouf/Lucid actuator layout",
+          "malouf_memory_slots": "Malouf/Lucid memory positions"
+        },
+        "data_description": {
+          "malouf_layout": "Physical controls on the remote. This is independent of BLE protocol: Lucid L600 beds have shipped with multiple protocols.",
+          "malouf_memory_slots": "Number of memory buttons on the physical remote. Auto exposes one for a two-motor L600-style layout and two for other layouts."
         }
       },
       "bluetooth_pairing": {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -53,6 +53,26 @@ To adjust settings after setup:
 
 **Tip:** Count the distinct moving sections when using your physical remote to determine the correct setting.
 
+### Malouf/Lucid Layout and Memory
+
+Malouf and Lucid entries have two additional settings because BLE command
+framing does not reveal the physical remote layout:
+
+| Setting | Options | Default | Description |
+|---------|---------|---------|-------------|
+| **Malouf/Lucid actuator layout** | Back + legs; add head tilt; add lumbar; four motor; Hi-Lo | Auto | Controls which motor entities are exposed |
+| **Malouf/Lucid memory positions** | Auto, 1, 2 | Auto | Must match the memory buttons on the physical remote |
+
+Auto uses back + legs for a two-motor entry, head tilt for a three-motor entry,
+and the standard head-tilt + lumbar layout for a four-motor entry. Hi-Lo must be
+selected explicitly because neither Legacy nor New OKIN framing proves the
+physical actuator arrangement. A two-motor layout defaults to one memory
+position; other layouts default to two.
+
+These settings are intentionally independent of protocol detection. **Lucid
+L600 is not a protocol name**: confirmed L600 hardware includes both OKIN CB24
+7-byte and legacy Malouf/OKIN 9-byte controllers.
+
 ---
 
 ## Advanced Settings

--- a/docs/SUPPORTED_ACTUATORS.md
+++ b/docs/SUPPORTED_ACTUATORS.md
@@ -21,7 +21,7 @@ This document provides an overview of supported bed brands. Click on a brand nam
 | [Serta](beds/serta.md) | ✅ Supported | Massage intensity control, Zero-G/TV/Lounge |
 | [Mattress Firm 900](beds/mattressfirm.md) | ✅ Supported | Older iFlex/Nordic UART bases, lumbar control, built-in presets |
 | [Nectar](beds/nectar.md) | ✅ Supported | Lumbar control, massage, lights, Zero-G/Anti-Snore/Lounge |
-| [Malouf](beds/malouf.md) | ✅ Supported | 2 memory presets, lumbar, head tilt, massage, lights |
+| [Malouf/Lucid](beds/malouf.md) | ✅ Supported | Configurable 2/3/4-motor or Hi-Lo layout, 1-2 memory positions, massage, lights |
 | [BedTech](beds/bedtech.md) | ✅ Supported | 5 presets, 4 massage modes, dual-base support |
 | [Sleep Number](beds/sleep_number.md) | 🧪 Needs Testing | Newer Fuzion: direct position, side selection, presence, climate. Older BAM/MCR: split firmness, foundation presets, under-bed lights |
 | [Sleepy's Elite](beds/sleepys.md) | ✅ Supported | Lumbar (BOX15), Zero-G, Flat presets |
@@ -49,6 +49,11 @@ For detailed configuration options including motor pulse settings, protocol vari
 ---
 
 ## Okin Protocol Family
+
+Retail brands and model numbers can appear in more than one row. Lucid L600,
+for example, is confirmed with both OKIN CB24 7-byte controllers and legacy
+Malouf/OKIN 9-byte controllers. Select or auto-detect the actuator protocol from
+BLE evidence; never select a protocol from the retail model alone.
 
 Several bed brands use Okin-based BLE controllers. While they share common roots, each uses a different command format or write method:
 

--- a/docs/beds/malouf.md
+++ b/docs/beds/malouf.md
@@ -10,6 +10,17 @@
 - Lucid
 - Structures
 
+These are retail brands, not protocol identifiers. **Lucid L600 is not one
+protocol.** Confirmed L600 devices include:
+
+| Advertising/GATT evidence | Integration protocol | Packet format |
+|---------------------------|----------------------|---------------|
+| `Smartbed237...`, Nordic UART, OKIN manufacturer ID 89 / `DOT` payload | OKIN CB24 | 7 bytes |
+| `OKIN-BLE...`, `BTCB` payload, connected FFE5/FFE9 | Malouf Legacy OKIN | 9 bytes |
+
+The integration uses those BLE signals and connected services. It does not map
+the string `L600` to either protocol.
+
 ## Apps
 
 | Analyzed | App | Package ID |
@@ -23,17 +34,35 @@
 |---------|-----------|
 | Motor Control | ✅ |
 | Position Feedback | ❌ |
-| Memory Presets | ✅ (2 slots) |
+| Memory Presets | ✅ (1 or 2 slots, configurable) |
+| Save Memory Position | ✅ |
 | Massage | ✅ |
 | Under-bed Lights | ✅ |
 | Zero-G / Anti-Snore / TV / Lounge | ✅ |
-| Lumbar | ✅ |
-| Head Tilt | ✅ |
+| Lumbar | Optional, layout-dependent |
+| Head Tilt | Optional, layout-dependent |
+| Hi-Lo / Bed Height | Optional, layout-dependent |
+
+## Physical Layout
+
+Protocol and physical actuators are separate settings. Choose the layout that
+matches the buttons on the physical remote:
+
+- Back + legs (the confirmed two-motor L600 app profile)
+- Back + legs + head tilt
+- Back + legs + lumbar
+- Back + legs + head tilt + lumbar
+- Hi-Lo
+
+The memory-position setting is separate too. The Lucid Base 1.3.3 L600 model
+defines one memory position, while other models in the same command family use
+two. Auto selects one slot for the two-motor layout and two otherwise; both can
+be overridden in integration options.
 
 ## Hi-Lo Layout
 
-Some OKIN/Malouf-protocol beds use a Hi-Lo actuator layout instead of the usual
-`back/legs/head/feet` ladder. For those beds, the integration exposes:
+Some OKIN/Malouf-protocol beds use a Hi-Lo actuator layout. Only entries set to
+the Hi-Lo layout expose:
 
 - Back
 - Legs
@@ -47,7 +76,8 @@ independently for lengthwise tilt.
 
 ## Protocol Variants
 
-Malouf beds use two distinct protocols. The integration auto-detects which one your bed uses.
+The Malouf/Lucid controller family implemented here uses two distinct protocols.
+The integration auto-detects framing from BLE evidence, not from retail model.
 
 ### NEW_OKIN (Nordic UART)
 
@@ -117,17 +147,29 @@ Both protocols use the same command values (32-bit integers):
 | Massage Timer | `0x200` |
 | Massage Off | `0x2000000` |
 
+### Save Memory Commands
+
+| Action | Value |
+|--------|-------|
+| Save Memory 1 | `0x10000` |
+| Save Memory 1 (`Smartbed238...` exception) | `0x80010000` |
+| Save Memory 2 | `0x80040000` |
+
 ## Command Timing
 
 From app disassembly analysis (Malouf Base / Lucid Base):
 
-| Protocol | Repeat Interval | Max Repeats |
-|----------|----------------|-------------|
-| Legacy OKIN (FFE5) | 150ms | 85 |
-| New OKIN (Nordic) | 100ms | 55 |
+| Operation | Legacy OKIN | New OKIN |
+|-----------|-------------|----------|
+| Held motor command | Every 150ms | Every 150ms in the app UI |
+| Preset recall | 3 queued acknowledged writes, no STOP | 1 write followed by STOP |
+| Save memory | 85 writes at 150ms | 55 writes at 100ms |
 
-The app supports multiple protocols with automatic detection:
-1. **Legacy OKIN (FFE5/FFE9)** - 9-byte packets
-2. **Custom OKIN (62741523)** - 10-byte packets
-3. **New OKIN (Nordic UART)** - 8-byte packets
-4. **Richmat WiLinke (FEE9)** - 5-byte packets
+The APK schedules the first save-memory write after one interval. At the end it
+calls the literal string `stopCommand`, but the dispatcher only recognizes
+`stopDriver`; therefore the official app does **not** transmit a final STOP for
+memory saving. The integration intentionally matches that observed behavior.
+
+Lucid Base 1.3.3's shared SDK also recognizes Custom OKIN and Richmat hardware,
+but those are separate integration protocols. Their presence in the same app
+does not make them Malouf Legacy/New OKIN packet variants.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1419,6 +1419,62 @@ class TestManualFlow:
         assert result["data"][CONF_BED_TYPE] == BED_TYPE_LINAK
         assert result["data"][CONF_MOTOR_COUNT] == 3
 
+    async def test_manual_entry_malouf_collects_layout(
+        self, hass: HomeAssistant, enable_custom_integrations
+    ):
+        """Picking a Malouf protocol from the dropdown collects layout/memory slots.
+
+        The manual-MAC form is built without a pre-selected bed type, so the Malouf
+        layout/memory fields aren't shown inline. Selecting a Malouf protocol must
+        route to a follow-up step that collects them instead of silently persisting
+        the default layout (regression: Hi-Lo / four-motor users lost those controls).
+        """
+        with patch(
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
+            return_value=[],
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_USER},
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADDRESS: "manual"},
+            )
+
+        # Submit the manual-entry form with a Malouf protocol but no layout fields
+        # (they were never rendered because the bed type wasn't pre-selected).
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_ADDRESS: "11:22:33:44:55:66",
+                CONF_BED_TYPE: BED_TYPE_MALOUF_LEGACY_OKIN,
+                CONF_NAME: "Malouf Bed",
+                CONF_MOTOR_COUNT: 4,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+        )
+
+        # Should route to the follow-up Malouf step, not create the entry yet.
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "manual_malouf"
+
+        with patch.object(AdjustableBedConfigFlow, "_verification_possible", return_value=False):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={
+                    CONF_MALOUF_LAYOUT: MALOUF_LAYOUT_HILO,
+                    CONF_MALOUF_MEMORY_SLOTS: 2,
+                },
+            )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_BED_TYPE] == BED_TYPE_MALOUF_LEGACY_OKIN
+        assert result["data"][CONF_MALOUF_LAYOUT] == MALOUF_LAYOUT_HILO
+        assert result["data"][CONF_MALOUF_MEMORY_SLOTS] == 2
+
     async def test_manual_entry_caches_kaidi_metadata(
         self, hass: HomeAssistant, enable_custom_integrations
     ):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,7 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
-from homeassistant.config_entries import SOURCE_BLUETOOTH, SOURCE_USER, ConfigEntryState
+from homeassistant.config_entries import (
+    SOURCE_BLUETOOTH,
+    SOURCE_IGNORE,
+    SOURCE_USER,
+    ConfigEntryState,
+)
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -27,6 +32,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_LEGGETT_PLATT,
     BED_TYPE_LEGGETT_WILINKE,
     BED_TYPE_LINAK,
+    BED_TYPE_MALOUF_LEGACY_OKIN,
     BED_TYPE_MOTOSLEEP,
     BED_TYPE_OCTO,
     BED_TYPE_OKIMAT,
@@ -54,12 +60,15 @@ from custom_components.adjustable_bed.const import (
     CONF_KAIDI_SOFA_ACU_NO,
     CONF_KAIDI_TARGET_VADDR,
     CONF_KAIDI_VARIANT_SOURCE,
+    CONF_MALOUF_LAYOUT,
+    CONF_MALOUF_MEMORY_SLOTS,
     CONF_MOTOR_COUNT,
     CONF_MOTOR_PULSE_COUNT,
     CONF_PASSIVE_POSITION_RECONCILIATION,
     CONF_PREFERRED_ADAPTER,
     DOMAIN,
     KAIDI_VARIANT_SEAT_1,
+    MALOUF_LAYOUT_HILO,
     RICHMAT_WILINKE_SERVICE_UUIDS,
     SUTA_SERVICE_UUID,
     TIMOTION_AHF_SERVICE_UUID,
@@ -1164,9 +1173,7 @@ class TestBluetoothDiscoveryFlow:
         )
 
         # Resolved to a real type and progressed past manual_config (no error).
-        assert not (
-            result["type"] == FlowResultType.FORM and result["step_id"] == "manual_config"
-        )
+        assert not (result["type"] == FlowResultType.FORM and result["step_id"] == "manual_config")
 
     async def test_manual_config_auto_detect_ambiguous_reprompts(
         self,
@@ -1392,9 +1399,7 @@ class TestManualFlow:
 
         # Now in manual_entry step, fill the form. No connectable scanner here,
         # so the read-only verify step is skipped and the entry is created directly.
-        with patch.object(
-            AdjustableBedConfigFlow, "_verification_possible", return_value=False
-        ):
+        with patch.object(AdjustableBedConfigFlow, "_verification_possible", return_value=False):
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"],
                 user_input={
@@ -1442,9 +1447,7 @@ class TestManualFlow:
                     sofa_acu_no=0x2004,
                 ),
             ),
-            patch.object(
-                AdjustableBedConfigFlow, "_verification_possible", return_value=False
-            ),
+            patch.object(AdjustableBedConfigFlow, "_verification_possible", return_value=False),
         ):
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"],
@@ -1521,9 +1524,7 @@ class TestManualFlow:
                 user_input={CONF_ADDRESS: "manual"},
             )
 
-        with patch.object(
-            AdjustableBedConfigFlow, "_verification_possible", return_value=False
-        ):
+        with patch.object(AdjustableBedConfigFlow, "_verification_possible", return_value=False):
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"],
                 user_input={
@@ -1671,6 +1672,41 @@ class TestUserFlow:
 
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "user"
+
+    async def test_user_flow_can_readd_previously_ignored_device(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info: BluetoothServiceInfoBleak,
+        enable_custom_integrations,
+    ):
+        """An ignored discovery must be visible and selectable in a manual user flow."""
+        ignored_entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=mock_bluetooth_service_info.name,
+            data={},
+            source=SOURCE_IGNORE,
+            unique_id=mock_bluetooth_service_info.address.upper(),
+        )
+        ignored_entry.add_to_hass(hass)
+
+        with patch(
+            "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
+            return_value=[mock_bluetooth_service_info],
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_USER},
+            )
+            selector_options = next(iter(result["data_schema"].schema.values())).container
+            assert mock_bluetooth_service_info.address in selector_options
+
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_ADDRESS: mock_bluetooth_service_info.address},
+            )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "bluetooth_confirm"
 
     async def test_user_flow_select_manual(
         self,
@@ -1860,6 +1896,45 @@ class TestOptionsFlow:
         assert await async_is_discovery_disabled(hass) is True
         assert CONF_DISABLE_DISCOVERY not in mock_config_entry.data
 
+    async def test_malouf_options_keep_layout_separate_from_protocol(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,
+    ):
+        """A Malouf protocol entry must expose independent hardware settings."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Lucid L600",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:58",
+                CONF_NAME: "OKIN-BLE00017786",
+                CONF_BED_TYPE: BED_TYPE_MALOUF_LEGACY_OKIN,
+                CONF_MOTOR_COUNT: 2,
+            },
+            unique_id="AA:BB:CC:DD:EE:58",
+        )
+        entry.add_to_hass(hass)
+        await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        schema_keys = {marker.schema for marker in result["data_schema"].schema}
+        assert CONF_MALOUF_LAYOUT in schema_keys
+        assert CONF_MALOUF_MEMORY_SLOTS in schema_keys
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_MALOUF_LAYOUT: MALOUF_LAYOUT_HILO,
+                CONF_MALOUF_MEMORY_SLOTS: 2,
+            },
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert entry.data[CONF_BED_TYPE] == BED_TYPE_MALOUF_LEGACY_OKIN
+        assert entry.data[CONF_MALOUF_LAYOUT] == MALOUF_LAYOUT_HILO
+        assert entry.data[CONF_MALOUF_MEMORY_SLOTS] == 2
+
     async def test_options_flow_toggle_not_applied_on_validation_error(
         self,
         hass: HomeAssistant,
@@ -1934,9 +2009,7 @@ async def test_verify_connection_success_then_creates_entry(
         available_sources=[],
     )
     with (
-        patch.object(
-            AdjustableBedConfigFlow, "_verification_possible", return_value=True
-        ),
+        patch.object(AdjustableBedConfigFlow, "_verification_possible", return_value=True),
         patch(
             "custom_components.adjustable_bed.config_flow.select_adapter",
             AsyncMock(return_value=selection),
@@ -1969,9 +2042,7 @@ async def test_verify_connection_success_then_creates_entry(
         # The probe must release the bed's single BLE connection.
         client.disconnect.assert_awaited()
 
-        created = await hass.config_entries.flow.async_configure(
-            verify["flow_id"], user_input={}
-        )
+        created = await hass.config_entries.flow.async_configure(verify["flow_id"], user_input={})
 
     assert created["type"] == FlowResultType.CREATE_ENTRY
     assert created["data"][CONF_BED_TYPE] == BED_TYPE_LINAK
@@ -2008,9 +2079,7 @@ async def test_verify_connection_warns_when_no_writable_characteristic(
         available_sources=[],
     )
     with (
-        patch.object(
-            AdjustableBedConfigFlow, "_verification_possible", return_value=True
-        ),
+        patch.object(AdjustableBedConfigFlow, "_verification_possible", return_value=True),
         patch(
             "custom_components.adjustable_bed.config_flow.select_adapter",
             AsyncMock(return_value=selection),
@@ -2036,9 +2105,7 @@ async def test_verify_connection_warns_when_no_writable_characteristic(
         assert "No writable characteristic found" in caps
         assert "⚠️" in caps
 
-        created = await hass.config_entries.flow.async_configure(
-            verify["flow_id"], user_input={}
-        )
+        created = await hass.config_entries.flow.async_configure(verify["flow_id"], user_input={})
 
     assert created["type"] == FlowResultType.CREATE_ENTRY
     assert created["data"][CONF_BED_TYPE] == BED_TYPE_LINAK
@@ -2063,9 +2130,7 @@ async def test_verify_connection_failure_still_creates_entry(
         available_sources=[],
     )
     with (
-        patch.object(
-            AdjustableBedConfigFlow, "_verification_possible", return_value=True
-        ),
+        patch.object(AdjustableBedConfigFlow, "_verification_possible", return_value=True),
         patch(
             "custom_components.adjustable_bed.config_flow.select_adapter",
             AsyncMock(return_value=selection),
@@ -2081,9 +2146,7 @@ async def test_verify_connection_failure_still_creates_entry(
         assert verify["step_id"] == "verify_connection"
         assert "Could not connect" in verify["description_placeholders"]["capabilities"]
 
-        created = await hass.config_entries.flow.async_configure(
-            verify["flow_id"], user_input={}
-        )
+        created = await hass.config_entries.flow.async_configure(verify["flow_id"], user_input={})
 
     assert created["type"] == FlowResultType.CREATE_ENTRY
     assert created["data"][CONF_BED_TYPE] == BED_TYPE_LINAK
@@ -2100,9 +2163,7 @@ async def test_verify_connection_skipped_without_scanner(
     )
     assert result["step_id"] == "bluetooth_confirm"
 
-    with patch.object(
-        AdjustableBedConfigFlow, "_verification_possible", return_value=False
-    ):
+    with patch.object(AdjustableBedConfigFlow, "_verification_possible", return_value=False):
         created = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_PREFERRED_ADAPTER: "auto"}
         )

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -218,9 +218,7 @@ class TestDetectBedTypeByServiceUUID:
             name="EC:C5:7F:6A:67:11",
             address="EC:C5:7F:6A:67:11",
             service_uuids=[],
-            manufacturer_data={
-                0xFFFF: bytes.fromhex("c0ff011e27000082020211676a7fc5ec")
-            },
+            manufacturer_data={0xFFFF: bytes.fromhex("c0ff011e27000082020211676a7fc5ec")},
         )
         result = detect_bed_type_detailed(service_info)
         assert result.bed_type is None
@@ -353,6 +351,22 @@ class TestDetectBedTypeByServiceUUID:
         assert "manufacturer_payload:btcb" in result.signals
         assert result.ambiguous_types == [BED_TYPE_MALOUF_NEW_OKIN]
 
+    def test_lucid_l600_retail_model_does_not_collapse_protocols(self):
+        """Two confirmed L600 signatures must continue to select different framing."""
+        legacy = _make_service_info(
+            name="OKIN-BLE00017786",
+            service_uuids=[MALOUF_NEW_OKIN_ADVERTISED_SERVICE_UUID],
+            manufacturer_data={3: b"BTCB.03"},
+        )
+        cb24 = _make_service_info(
+            name="Smartbed237004683",
+            service_uuids=[NORDIC_UART_SERVICE_UUID],
+            manufacturer_data={MANUFACTURER_ID_OKIN: b"DOT\x00\x02"},
+        )
+
+        assert detect_bed_type(legacy) == BED_TYPE_MALOUF_LEGACY_OKIN
+        assert detect_bed_type(cb24) == BED_TYPE_OKIN_CB24
+
     def test_detect_leggett_gen2_by_uuid(self):
         """Test Leggett Gen2 detection by unique service UUID."""
         service_info = _make_service_info(
@@ -373,15 +387,11 @@ class TestDetectBedTypeByServiceUUID:
         assert detect_bed_type(service_info) == BED_TYPE_LEGGETT_GEN2
 
         # "CP" prefix is also accepted.
-        cp = _make_service_info(
-            name="Smart Bed", manufacturer_data={0x092D: b"CP\x00\x00"}
-        )
+        cp = _make_service_info(name="Smart Bed", manufacturer_data={0x092D: b"CP\x00\x00"})
         assert detect_bed_type(cp) == BED_TYPE_LEGGETT_GEN2
 
         # Same company id but an unrelated payload must NOT match.
-        other = _make_service_info(
-            name="Smart Bed", manufacturer_data={0x092D: b"ZZ\x00\x00"}
-        )
+        other = _make_service_info(name="Smart Bed", manufacturer_data={0x092D: b"ZZ\x00\x00"})
         assert detect_bed_type(other) != BED_TYPE_LEGGETT_GEN2
 
     def test_detect_reverie_nightstand_by_uuid(self):
@@ -1751,15 +1761,10 @@ class TestW5WiLinkeNameGuard:
         from pathlib import Path
 
         manifest_path = (
-            Path(__file__).parents[1]
-            / "custom_components"
-            / "adjustable_bed"
-            / "manifest.json"
+            Path(__file__).parents[1] / "custom_components" / "adjustable_bed" / "manifest.json"
         )
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        service_uuids = {
-            entry.get("service_uuid", "").lower() for entry in manifest["bluetooth"]
-        }
+        service_uuids = {entry.get("service_uuid", "").lower() for entry in manifest["bluetooth"]}
         assert RICHMAT_WILINKE_W5_SERVICE_UUID.lower() not in service_uuids
 
 
@@ -1777,9 +1782,7 @@ class TestW4WiLinkeNameGuard:
             address="50:E4:78:14:28:EE",
             service_uuids=[RICHMAT_WILINKE_W4_SERVICE_UUID],
             manufacturer_data={
-                0x3035: bytes.fromhex(
-                    "453437383134323845455f4652433334335253503838445f30"
-                )
+                0x3035: bytes.fromhex("453437383134323845455f4652433334335253503838445f30")
             },
         )
         result = detect_bed_type_detailed(service_info)
@@ -1828,15 +1831,10 @@ class TestW4WiLinkeNameGuard:
         from pathlib import Path
 
         manifest_path = (
-            Path(__file__).parents[1]
-            / "custom_components"
-            / "adjustable_bed"
-            / "manifest.json"
+            Path(__file__).parents[1] / "custom_components" / "adjustable_bed" / "manifest.json"
         )
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        service_uuids = {
-            entry.get("service_uuid", "").lower() for entry in manifest["bluetooth"]
-        }
+        service_uuids = {entry.get("service_uuid", "").lower() for entry in manifest["bluetooth"]}
         assert RICHMAT_WILINKE_W4_SERVICE_UUID.lower() in service_uuids
 
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -31,6 +31,7 @@ from custom_components.adjustable_bed.const import (
     CONF_DISABLE_ANGLE_SENSING,
     CONF_HAS_MASSAGE,
     CONF_KAIDI_PRODUCT_ID,
+    CONF_MALOUF_LAYOUT,
     CONF_MOTOR_COUNT,
     CONF_PREFERRED_ADAPTER,
     CONF_PROTOCOL_VARIANT,
@@ -38,6 +39,7 @@ from custom_components.adjustable_bed.const import (
     DOMAIN,
     KAIDI_VARIANT_SEAT_1,
     LEGGETT_GEN2_WRITE_CHAR_UUID,
+    MALOUF_LAYOUT_HILO,
     OKIN_FOOT_MAX_ANGLE,
     OKIN_HEAD_MAX_ANGLE,
     SLEEP_NUMBER_VARIANT_LEFT,
@@ -80,6 +82,7 @@ class TestCoverEntities:
                 "name": "Malouf Hi-Lo Bed",
                 CONF_BED_TYPE: BED_TYPE_MALOUF_NEW_OKIN,
                 CONF_MOTOR_COUNT: 4,
+                CONF_MALOUF_LAYOUT: MALOUF_LAYOUT_HILO,
                 CONF_HAS_MASSAGE: True,
                 CONF_DISABLE_ANGLE_SENSING: True,
                 CONF_PREFERRED_ADAPTER: "auto",
@@ -142,7 +145,9 @@ class TestCoverEntities:
 
         assert registry.async_get_entity_id("button", DOMAIN, "AA:BB:CC:DD:EE:44_stop")
         for key in ("preset_flat", "preset_memory_1", "toggle_light", "massage_all_toggle"):
-            assert registry.async_get_entity_id("button", DOMAIN, f"AA:BB:CC:DD:EE:44_{key}") is None
+            assert (
+                registry.async_get_entity_id("button", DOMAIN, f"AA:BB:CC:DD:EE:44_{key}") is None
+            )
 
     async def test_malouf_hilo_cover_setup_removes_stale_head_and_feet(
         self,
@@ -842,9 +847,7 @@ class TestSleepNumberEntities:
             is None
         )
         assert (
-            registry.async_get_entity_id(
-                "number", DOMAIN, "AA:BB:CC:DD:EE:42_sleep_number_setting"
-            )
+            registry.async_get_entity_id("number", DOMAIN, "AA:BB:CC:DD:EE:42_sleep_number_setting")
             is None
         )
         assert (
@@ -1146,14 +1149,17 @@ class TestSleepNumberEntities:
 
             return unregister
 
-        with patch(
-            "custom_components.adjustable_bed.light."
-            "AdjustableBedOnOffLight.async_get_last_state",
-            new=AsyncMock(return_value=MagicMock(state=STATE_OFF)),
-        ), patch(
-            "custom_components.adjustable_bed.coordinator."
-            "AdjustableBedCoordinator.register_controller_state_callback",
-            new=_register_without_initial_state,
+        with (
+            patch(
+                "custom_components.adjustable_bed.light."
+                "AdjustableBedOnOffLight.async_get_last_state",
+                new=AsyncMock(return_value=MagicMock(state=STATE_OFF)),
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator."
+                "AdjustableBedCoordinator.register_controller_state_callback",
+                new=_register_without_initial_state,
+            ),
         ):
             await hass.config_entries.async_setup(entry.entry_id)
             await hass.async_block_till_done()
@@ -1529,6 +1535,7 @@ class TestSwitchEntities:
             ) -> object:
                 nonlocal scheduled_auto_off
                 if getattr(callback, "__name__", "") == "auto_off_callback":
+
                     def invoke_auto_off() -> None:
                         callback(*args)
 
@@ -1689,8 +1696,7 @@ class TestLightEntities:
             is not None
         )
         assert (
-            registry.async_get_entity_id("select", DOMAIN, "57:4C:62:B0:EF:3D_light_timer")
-            is None
+            registry.async_get_entity_id("select", DOMAIN, "57:4C:62:B0:EF:3D_light_timer") is None
         )
 
     async def test_bedtech_setup_removes_stale_light_switch_and_timer(
@@ -1749,8 +1755,7 @@ class TestLightEntities:
             is None
         )
         assert (
-            registry.async_get_entity_id("select", DOMAIN, "57:4C:54:30:76:51_light_timer")
-            is None
+            registry.async_get_entity_id("select", DOMAIN, "57:4C:54:30:76:51_light_timer") is None
         )
         assert (
             registry.async_get_entity_id("button", DOMAIN, "57:4C:54:30:76:51_toggle_light")
@@ -2543,17 +2548,13 @@ class TestSensorEntities:
         registry = er.async_get(hass)
         for axis in ("back", "legs", "head", "feet"):
             assert (
-                registry.async_get_entity_id(
-                    "sensor", DOMAIN, f"AA:BB:CC:DD:EE:60_{axis}_angle"
-                )
+                registry.async_get_entity_id("sensor", DOMAIN, f"AA:BB:CC:DD:EE:60_{axis}_angle")
                 is None
             )
         # And no position-seeking number entities (MCR cannot read positions).
         for axis in ("back", "legs", "head", "feet"):
             assert (
-                registry.async_get_entity_id(
-                    "number", DOMAIN, f"AA:BB:CC:DD:EE:60_{axis}_position"
-                )
+                registry.async_get_entity_id("number", DOMAIN, f"AA:BB:CC:DD:EE:60_{axis}_position")
                 is None
             )
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -42,6 +42,7 @@ from custom_components.adjustable_bed.const import (
     CONF_DISABLE_ANGLE_SENSING,
     CONF_HAS_MASSAGE,
     CONF_KAIDI_PRODUCT_ID,
+    CONF_MALOUF_LAYOUT,
     CONF_MOTOR_COUNT,
     CONF_MOTOR_PULSE_COUNT,
     CONF_MOTOR_PULSE_DELAY_MS,
@@ -50,6 +51,7 @@ from custom_components.adjustable_bed.const import (
     CONF_RICHMAT_REMOTE,
     DOMAIN,
     KAIDI_VARIANT_SEAT_1,
+    MALOUF_LAYOUT_HILO,
     OKIN_HEAD_MAX_ANGLE,
 )
 
@@ -1188,6 +1190,7 @@ class TestServices:
                 CONF_NAME: "Malouf Timed Move Bed",
                 CONF_BED_TYPE: BED_TYPE_MALOUF_LEGACY_OKIN,
                 CONF_MOTOR_COUNT: 4,
+                CONF_MALOUF_LAYOUT: MALOUF_LAYOUT_HILO,
                 CONF_HAS_MASSAGE: True,
                 CONF_DISABLE_ANGLE_SENSING: True,
                 CONF_PREFERRED_ADAPTER: "auto",

--- a/tests/test_malouf.py
+++ b/tests/test_malouf.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
@@ -18,9 +18,13 @@ from custom_components.adjustable_bed.const import (
     CONF_BED_TYPE,
     CONF_DISABLE_ANGLE_SENSING,
     CONF_HAS_MASSAGE,
+    CONF_MALOUF_LAYOUT,
+    CONF_MALOUF_MEMORY_SLOTS,
     CONF_MOTOR_COUNT,
     CONF_PREFERRED_ADAPTER,
     DOMAIN,
+    MALOUF_LAYOUT_FOUR_MOTOR,
+    MALOUF_LAYOUT_HILO,
     MALOUF_LEGACY_OKIN_WRITE_CHAR_UUID,
     MALOUF_NEW_OKIN_WRITE_CHAR_UUID,
 )
@@ -145,6 +149,19 @@ class TestMaloufNewOkinController:
 
         assert coordinator.controller.control_characteristic_uuid == MALOUF_NEW_OKIN_WRITE_CHAR_UUID
 
+    async def test_coordinator_preserves_observed_ble_name(
+        self,
+        hass: HomeAssistant,
+        mock_malouf_new_config_entry,
+        mock_coordinator_connected,
+    ):
+        """APK name-specific commands use advertising name, not the entry title."""
+        coordinator = AdjustableBedCoordinator(hass, mock_malouf_new_config_entry)
+        await coordinator.async_connect()
+
+        assert coordinator.name == "Malouf Test Bed"
+        assert coordinator.ble_device_name == "Test Bed"
+
     async def test_build_command_format(
         self,
         hass: HomeAssistant,
@@ -212,7 +229,9 @@ class TestMaloufLegacyOkinController:
         coordinator = AdjustableBedCoordinator(hass, mock_malouf_legacy_config_entry)
         await coordinator.async_connect()
 
-        assert coordinator.controller.control_characteristic_uuid == MALOUF_LEGACY_OKIN_WRITE_CHAR_UUID
+        assert (
+            coordinator.controller.control_characteristic_uuid == MALOUF_LEGACY_OKIN_WRITE_CHAR_UUID
+        )
 
     async def test_build_command_format(
         self,
@@ -438,7 +457,14 @@ class TestMaloufNewOkinPresets:
         mock_coordinator_connected,
         mock_bleak_client: MagicMock,
     ):
-        """Test preset memory 2 sends command then STOP."""
+        """Test an explicitly configured second memory sends command then STOP."""
+        hass.config_entries.async_update_entry(
+            mock_malouf_new_config_entry,
+            data={
+                **mock_malouf_new_config_entry.data,
+                CONF_MALOUF_MEMORY_SLOTS: 2,
+            },
+        )
         coordinator = AdjustableBedCoordinator(hass, mock_malouf_new_config_entry)
         await coordinator.async_connect()
 
@@ -452,32 +478,83 @@ class TestMaloufNewOkinPresets:
         assert sent_commands[-1] == expected_stop
 
 
+class TestMaloufMemoryProgramming:
+    """Test the long-press sequences recovered from Lucid Base 1.3.3."""
+
+    async def test_new_okin_programs_55_times_without_stop(
+        self,
+        hass: HomeAssistant,
+        mock_malouf_new_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """NEW_OKIN uses 55 writes at 100 ms and emits no trailing STOP."""
+        coordinator = AdjustableBedCoordinator(hass, mock_malouf_new_config_entry)
+        await coordinator.async_connect()
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        with patch(
+            "custom_components.adjustable_bed.beds.malouf.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await coordinator.controller.program_memory(1)
+
+        expected = coordinator.controller._build_command(MaloufCommands.MEMORY_1)
+        assert [call.args[1] for call in mock_bleak_client.write_gatt_char.call_args_list] == [
+            expected
+        ] * 55
+
+    async def test_legacy_smartbed238_uses_modified_save_and_no_stop(
+        self,
+        hass: HomeAssistant,
+        mock_malouf_legacy_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Smartbed238 uses the APK's modified Memory 1 save command 85 times."""
+        coordinator = AdjustableBedCoordinator(hass, mock_malouf_legacy_config_entry)
+        await coordinator.async_connect()
+        coordinator._ble_device_name = "Smartbed238001234"  # noqa: SLF001
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        with patch(
+            "custom_components.adjustable_bed.beds.malouf.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await coordinator.controller.program_memory(1)
+
+        expected = coordinator.controller._build_command(MaloufCommands.SET_MEMORY_1_SMARTBED238)
+        assert [call.args[1] for call in mock_bleak_client.write_gatt_char.call_args_list] == [
+            expected
+        ] * 85
+
+
 class TestMaloufCapabilities:
     """Test Malouf capability properties."""
 
-    async def test_supports_lumbar(
+    async def test_two_motor_layout_does_not_expose_lumbar(
         self,
         hass: HomeAssistant,
         mock_malouf_new_config_entry,
         mock_coordinator_connected,
     ):
-        """Test Malouf reports lumbar support."""
+        """A two-motor L600-style layout must not invent lumbar support."""
         coordinator = AdjustableBedCoordinator(hass, mock_malouf_new_config_entry)
         await coordinator.async_connect()
 
-        assert coordinator.controller.has_lumbar_support is True
+        assert coordinator.controller.has_lumbar_support is False
 
-    async def test_supports_tilt(
+    async def test_two_motor_layout_does_not_expose_tilt(
         self,
         hass: HomeAssistant,
         mock_malouf_new_config_entry,
         mock_coordinator_connected,
     ):
-        """Test Malouf reports tilt support."""
+        """A two-motor L600-style layout must not invent tilt support."""
         coordinator = AdjustableBedCoordinator(hass, mock_malouf_new_config_entry)
         await coordinator.async_connect()
 
-        assert coordinator.controller.has_tilt_support is True
+        assert coordinator.controller.has_tilt_support is False
 
     async def test_supports_lights_toggle_only(
         self,
@@ -492,74 +569,133 @@ class TestMaloufCapabilities:
         assert coordinator.controller.supports_lights is True
         assert coordinator.controller.supports_discrete_light_control is False
 
-    async def test_memory_slot_count_is_two(
+    async def test_two_motor_layout_defaults_to_one_memory_slot(
         self,
         hass: HomeAssistant,
         mock_malouf_new_config_entry,
         mock_coordinator_connected,
     ):
-        """Test Malouf reports 2 memory slots."""
+        """The confirmed Lucid L600 app profile exposes one memory position."""
         coordinator = AdjustableBedCoordinator(hass, mock_malouf_new_config_entry)
         await coordinator.async_connect()
 
-        assert coordinator.controller.memory_slot_count == 2
+        assert coordinator.controller.memory_slot_count == 1
 
-    async def test_new_okin_exposes_hilo_motor_layout(
+    async def test_new_okin_two_motor_layout_is_not_hilo(
         self,
         hass: HomeAssistant,
         mock_malouf_new_config_entry,
         mock_coordinator_connected,
     ):
-        """Test NEW_OKIN exposes the Hi-Lo motor layout without head/feet aliases."""
+        """NEW_OKIN protocol alone must not imply a Hi-Lo actuator layout."""
         coordinator = AdjustableBedCoordinator(hass, mock_malouf_new_config_entry)
         await coordinator.async_connect()
 
         specs = coordinator.controller.motor_control_specs
 
-        assert [spec.key for spec in specs] == [
-            "back",
-            "legs",
+        assert [spec.key for spec in specs] == ["back", "legs"]
+        assert coordinator.controller.stale_motor_entity_keys == {
+            "head",
+            "feet",
             "tilt",
             "lumbar",
             "bed_height",
-        ]
-        assert specs[2].translation_key == "head_end_tilt"
-        assert specs[3].translation_key == "foot_end_tilt"
-        assert coordinator.controller.stale_motor_entity_keys == {"head", "feet"}
+        }
 
-    async def test_legacy_okin_exposes_hilo_motor_layout(
+    async def test_legacy_okin_two_motor_layout_is_not_hilo(
         self,
         hass: HomeAssistant,
         mock_malouf_legacy_config_entry,
         mock_coordinator_connected,
     ):
-        """Test LEGACY_OKIN exposes the Hi-Lo motor layout without head/feet aliases."""
+        """LEGACY_OKIN protocol alone must not imply extra L600 actuators."""
         coordinator = AdjustableBedCoordinator(hass, mock_malouf_legacy_config_entry)
         await coordinator.async_connect()
 
         specs = coordinator.controller.motor_control_specs
 
-        assert [spec.key for spec in specs] == [
-            "back",
-            "legs",
-            "tilt",
-            "lumbar",
-            "bed_height",
-        ]
-        assert specs[2].translation_key == "head_end_tilt"
-        assert specs[3].translation_key == "foot_end_tilt"
+        assert [spec.key for spec in specs] == ["back", "legs"]
 
-    async def test_does_not_support_memory_programming(
+    async def test_supports_memory_programming(
         self,
         hass: HomeAssistant,
         mock_malouf_new_config_entry,
         mock_coordinator_connected,
     ):
-        """Test Malouf does not support programming memory positions."""
+        """The official app implements timed memory programming."""
         coordinator = AdjustableBedCoordinator(hass, mock_malouf_new_config_entry)
         await coordinator.async_connect()
 
-        assert coordinator.controller.supports_memory_programming is False
+        assert coordinator.controller.supports_memory_programming is True
+
+    @pytest.mark.parametrize(
+        ("bed_type", "layout", "expected"),
+        [
+            (
+                BED_TYPE_MALOUF_NEW_OKIN,
+                MALOUF_LAYOUT_FOUR_MOTOR,
+                ["back", "legs", "tilt", "lumbar"],
+            ),
+            (
+                BED_TYPE_MALOUF_LEGACY_OKIN,
+                MALOUF_LAYOUT_HILO,
+                ["back", "legs", "tilt", "lumbar", "bed_height"],
+            ),
+        ],
+    )
+    async def test_explicit_layout_is_independent_of_protocol(
+        self,
+        hass: HomeAssistant,
+        mock_malouf_new_config_entry,
+        mock_coordinator_connected,
+        bed_type: str,
+        layout: str,
+        expected: list[str],
+    ):
+        """The same command family can expose different physical layouts."""
+        hass.config_entries.async_update_entry(
+            mock_malouf_new_config_entry,
+            data={
+                **mock_malouf_new_config_entry.data,
+                CONF_BED_TYPE: bed_type,
+                CONF_MOTOR_COUNT: 4,
+                CONF_MALOUF_LAYOUT: layout,
+            },
+        )
+        coordinator = AdjustableBedCoordinator(hass, mock_malouf_new_config_entry)
+        await coordinator.async_connect()
+
+        assert [spec.key for spec in coordinator.controller.motor_control_specs] == expected
+
+    @pytest.mark.parametrize(
+        "bed_type", [BED_TYPE_MALOUF_NEW_OKIN, BED_TYPE_MALOUF_LEGACY_OKIN]
+    )
+    async def test_auto_four_motor_layout_does_not_infer_hilo_from_protocol(
+        self,
+        hass: HomeAssistant,
+        mock_malouf_new_config_entry,
+        mock_coordinator_connected,
+        bed_type: str,
+    ):
+        """Hi-Lo requires explicit hardware evidence from the user's remote."""
+        hass.config_entries.async_update_entry(
+            mock_malouf_new_config_entry,
+            data={
+                **mock_malouf_new_config_entry.data,
+                CONF_BED_TYPE: bed_type,
+                CONF_MOTOR_COUNT: 4,
+            },
+        )
+        coordinator = AdjustableBedCoordinator(hass, mock_malouf_new_config_entry)
+        await coordinator.async_connect()
+
+        assert [spec.key for spec in coordinator.controller.motor_control_specs] == [
+            "back",
+            "legs",
+            "tilt",
+            "lumbar",
+        ]
+        assert coordinator.controller.has_bed_height_support is False
 
 
 class TestMaloufLumbarAndTilt:

--- a/tests/test_malouf.py
+++ b/tests/test_malouf.py
@@ -524,10 +524,82 @@ class TestMaloufMemoryProgramming:
         ):
             await coordinator.controller.program_memory(1)
 
-        expected = coordinator.controller._build_command(MaloufCommands.SET_MEMORY_1_SMARTBED238)
+        expected = coordinator.controller._build_command(MaloufCommands.SAVE_MEMORY_1_SMARTBED238)
         assert [call.args[1] for call in mock_bleak_client.write_gatt_char.call_args_list] == [
             expected
         ] * 85
+
+    async def test_new_okin_program_memory_streams_save(
+        self,
+        hass: HomeAssistant,
+        mock_malouf_new_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test NEW_OKIN programming streams the save command at 55x100ms."""
+        coordinator = AdjustableBedCoordinator(hass, mock_malouf_new_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        with patch.object(controller, "write_command", new=AsyncMock()) as mock_write:
+            await controller.program_memory(1)
+
+        mock_write.assert_called_once()
+        save_call = mock_write.call_args
+        assert save_call.args[0] == controller._build_command(MaloufCommands.SAVE_MEMORY_1)
+        assert save_call.kwargs["repeat_count"] == 55
+        assert save_call.kwargs["repeat_delay_ms"] == 100
+
+    async def test_legacy_okin_program_memory_streams_save(
+        self,
+        hass: HomeAssistant,
+        mock_malouf_legacy_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test LEGACY_OKIN programming streams the save command at 85x150ms."""
+        hass.config_entries.async_update_entry(
+            mock_malouf_legacy_config_entry,
+            data={
+                **mock_malouf_legacy_config_entry.data,
+                CONF_MALOUF_MEMORY_SLOTS: 2,
+            },
+        )
+        coordinator = AdjustableBedCoordinator(hass, mock_malouf_legacy_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        with patch.object(controller, "write_command", new=AsyncMock()) as mock_write:
+            await controller.program_memory(2)
+
+        mock_write.assert_called_once()
+        save_call = mock_write.call_args
+        assert save_call.args[0] == controller._build_command(MaloufCommands.SAVE_MEMORY_2)
+        assert save_call.kwargs["repeat_count"] == 85
+        assert save_call.kwargs["repeat_delay_ms"] == 150
+
+    async def test_program_memory_invalid_slot_writes_nothing(
+        self,
+        hass: HomeAssistant,
+        mock_malouf_legacy_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test invalid memory slots are rejected without any BLE writes."""
+        coordinator = AdjustableBedCoordinator(hass, mock_malouf_legacy_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        with patch.object(controller, "write_command", new=AsyncMock()) as mock_write:
+            await controller.program_memory(3)
+
+        mock_write.assert_not_called()
+
+    def test_save_memory_command_values(self):
+        """Test save values match the app (slot 1 recall value, slot 2 save bit)."""
+        assert _save_memory_command(1, "OKIN-BLE00017786") == 0x10000
+        assert _save_memory_command(1, "Smartbed238-0042") == 0x80010000
+        assert _save_memory_command(2, "OKIN-BLE00017786") == 0x80040000
+        assert _save_memory_command(2, "Smartbed238-0042") == 0x80040000
+        assert _save_memory_command(3, "OKIN-BLE00017786") is None
+        assert _save_memory_command(1, None) == 0x10000
 
 
 class TestMaloufCapabilities:
@@ -697,82 +769,6 @@ class TestMaloufCapabilities:
             "lumbar",
         ]
         assert coordinator.controller.has_bed_height_support is False
-
-
-class TestMaloufMemoryProgramming:
-    """Test Malouf hold-to-save memory programming."""
-
-    async def test_new_okin_program_memory_streams_save(
-        self,
-        hass: HomeAssistant,
-        mock_malouf_new_config_entry,
-        mock_coordinator_connected,
-    ):
-        """Test NEW_OKIN programming streams the save command at 55x100ms."""
-        coordinator = AdjustableBedCoordinator(hass, mock_malouf_new_config_entry)
-        await coordinator.async_connect()
-        controller = coordinator.controller
-
-        with patch.object(controller, "write_command", new=AsyncMock()) as mock_write:
-            await controller.program_memory(1)
-
-        mock_write.assert_called_once()
-        save_call = mock_write.call_args
-        assert save_call.args[0] == controller._build_command(MaloufCommands.SAVE_MEMORY_1)
-        assert save_call.kwargs["repeat_count"] == 55
-        assert save_call.kwargs["repeat_delay_ms"] == 100
-
-    async def test_legacy_okin_program_memory_streams_save(
-        self,
-        hass: HomeAssistant,
-        mock_malouf_legacy_config_entry,
-        mock_coordinator_connected,
-    ):
-        """Test LEGACY_OKIN programming streams the save command at 85x150ms."""
-        hass.config_entries.async_update_entry(
-            mock_malouf_legacy_config_entry,
-            data={
-                **mock_malouf_legacy_config_entry.data,
-                CONF_MALOUF_MEMORY_SLOTS: 2,
-            },
-        )
-        coordinator = AdjustableBedCoordinator(hass, mock_malouf_legacy_config_entry)
-        await coordinator.async_connect()
-        controller = coordinator.controller
-
-        with patch.object(controller, "write_command", new=AsyncMock()) as mock_write:
-            await controller.program_memory(2)
-
-        mock_write.assert_called_once()
-        save_call = mock_write.call_args
-        assert save_call.args[0] == controller._build_command(MaloufCommands.SAVE_MEMORY_2)
-        assert save_call.kwargs["repeat_count"] == 85
-        assert save_call.kwargs["repeat_delay_ms"] == 150
-
-    async def test_program_memory_invalid_slot_writes_nothing(
-        self,
-        hass: HomeAssistant,
-        mock_malouf_legacy_config_entry,
-        mock_coordinator_connected,
-    ):
-        """Test invalid memory slots are rejected without any BLE writes."""
-        coordinator = AdjustableBedCoordinator(hass, mock_malouf_legacy_config_entry)
-        await coordinator.async_connect()
-        controller = coordinator.controller
-
-        with patch.object(controller, "write_command", new=AsyncMock()) as mock_write:
-            await controller.program_memory(3)
-
-        mock_write.assert_not_called()
-
-    def test_save_memory_command_values(self):
-        """Test save values match the app (slot 1 recall value, slot 2 save bit)."""
-        assert _save_memory_command(1, "OKIN-BLE00017786") == 0x10000
-        assert _save_memory_command(1, "Smartbed238-0042") == 0x80010000
-        assert _save_memory_command(2, "OKIN-BLE00017786") == 0x80040000
-        assert _save_memory_command(2, "Smartbed238-0042") == 0x80040000
-        assert _save_memory_command(3, "OKIN-BLE00017786") is None
-        assert _save_memory_command(1, None) == 0x10000
 
 
 class TestMaloufLumbarAndTilt:


### PR DESCRIPTION
## Summary

- keep Lucid L600 as a retail model instead of collapsing it into one BLE protocol
- preserve separate regression paths for confirmed L600 CB24 and Legacy OKIN signatures
- configure Malouf/Lucid actuator layout and memory capacity independently from command framing
- match Lucid Base 1.3.3 preset and memory-programming behavior, including the Smartbed238 save exception
- let user-started setup flows re-add devices that were previously ignored in Home Assistant
- update protocol, configuration, actuator, and supported-bed documentation

## Root cause

Lucid L600 bases have shipped with different controllers. Confirmed devices include `Smartbed237...` units using 7-byte OKIN CB24 packets and `OKIN-BLE...`/`BTCB` units using 9-byte Legacy OKIN packets. The retail model therefore cannot determine command framing, actuator layout, or memory capacity.

The second report in #358 was a separate setup-state problem. Home Assistant ignored-entry placeholders were counted as configured entries by the integration's device browser, which hid the bed from user-started setup even though Home Assistant supports replacing an ignored entry.

## User impact

- two-motor L600-style entries expose only back and legs by default
- four-motor and Hi-Lo layouts no longer get inferred from a retail model or BLE protocol
- users can explicitly choose head tilt, lumbar, four-motor, or Hi-Lo layouts
- one or two physical memory positions can be selected independently
- memory saving follows the official app's exact repeat counts and does not send a STOP packet that the APK itself never emits
- previously ignored beds can be selected and configured again

## Validation

- `433 passed` across `test_malouf.py`, `test_detection.py`, `test_config_flow.py`, and `test_entities.py`
- Ruff checks passed for all changed Python modules and tests
- integration JSON files validated successfully
- `git diff --check` passed

Fixes #358


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Malouf/Lucid physical actuator layout and memory-slot configuration options.
  * Improved automatic layout and memory-capacity detection.
  * Added memory preset programming for supported Malouf/Lucid beds and protocols.
  * Updated supported-bed identification for Lucid models, including clearer protocol detection guidance.

* **Bug Fixes**
  * Corrected exposed controls and capabilities for different actuator layouts.
  * Improved handling of previously ignored devices during setup.
  * Refined preset validation and command timing behavior.

* **Documentation**
  * Expanded configuration and supported-bed documentation for Malouf/Lucid layouts, memory positions, and model identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->