### PR TITLE
Fix BedTech QRRM runtime detection

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -51,13 +51,11 @@ from .const import (
     DOMAIN,
     KEESON_VARIANT_ERGOMOTION,
     OKIN_CST_POSITION_AXES,
-    RICHMAT_REMOTE_AUTO,
     VARIANT_AUTO,
     connection_gated_by_bond,
     requires_pairing,
 )
 from .coordinator import AdjustableBedCoordinator
-from .detection import detect_richmat_remote_from_name
 from .kaidi_metadata import add_kaidi_entry_metadata, resolve_kaidi_advertisement
 from .unsupported import (
     async_clear_unsupported_device_issues,
@@ -462,26 +460,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def _async_maybe_reclassify_bedtech_qrrm_entry(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> None:
-    """Correct FEE9/QRRM entries persisted with the wrong protocol.
+    """Correct a persisted Richmat QRRM entry from advertisement evidence.
 
     QRRM is used by both BedTech white-light controllers and Richmat/Casper RGB
-    controllers, and both use the shared FEE9 service. Confirmed BedTech
-    controllers additionally advertise manufacturer ID 0x4C57 while confirmed
-    Richmat QRRM controllers do not, so that signal decides the direction:
-
-    - Entries persisted as Richmat whose advertisement carries the BedTech
-      manufacturer ID are corrected to BedTech (older releases treated every
-      QRRM name as Richmat, issue #410).
-    - Entries persisted as BedTech whose advertisement lacks the BedTech
-      manufacturer ID but matches a Richmat remote name are corrected to
-      Richmat (older releases could persist Richmat QRRM devices as BedTech,
-      issue #243).
-
-    The two directions key on mutually exclusive advertisement contents, so a
-    stable advertisement cannot make an entry oscillate between them.
+    controllers, and both use the shared FEE9 service. A present manufacturer
+    ID 0x4C57 is positive BedTech evidence, but its absence is inconclusive:
+    ESPHome proxy snapshots can omit manufacturer data for the same device.
+    Connected Device Information provides a second, model-specific correction
+    path in the coordinator (issue #410).
     """
     bed_type = entry.data.get(CONF_BED_TYPE)
-    if bed_type not in (BED_TYPE_RICHMAT, BED_TYPE_BEDTECH):
+    if bed_type != BED_TYPE_RICHMAT:
         return
 
     address = entry.data.get(CONF_ADDRESS)
@@ -509,65 +498,35 @@ async def _async_maybe_reclassify_bedtech_qrrm_entry(
     manufacturer_data = getattr(service_info, "manufacturer_data", None) or {}
     has_bedtech_manufacturer = BEDTECH_MANUFACTURER_ID in manufacturer_data
 
-    if bed_type == BED_TYPE_RICHMAT:
-        if not isinstance(device_name, str) or not device_name.lower().startswith("qrrm"):
-            return
-        if not has_bedtech_manufacturer:
-            _LOGGER.info(
-                "QRRM entry %s (%s) stays Richmat: advertisement carries no BedTech "
-                "manufacturer ID 0x%04X (manufacturer IDs seen: %s)",
-                entry.title,
-                entry.entry_id,
-                BEDTECH_MANUFACTURER_ID,
-                sorted(manufacturer_data) or "none",
-            )
-            return
-
-        new_data = {
-            **entry.data,
-            CONF_BED_TYPE: BED_TYPE_BEDTECH,
-            CONF_PROTOCOL_VARIANT: VARIANT_AUTO,
-        }
-        new_data.pop(CONF_RICHMAT_REMOTE, None)
-
-        hass.config_entries.async_update_entry(entry, data=new_data)
-        _LOGGER.warning(
-            "Corrected config entry %s (%s) from Richmat to BedTech because BLE name %r "
-            "uses the shared FEE9 service and advertises BedTech manufacturer ID 0x%04X",
+    if not isinstance(device_name, str) or not device_name.lower().startswith("qrrm"):
+        return
+    if not has_bedtech_manufacturer:
+        _LOGGER.info(
+            "QRRM entry %s (%s) has no protocol-specific advertisement evidence: "
+            "manufacturer ID 0x%04X is absent (manufacturer IDs seen: %s); "
+            "connected Device Information will be checked",
             entry.title,
             entry.entry_id,
-            device_name,
             BEDTECH_MANUFACTURER_ID,
+            sorted(manufacturer_data) or "none",
         )
-        return
-
-    # Entry is persisted as BedTech. A present BedTech manufacturer ID confirms the
-    # persisted type; without it, a Richmat remote name identifies a legacy
-    # misclassified Richmat QRRM device.
-    if has_bedtech_manufacturer:
-        return
-
-    detected_remote = detect_richmat_remote_from_name(device_name)
-    if not detected_remote:
         return
 
     new_data = {
         **entry.data,
-        CONF_BED_TYPE: BED_TYPE_RICHMAT,
+        CONF_BED_TYPE: BED_TYPE_BEDTECH,
         CONF_PROTOCOL_VARIANT: VARIANT_AUTO,
     }
-    if entry.data.get(CONF_RICHMAT_REMOTE, RICHMAT_REMOTE_AUTO) == RICHMAT_REMOTE_AUTO:
-        new_data[CONF_RICHMAT_REMOTE] = detected_remote
+    new_data.pop(CONF_RICHMAT_REMOTE, None)
 
     hass.config_entries.async_update_entry(entry, data=new_data)
     _LOGGER.warning(
-        "Corrected config entry %s (%s) from BedTech to Richmat because BLE name %r "
-        "matches Richmat remote %r on the shared FEE9 service without the BedTech "
-        "manufacturer ID",
+        "Corrected config entry %s (%s) from Richmat to BedTech because BLE name %r "
+        "uses the shared FEE9 service and advertises BedTech manufacturer ID 0x%04X",
         entry.title,
         entry.entry_id,
         device_name,
-        detected_remote,
+        BEDTECH_MANUFACTURER_ID,
     )
 
 

--- a/custom_components/adjustable_bed/adapter.py
+++ b/custom_components/adjustable_bed/adapter.py
@@ -482,4 +482,41 @@ async def read_ble_device_info(client: BleakClient, address: str) -> tuple[str |
     except (BleakError, TimeoutError, OSError) as err:
         _LOGGER.debug("Could not read model number: %s", err)
 
+    # WLT QRRM controllers do not expose the standard Model Number
+    # characteristic. Instead, they expose two Software Revision (0x2A28)
+    # characteristics: a firmware version followed by a vendor model such as
+    # ``WLT825X_H35``. Reading 0x2A28 by UUID only returns the first instance,
+    # so inspect the characteristic objects to recover the model from the
+    # duplicate instance. This model distinguishes otherwise identical BedTech
+    # and Richmat/Casper QRRM controllers (issues #410 and #300).
+    if model is None and (manufacturer or "").strip().casefold() == "wlt":
+        software_revision_uuid = DEVICE_INFO_CHARS["software_revision"]
+        software_revision_chars = [
+            characteristic
+            for service in client.services
+            if service.uuid.lower() == DEVICE_INFO_SERVICE_UUID
+            for characteristic in service.characteristics
+            if characteristic.uuid.lower() == software_revision_uuid
+        ]
+        if len(software_revision_chars) > 1:
+            for characteristic in software_revision_chars:
+                try:
+                    value = await asyncio.wait_for(
+                        client.read_gatt_char(characteristic),
+                        DEVICE_INFO_READ_TIMEOUT,
+                    )
+                    candidate = value.decode("utf-8").rstrip("\x00")
+                except (BleakError, TimeoutError, OSError, UnicodeDecodeError) as err:
+                    _LOGGER.debug(
+                        "Could not read WLT vendor model from handle %s: %s",
+                        getattr(characteristic, "handle", "unknown"),
+                        err,
+                    )
+                    continue
+
+                if candidate.upper().startswith("WLT"):
+                    model = candidate
+                    _LOGGER.debug("BLE vendor model: %s", model)
+                    break
+
     return manufacturer, model

--- a/custom_components/adjustable_bed/adapter.py
+++ b/custom_components/adjustable_bed/adapter.py
@@ -489,7 +489,7 @@ async def read_ble_device_info(client: BleakClient, address: str) -> tuple[str |
     # so inspect the characteristic objects to recover the model from the
     # duplicate instance. This model distinguishes otherwise identical BedTech
     # and Richmat/Casper QRRM controllers (issues #410 and #300).
-    if model is None and (manufacturer or "").strip().casefold() == "wlt":
+    if not (model or "").strip() and (manufacturer or "").strip().casefold() == "wlt":
         software_revision_uuid = DEVICE_INFO_CHARS["software_revision"]
         software_revision_chars = [
             characteristic

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -44,6 +44,7 @@ from .ble_auth import is_ble_authentication_error
 from .const import (
     ADAPTER_AUTO,
     BED_MOTOR_PULSE_DEFAULTS,
+    BED_TYPE_BEDTECH,
     BED_TYPE_COMFORT_MOTION,
     BED_TYPE_DEWERTOKIN,
     BED_TYPE_DIAGNOSTIC,
@@ -151,6 +152,7 @@ from .detection import (
     refine_nordic_uart_protocol_from_device_info,
     refine_okin_dot_protocol_from_gatt,
     refine_okin_shared_uuid_protocol_from_gatt,
+    refine_qrrm_protocol_from_device_info,
 )
 from .diagnostic_payloads import new_connection_attempt_details
 from .unsupported import (
@@ -413,6 +415,8 @@ class AdjustableBedCoordinator:
 
         entry_data = dict(self.entry.data)
         entry_data[CONF_BED_TYPE] = corrected_bed_type
+        if corrected_bed_type == BED_TYPE_BEDTECH:
+            entry_data.pop(CONF_RICHMAT_REMOTE, None)
         angle_sensing_defaulted = CONF_DISABLE_ANGLE_SENSING not in self.entry.data or (
             self.entry.data.get(CONF_DISABLE_ANGLE_SENSING) is True
             and (
@@ -1746,6 +1750,11 @@ class AdjustableBedCoordinator:
                     corrected_bed_type,
                     device.name,
                     ble_manufacturer,
+                    ble_model,
+                )
+                corrected_bed_type = refine_qrrm_protocol_from_device_info(
+                    corrected_bed_type,
+                    device.name,
                     ble_model,
                 )
                 corrected_bed_type = refine_okin_dot_protocol_from_gatt(

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -802,6 +802,41 @@ def refine_nordic_uart_protocol_from_device_info(
     return BED_TYPE_OKIN_64BIT
 
 
+def refine_qrrm_protocol_from_device_info(
+    bed_type: str,
+    device_name: str | None,
+    ble_model: str | None,
+) -> str:
+    """Disambiguate QRRM BedTech and Richmat controllers by exact WLT model.
+
+    The confirmed BedTech BT3000 from issue #410 and Casper/Richmat HJC27 from
+    issue #300 share the QRRM name family, FEE9 GATT layout, and WLT
+    manufacturer. Their vendor models differ by the Richmat controller's ``_S``
+    suffix, so only these observed exact models are safe correction signals.
+    """
+    if bed_type not in {BED_TYPE_BEDTECH, BED_TYPE_RICHMAT}:
+        return bed_type
+    if not (device_name or "").strip().casefold().startswith("qrrm"):
+        return bed_type
+
+    normalized_model = (ble_model or "").strip().casefold()
+    corrected_bed_type = {
+        "wlt825x_h35": BED_TYPE_BEDTECH,
+        "wlt825x_h35_s": BED_TYPE_RICHMAT,
+    }.get(normalized_model)
+    if corrected_bed_type is None:
+        return bed_type
+
+    if corrected_bed_type != bed_type:
+        _LOGGER.info(
+            "Refined QRRM protocol from %s to %s using Device Info model %s",
+            bed_type,
+            corrected_bed_type,
+            ble_model,
+        )
+    return corrected_bed_type
+
+
 def detect_bed_type(service_info: BluetoothServiceInfoBleak) -> str | None:
     """Detect bed type from service info.
 

--- a/docs/beds/bedtech.md
+++ b/docs/beds/bedtech.md
@@ -36,9 +36,10 @@
 > BedTech shares the FEE9 service UUID and characteristic with Richmat WiLinke.
 > Both use a similar 5-byte command format with `0x6E` prefix.
 > QRRM controllers that advertise manufacturer ID `0x4C57` are identified as
-> BedTech; QRRM controllers without that field remain Richmat (including the
-> confirmed Casper RGB-light controller). Manual selection may still be required
-> if an advertisement omits the manufacturer field.
+> BedTech. Because ESPHome proxy snapshots can omit that field, the integration
+> also checks the connected controller's vendor model: the confirmed BedTech
+> BT3000 reports `WLT825X_H35`, while the confirmed Casper/Richmat HJC27 reports
+> `WLT825X_H35_S`. Unknown QRRM models are left unchanged rather than guessed.
 
 ### Packet Format
 
@@ -52,10 +53,9 @@ Commands use ASCII character codes. The last byte is a simple checksum.
 The official app (react-native-ble-manager) uses **write-with-response**
 (`BleManager.write`) for every command; its `writeWithoutResponse` wrapper is
 never called. An earlier claim that the app used write-without-response (and
-that write-with-response made lights/lounge fail) traced back to issue #243,
-whose device turned out to be a misclassified Richmat QRRM — it never applied
-to real BedTech hardware. Verified against BedTech 7.1.3 Hermes bytecode
-(2026-07-10, issue #410).
+that write-with-response made lights/lounge fail) came from an experiment for
+issue #243, not from the official app's implementation. Verified against
+BedTech 7.1.3 Hermes bytecode (2026-07-10, issue #410).
 
 ### Command Repeats
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -164,3 +164,41 @@ class TestReadBleDeviceInfo:
 
         assert manufacturer == "WLT"
         assert model == "WLT825X_H35"
+
+    async def test_recovers_wlt_model_when_standard_model_is_blank(self) -> None:
+        """Blank standard model data should not block WLT vendor model recovery."""
+        firmware_char = MagicMock(
+            uuid=DEVICE_INFO_CHARS["software_revision"],
+            handle=36,
+        )
+        model_char = MagicMock(
+            uuid=DEVICE_INFO_CHARS["software_revision"],
+            handle=42,
+        )
+        device_info_service = MagicMock(
+            uuid=DEVICE_INFO_SERVICE_UUID,
+            characteristics=[firmware_char, model_char],
+        )
+        client = MagicMock()
+        client.is_connected = True
+        client.services = [device_info_service]
+
+        async def read_gatt_char(characteristic: object) -> bytes:
+            if characteristic == DEVICE_INFO_CHARS["manufacturer_name"]:
+                return b"WLT"
+            if characteristic == DEVICE_INFO_CHARS["model_number"]:
+                return b"\x00\x00"
+            if characteristic is firmware_char:
+                return b"V216.17.8"
+            if characteristic is model_char:
+                return b"WLT825X_H35"
+            raise AssertionError(f"Unexpected characteristic: {characteristic}")
+
+        client.read_gatt_char = AsyncMock(side_effect=read_gatt_char)
+
+        manufacturer, model = await read_ble_device_info(
+            client, "57:4C:54:30:76:51"
+        )
+
+        assert manufacturer == "WLT"
+        assert model == "WLT825X_H35"

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from bleak.exc import BleakError
 from homeassistant.core import HomeAssistant
 
 from custom_components.adjustable_bed.adapter import (
@@ -12,7 +13,10 @@ from custom_components.adjustable_bed.adapter import (
     get_discovered_service_info,
     read_ble_device_info,
 )
-from custom_components.adjustable_bed.const import DEVICE_INFO_SERVICE_UUID
+from custom_components.adjustable_bed.const import (
+    DEVICE_INFO_CHARS,
+    DEVICE_INFO_SERVICE_UUID,
+)
 
 
 class TestAdapterFallbacks:
@@ -122,3 +126,41 @@ class TestReadBleDeviceInfo:
         assert manufacturer is None
         assert model is None
         assert client.read_gatt_char.await_count == 2
+
+    async def test_recovers_wlt_model_from_duplicate_software_revision(self) -> None:
+        """WLT's second 0x2A28 instance contains the actual QRRM controller model."""
+        firmware_char = MagicMock(
+            uuid=DEVICE_INFO_CHARS["software_revision"],
+            handle=36,
+        )
+        model_char = MagicMock(
+            uuid=DEVICE_INFO_CHARS["software_revision"],
+            handle=42,
+        )
+        device_info_service = MagicMock(
+            uuid=DEVICE_INFO_SERVICE_UUID,
+            characteristics=[firmware_char, model_char],
+        )
+        client = MagicMock()
+        client.is_connected = True
+        client.services = [device_info_service]
+
+        async def read_gatt_char(characteristic: object) -> bytes:
+            if characteristic == DEVICE_INFO_CHARS["manufacturer_name"]:
+                return b"WLT"
+            if characteristic == DEVICE_INFO_CHARS["model_number"]:
+                raise BleakError("model number characteristic missing")
+            if characteristic is firmware_char:
+                return b"V216.17.8"
+            if characteristic is model_char:
+                return b"WLT825X_H35"
+            raise AssertionError(f"Unexpected characteristic: {characteristic}")
+
+        client.read_gatt_char = AsyncMock(side_effect=read_gatt_char)
+
+        manufacturer, model = await read_ble_device_info(
+            client, "57:4C:54:30:76:51"
+        )
+
+        assert manufacturer == "WLT"
+        assert model == "WLT825X_H35"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2745,6 +2745,47 @@ class TestRuntimeBedTypeCorrection:
         assert entry.data[CONF_BED_TYPE] == BED_TYPE_BEDTECH
         assert CONF_RICHMAT_REMOTE not in entry.data
 
+    async def test_qrrm_hjc27_model_correction_selects_richmat_controller(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected: None,
+        mock_async_ble_device_from_address: MagicMock,
+    ) -> None:
+        """A persisted BedTech fallback must correct Casper/HJC27 back to Richmat."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="QRRM141291",
+            data={
+                CONF_ADDRESS: "57:4C:54:30:76:52",
+                CONF_NAME: "QRRM141291",
+                CONF_BED_TYPE: BED_TYPE_BEDTECH,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: True,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="57:4C:54:30:76:52",
+            entry_id="test_entry_qrrm_hjc27_runtime_correction",
+        )
+        entry.add_to_hass(hass)
+        mock_async_ble_device_from_address.return_value.address = "57:4C:54:30:76:52"
+        mock_async_ble_device_from_address.return_value.name = "QRRM141291"
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator.read_ble_device_info",
+            new_callable=AsyncMock,
+            return_value=("WLT", "WLT825X_H35_S"),
+        ):
+            coordinator = AdjustableBedCoordinator(hass, entry)
+            result = await coordinator.async_connect()
+
+        assert result is True
+        assert coordinator.bed_type == BED_TYPE_RICHMAT
+        assert coordinator.controller.__class__.__name__ == "RichmatController"
+        assert coordinator.controller._remote_code == "qrrm"
+        assert entry.data[CONF_BED_TYPE] == BED_TYPE_RICHMAT
+        assert CONF_RICHMAT_REMOTE not in entry.data
+
     async def test_correction_to_pairing_required_type_reconnects_before_controller_startup(
         self,
         hass: HomeAssistant,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -14,6 +14,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adjustable_bed.const import (
     BED_MOTOR_PULSE_DEFAULTS,
+    BED_TYPE_BEDTECH,
     BED_TYPE_KEESON,
     BED_TYPE_LEGGETT_OKIN,
     BED_TYPE_LINAK,
@@ -2702,6 +2703,47 @@ class TestRuntimeBedTypeCorrection:
         coordinator._apply_runtime_bed_type_correction(BED_TYPE_OKIN_64BIT)
 
         assert coordinator.bed_type == BED_TYPE_OKIN_64BIT
+
+    async def test_qrrm_bt3000_model_correction_selects_bedtech_controller(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected: None,
+        mock_async_ble_device_from_address: MagicMock,
+    ) -> None:
+        """Issue #410's connected model must replace the persisted Richmat fallback."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="QRRM157738",
+            data={
+                CONF_ADDRESS: "57:4C:54:30:76:51",
+                CONF_NAME: "QRRM157738",
+                CONF_BED_TYPE: BED_TYPE_RICHMAT,
+                CONF_RICHMAT_REMOTE: "qrrm",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: True,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="57:4C:54:30:76:51",
+            entry_id="test_entry_qrrm_bt3000_runtime_correction",
+        )
+        entry.add_to_hass(hass)
+        mock_async_ble_device_from_address.return_value.address = "57:4C:54:30:76:51"
+        mock_async_ble_device_from_address.return_value.name = "QRRM157738"
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator.read_ble_device_info",
+            new_callable=AsyncMock,
+            return_value=("WLT", "WLT825X_H35"),
+        ):
+            coordinator = AdjustableBedCoordinator(hass, entry)
+            result = await coordinator.async_connect()
+
+        assert result is True
+        assert coordinator.bed_type == BED_TYPE_BEDTECH
+        assert coordinator.controller.__class__.__name__ == "BedTechController"
+        assert entry.data[CONF_BED_TYPE] == BED_TYPE_BEDTECH
+        assert CONF_RICHMAT_REMOTE not in entry.data
 
     async def test_correction_to_pairing_required_type_reconnects_before_controller_startup(
         self,

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -109,6 +109,7 @@ from custom_components.adjustable_bed.detection import (
     refine_malouf_protocol_from_gatt,
     refine_nordic_uart_protocol_from_device_info,
     refine_okin_shared_uuid_protocol_from_gatt,
+    refine_qrrm_protocol_from_device_info,
 )
 
 
@@ -1458,6 +1459,39 @@ class TestOkinUUIDDisambiguation:
                 "Unknown Nordic",
                 "Unknown",
                 "Unknown",
+            )
+            == BED_TYPE_RICHMAT
+        )
+
+    def test_qrrm_device_info_refinement_corrects_bt3000_to_bedtech(self) -> None:
+        """The issue #410 BT3000 model must use BedTech five-byte commands."""
+        assert (
+            refine_qrrm_protocol_from_device_info(
+                BED_TYPE_RICHMAT,
+                "QRRM157738",
+                "WLT825X_H35",
+            )
+            == BED_TYPE_BEDTECH
+        )
+
+    def test_qrrm_device_info_refinement_keeps_casper_hjc27_as_richmat(self) -> None:
+        """The issue #300 Casper model must retain Richmat RGB commands."""
+        assert (
+            refine_qrrm_protocol_from_device_info(
+                BED_TYPE_BEDTECH,
+                "QRRM105550",
+                "WLT825X_H35_S",
+            )
+            == BED_TYPE_RICHMAT
+        )
+
+    def test_qrrm_device_info_refinement_leaves_unknown_model_unchanged(self) -> None:
+        """Do not extrapolate a protocol for unverified QRRM model strings."""
+        assert (
+            refine_qrrm_protocol_from_device_info(
+                BED_TYPE_RICHMAT,
+                "QRRM999999",
+                "WLT999X_UNKNOWN",
             )
             == BED_TYPE_RICHMAT
         )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -540,7 +540,7 @@ class TestIntegrationSetup:
         coordinator = hass.data[DOMAIN][entry.entry_id]
         assert coordinator.controller.__class__.__name__ == "RichmatController"
 
-    async def test_setup_entry_reclassifies_legacy_bedtech_qrrm_entry(
+    async def test_setup_entry_keeps_bedtech_qrrm_when_advertisement_data_is_missing(
         self,
         hass: HomeAssistant,
         mock_coordinator_connected,
@@ -548,7 +548,7 @@ class TestIntegrationSetup:
         mock_async_ble_device_from_address: MagicMock,
         enable_custom_integrations,
     ):
-        """Legacy BedTech entries without the manufacturer field become Richmat."""
+        """A missing manufacturer field is inconclusive and must not downgrade BedTech."""
         entry = MockConfigEntry(
             domain=DOMAIN,
             title="Legacy BedTech QRRM",
@@ -588,11 +588,11 @@ class TestIntegrationSetup:
             await hass.async_block_till_done()
 
         assert entry.state == ConfigEntryState.LOADED
-        assert entry.data[CONF_BED_TYPE] == BED_TYPE_RICHMAT
-        assert entry.data[CONF_RICHMAT_REMOTE] == "qrrm"
+        assert entry.data[CONF_BED_TYPE] == BED_TYPE_BEDTECH
+        assert CONF_RICHMAT_REMOTE not in entry.data
         coordinator = hass.data[DOMAIN][entry.entry_id]
-        assert coordinator._bed_type == BED_TYPE_RICHMAT
-        assert coordinator.controller.__class__.__name__ == "RichmatController"
+        assert coordinator._bed_type == BED_TYPE_BEDTECH
+        assert coordinator.controller.__class__.__name__ == "BedTechController"
 
     async def test_setup_entry_keeps_bedtech_qrrm_entry_with_bedtech_manufacturer(
         self,


### PR DESCRIPTION
## Summary

- Recover the vendor model from WLT QRRM controllers that expose it through a duplicate Software Revision characteristic.
- Use the observed vendor models to distinguish BedTech BT3000 (`WLT825X_H35`) from Casper/Richmat HJC27 (`WLT825X_H35_S`).
- Correct persisted Richmat entries to BedTech during the first successful connection and remove stale Richmat-only configuration.
- Treat missing advertisement manufacturer data as inconclusive so ESPHome proxy snapshots cannot downgrade a BedTech entry.

## Root cause

The 3.1.1 support bundle still instantiated `RichmatController` because its latest ESPHome advertisement omitted manufacturer ID `0x4C57`. The same physical device had included that field in an earlier bundle, so absence was not a reliable Richmat signal.

BedTech BT3000 and Casper/Richmat HJC27 share the QRRM name family, FEE9 GATT layout, WLT manufacturer, and most Device Information values. Their connected vendor models provide the verified discriminator: BedTech reports `WLT825X_H35`, while the Casper controller reports `WLT825X_H35_S`.

## User impact

Affected users only need to update and restart or reload the integration. On the first successful connection, the stored protocol is corrected automatically before entity setup. The old Richmat light and timer entities are removed by the existing cleanup paths, and the BedTech light-toggle control is created.

## Validation

- Ruff checks passed for all changed Python files.
- Five focused BT3000, Casper, adapter, coordinator, and setup regression tests passed.
- The broader adapter, detection, coordinator, setup, BedTech, and entity suite passed with 470 tests before the clean worktree replay.
- The isolated worktree's fresh Home Assistant environment stalled during dependency imports before pytest collection; no test failure was reported.

Ref #410


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QRRM controller identification using vendor model information.
  * Correctly distinguishes BedTech and Richmat controllers, including BT3000 and Casper models.
  * Preserves BedTech classification when advertisement data is incomplete.
  * Recovers WLT controller model details when the standard model characteristic is unavailable.

* **Documentation**
  * Clarified BedTech model identification and QRRM handling guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->