### PR TITLE
Fix BOX25 Star controls using OEM protocol

### DIFF
--- a/custom_components/adjustable_bed/beds/sleepys_box25.py
+++ b/custom_components/adjustable_bed/beds/sleepys_box25.py
@@ -3,26 +3,20 @@
 Reverse-engineered from the Sleepy's Elite app (com.okin.bedding.sleepy)
 for the DewertOkin BOX25 Star controller using Nordic UART Service.
 
-Protocol: BOX25 Star (NUS-based, multi-subsystem)
+Protocol: BOX25 Star (NUS-based StarCode)
 BLE Name: Star*
 Service: Nordic UART (6e400001-b5a3-f393-e0a9-e50e24dcca9e)
 Write:   TX characteristic (6e400002)
 Notify:  RX characteristic (6e400003)
 
-The BOX25 protocol uses a two-track initialization system:
-- Motor/preset commands require CMD_MOTOR_INIT (0x00 0xD0)
-- Massage/light commands require CMD_MASSAGE_LIGHT_INIT (0x00 0xB0)
-Both tracks require a wake command (0x5A 0x0B 0x00 0xA5) first.
-
 Command formats:
-- Motor:        05 02 [b2] [b3] [b4] [b5] [b6] (7 bytes)
-- Preset:       5A 01 03 10 30 [key] A5 (7 bytes)
-- Position:     03 F0 [zone] [pos 0-100] 00 (5 bytes)
-- Lighting:     04 E0 [sub] [val] 00 00 (6 bytes)
-- Vibration:    04 E0 06 [head 0-8] [foot 0-8] 00 (6 bytes)
-- Massage:      08 02 [hAdd] [hRed] [fAdd] [fRed] [allFlags] [mode] [timer] 00 (10 bytes)
+- Motor/preset/light/massage: 5A 01 03 10 [category] [key] A5 (7 bytes)
+- Position:                   5A F0 03 [zone] [position] 00 A5 (7 bytes)
+- Position query:             5A B0 00 A5 (4 bytes)
 
