### PR TITLE
Match Keeson motor timings to OEM apps

### DIFF
--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -999,6 +999,11 @@ class KeesonController(BedController):
         if configured != BED_MOTOR_PULSE_DEFAULTS[BED_TYPE_KEESON]:
             return configured
 
+        if self._betterliving_presets:
+            if self._coordinator.motor_count == 3:
+                return _THREE_MOTOR_BETTERLIVING_PULSES
+            return _APP_MOTOR_PULSE_DEFAULTS[KEESON_VARIANT_SINO]
+
         if self._variant in {KEESON_VARIANT_OKIN, KEESON_VARIANT_SINO}:
             if self._coordinator.motor_count == 3:
                 return _THREE_MOTOR_BETTERLIVING_PULSES

--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -25,6 +25,8 @@ from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.exc import BleakError
 
 from ..const import (
+    BED_MOTOR_PULSE_DEFAULTS,
+    BED_TYPE_KEESON,
     KEESON_BASE_NOTIFY_CHAR_UUID,
     KEESON_BASE_SERVICE_UUID,
     KEESON_BASE_WRITE_CHAR_UUID,
@@ -35,12 +37,15 @@ from ..const import (
     KEESON_KSBT_CHAR_UUID,
     KEESON_KSBT_FALLBACK_GATT_PAIRS,
     KEESON_KSBT_SERVICE_UUID,
+    KEESON_VARIANT_BASE,
     KEESON_VARIANT_ERGOMOTION,
     KEESON_VARIANT_JSON,
+    KEESON_VARIANT_KSBT,
     KEESON_VARIANT_KSBT04C,
     KEESON_VARIANT_KSBT_CR,
     KEESON_VARIANT_OKIN,
     KEESON_VARIANT_PURPLE,
+    KEESON_VARIANT_SERTA,
     KEESON_VARIANT_SINO,
 )
 from .base import BedController, MotorControlSpec
@@ -50,6 +55,25 @@ if TYPE_CHECKING:
     from ..coordinator import AdjustableBedCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+# OEM app hold cadences, normalized to an approximately one-second HA movement
+# command. JSON/A00A remains at the generic setting: Juna and Linx request writes
+# every 5/3 ms respectively, but their BLE service drops requests while a
+# write-with-response is outstanding, so there is no fixed on-air interval to copy.
+_APP_MOTOR_PULSE_DEFAULTS: dict[str, tuple[int, int]] = {
+    KEESON_VARIANT_BASE: (3, 400),
+    KEESON_VARIANT_JSON: (10, 100),
+    KEESON_VARIANT_KSBT: (4, 300),
+    KEESON_VARIANT_KSBT_CR: (4, 300),
+    KEESON_VARIANT_KSBT04C: (4, 300),
+    KEESON_VARIANT_ERGOMOTION: (10, 100),
+    KEESON_VARIANT_OKIN: (10, 100),
+    KEESON_VARIANT_SERTA: (10, 100),
+    KEESON_VARIANT_SINO: (10, 100),
+    KEESON_VARIANT_PURPLE: (10, 100),
+}
+
+_THREE_MOTOR_BETTERLIVING_PULSES = (5, 200)
 
 
 def is_ksbt03c_name(name: str | None) -> bool:
@@ -406,10 +430,10 @@ class KeesonController(BedController):
     def _single_shot_count(self) -> int:
         """Repeat count for single-shot commands (massage, presets, lights).
 
-        KSBT variants require sending twice per the Sleep Harmony app's singleSend().
-        The bed firmware uses the first send as wake/sync.
+        Sleep Harmony sends KSBT04C one-shot commands twice. Ergomotion Sync,
+        Adjustable Lite, and SomosBeds send their KSBT/KSBT03CR one-shots once.
         """
-        return 2 if self._is_ksbt else 1
+        return 2 if self._variant == KEESON_VARIANT_KSBT04C else 1
 
     # Capability properties
     @property
@@ -958,24 +982,48 @@ class KeesonController(BedController):
             command += KeesonCommands.MOTOR_LUMBAR_DOWN
         return command
 
+    def _motor_pulse_settings(self) -> tuple[int, int]:
+        """Return the effective movement cadence for this controller.
+
+        Keeson app families use different hold intervals even when their packet
+        payloads share the same 32-bit command values. Translate only the stored
+        generic Keeson default so an explicitly customized cadence remains
+        authoritative. BetterLiving chooses 100 ms for its two-motor screen and
+        200 ms for its three-motor screen; the other app families have a fixed
+        variant-level interval.
+        """
+        configured = (
+            self._coordinator.motor_pulse_count,
+            self._coordinator.motor_pulse_delay_ms,
+        )
+        if configured != BED_MOTOR_PULSE_DEFAULTS[BED_TYPE_KEESON]:
+            return configured
+
+        if self._variant in {KEESON_VARIANT_OKIN, KEESON_VARIANT_SINO}:
+            if self._coordinator.motor_count == 3:
+                return _THREE_MOTOR_BETTERLIVING_PULSES
+
+        return _APP_MOTOR_PULSE_DEFAULTS.get(self._variant, configured)
+
     async def _move_motor(self, motor: str, direction: bool | None) -> None:
         """Move a motor in a direction or stop it, always sending STOP at the end."""
         self._motor_state[motor] = direction
         command = self._get_move_command()
+        repeat_count, repeat_delay_ms = self._motor_pulse_settings()
 
         try:
             if command:
                 if self._is_json_variant:
                     await self._write_json_motion_command(
                         command,
-                        repeat_count=self._coordinator.motor_pulse_count,
-                        repeat_delay_ms=self._coordinator.motor_pulse_delay_ms,
+                        repeat_count=repeat_count,
+                        repeat_delay_ms=repeat_delay_ms,
                     )
                 else:
                     await self.write_command(
                         self._build_command(command),
-                        repeat_count=self._coordinator.motor_pulse_count,
-                        repeat_delay_ms=self._coordinator.motor_pulse_delay_ms,
+                        repeat_count=repeat_count,
+                        repeat_delay_ms=repeat_delay_ms,
                     )
         finally:
             # Always send stop with a fresh event so it's not affected by cancellation

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -212,6 +212,9 @@ For existing Keeson entries, the integration translates only the stored generic
 `10 x 100ms` values to the matching app profile. Any pulse count or delay that a
 user customized remains authoritative. Dedicated Ergomotion, Serta, and OKIN FFE
 bed types already store their own app-derived defaults and are left unchanged.
+BetterLiving devices use the BetterLiving cadence whenever that app profile is
+detected, even if a future factory path pairs the profile flag with a different
+base Keeson variant.
 
 Release behavior also varies. Ergomotion and Purple send an explicit zero frame;
 standard KSBT and Member's Mark merely cancel their repeat timer; Sleep Harmony

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -187,16 +187,37 @@ Position data includes:
 
 ## Command Timing
 
-From app disassembly analysis:
+Fresh decompilation of each relevant OEM app found that cadence belongs to the
+app/protocol family, not to the shared 32-bit command values:
 
-| App | Motor Command Interval | Source |
-|-----|------------------------|--------|
-| Ergomotion | 100ms | `handler.postDelayed(this, 100)` |
-| Ergomotion 4.0 | 100ms | Same as Ergomotion |
-| Tempur Zero G | 100ms | Same as Ergomotion |
-| Member's Mark | 400ms | `scheduleWithFixedDelay(..., 400L, TimeUnit.MILLISECONDS)` |
+| Integration variant | OEM app evidence | App hold behavior | Effective default burst |
+|---------------------|------------------|-------------------|-------------------------|
+| BaseI4/BaseI5 | Member's Mark | 400ms fixed-delay scheduler | 3 writes, 400ms apart |
+| JSON/A00A | Juna / Linx | Requests every 5ms / 3ms, but drops requests while a write-with-response is pending | Existing safe 10 writes, 100ms apart |
+| KSBT | Ergomotion Sync / Adjustable Lite | 300ms `Timer.schedule` | 4 writes, 300ms apart |
+| KSBT03CR | SomosBeds | 300ms `Timer.schedule` | 4 writes, 300ms apart |
+| KSBT04C | Sleep Harmony | 300ms handler loop | 4 writes, 300ms apart |
+| Ergomotion | Ergomotion / Ergomotion 4.0 / Tempur Zero G | 100ms handler loop | 10 writes, 100ms apart |
+| Serta | Serta MP Remote | 100ms handler loop | 10 writes, 100ms apart |
+| Sino / BetterLiving OKIN | BetterLiving | 100ms on the two-motor screen, 200ms on the three-motor screen | 10 x 100ms or 5 x 200ms |
+| Purple | Purple Smart Base | 100ms fixed-delay scheduler | 10 writes, 100ms apart |
 
-Motor commands are sent repeatedly while the button is held. A stop command (`0x00000000`) is sent on button release.
+The JSON apps do not provide a fixed on-air cadence: their 3/5ms scheduler only
+requests a write, and the BLE layer permits one outstanding acknowledged write.
+Copying 3/5ms as a BLE delay would therefore be misleading and could shorten an
+HA movement burst substantially. The integration retains its established safe
+JSON burst until an on-air capture provides a device-independent interval.
+
+For existing Keeson entries, the integration translates only the stored generic
+`10 x 100ms` values to the matching app profile. Any pulse count or delay that a
+user customized remains authoritative. Dedicated Ergomotion, Serta, and OKIN FFE
+bed types already store their own app-derived defaults and are left unchanged.
+
+Release behavior also varies. Ergomotion and Purple send an explicit zero frame;
+standard KSBT and Member's Mark merely cancel their repeat timer; Sleep Harmony
+sends two delayed zero frames. The integration intentionally sends an immediate
+zero frame after every movement for hardware safety. One-shot commands are sent
+once on KSBT and KSBT03CR, while Sleep Harmony's KSBT04C variant sends them twice.
 
 ## Split-Bed Support (Member's Mark)
 

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -1200,6 +1200,29 @@ class TestKsbt03cMotorLayout:
 
         assert controller._motor_pulse_settings() == expected
 
+    @pytest.mark.parametrize(
+        ("motor_count", "expected"),
+        [
+            (2, (10, 100)),
+            (3, (5, 200)),
+        ],
+    )
+    def test_betterliving_flag_uses_betterliving_motor_cadence(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        motor_count: int,
+        expected: tuple[int, int],
+    ):
+        """Test BetterLiving cadence follows the explicit preset flag."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        coordinator._motor_count = motor_count
+        controller = KeesonController(
+            coordinator, variant="base", betterliving_presets=True
+        )
+
+        assert controller._motor_pulse_settings() == expected
+
     async def test_custom_motor_cadence_is_preserved(
         self,
         hass: HomeAssistant,

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
@@ -1167,6 +1167,81 @@ class TestKsbt03cMotorLayout:
             "tilt",
             "lumbar",
         ]
+
+    @pytest.mark.parametrize(
+        ("variant", "motor_count", "expected"),
+        [
+            ("base", 2, (3, 400)),
+            ("json", 2, (10, 100)),
+            ("ksbt", 2, (4, 300)),
+            ("ksbt_cr", 2, (4, 300)),
+            ("ksbt04c", 2, (4, 300)),
+            ("ergomotion", 2, (10, 100)),
+            ("okin", 2, (10, 100)),
+            ("okin", 3, (5, 200)),
+            ("serta", 2, (10, 100)),
+            ("sino", 2, (10, 100)),
+            ("sino", 3, (5, 200)),
+            ("purple", 2, (10, 100)),
+        ],
+    )
+    def test_variant_uses_oem_motor_cadence_for_generic_defaults(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        variant: str,
+        motor_count: int,
+        expected: tuple[int, int],
+    ):
+        """Test generic Keeson defaults are translated to each OEM app cadence."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        coordinator._motor_count = motor_count
+        controller = KeesonController(coordinator, variant=variant)
+
+        assert controller._motor_pulse_settings() == expected
+
+    async def test_custom_motor_cadence_is_preserved(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test per-device pulse tuning overrides the OEM app default."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        coordinator._motor_pulse_count = 6
+        coordinator._motor_pulse_delay_ms = 250
+        controller = KeesonController(
+            coordinator, variant="ksbt", device_name="KSBT03C300039050"
+        )
+        controller.write_command = AsyncMock()
+
+        await controller.move_head_up()
+
+        first_call = controller.write_command.await_args_list[0]
+        assert first_call.kwargs["repeat_count"] == 6
+        assert first_call.kwargs["repeat_delay_ms"] == 250
+
+    @pytest.mark.parametrize(
+        ("variant", "expected"),
+        [
+            ("ksbt", 1),
+            ("ksbt_cr", 1),
+            ("ksbt04c", 2),
+        ],
+    )
+    def test_ksbt_single_shot_count_matches_oem_app(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        variant: str,
+        expected: int,
+    ):
+        """Test only Sleep Harmony's KSBT04C one-shots are duplicated."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        controller = KeesonController(coordinator, variant=variant)
+
+        assert controller._single_shot_count == expected
 
     async def test_stale_motor_entity_keys(
         self,


### PR DESCRIPTION
## Summary

- apply OEM app-derived motor cadence per Keeson protocol variant
- use 300 ms for KSBT, KSBT03CR, and KSBT04C, 400 ms for Member's Mark BaseI4/BaseI5, and 100/200 ms for BetterLiving based on motor count
- preserve user-customized pulse settings and the integration's guaranteed STOP behavior
- send single-shot commands once on KSBT and KSBT03CR, while retaining Sleep Harmony's double-send behavior on KSBT04C
- document the fresh app audit, including the ACK-gated JSON/A00A exception

## Root cause

All Keeson variants inherited the generic 10 x 100 ms movement profile even though the OEM apps schedule held motor commands differently. On KSBT03C hardware, the overly frequent frames repeatedly interrupted motor movement and caused visible stuttering. Fresh decompilation showed that timing follows the app/protocol family rather than the shared 32-bit command values.

## Validation

- `uv run pytest tests/test_keeson.py tests/test_ergomotion.py -q -n 0` (108 passed)
- `uv run ruff check custom_components/adjustable_bed/beds/keeson.py tests/test_keeson.py`
- `uv run pyright custom_components/adjustable_bed/beds/keeson.py tests/test_keeson.py` (0 errors)

Ref #408


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved motor movement timing across supported Keeson bed variants, including held-motion repeat cadence and updated one-shot command handling.
  * Preserved user/customized per-device pulse count and delay while applying the correct default behavior when needed.
  * Ensured better alignment of JSON vs non-JSON motion command cadence behavior for specific variants.

* **Documentation**
  * Rewrote command-timing guidance with a variant-specific cadence matrix, plus clearer release/stop behavior details.

* **Tests**
  * Added/expanded coverage for motor cadence defaults, BetterLiving selection, and KSBT one-shot/duplication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->