-Ported from ha-dewertokin-bed standalone integration.
+The OEM app sends commands every 100 ms while a button is held and writes to
+Nordic UART without response. A Star252201 controller is the BOX25_STAR variant,
+which must not be confused with the legacy BOX25 packet formats in the same app.
 """
 
 from __future__ import annotations
@@ -44,103 +38,68 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# Valid massage mode flags (byte 7 of massage command)
-_MASSAGE_MODES = (0x08, 0x10, 0x20)  # wave1, wave2, wave3
+
+def _star_command(key: int, category: int = 0x30) -> bytes:
+    """Build an OEM BOX25_STAR command frame."""
+    return bytes([0x5A, 0x01, 0x03, 0x10, category, key, 0xA5])
+
+
+_MASSAGE_MODES = (0x52, 0x53, 0x54)
 
 
 class Box25Commands:
     """BOX25 Star protocol command constants."""
 
-    # ─── Initialization ──────────────────────────────────────────────────
+    # The previously used 00 D0 / 00 B0 initializers and 05/08/04 command
+    # families belong to legacy BOX25. The Sleepy's app selects BOX25_STAR for
+    # Star252201 devices and uses StarCode for every control (issue #372).
     WAKE = bytes([0x5A, 0x0B, 0x00, 0xA5])
-    MOTOR_INIT = bytes([0x00, 0xD0])
-    MASSAGE_LIGHT_INIT = bytes([0x00, 0xB0])
+    QUERY_STATUS = bytes([0x5A, 0xB0, 0x00, 0xA5])
 
-    # ─── Motor / Preset (05 02 prefix, 7 bytes) ─────────────────────────
-    MOTOR_STOP = bytes([0x05, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00])
+    MOTOR_STOP = _star_command(0x0F)
+    HEAD_UP = _star_command(0x00)
+    HEAD_DOWN = _star_command(0x01)
+    FOOT_UP = _star_command(0x02)
+    FOOT_DOWN = _star_command(0x03)
+    LUMBAR_UP = _star_command(0x06)
+    LUMBAR_DOWN = _star_command(0x07)
+    NECK_TILT_UP = _star_command(0x0A)
+    NECK_TILT_DOWN = _star_command(0x0B)
 
-    # Directional motor control
-    HEAD_UP = bytes([0x05, 0x02, 0x00, 0x01, 0x00, 0x00, 0x00])
-    HEAD_DOWN = bytes([0x05, 0x02, 0x00, 0x02, 0x00, 0x00, 0x00])
-    FOOT_UP = bytes([0x05, 0x02, 0x00, 0x04, 0x00, 0x00, 0x00])
-    FOOT_DOWN = bytes([0x05, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00])
-    LUMBAR_UP = bytes([0x05, 0x02, 0x00, 0x10, 0x00, 0x00, 0x00])
-    LUMBAR_DOWN = bytes([0x05, 0x02, 0x00, 0x20, 0x00, 0x00, 0x00])
-    NECK_TILT_UP = bytes([0x05, 0x02, 0x00, 0x40, 0x00, 0x00, 0x00])
-    NECK_TILT_DOWN = bytes([0x05, 0x02, 0x00, 0x80, 0x00, 0x00, 0x00])
-
-    # Presets (preset key, repeated, then a trailing MOTOR_STOP to commit it)
-    PRESET_FLAT = bytes([0x05, 0x02, 0x08, 0x00, 0x00, 0x00, 0x00])
-    PRESET_ZERO_GRAVITY = bytes([0x05, 0x02, 0x00, 0x00, 0x10, 0x00, 0x00])
-    PRESET_ANTI_SNORE = bytes([0x05, 0x02, 0x00, 0x00, 0x80, 0x00, 0x00])
-    PRESET_LOUNGE = bytes([0x05, 0x02, 0x00, 0x00, 0x20, 0x00, 0x00])  # "Relax"
-
-    # Memory recall (4 slots)
-    MEMORY_RECALL_1 = bytes([0x05, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00])
-    MEMORY_RECALL_2 = bytes([0x05, 0x02, 0x00, 0x00, 0x00, 0x02, 0x00])
-    MEMORY_RECALL_3 = bytes([0x05, 0x02, 0x00, 0x00, 0x00, 0x04, 0x00])
-    MEMORY_RECALL_4 = bytes([0x05, 0x02, 0x00, 0x00, 0x00, 0x08, 0x00])
-
-    # Memory store (4 slots)
-    MEMORY_STORE_1 = bytes([0x05, 0x02, 0x00, 0x00, 0x01, 0x00, 0x00])
-    MEMORY_STORE_2 = bytes([0x05, 0x02, 0x00, 0x00, 0x02, 0x00, 0x00])
-    MEMORY_STORE_3 = bytes([0x05, 0x02, 0x00, 0x00, 0x04, 0x00, 0x00])
-    MEMORY_STORE_4 = bytes([0x05, 0x02, 0x00, 0x00, 0x08, 0x00, 0x00])
-
-    MEMORY_RECALL: tuple[bytes, bytes, bytes, bytes] = (
-        MEMORY_RECALL_1,
-        MEMORY_RECALL_2,
-        MEMORY_RECALL_3,
-        MEMORY_RECALL_4,
-    )
-    MEMORY_STORE: tuple[bytes, bytes, bytes, bytes] = (
-        MEMORY_STORE_1,
-        MEMORY_STORE_2,
-        MEMORY_STORE_3,
-        MEMORY_STORE_4,
-    )
-
-    # ─── StarCode presets (5A 01 03 10 30 KK A5, 7 bytes) ────────────────
-    # Star* devices (the "is StarCode" device flag is set) drive presets with
-    # StarCode framing, NOT the CB25 "05 02 …" framing above. Verified against
-    # com.starcode.adjustablem1x12 — the app for these beds (Star252201… /
-    # Ashley/Nectar M1X1232): flat()/callMemory() enqueue the preset key ×3 then
-    # the StarCode terminator 0x0F (NOT the 0x1F motor-interrupt) to commit.
-    # The bed accepts CB25 framing for motors/lights/massage (kept above), but the
-    # CB25 preset bytes never committed on real hardware (#372); these do.
-    # key = 0x03103000 | idx  →  big-endian bytes 03 10 30 <idx>.
-    STAR_PRESET_FLAT = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x10, 0xA5])
-    STAR_PRESET_ZERO_GRAVITY = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x13, 0xA5])
-    STAR_PRESET_ANTI_SNORE = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x16, 0xA5])
-    STAR_PRESET_LOUNGE = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x17, 0xA5])  # app "reading"
-    STAR_PRESET_MEMORY_1 = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x1A, 0xA5])
-    STAR_PRESET_MEMORY_2 = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x1B, 0xA5])
+    STAR_PRESET_FLAT = _star_command(0x10)
+    STAR_PRESET_ZERO_GRAVITY = _star_command(0x13)
+    STAR_PRESET_ANTI_SNORE = _star_command(0x16)
+    STAR_PRESET_LOUNGE = _star_command(0x17)  # app "reading"
+    STAR_PRESET_MEMORY_1 = _star_command(0x1A)
+    STAR_PRESET_MEMORY_2 = _star_command(0x1B)
     STAR_MEMORY_PRESETS = (STAR_PRESET_MEMORY_1, STAR_PRESET_MEMORY_2)
-    STAR_PRESET_TERMINATOR = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x0F, 0xA5])
+    STAR_PRESET_TERMINATOR = MOTOR_STOP
 
     # Saving a position is a long-press operation in the M1X12 app. It repeats
     # the selected key 110 times at the sender's 100 ms interval, without a
     # trailing terminator.
-    STAR_STORE_MEMORY_1 = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x94, 0xA5])
-    STAR_STORE_MEMORY_2 = bytes([0x5A, 0x01, 0x03, 0x10, 0x30, 0x95, 0xA5])
+    STAR_STORE_MEMORY_1 = _star_command(0x94)
+    STAR_STORE_MEMORY_2 = _star_command(0x95)
     STAR_MEMORY_STORE = (STAR_STORE_MEMORY_1, STAR_STORE_MEMORY_2)
 
-    # ─── Lighting (04 E0 prefix, 6 bytes) ────────────────────────────────
-    LIGHT_OFF = bytes([0x04, 0xE0, 0x01, 0x00, 0x00, 0x00])
-    LIGHT_ON_WHITE = bytes([0x04, 0xE0, 0x01, 0x01, 0x00, 0x00])
-
-    # ─── Massage exit ────────────────────────────────────────────────────
-    MASSAGE_EXIT = bytes([0x05, 0x02, 0x02, 0x00, 0x00, 0x00, 0x00])
-
-    # ─── Massage mode commands (08 02 prefix, 10 bytes) ──────────────────
-    MASSAGE_WAVE1 = bytes([0x08, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00])
-    MASSAGE_WAVE2 = bytes([0x08, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00])
-    MASSAGE_WAVE3 = bytes([0x08, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00])
+    LIGHT_ON_WHITE = _star_command(0x73)
+    LIGHT_OFF = _star_command(0x74)
+    LIGHT_TOGGLE = _star_command(0x71)
+    MASSAGE_EXIT = _star_command(0x6F)
+    MASSAGE_WAVE1 = _star_command(0x52)
+    MASSAGE_WAVE2 = _star_command(0x53)
+    MASSAGE_WAVE3 = _star_command(0x54)
+    MASSAGE_INTENSITY_UP = _star_command(0x60, category=0x40)
+    MASSAGE_INTENSITY_DOWN = _star_command(0x61, category=0x40)
+    MASSAGE_HEAD_UP = _star_command(0x60)
+    MASSAGE_HEAD_DOWN = _star_command(0x61)
+    MASSAGE_FOOT_UP = _star_command(0x62)
+    MASSAGE_FOOT_DOWN = _star_command(0x63)
+    MASSAGE_MODES = (MASSAGE_WAVE1, MASSAGE_WAVE2, MASSAGE_WAVE3)
 
 
 # Timing constants (seconds)
 _WAKE_DELAY = 0.15
-_INIT_DELAY = 0.08
 
 # Preset send tuning, mirroring the decompiled "Adjustable Comfort M1X12" app
 # (StarCode/DewertOkin CB25 protocol). The app enqueues every preset as four
@@ -157,9 +116,8 @@ _MEMORY_STORE_REPEAT_COUNT = 110
 class SleepysBox25Controller(BedController):
     """Controller for Sleepy's Elite BOX25 Star beds.
 
-    Uses Nordic UART Service with a two-track initialization system:
-    motor commands require 0xD0 init, massage/light commands require 0xB0 init.
-    Both tracks need a wake command (5A 0B 00 A5) sent first.
+    Uses the OEM app's BOX25_STAR command family over Nordic UART. All controls
+    share the same StarCode framing and use write-without-response.
 
     Presets are armed by repeating the StarCode key, then committed by a trailing
     StarCode 0x0F frame — see _send_preset (#372).
@@ -173,8 +131,7 @@ class SleepysBox25Controller(BedController):
     def __init__(self, coordinator: AdjustableBedCoordinator) -> None:
         """Initialize the BOX25 Star controller."""
         super().__init__(coordinator)
-        self._motor_initialized = False
-        self._massage_initialized = False
+        self._initialized = False
         self._head_position: float | None = None
         self._foot_position: float | None = None
         self._lumbar_position: float | None = None
@@ -307,95 +264,39 @@ class SleepysBox25Controller(BedController):
         effective_cancel = self._effective_cancel_event(cancel_event)
         return effective_cancel.is_set() if effective_cancel is not None else False
 
-    async def _ensure_wake(self, cancel_event: asyncio.Event | None = None) -> None:
-        """Send wake command to ensure the controller is responsive."""
-        if self._is_cancelled(cancel_event):
+    async def _ensure_initialized(self, cancel_event: asyncio.Event | None = None) -> None:
+        """Send the proven Star wake frame once per connection."""
+        if self._initialized or self._is_cancelled(cancel_event):
             return
+
         await self._write_gatt_with_retry(
             self.control_characteristic_uuid,
             Box25Commands.WAKE,
             cancel_event=cancel_event,
+            response=False,
         )
         if self._is_cancelled(cancel_event):
             return
         await asyncio.sleep(_WAKE_DELAY)
-
-    async def _ensure_motor_init(self, cancel_event: asyncio.Event | None = None) -> None:
-        """Ensure motor subsystem is initialized."""
-        if self._motor_initialized or self._is_cancelled(cancel_event):
-            return
-
-        await self._ensure_wake(cancel_event)
         if self._is_cancelled(cancel_event):
             return
-        await self._write_gatt_with_retry(
-            self.control_characteristic_uuid,
-            Box25Commands.MOTOR_INIT,
-            cancel_event=cancel_event,
-        )
-        if self._is_cancelled(cancel_event):
-            return
-        await asyncio.sleep(_INIT_DELAY)
-        if self._is_cancelled(cancel_event):
-            return
-        self._motor_initialized = True
-
-    async def _ensure_massage_light_init(
-        self,
-        cancel_event: asyncio.Event | None = None,
-    ) -> None:
-        """Ensure massage/light subsystem is initialized."""
-        if self._massage_initialized or self._is_cancelled(cancel_event):
-            return
-
-        await self._ensure_wake(cancel_event)
-        if self._is_cancelled(cancel_event):
-            return
-        await self._write_gatt_with_retry(
-            self.control_characteristic_uuid,
-            Box25Commands.MASSAGE_LIGHT_INIT,
-            cancel_event=cancel_event,
-        )
-        if self._is_cancelled(cancel_event):
-            return
-        await asyncio.sleep(_INIT_DELAY)
-        if self._is_cancelled(cancel_event):
-            return
-        self._massage_initialized = True
+        self._initialized = True
 
     async def _write_motor_command(
         self,
         command: bytes,
         cancel_event: asyncio.Event | None = None,
     ) -> None:
-        """Write a motor or preset command with motor init."""
-        if self._is_cancelled(cancel_event):
-            return
-        await self._ensure_motor_init(cancel_event)
-        if self._is_cancelled(cancel_event):
-            return
-        await self._write_gatt_with_retry(
-            self.control_characteristic_uuid,
-            command,
-            cancel_event=cancel_event,
-        )
+        """Write a BOX25_STAR motor or position command."""
+        await self.write_command(command, cancel_event=cancel_event)
 
     async def _write_massage_light_command(
         self,
         command: bytes,
         cancel_event: asyncio.Event | None = None,
     ) -> None:
-        """Write a massage or light command with subsystem init."""
-        if self._is_cancelled(cancel_event):
-            return
-        await self._ensure_massage_light_init(cancel_event)
-        if self._is_cancelled(cancel_event):
-            return
-        await self._write_gatt_with_retry(
-            self.control_characteristic_uuid,
-            command,
-            cancel_event=cancel_event,
-        )
+        """Write a BOX25_STAR massage or light command."""
+        await self.write_command(command, cancel_event=cancel_event)
 
     async def write_command(
         self,
@@ -404,10 +305,10 @@ class SleepysBox25Controller(BedController):
         repeat_delay_ms: int = 100,
         cancel_event: asyncio.Event | None = None,
     ) -> None:
-        """Write a motor command with init sequence."""
+        """Write a BOX25_STAR command using the OEM app's BLE write mode."""
         if self._is_cancelled(cancel_event):
             return
-        await self._ensure_motor_init(cancel_event)
+        await self._ensure_initialized(cancel_event)
         if self._is_cancelled(cancel_event):
             return
         await self._write_gatt_with_retry(
@@ -416,6 +317,7 @@ class SleepysBox25Controller(BedController):
             repeat_count=repeat_count,
             repeat_delay_ms=repeat_delay_ms,
             cancel_event=cancel_event,
+            response=False,
         )
 
     # ─── Notification Handling ───────────────────────────────────────────
@@ -430,7 +332,20 @@ class SleepysBox25Controller(BedController):
 
         length = len(raw)
 
-        if length >= 7 and raw[0] == 0x05:
+        if length >= 9 and raw[0:2] == bytes([0xA5, 0x0D]):
+            # BOX25_STAR status frame. The Sleepy's app reads the 0-100 motor
+            # positions from bytes 4, 6, and 8 respectively.
+            for key, attr, position in (
+                ("head", "_head_position", raw[4]),
+                ("feet", "_foot_position", raw[6]),
+                ("lumbar", "_lumbar_position", raw[8]),
+            ):
+                if 0 <= position <= 100:
+                    value = float(position)
+                    setattr(self, attr, value)
+                    if self._notify_callback:
+                        self._notify_callback(key, value)
+        elif length >= 7 and raw[0] == 0x05:
             self._is_moving = any(b != 0 for b in raw[2:7])
         elif length >= 4 and raw[0] == 0x03:
             zone = raw[1]
@@ -482,7 +397,8 @@ class SleepysBox25Controller(BedController):
                 pass
 
     async def read_positions(self, motor_count: int = 2) -> None:  # noqa: ARG002
-        """Positions are pushed via notifications, no polling needed."""
+        """Request the BOX25_STAR status frame used for motor positions."""
+        await self.write_command(Box25Commands.QUERY_STATUS)
 
     # ─── Direct Position Control ─────────────────────────────────────────
 
@@ -500,7 +416,7 @@ class SleepysBox25Controller(BedController):
             raise ValueError(f"Unknown motor: {motor}")
 
         pos = max(0, min(100, int(position)))
-        cmd = bytes([0x03, 0xF0, zone, pos, 0x00])
+        cmd = bytes([0x5A, 0xF0, 0x03, zone, pos, 0x00, 0xA5])
         await self._write_motor_command(cmd)
 
     def angle_to_native_position(self, motor: str, angle: float) -> int:  # noqa: ARG002
@@ -666,7 +582,7 @@ class SleepysBox25Controller(BedController):
         await self._write_massage_light_command(Box25Commands.LIGHT_OFF)
 
     async def lights_toggle(self) -> None:
-        await self.lights_on()
+        await self._write_massage_light_command(Box25Commands.LIGHT_TOGGLE)
 
     # ─── Massage ─────────────────────────────────────────────────────────
 
@@ -686,33 +602,27 @@ class SleepysBox25Controller(BedController):
 
     async def massage_intensity_up(self) -> None:
         """Increase massage intensity (both zones)."""
-        cmd = bytes([0x08, 0x02, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00])
-        await self._write_massage_light_command(cmd)
+        await self._write_massage_light_command(Box25Commands.MASSAGE_INTENSITY_UP)
 
     async def massage_intensity_down(self) -> None:
         """Decrease massage intensity (both zones)."""
-        cmd = bytes([0x08, 0x02, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00])
-        await self._write_massage_light_command(cmd)
+        await self._write_massage_light_command(Box25Commands.MASSAGE_INTENSITY_DOWN)
 
     async def massage_head_up(self) -> None:
-        cmd = bytes([0x08, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
-        await self._write_massage_light_command(cmd)
+        await self._write_massage_light_command(Box25Commands.MASSAGE_HEAD_UP)
 
     async def massage_head_down(self) -> None:
-        cmd = bytes([0x08, 0x02, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
-        await self._write_massage_light_command(cmd)
+        await self._write_massage_light_command(Box25Commands.MASSAGE_HEAD_DOWN)
 
     async def massage_foot_up(self) -> None:
-        cmd = bytes([0x08, 0x02, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00])
-        await self._write_massage_light_command(cmd)
+        await self._write_massage_light_command(Box25Commands.MASSAGE_FOOT_UP)
 
     async def massage_foot_down(self) -> None:
-        cmd = bytes([0x08, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00])
-        await self._write_massage_light_command(cmd)
+        await self._write_massage_light_command(Box25Commands.MASSAGE_FOOT_DOWN)
 
     async def massage_mode_step(self) -> None:
         """Cycle through massage wave modes (wave1 -> wave2 -> wave3 -> wave1)."""
         self._massage_mode_index = (self._massage_mode_index + 1) % len(_MASSAGE_MODES)
-        mode_flag = _MASSAGE_MODES[self._massage_mode_index]
-        cmd = bytes([0x08, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, mode_flag, 0x00, 0x00])
-        await self._write_massage_light_command(cmd)
+        await self._write_massage_light_command(
+            Box25Commands.MASSAGE_MODES[self._massage_mode_index]
+        )

--- a/docs/beds/sleepys.md
+++ b/docs/beds/sleepys.md
@@ -24,7 +24,7 @@ The Sleepy's Elite app supports multiple control box types. This integration imp
 |---------|-------------|----------|--------|------|--------|---------|-----------|--------------|
 | BOX15 | 9 bytes | Yes | ✅ | ❌ | ❌ | ❌ | ❌ | FFE5 |
 | BOX24 | 7 bytes | No | ❌ | ❌ | ❌ | ❌ | ❌ | 62741523 (OKIN 64-bit) |
-| BOX25 Star | 5-10 bytes | No | ✅ | ✅ | ✅ | ✅ | ✅ | 6e400001 (Nordic UART) |
+| BOX25 Star | 4/7/20 bytes | No | ✅ | ✅ | ✅ | ✅ | ✅ | 6e400001 (Nordic UART) |
 
 **Protocol Selection:**
 
@@ -141,7 +141,7 @@ E6 FE 2C 02 00 00 00 00 [checksum]
 A5 5A 00 00 00 40 02
 ```
 
-### BOX25 Star Protocol (multi-subsystem, Nordic UART)
+### BOX25 Star Protocol (StarCode, Nordic UART)
 
 **Service UUID:** `6E400001-B5A3-F393-E0A9-E50E24DCCA9E` (Nordic UART)
 
@@ -155,34 +155,32 @@ A5 5A 00 00 00 40 02
 
 **Integration direct-position surface:** `head` and `feet` sliders/services. The protocol also reports lumbar position and accepts direct lumbar position commands, but neck tilt does not currently have a protocol-backed position zone.
 
-The BOX25 Star uses a multi-subsystem protocol with a two-track initialization:
-
-1. **Wake:** Send `5A 0B 00 A5`, wait 150ms
-2. **Motor init:** Send `00 D0`, wait 80ms (required before motor/preset commands)
-3. **Massage/Light init:** Send `00 B0`, wait 80ms (required before massage/light commands)
-
-#### Motor Commands (7 bytes, `05 02` prefix)
+The Sleepy's app classifies `Star252201...` devices as `BOX25_STAR`. This is
+important because the app also contains a different legacy `BOX25` protocol.
+`BOX25_STAR` uses StarCode for every motor, preset, light, and massage action:
 
 ```text
-[0-1]  Header: 05 02
-[2]    Flags
-[3]    Motor bitmask (directional)
-[4-5]  Reserved for motor commands
-[6]    Reserved: 0x00
+5A 01 03 10 [category] [command] A5
 ```
 
-**Motor Bitmask (byte 3):**
+Commands are written to Nordic UART without response. The integration sends the
+proven `5A 0B 00 A5` wake frame once before the first command. The legacy
+`00 D0` / `00 B0` subsystem initializers and `05 02`, `08 02`, and `04 E0`
+command families do not apply to `BOX25_STAR`.
 
-| Bit | Motor | Direction |
-|-----|-------|-----------|
-| 0x01 | Head | Up |
-| 0x02 | Head | Down |
-| 0x04 | Foot | Up |
-| 0x08 | Foot | Down |
-| 0x10 | Lumbar | Up |
-| 0x20 | Lumbar | Down |
-| 0x40 | Neck Tilt | Up |
-| 0x80 | Neck Tilt | Down |
+#### Motor Commands (category `0x30`)
+
+| Command | Action |
+|---------|--------|
+| `0x00` | Head up |
+| `0x01` | Head down |
+| `0x02` | Foot up |
+| `0x03` | Foot down |
+| `0x06` | Lumbar up |
+| `0x07` | Lumbar down |
+| `0x0A` | Neck tilt up |
+| `0x0B` | Neck tilt down |
+| `0x0F` | Stop |
 
 #### Preset and Memory Recall Commands (StarCode, 7 bytes)
 
@@ -209,63 +207,43 @@ Saving Memory 1/2 uses command `0x94`/`0x95`, respectively. The app models this
 as a long press: it repeats the save frame 110 times at 100 ms intervals and
 does not append the preset commit frame.
 
-#### Position Commands (5 bytes, `03 F0` prefix)
+#### Position Commands
 
 ```text
-[0-1]  Header: 03 F0
-[2]    Zone (0x00=head, 0x01=foot, 0x02=lumbar, 0x07=sync)
-[3]    Position (0-100)
-[4]    Reserved: 0x00
+5A F0 03 [zone] [position 0-100] 00 A5
 ```
 
-#### Lighting Commands (6 bytes, `04 E0` prefix)
+Zones are `0x00` for head, `0x01` for foot, and `0x02` for lumbar. The status
+query is `5A B0 00 A5`.
 
-```text
-Color:      04 E0 01 [color 0-7] 00 00
-Brightness: 04 E0 00 [level 1-6] 00 00
-```
+#### Lighting Commands (category `0x30`)
 
-| Color | Value |
-|-------|-------|
-| Off | 0x00 |
-| White | 0x01 |
-| Red | 0x02 |
-| Orange | 0x03 |
-| Yellow | 0x04 |
-| Green | 0x05 |
-| Blue | 0x06 |
-| Purple | 0x07 |
+| Command | Action |
+|---------|--------|
+| `0x71` | Toggle under-bed light |
+| `0x73` | Turn under-bed light on |
+| `0x74` | Turn under-bed light off |
 
-#### Vibration Commands (6 bytes, `04 E0 06` prefix)
+#### Massage Commands
 
-```text
-04 E0 06 [head 0-8] [foot 0-8] 00
-```
-
-#### Massage Commands (10 bytes, `08 02` prefix)
-
-```text
-[0-1]  Header: 08 02
-[2]    Head intensity add (0x01 = step up)
-[3]    Head intensity reduce (0x01 = step down)
-[4]    Foot intensity add
-[5]    Foot intensity reduce
-[6]    All flags (0x01 = all add, 0x02 = all reduce)
-[7]    Mode (0x08 = wave1, 0x10 = wave2, 0x20 = wave3)
-[8]    Timer
-[9]    Reserved: 0x00
-```
+| Category | Command | Action |
+|----------|---------|--------|
+| `0x30` | `0x52` / `0x53` / `0x54` | Massage modes 1-3 |
+| `0x30` | `0x6F` | Massage off |
+| `0x30` | `0x60` / `0x61` | Head strength up/down |
+| `0x30` | `0x62` / `0x63` | Foot strength up/down |
+| `0x40` | `0x60` / `0x61` | Overall strength up/down |
 
 #### Notification Parsing
 
-The bed pushes status via Nordic UART RX notifications:
+The `BOX25_STAR` bed pushes a 20-byte status packet via Nordic UART RX:
 
-| Prefix | Length | Content |
-|--------|--------|---------|
-| `05` | 7+ bytes | Motor/movement status (bytes 2-6 non-zero = moving) |
-| `03` | 4+ bytes | Position report: byte 1 = zone, byte 2 = position (0-100) |
-| `04` | 6+ bytes | Light/vibration status |
-| `08` | 10 bytes | Massage status (byte 7 = active mode, 0 = off) |
+```text
+A5 0D ... [head at byte 4] ... [foot at byte 6] ... [lumbar at byte 8] ...
+```
+
+Each motor position is clamped to the app's 0-100 range. Issue #372's captured
+notification `A5 0D 11 01 16 00 00 ...` therefore reports head position 22.
 
 ## Checksum Calculation (BOX15 only)
 
@@ -282,8 +260,8 @@ From app disassembly:
 - **Repeat Interval:** Continuous while button held
 - **Pattern:** Send command repeatedly with ~100ms delay
 - **Stop Required:** Yes, explicit stop after motor release
-- **BOX25 wake delay:** 150ms after wake command
-- **BOX25 init delay:** 80ms after subsystem init
+- **BOX25 Star write mode:** write without response
+- **BOX25 Star wake delay:** 150ms after the one-time wake command
 
 ## Detection
 

--- a/tests/test_sleepys.py
+++ b/tests/test_sleepys.py
@@ -1194,13 +1194,13 @@ class TestSleepysBox25Controller:
         assert controller.motor_control_specs[3].translation_key == "head_end_tilt"
         assert controller.stale_motor_entity_keys == {"back", "legs"}
 
-    async def test_lumbar_notifications_propagate(
+    async def test_star_status_notifications_propagate_motor_positions(
         self,
         hass: HomeAssistant,
         mock_sleepys_box25_config_entry,
         mock_coordinator_connected,
     ):
-        """Lumbar position notifications should reach coordinator callbacks."""
+        """BOX25_STAR A5 0D status bytes should update head, feet, and lumbar."""
         coordinator = AdjustableBedCoordinator(hass, mock_sleepys_box25_config_entry)
         await coordinator.async_connect()
         controller = coordinator.controller
@@ -1210,9 +1210,12 @@ class TestSleepysBox25Controller:
 
         characteristic = MagicMock()
         characteristic.uuid = "test-char"
-        controller._on_notification(characteristic, bytearray([0x03, 0x02, 55, 0x00]))
+        controller._on_notification(
+            characteristic,
+            bytearray.fromhex("A5 0D 11 01 16 00 21 00 37 00 00 00 70 01 01 00 00 00 00 00"),
+        )
 
-        assert updates == [("lumbar", 55.0)]
+        assert updates == [("head", 22.0), ("feet", 33.0), ("lumbar", 55.0)]
 
     async def test_cancelled_write_command_does_not_mark_init_complete(
         self,
@@ -1234,8 +1237,99 @@ class TestSleepysBox25Controller:
         ):
             await controller.write_command(Box25Commands.HEAD_UP, cancel_event=cancel_event)
 
-        assert controller._motor_initialized is False
+        assert controller._initialized is False
         mock_client.write_gatt_char.assert_not_called()
+
+    async def test_all_controls_use_oem_box25_star_frames(
+        self,
+        hass: HomeAssistant,
+        mock_sleepys_box25_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Motors, lights, and massage must use BOX25_STAR, not legacy BOX25."""
+        coordinator = AdjustableBedCoordinator(hass, mock_sleepys_box25_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        commands = (
+            (controller.move_head_up, "5A0103103000A5"),
+            (controller.move_head_down, "5A0103103001A5"),
+            (controller.move_feet_up, "5A0103103002A5"),
+            (controller.move_feet_down, "5A0103103003A5"),
+            (controller.move_lumbar_up, "5A0103103006A5"),
+            (controller.move_lumbar_down, "5A0103103007A5"),
+            (controller.move_tilt_up, "5A010310300AA5"),
+            (controller.move_tilt_down, "5A010310300BA5"),
+            (controller.lights_on, "5A0103103073A5"),
+            (controller.lights_off, "5A0103103074A5"),
+            (controller.lights_toggle, "5A0103103071A5"),
+            (controller.massage_off, "5A010310306FA5"),
+            (controller.massage_intensity_up, "5A0103104060A5"),
+            (controller.massage_intensity_down, "5A0103104061A5"),
+            (controller.massage_head_up, "5A0103103060A5"),
+            (controller.massage_head_down, "5A0103103061A5"),
+            (controller.massage_foot_up, "5A0103103062A5"),
+            (controller.massage_foot_down, "5A0103103063A5"),
+        )
+        for method, expected_hex in commands:
+            with (
+                patch.object(controller, "write_command", AsyncMock()) as mock_write,
+                patch.object(controller, "_move_with_stop", AsyncMock()) as mock_move,
+            ):
+                await method()
+
+            expected = bytes.fromhex(expected_hex)
+            if mock_move.await_count:
+                mock_move.assert_awaited_once_with(expected)
+            else:
+                mock_write.assert_awaited_once_with(expected, cancel_event=None)
+
+    async def test_star_wake_and_commands_use_write_without_response(
+        self,
+        hass: HomeAssistant,
+        mock_sleepys_box25_config_entry,
+        mock_coordinator_connected,
+    ):
+        """The Sleepy's app writes BOX25_STAR packets without response."""
+        coordinator = AdjustableBedCoordinator(hass, mock_sleepys_box25_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        with (
+            patch.object(controller, "_write_gatt_with_retry", AsyncMock()) as mock_write,
+            patch("custom_components.adjustable_bed.beds.sleepys_box25.asyncio.sleep", AsyncMock()),
+        ):
+            await controller.write_command(Box25Commands.HEAD_UP)
+
+        assert mock_write.await_count == 2
+        assert mock_write.call_args_list[0].args[1] == Box25Commands.WAKE
+        assert mock_write.call_args_list[0].kwargs["response"] is False
+        assert mock_write.call_args_list[1].args[1] == Box25Commands.HEAD_UP
+        assert mock_write.call_args_list[1].kwargs["response"] is False
+
+    async def test_massage_toggle_and_mode_cycle_use_star_frames(
+        self,
+        hass: HomeAssistant,
+        mock_sleepys_box25_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Massage state changes should retain the OEM BOX25_STAR framing."""
+        coordinator = AdjustableBedCoordinator(hass, mock_sleepys_box25_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        with patch.object(controller, "write_command", AsyncMock()) as mock_write:
+            await controller.massage_toggle()
+            await controller.massage_mode_step()
+            await controller.massage_mode_step()
+            await controller.massage_toggle()
+
+        assert [call.args[0] for call in mock_write.await_args_list] == [
+            Box25Commands.MASSAGE_WAVE1,
+            Box25Commands.MASSAGE_WAVE2,
+            Box25Commands.MASSAGE_WAVE3,
+            Box25Commands.MASSAGE_EXIT,
+        ]
 
     async def test_preset_arms_then_commits_with_starcode_terminator(
         self,
@@ -1366,4 +1460,20 @@ class TestSleepysBox25Controller:
         with patch.object(controller, "_write_motor_command", AsyncMock()) as mock_write:
             await controller.set_motor_position("lumbar", 57)
 
-        mock_write.assert_awaited_once_with(bytes([0x03, 0xF0, 0x02, 57, 0x00]))
+        mock_write.assert_awaited_once_with(bytes([0x5A, 0xF0, 0x03, 0x02, 57, 0x00, 0xA5]))
+
+    async def test_read_positions_sends_star_status_query(
+        self,
+        hass: HomeAssistant,
+        mock_sleepys_box25_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Position refresh should request the A5 0D status notification."""
+        coordinator = AdjustableBedCoordinator(hass, mock_sleepys_box25_config_entry)
+        await coordinator.async_connect()
+        controller = coordinator.controller
+
+        with patch.object(controller, "write_command", AsyncMock()) as mock_write:
+            await controller.read_positions()
+
+        mock_write.assert_awaited_once_with(Box25Commands.QUERY_STATUS)


### PR DESCRIPTION
## Summary

- replace legacy BOX25 motor, light, and massage packets with the OEM app's BOX25_STAR StarCode frames
- use the app's write-without-response behavior, status query, direct-position frame, and `A5 0D` position parsing
- document the corrected protocol and add regression coverage for every affected control family

## Root cause

The reporter's `Star252201` controller is classified as `BOX25_STAR` by the Sleepy's APK. Earlier releases accidentally routed it through `OkinCB35`, which happened to send StarCode for ordinary controls but did not implement the correct preset sequence.

Version 3.1.1 corrected the controller routing and converted presets to StarCode, but the dedicated Sleepy's controller still sent legacy BOX25 `05 02`, `08 02`, and `04 E0` packets for movement, massage, and lighting. This produced the exact issue #372 regression: presets began working while all previously working controls stopped responding.

The corrected command keys, categories, continuous-command timing, BLE write mode, direct-position format, status query, and notification offsets were derived from `com.okin.bedding.sleepy` and cross-checked against the reporter's 3.1.1 support bundle.

## User impact

This restores head, foot, lumbar, neck tilt, under-bed lighting, and massage controls for Sleepy's BOX25 Star beds while retaining the preset and memory fix from 3.1.1.

## Validation

- `uvx ruff format --check custom_components/adjustable_bed/beds/sleepys_box25.py tests/test_sleepys.py`
- `uvx ruff check custom_components/adjustable_bed/beds/sleepys_box25.py tests/test_sleepys.py`
- clean worktree from this commit: `2201 passed`

Fixes #372
