### PR TITLE
Improve support bundle Bluetooth diagnostics

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -1212,11 +1212,18 @@ async def _async_register_services(hass: HomeAssistant) -> None:
 
             download_url = register_download(hass, filepath)
             notification_count = len(report.get("notifications", []))
+            evidence_warnings = report.get("evidence", {}).get("warnings", [])
+            warning_summary = ""
+            if evidence_warnings:
+                warning_summary = "\n\n**Capture warnings:**\n" + "\n".join(
+                    f"- {warning}" for warning in evidence_warnings
+                )
             async_create(
                 hass,
                 f"[**Download support bundle**]({download_url})\n\n"
                 f"Captured {notification_count} notifications over "
-                f"{capture_duration} seconds.\n\n"
+                f"{capture_duration} seconds."
+                f"{warning_summary}\n\n"
                 "Attach this JSON file when reporting unsupported or broken beds.\n\n"
                 f"File path: `{filepath}`",
                 title="Adjustable Bed Support Bundle Ready",

--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -200,6 +200,7 @@ class BLEDiagnosticRunner:
         self._actual_source: str | None = None
         self._selected_ble_device: BLEDevice | None = None
         self._using_non_connectable_fallback: bool = False
+        self._connection_path: str = "standalone"
         self._background_tasks: set[asyncio.Task[None]] = set()
         self._reconnect_count: int = 0
 
@@ -308,6 +309,7 @@ class BLEDiagnosticRunner:
         """Connect to the BLE device."""
         if self.coordinator and self.coordinator.client and self.coordinator.is_connected:
             _LOGGER.info("Using existing connection from coordinator")
+            self._connection_path = "existing_coordinator"
             self._client = self.coordinator.client
             self._using_coordinator_connection = True
             self._selected_source = self.coordinator.connection_source
@@ -316,6 +318,38 @@ class BLEDiagnosticRunner:
             self._selected_connectable = True
             self.coordinator.pause_disconnect_timer()
             return
+
+        if self.coordinator is not None:
+            _LOGGER.info(
+                "Connecting through the coordinator so diagnostics use the configured "
+                "adapter, pairing, and controller startup path"
+            )
+            try:
+                connected = await self.coordinator.async_ensure_connected(reset_timer=False)
+            except Exception as err:  # noqa: BLE001 - preserve a standalone diagnostic fallback
+                connected = False
+                message = f"Coordinator connection failed before diagnostics: {err}"
+                _LOGGER.warning(message)
+                self._errors.append(message)
+
+            if connected and self.coordinator.client and self.coordinator.is_connected:
+                self._connection_path = "coordinator_connected_for_diagnostics"
+                self._client = self.coordinator.client
+                self._using_coordinator_connection = True
+                self._selected_source = self.coordinator.connection_source
+                self._actual_source = self.coordinator.connection_source
+                self._selected_rssi = self.coordinator.connection_rssi
+                self._selected_connectable = True
+                self.coordinator.pause_disconnect_timer()
+                return
+
+            self._connection_path = "standalone_after_coordinator_failure"
+            message = (
+                "Coordinator could not establish the configured connection; "
+                "continuing with a standalone diagnostic connection"
+            )
+            _LOGGER.warning(message)
+            self._errors.append(message)
 
         _LOGGER.info("Establishing new BLE connection to %s", self.address)
         self._using_coordinator_connection = False
@@ -997,6 +1031,7 @@ class BLEDiagnosticRunner:
             "actual_source": self._actual_source,
             "connectable": self._selected_connectable,
             "non_connectable_fallback_used": self._using_non_connectable_fallback,
+            "connection_path": self._connection_path,
             "backend_details": details,
             "pairing": pairing,
             "scanner_count": self._get_scanner_count(),

--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -201,6 +201,7 @@ class BLEDiagnosticRunner:
         self._selected_ble_device: BLEDevice | None = None
         self._using_non_connectable_fallback: bool = False
         self._connection_path: str = "standalone"
+        self._configured_connection_attempt_details: list[dict[str, Any]] = []
         self._background_tasks: set[asyncio.Task[None]] = set()
         self._reconnect_count: int = 0
 
@@ -268,7 +269,16 @@ class BLEDiagnosticRunner:
         connection_history: dict[str, Any] = (
             self.coordinator.connection_history if self.coordinator else {}
         )
-        connection_attempt_details = self._connection_attempt_details
+        connection_attempt_details = [
+            *self._configured_connection_attempt_details,
+            *[
+                {
+                    **details,
+                    "diagnostic_connection_path": self._connection_path,
+                }
+                for details in self._connection_attempt_details
+            ],
+        ]
         if not connection_attempt_details and self.coordinator is not None:
             connection_attempt_details = self.coordinator.connection_attempt_details
 
@@ -344,6 +354,13 @@ class BLEDiagnosticRunner:
                 return
 
             self._connection_path = "standalone_after_coordinator_failure"
+            self._configured_connection_attempt_details = [
+                {
+                    **details,
+                    "diagnostic_connection_path": "configured_coordinator",
+                }
+                for details in self.coordinator.connection_attempt_details
+            ]
             message = (
                 "Coordinator could not establish the configured connection; "
                 "continuing with a standalone diagnostic connection"
@@ -707,7 +724,16 @@ class BLEDiagnosticRunner:
             if self.coordinator is not None:
                 _LOGGER.debug("Registering raw notification callback with coordinator")
                 self.coordinator.set_raw_notify_callback(self._raw_notify_callback)
-                if self.coordinator.disable_angle_sensing:
+                controller = self.coordinator.controller
+                requires_notify_channel = bool(
+                    controller is not None
+                    and getattr(controller, "requires_notification_channel", False)
+                    is True
+                )
+                if (
+                    self.coordinator.disable_angle_sensing
+                    and not requires_notify_channel
+                ):
                     _LOGGER.info(
                         "Angle sensing disabled - starting notifications for diagnostic capture"
                     )

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -357,6 +357,7 @@ class AdjustableBedCoordinator:
         # Command timing tracking for diagnostics (issue #168)
         self._last_command_start: datetime | None = None
         self._last_command_end: datetime | None = None
+        self._active_operation_name: str | None = None
         self._last_notify_received: datetime | None = None
 
         # Adapter selection details for diagnostics (issue #168)
@@ -1176,6 +1177,7 @@ class AdjustableBedCoordinator:
                 "repeat_count": repeat_count,
                 "repeat_delay_ms": repeat_delay_ms,
                 "command_origin": command_origin,
+                "operation_name": self._active_operation_name,
             }
         )
 
@@ -3007,6 +3009,7 @@ class AdjustableBedCoordinator:
                     if raise_on_lock_cancel:
                         raise asyncio.CancelledError
                     return None
+                self._active_operation_name = operation_name
                 self._last_command_start = datetime.now(UTC)
 
                 poll_stop: asyncio.Event | None = None
@@ -3030,6 +3033,7 @@ class AdjustableBedCoordinator:
                     )
                 finally:
                     self._last_command_end = datetime.now(UTC)
+                    self._active_operation_name = None
                     if poll_stop is not None:
                         poll_stop.set()
                     if poll_task is not None:

--- a/custom_components/adjustable_bed/services.yaml
+++ b/custom_components/adjustable_bed/services.yaml
@@ -147,7 +147,7 @@ timed_move:
 
 generate_support_bundle:
   name: Generate Support Bundle
-  description: Capture the full adjustable-bed support bundle. This combines BLE diagnostics, detection reasoning, GATT details, scanner state, and recent integration logs into one JSON file.
+  description: Capture the full adjustable-bed support bundle. This combines BLE diagnostics, pairing evidence, adapter and ESPHome proxy health, GATT details, scanner state, command trace, and recent integration logs into one JSON file.
   fields:
     device_id:
       name: Device

--- a/custom_components/adjustable_bed/support_bundle.py
+++ b/custom_components/adjustable_bed/support_bundle.py
@@ -2,19 +2,39 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 from datetime import UTC, datetime
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
 from homeassistant.components import bluetooth
+from homeassistant.components.bluetooth.const import (
+    CONF_SOURCE_CONFIG_ENTRY_ID,
+    CONF_SOURCE_DEVICE_ID,
+    CONF_SOURCE_DOMAIN,
+    CONF_SOURCE_MODEL,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_SOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.loader import async_get_integration
 
+from .ble_auth import is_ble_authentication_error
 from .ble_diagnostics import BLEDiagnosticRunner
-from .const import DOMAIN, SUPPORTED_BED_TYPES
+from .const import (
+    ADAPTER_AUTO,
+    CONF_BED_TYPE,
+    CONF_BLE_BOND_ESTABLISHED,
+    CONF_PREFERRED_ADAPTER,
+    CONF_PROTOCOL_VARIANT,
+    DEVICE_INFO_CHARS,
+    DOMAIN,
+    SUPPORTED_BED_TYPES,
+    requires_pairing,
+)
 from .redaction import redact_pins_only
 from .support_report import (
     _get_bluetooth_info,
@@ -27,6 +47,16 @@ from .support_report import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+_REPORT_VERSION = "2.1"
+_BLUETOOTH_DOMAIN = "bluetooth"
+_ESPHOME_DOMAIN = "esphome"
+_ESPHOME_PAIRING_FEATURE_FLAG = 1 << 3
+_OMITTED_SCANNER_DIAGNOSTIC_FRAGMENTS = (
+    "advertisement",
+    "discovered_device",
+    "history",
+)
 
 
 async def generate_support_bundle(
@@ -72,10 +102,26 @@ async def generate_support_bundle(
         position_data = {}
 
     recent_logs = await _get_recent_logs(hass) if include_logs else []
+    diagnostic_dict = diagnostics_report.to_dict()
+    pairing = _build_pairing_assessment(
+        diagnostic_dict,
+        entry=entry,
+        coordinator=coordinator,
+    )
+    evidence = _build_evidence_summary(
+        capture_duration=capture_duration,
+        include_logs=include_logs,
+        recent_logs=recent_logs,
+        diagnostic_report=diagnostic_dict,
+        pairing=pairing,
+        bluetooth_info=bluetooth_info,
+        configured=entry is not None,
+        controller=controller,
+    )
 
     report: dict[str, Any] = {
         "metadata": {
-            "report_version": "2.1",
+            "report_version": _REPORT_VERSION,
             "generated_at": timestamp.isoformat(),
             "capture_duration_seconds": capture_duration,
             "integration_domain": DOMAIN,
@@ -94,13 +140,9 @@ async def generate_support_bundle(
         "connection": connection,
         "connection_history": connection_history,
         "connection_attempt_details": diagnostics_report.connection_attempt_details,
-        "pairing": _get_pairing_info(
-            entry,
-            coordinator,
-            diagnostic_backend=diagnostics_report.device.get("pairing", {}),
-        ),
         "adapter": adapter,
         "bluetooth": bluetooth_info,
+        "pairing": pairing,
         "gatt_services": diagnostics_report.gatt_services,
         "gatt_summary": diagnostics_report.gatt_summary,
         "device_information": diagnostics_report.device_information,
@@ -110,6 +152,7 @@ async def generate_support_bundle(
         "notification_summary": diagnostics_report.notification_summary,
         "command_trace": diagnostics_report.command_trace if coordinator is not None else [],
         "recent_logs": recent_logs,
+        "evidence": evidence,
         "supported_bed_types": list(SUPPORTED_BED_TYPES),
         "errors": list(diagnostics_report.errors),
     }
@@ -141,21 +184,436 @@ async def _build_bluetooth_section(
     )
     info["target_address"] = address
 
-    if "scanners" not in info or not info["scanners"]:
-        try:
-            scanners = bluetooth.async_current_scanners(hass)
-            info["scanners"] = [
-                {
-                    "source": getattr(scanner, "source", "unknown"),
-                    "name": getattr(scanner, "name", "unknown"),
-                    "scanning": getattr(scanner, "scanning", None),
-                }
-                for scanner in scanners
-            ]
-        except Exception as err:
-            info["scanners_error"] = str(err)
+    try:
+        info["scanners"] = await _build_scanner_status(
+            hass,
+            diagnostics_report.get("advertisements_by_source", []),
+        )
+    except Exception as err:  # noqa: BLE001 - diagnostics must degrade gracefully
+        info["scanners_error"] = str(err)
 
     return info
+
+
+async def _build_scanner_status(
+    hass: HomeAssistant,
+    advertisements_by_source: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return enriched status for local adapters and remote Bluetooth proxies."""
+    advertisements = {
+        row.get("source"): row
+        for row in advertisements_by_source
+        if isinstance(row, dict) and row.get("source")
+    }
+    registrations = {
+        entry.data.get(CONF_SOURCE): entry
+        for entry in hass.config_entries.async_entries(_BLUETOOTH_DOMAIN)
+        if entry.data.get(CONF_SOURCE)
+    }
+
+    rows: list[dict[str, Any]] = []
+    for scanner in bluetooth.async_current_scanners(hass):
+        source = str(getattr(scanner, "source", "unknown"))
+        connector = getattr(scanner, "connector", None)
+        registration = registrations.get(source)
+        registration_data = registration.data if registration is not None else {}
+        source_domain = registration_data.get(CONF_SOURCE_DOMAIN)
+        target = advertisements.get(source)
+
+        row: dict[str, Any] = {
+            "source": source,
+            "name": getattr(scanner, "name", "unknown"),
+            "scanner_class": type(scanner).__name__,
+            "scanner_type": _scanner_type(source_domain, connector),
+            "source_domain": source_domain,
+            "source_model": registration_data.get(CONF_SOURCE_MODEL),
+            "scanning": getattr(scanner, "scanning", None),
+            "connectable": getattr(scanner, "connectable", None),
+            "connector": type(connector).__name__ if connector is not None else None,
+            "current_mode": _simple_value(getattr(scanner, "current_mode", None)),
+            "requested_mode": _simple_value(getattr(scanner, "requested_mode", None)),
+            "connecting_count": getattr(scanner, "connecting_count", None),
+            "connections_in_progress": getattr(scanner, "connections_in_progress", None),
+            "connection_failures": _json_friendly(
+                getattr(scanner, "connection_failures", None)
+            ),
+            "target_visible": target is not None,
+            "target_rssi": target.get("rssi") if target else None,
+            "target_connectable": target.get("connectable") if target else None,
+            "selected_for_connection": bool(
+                target and target.get("selected_for_connection")
+            ),
+        }
+
+        details = getattr(scanner, "details", None)
+        if isinstance(details, dict):
+            row["details"] = _json_friendly(details)
+
+        diagnostics_method = getattr(scanner, "async_diagnostics", None)
+        if callable(diagnostics_method):
+            try:
+                scanner_diagnostics = diagnostics_method()
+                if inspect.isawaitable(scanner_diagnostics):
+                    scanner_diagnostics = await scanner_diagnostics
+                if isinstance(scanner_diagnostics, dict):
+                    row["diagnostics"] = _compact_scanner_diagnostics(
+                        scanner_diagnostics
+                    )
+            except Exception as err:  # noqa: BLE001
+                row["diagnostics_error"] = str(err)
+
+        if registration is not None:
+            row["bluetooth_registration"] = {
+                "entry_id": registration.entry_id,
+                "entry_state": _simple_value(registration.state),
+                "source_config_entry_id": registration_data.get(
+                    CONF_SOURCE_CONFIG_ENTRY_ID
+                ),
+                "source_device_id": registration_data.get(CONF_SOURCE_DEVICE_ID),
+            }
+
+        if source_domain == _ESPHOME_DOMAIN:
+            row["esphome_proxy"] = _build_esphome_proxy_status(
+                hass,
+                registration_data.get(CONF_SOURCE_CONFIG_ENTRY_ID),
+            )
+
+        rows.append(row)
+
+    rows.sort(key=lambda row: (not row["selected_for_connection"], row["source"]))
+    return rows
+
+
+def _scanner_type(source_domain: Any, connector: Any) -> str:
+    """Classify a scanner without depending on optional integration modules."""
+    if source_domain == _ESPHOME_DOMAIN:
+        return "esphome_proxy"
+    if source_domain:
+        return "remote_proxy"
+    if connector is not None and "remote" in type(connector).__name__.lower():
+        return "remote_proxy"
+    return "local_adapter"
+
+
+def _build_esphome_proxy_status(
+    hass: HomeAssistant,
+    source_config_entry_id: Any,
+) -> dict[str, Any]:
+    """Return ESPHome runtime and Bluetooth slot status when HA exposes it."""
+    status: dict[str, Any] = {
+        "config_entry_id": source_config_entry_id,
+        "entry_found": False,
+    }
+    if not isinstance(source_config_entry_id, str):
+        return status
+
+    entry = hass.config_entries.async_get_entry(source_config_entry_id)
+    if entry is None:
+        return status
+
+    status.update(
+        {
+            "entry_found": True,
+            "title": entry.title,
+            "entry_state": _simple_value(entry.state),
+            "disabled_by": _simple_value(entry.disabled_by),
+        }
+    )
+
+    try:
+        runtime = entry.runtime_data
+    except (AttributeError, RuntimeError):
+        runtime = None
+    if runtime is None:
+        status["runtime_data_available"] = False
+        return status
+
+    status["runtime_data_available"] = True
+    status["available"] = getattr(runtime, "available", None)
+    status["api_version"] = _api_version(getattr(runtime, "api_version", None))
+
+    device_info = getattr(runtime, "device_info", None)
+    if device_info is not None:
+        raw_feature_flags = getattr(
+            device_info, "bluetooth_proxy_feature_flags", None
+        )
+        feature_flags = raw_feature_flags
+        feature_flags_compat = getattr(
+            device_info, "bluetooth_proxy_feature_flags_compat", None
+        )
+        if callable(feature_flags_compat):
+            try:
+                feature_flags = feature_flags_compat(
+                    getattr(runtime, "api_version", None)
+                )
+            except Exception:  # noqa: BLE001 - raw flags still provide useful evidence
+                pass
+        status["device"] = {
+            "name": getattr(device_info, "name", None),
+            "friendly_name": getattr(device_info, "friendly_name", None),
+            "model": getattr(device_info, "model", None),
+            "manufacturer": getattr(device_info, "manufacturer", None),
+            "esphome_version": getattr(device_info, "esphome_version", None),
+            "compilation_time": getattr(device_info, "compilation_time", None),
+            "project_name": getattr(device_info, "project_name", None),
+            "project_version": getattr(device_info, "project_version", None),
+            "bluetooth_mac_address": getattr(
+                device_info, "bluetooth_mac_address", None
+            ),
+            "bluetooth_proxy_feature_flags": raw_feature_flags,
+            "bluetooth_proxy_feature_flags_effective": _simple_value(feature_flags),
+            "pairing_supported": (
+                bool(feature_flags & _ESPHOME_PAIRING_FEATURE_FLAG)
+                if isinstance(feature_flags, int)
+                else None
+            ),
+        }
+
+    bluetooth_device = getattr(runtime, "bluetooth_device", None)
+    if bluetooth_device is not None:
+        status["bluetooth"] = {
+            "available": getattr(bluetooth_device, "available", None),
+            "connections_free": getattr(
+                bluetooth_device, "ble_connections_free", None
+            ),
+            "connections_limit": getattr(
+                bluetooth_device, "ble_connections_limit", None
+            ),
+        }
+
+    return status
+
+
+def _build_pairing_assessment(
+    diagnostics_report: dict[str, Any],
+    *,
+    entry: ConfigEntry | None,
+    coordinator: Any | None,
+) -> dict[str, Any]:
+    """Turn raw GATT authentication evidence into a clear pairing verdict."""
+    detection = diagnostics_report.get("detection", {})
+    bed_type = (
+        entry.data.get(CONF_BED_TYPE)
+        if entry is not None
+        else detection.get("bed_type")
+    )
+    protocol_variant = (
+        entry.data.get(CONF_PROTOCOL_VARIANT)
+        if entry is not None
+        else None
+    )
+    pairing_required = bool(bed_type and requires_pairing(bed_type, protocol_variant))
+    probe_uuids = {uuid.lower() for uuid in DEVICE_INFO_CHARS.values()}
+    successful_probes: list[str] = []
+    authentication_errors: list[dict[str, Any]] = []
+
+    for service in diagnostics_report.get("gatt_services", []):
+        for characteristic in service.get("characteristics", []):
+            uuid = str(characteristic.get("uuid", "")).lower()
+            read_error = characteristic.get("read_error")
+            if isinstance(read_error, str) and is_ble_authentication_error(
+                Exception(read_error)
+            ):
+                authentication_errors.append(
+                    {
+                        "uuid": characteristic.get("uuid"),
+                        "handle": characteristic.get("handle"),
+                        "error": read_error,
+                    }
+                )
+            if uuid in probe_uuids and characteristic.get("read_result") is not None:
+                successful_probes.append(characteristic.get("uuid"))
+
+    if not pairing_required:
+        status = "not_required"
+    elif authentication_errors:
+        status = "authentication_failed"
+    elif successful_probes:
+        status = "verified"
+    else:
+        status = "unverified"
+
+    saved_bond = (
+        entry.data.get(CONF_BLE_BOND_ESTABLISHED) if entry is not None else None
+    )
+    pairing_supported = getattr(coordinator, "pairing_supported", None)
+    if not isinstance(pairing_supported, bool):
+        pairing_supported = None
+
+    device = diagnostics_report.get("device", {})
+    preferred = (
+        entry.data.get(CONF_PREFERRED_ADAPTER, ADAPTER_AUTO)
+        if entry is not None
+        else ADAPTER_AUTO
+    )
+    selected = device.get("selected_source")
+    actual = device.get("actual_source")
+    coordinator_pairing = getattr(coordinator, "pairing_diagnostics", None)
+    base_pairing = _get_pairing_info(
+        entry,
+        coordinator if isinstance(coordinator_pairing, dict) else None,
+        diagnostic_backend=device.get("pairing", {}),
+    )
+
+    return {
+        **base_pairing,
+        "required": pairing_required,
+        "status": status,
+        "bed_type": bed_type,
+        "protocol_variant": protocol_variant,
+        "configured_bond_marker": saved_bond,
+        "configured_bond_conflicts_with_capture": bool(
+            pairing_required and saved_bond is True and authentication_errors
+        ),
+        "coordinator_pairing_supported": pairing_supported,
+        "backend_flags": device.get("pairing", {}),
+        "auth_gated_probe": {
+            "successful_characteristics": successful_probes,
+            "authentication_errors": authentication_errors,
+        },
+        "source": {
+            "preferred": preferred,
+            "selected": selected,
+            "actual": actual,
+            "matches_preference": (
+                None
+                if not preferred or preferred == ADAPTER_AUTO or actual is None
+                else actual == preferred
+            ),
+        },
+    }
+
+def _build_evidence_summary(
+    *,
+    capture_duration: int,
+    include_logs: bool,
+    recent_logs: list[dict[str, str]],
+    diagnostic_report: dict[str, Any],
+    pairing: dict[str, Any],
+    bluetooth_info: dict[str, Any],
+    configured: bool,
+    controller: dict[str, Any],
+) -> dict[str, Any]:
+    """Summarize whether the bundle contains enough evidence to act on."""
+    command_count = len(diagnostic_report.get("command_trace", []))
+    notification_count = diagnostic_report.get("notification_summary", {}).get(
+        "total_notifications", 0
+    )
+    log_capture_failed = bool(
+        recent_logs
+        and any(
+            log.get("name") == DOMAIN
+            and log.get("message", "").startswith("Could not read ")
+            for log in recent_logs
+        )
+    )
+    if not include_logs:
+        log_status = "not_requested"
+    elif log_capture_failed:
+        log_status = "unavailable"
+    elif recent_logs:
+        log_status = "available"
+    else:
+        log_status = "empty"
+
+    warnings: list[str] = []
+    if configured and command_count == 0:
+        warnings.append(
+            "No integration-issued command was captured. Reproduce at least one "
+            "failed command before generating the bundle."
+        )
+    if capture_duration > 0 and not notification_count:
+        warnings.append(
+            "No BLE notifications were captured. Operate the physical remote during "
+            "the capture window when protocol traffic is needed."
+        )
+    if log_status == "not_requested":
+        warnings.append("Recent logs were not requested for this bundle.")
+    elif log_status == "unavailable":
+        warnings.append(
+            "Home Assistant file logging was unavailable, so the reproduction log "
+            "is missing."
+        )
+    elif log_status == "empty":
+        warnings.append("No relevant Adjustable Bed or Bluetooth log entries were found.")
+    if pairing.get("configured_bond_conflicts_with_capture"):
+        warnings.append(
+            "The saved bond marker says paired, but this capture observed an "
+            "unauthenticated GATT link on the selected source."
+        )
+    if configured and not controller.get("initialized"):
+        warnings.append("The controller was not initialized when the bundle was assembled.")
+
+    selected_source = pairing.get("source", {}).get("actual") or pairing.get(
+        "source", {}
+    ).get("selected")
+    for scanner in bluetooth_info.get("scanners", []):
+        if scanner.get("source") != selected_source:
+            continue
+        proxy = scanner.get("esphome_proxy")
+        if isinstance(proxy, dict) and proxy.get("available") is False:
+            warnings.append("The selected ESPHome Bluetooth proxy reports unavailable.")
+        bluetooth_status = proxy.get("bluetooth", {}) if isinstance(proxy, dict) else {}
+        if bluetooth_status.get("connections_free") == 0:
+            warnings.append("The selected ESPHome proxy has no free BLE connection slots.")
+
+    return {
+        "command_trace_count": command_count,
+        "notification_count": notification_count,
+        "log_capture_status": log_status,
+        "recent_log_entry_count": len(recent_logs),
+        "usable_recent_log_entry_count": 0 if log_capture_failed else len(recent_logs),
+        "pairing_status": pairing.get("status"),
+        "complete": not warnings,
+        "warnings": warnings,
+    }
+
+
+def _compact_scanner_diagnostics(value: dict[str, Any]) -> dict[str, Any]:
+    """Drop large advertisement inventories while preserving scanner health."""
+    return {
+        str(key): _json_friendly(item)
+        for key, item in value.items()
+        if not any(
+            fragment in str(key).lower()
+            for fragment in _OMITTED_SCANNER_DIAGNOSTIC_FRAGMENTS
+        )
+    }
+
+
+def _json_friendly(value: Any) -> Any:
+    """Convert diagnostic values to stable JSON-friendly primitives."""
+    if value is None or isinstance(value, bool | int | float | str):
+        return value
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, bytes):
+        return value.hex()
+    if isinstance(value, dict):
+        return {str(key): _json_friendly(item) for key, item in value.items()}
+    if isinstance(value, list | tuple | set):
+        return [_json_friendly(item) for item in value]
+    return str(value)
+
+
+def _simple_value(value: Any) -> Any:
+    """Return the scalar value of enums used by Home Assistant APIs."""
+    if isinstance(value, Enum):
+        return value.value
+    if value is None or isinstance(value, bool | int | float | str):
+        return value
+    return str(value)
+
+
+def _api_version(value: Any) -> dict[str, int] | str | None:
+    """Serialize an ESPHome API version without importing optional modules."""
+    if value is None:
+        return None
+    major = getattr(value, "major", None)
+    minor = getattr(value, "minor", None)
+    if isinstance(major, int) and isinstance(minor, int):
+        return {"major": major, "minor": minor}
+    return str(value)
 
 
 def _build_connection_info_from_diagnostics(diagnostics_report: dict[str, Any]) -> dict[str, Any]:
@@ -192,6 +650,7 @@ def _empty_integration_info(address: str) -> dict[str, Any]:
         "has_massage": None,
         "disable_angle_sensing": None,
         "preferred_adapter": None,
+        "ble_bond_established": None,
         "address": address,
         "kaidi_room_id": None,
         "kaidi_target_vaddr": None,

--- a/custom_components/adjustable_bed/support_bundle.py
+++ b/custom_components/adjustable_bed/support_bundle.py
@@ -73,6 +73,14 @@ async def generate_support_bundle(
     timestamp = datetime.now(UTC)
     integration = await async_get_integration(hass, DOMAIN)
     integration_version = str(integration.version) if integration.version is not None else "unknown"
+    pre_capture_command_trace = (
+        list(coordinator.command_trace) if coordinator is not None else []
+    )
+    reproduction_command_trace = [
+        trace
+        for trace in pre_capture_command_trace
+        if trace.get("operation_name") == "command"
+    ]
 
     diagnostics_report = await BLEDiagnosticRunner(
         hass,
@@ -113,6 +121,7 @@ async def generate_support_bundle(
         include_logs=include_logs,
         recent_logs=recent_logs,
         diagnostic_report=diagnostic_dict,
+        reproduction_command_trace=reproduction_command_trace,
         pairing=pairing,
         bluetooth_info=bluetooth_info,
         configured=entry is not None,
@@ -424,10 +433,10 @@ def _build_pairing_assessment(
             if uuid in probe_uuids and characteristic.get("read_result") is not None:
                 successful_probes.append(characteristic.get("uuid"))
 
-    if not pairing_required:
-        status = "not_required"
-    elif authentication_errors:
+    if authentication_errors:
         status = "authentication_failed"
+    elif not pairing_required:
+        status = "not_required"
     elif successful_probes:
         status = "verified"
     else:
@@ -463,7 +472,7 @@ def _build_pairing_assessment(
         "protocol_variant": protocol_variant,
         "configured_bond_marker": saved_bond,
         "configured_bond_conflicts_with_capture": bool(
-            pairing_required and saved_bond is True and authentication_errors
+            saved_bond is True and authentication_errors
         ),
         "coordinator_pairing_supported": pairing_supported,
         "backend_flags": device.get("pairing", {}),
@@ -489,6 +498,7 @@ def _build_evidence_summary(
     include_logs: bool,
     recent_logs: list[dict[str, str]],
     diagnostic_report: dict[str, Any],
+    reproduction_command_trace: list[dict[str, Any]],
     pairing: dict[str, Any],
     bluetooth_info: dict[str, Any],
     configured: bool,
@@ -496,6 +506,7 @@ def _build_evidence_summary(
 ) -> dict[str, Any]:
     """Summarize whether the bundle contains enough evidence to act on."""
     command_count = len(diagnostic_report.get("command_trace", []))
+    reproduction_command_count = len(reproduction_command_trace)
     notification_count = diagnostic_report.get("notification_summary", {}).get(
         "total_notifications", 0
     )
@@ -517,10 +528,10 @@ def _build_evidence_summary(
         log_status = "empty"
 
     warnings: list[str] = []
-    if configured and command_count == 0:
+    if configured and reproduction_command_count == 0:
         warnings.append(
-            "No integration-issued command was captured. Reproduce at least one "
-            "failed command before generating the bundle."
+            "No user command reproduction was captured. Retry at least one failed "
+            "Home Assistant command before generating the bundle."
         )
     if capture_duration > 0 and not notification_count:
         warnings.append(
@@ -559,6 +570,10 @@ def _build_evidence_summary(
 
     return {
         "command_trace_count": command_count,
+        "reproduction_command_trace_count": reproduction_command_count,
+        "non_reproduction_command_trace_count": max(
+            0, command_count - reproduction_command_count
+        ),
         "notification_count": notification_count,
         "log_capture_status": log_status,
         "recent_log_entry_count": len(recent_logs),

--- a/custom_components/adjustable_bed/support_report.py
+++ b/custom_components/adjustable_bed/support_report.py
@@ -128,6 +128,7 @@ def _get_integration_info(entry: ConfigEntry) -> dict[str, Any]:
         "has_massage": entry.data.get(CONF_HAS_MASSAGE),
         "disable_angle_sensing": entry.data.get(CONF_DISABLE_ANGLE_SENSING),
         "preferred_adapter": entry.data.get(CONF_PREFERRED_ADAPTER),
+        "ble_bond_established": entry.data.get(CONF_BLE_BOND_ESTABLISHED),
         "address": entry.data.get(CONF_ADDRESS),
         "kaidi_room_id": entry.data.get(CONF_KAIDI_ROOM_ID),
         "kaidi_target_vaddr": entry.data.get(CONF_KAIDI_TARGET_VADDR),

--- a/docs/GETTING_HELP.md
+++ b/docs/GETTING_HELP.md
@@ -54,18 +54,21 @@ The support bundle includes everything we need in one file:
 
 1. Go to **Developer Tools** → **Actions**
 2. Search for `adjustable_bed.generate_support_bundle`
-3. Select your bed device, or enter `target_address` for an unconfigured device, then click **Perform action**
-4. (Optional) Adjust `capture_duration` to change how long notifications are captured (default: 120 seconds). Operate the physical remote during capture to generate useful traffic.
-5. A notification will appear with a **download link** — click it to save the file
-6. Attach the JSON file to your GitHub issue
+3. For a control problem, first try the failing Home Assistant command so it is present in the command trace.
+4. Select that same bed device, or enter `target_address` for an unconfigured device, then click **Perform action**.
+5. (Optional) Adjust `capture_duration` to change how long notifications are captured (default: 120 seconds). Operate the physical remote during capture to generate useful traffic.
+6. A notification will appear with a **download link** — click it to save the file.
+7. Attach the JSON file to your GitHub issue. Check its `evidence.warnings` section for anything that could not be captured.
 
 The support bundle includes:
 - System info (HA version, Python version, platform)
 - Integration configuration and detected bed type
-- Connection status, BLE adapter info, and connection attempt details
+- Connection status, BLE adapter/proxy health, and connection attempt details
+- ESPHome proxy firmware, API version, pairing capability, availability, and free BLE connection slots when Home Assistant exposes them
 - BLE advertisements by source, detection reasoning, and GATT/descriptor details
+- A structured pairing assessment that detects stale saved bond state and adapter mismatches
 - Captured notifications and buffered command trace
-- Recent error logs
+- Recent error logs plus evidence warnings when logs or a command reproduction are missing
 
 **Privacy note:** PINs are redacted. MAC addresses, device names, and other BLE identifiers are preserved since they are essential for debugging.
 
@@ -143,17 +146,21 @@ The `generate_support_bundle` action captures GATT structure, device info, scann
 
 1. Go to **Developer Tools** → **Actions**
 2. Search for `adjustable_bed.generate_support_bundle`
-3. Select your bed device (or enter `target_address` for unconfigured devices)
-4. Click **Perform action**
-5. Optionally operate your physical remote during capture to record notifications
-6. Find the JSON report in your `/config/` folder
+3. Try the failing Home Assistant control once if you are troubleshooting commands.
+4. Select that same bed device (or enter `target_address` for unconfigured devices).
+5. Click **Perform action**.
+6. Optionally operate your physical remote during capture to record notifications.
+7. Find the JSON report in your `/config/` folder.
 
 This captures:
 - All GATT services and characteristics
 - Device name and advertising data
 - Notifications sent BY the device (e.g., position updates)
+- Commands recently sent by this integration
+- Adapter and ESPHome Bluetooth proxy health
+- Pairing/authentication evidence and a completeness summary
 
-**Limitation:** This captures what the device *sends*, not commands sent *to* the device. For capturing outgoing commands from an app, see [Capturing App Traffic](#capturing-app-traffic-for-new-bed-support).
+**Limitation:** The command trace contains commands sent by this integration, not commands sent by the official mobile app. For capturing outgoing commands from an app, see [Capturing App Traffic](#capturing-app-traffic-for-new-bed-support).
 
 ---
 

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bleak.exc import BleakError
@@ -35,7 +36,12 @@ from custom_components.adjustable_bed.const import (
     SOLACE_SERVICE_UUID,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
-from custom_components.adjustable_bed.support_bundle import generate_support_bundle
+from custom_components.adjustable_bed.support_bundle import (
+    _build_evidence_summary,
+    _build_pairing_assessment,
+    _build_scanner_status,
+    generate_support_bundle,
+)
 
 
 class _FakeServices:
@@ -687,6 +693,69 @@ class TestBleDiagnosticsRunner:
         coordinator.set_raw_notify_callback.assert_called_with(None)
         client2.disconnect.assert_not_awaited()
 
+    async def test_run_diagnostics_initially_connects_through_coordinator(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,
+    ):
+        """Configured diagnostics should use pairing and adapter logic from the coordinator."""
+        service_info = _build_unknown_service_info(
+            source="proxy_1",
+            connectable=True,
+            rssi=-58,
+        )
+        client = _build_diagnostic_client(_FakeServices([]))
+        coordinator = MagicMock()
+        coordinator.client = None
+        coordinator.is_connected = False
+        coordinator.connection_source = None
+        coordinator.connection_rssi = None
+        coordinator.disable_angle_sensing = True
+        coordinator.adapter_details = {}
+        coordinator.connection_history = {}
+        coordinator.connection_attempt_details = []
+        coordinator.command_trace = []
+
+        async def _connect_through_coordinator(*, reset_timer):
+            assert reset_timer is False
+            coordinator.client = client
+            coordinator.is_connected = True
+            coordinator.connection_source = "proxy_1"
+            coordinator.connection_rssi = -58
+            return True
+
+        coordinator.async_ensure_connected = AsyncMock(
+            side_effect=_connect_through_coordinator
+        )
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.get_service_info_snapshots_by_address",
+                return_value=[(service_info, True)],
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.bluetooth.async_scanner_count",
+                return_value=1,
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.select_adapter"
+            ) as select_adapter,
+        ):
+            report = await BLEDiagnosticRunner(
+                hass,
+                service_info.address,
+                capture_duration=0,
+                coordinator=coordinator,
+            ).run_diagnostics()
+
+        coordinator.async_ensure_connected.assert_awaited_once_with(reset_timer=False)
+        select_adapter.assert_not_called()
+        assert report.device["connection_path"] == "coordinator_connected_for_diagnostics"
+        assert report.device["actual_source"] == "proxy_1"
+        coordinator.pause_disconnect_timer.assert_called_once()
+        coordinator.resume_disconnect_timer.assert_called_once()
+        client.disconnect.assert_not_awaited()
+
 
 class TestSupportBundle:
     """Test support bundle orchestration."""
@@ -895,6 +964,177 @@ class TestSupportBundle:
         assert pairing["runtime_bond_established"] is None
         assert pairing["diagnostic_backend"]["paired"] is False
         assert pairing["diagnostic_backend"]["bonded"] is False
+
+    async def test_scanner_status_includes_esphome_proxy_runtime_and_slots(
+        self,
+        hass: HomeAssistant,
+    ):
+        """Proxy rows should expose firmware, API, availability, and BLE slot health."""
+        runtime = SimpleNamespace(
+            available=True,
+            api_version=SimpleNamespace(major=1, minor=12),
+            device_info=SimpleNamespace(
+                name="bed_proxy",
+                friendly_name="Bed Proxy",
+                model="ESP32-C3",
+                manufacturer="Espressif",
+                esphome_version="2026.7.1",
+                compilation_time="2026-07-10 12:00:00",
+                project_name="esphome.bluetooth-proxy",
+                project_version="1.0",
+                bluetooth_mac_address="11:22:33:44:55:66",
+                bluetooth_proxy_feature_flags=0x0F,
+            ),
+            bluetooth_device=SimpleNamespace(
+                available=True,
+                ble_connections_free=2,
+                ble_connections_limit=3,
+            ),
+        )
+        proxy_entry = MockConfigEntry(
+            domain="esphome",
+            title="Bed Proxy",
+            data={},
+            entry_id="esphome_proxy_entry",
+        )
+        proxy_entry.runtime_data = runtime
+        proxy_entry.add_to_hass(hass)
+        bluetooth_entry = MockConfigEntry(
+            domain="bluetooth",
+            title="Bed Proxy Bluetooth",
+            data={
+                "source": "11:22:33:44:55:66",
+                "source_domain": "esphome",
+                "source_model": "ESP32-C3",
+                "source_config_entry_id": proxy_entry.entry_id,
+                "source_device_id": "proxy-device-id",
+            },
+            unique_id="11:22:33:44:55:66",
+        )
+        bluetooth_entry.add_to_hass(hass)
+
+        scanner = MagicMock()
+        scanner.source = "11:22:33:44:55:66"
+        scanner.name = "bed-proxy"
+        scanner.scanning = True
+        scanner.connectable = True
+        scanner.connector = MagicMock()
+        scanner.current_mode = "active"
+        scanner.requested_mode = "active"
+        scanner.connecting_count = 1
+        scanner.connections_in_progress = 1
+        scanner.connection_failures = 0
+        scanner.details = {"source": scanner.source, "type": "ESPHomeScanner"}
+        scanner.async_diagnostics = AsyncMock(
+            return_value={
+                "scanner_state": "running",
+                "discovered_devices_and_advertisement_data": {"omitted": True},
+            }
+        )
+
+        with patch(
+            "custom_components.adjustable_bed.support_bundle.bluetooth.async_current_scanners",
+            return_value=[scanner],
+        ):
+            rows = await _build_scanner_status(
+                hass,
+                [
+                    {
+                        "source": scanner.source,
+                        "rssi": -71,
+                        "connectable": True,
+                        "selected_for_connection": True,
+                    }
+                ],
+            )
+
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["scanner_type"] == "esphome_proxy"
+        assert row["target_visible"] is True
+        assert row["target_rssi"] == -71
+        assert row["diagnostics"] == {"scanner_state": "running"}
+        proxy = row["esphome_proxy"]
+        assert proxy["available"] is True
+        assert proxy["api_version"] == {"major": 1, "minor": 12}
+        assert proxy["device"]["esphome_version"] == "2026.7.1"
+        assert proxy["device"]["pairing_supported"] is True
+        assert proxy["bluetooth"]["connections_free"] == 2
+        assert proxy["bluetooth"]["connections_limit"] == 3
+
+    def test_pairing_and_evidence_call_out_stale_bond_and_missing_reproduction(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+    ):
+        """Bundles should explain contradictory bond state and missing evidence."""
+        hass.config_entries.async_update_entry(
+            mock_config_entry,
+            data={
+                **mock_config_entry.data,
+                CONF_BED_TYPE: BED_TYPE_OKIN_CST,
+                CONF_PREFERRED_ADAPTER: "proxy_1",
+                CONF_BLE_BOND_ESTABLISHED: True,
+            },
+        )
+        diagnostics = {
+            "detection": {"bed_type": BED_TYPE_OKIN_CST},
+            "device": {
+                "selected_source": "proxy_1",
+                "actual_source": "proxy_1",
+                "pairing": {"paired": None, "bonded": None},
+            },
+            "gatt_services": [
+                {
+                    "uuid": "0000180a-0000-1000-8000-00805f9b34fb",
+                    "characteristics": [
+                        {
+                            "uuid": DEVICE_INFO_CHARS["model_number"],
+                            "handle": 24,
+                            "read_result": None,
+                            "read_error": (
+                                "Bluetooth GATT Error handle=24 error=5 "
+                                "description=Insufficient authentication"
+                            ),
+                        }
+                    ],
+                }
+            ],
+            "command_trace": [],
+            "notification_summary": {"total_notifications": 0},
+        }
+        pairing = _build_pairing_assessment(
+            diagnostics,
+            entry=mock_config_entry,
+            coordinator=SimpleNamespace(pairing_supported=True),
+        )
+
+        evidence = _build_evidence_summary(
+            capture_duration=120,
+            include_logs=True,
+            recent_logs=[
+                {
+                    "timestamp": "2026-07-12T00:00:00+00:00",
+                    "level": "INFO",
+                    "name": "adjustable_bed",
+                    "message": "Could not read /config/home-assistant.log: missing",
+                }
+            ],
+            diagnostic_report=diagnostics,
+            pairing=pairing,
+            bluetooth_info={"scanners": []},
+            configured=True,
+            controller={"initialized": False},
+        )
+
+        assert pairing["status"] == "authentication_failed"
+        assert pairing["configured_bond_conflicts_with_capture"] is True
+        assert pairing["source"]["matches_preference"] is True
+        assert evidence["command_trace_count"] == 0
+        assert evidence["notification_count"] == 0
+        assert evidence["log_capture_status"] == "unavailable"
+        assert evidence["complete"] is False
+        assert any("saved bond marker" in warning for warning in evidence["warnings"])
 
     async def test_coordinator_records_command_trace(
         self,

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -715,6 +715,8 @@ class TestBleDiagnosticsRunner:
         coordinator.connection_history = {}
         coordinator.connection_attempt_details = []
         coordinator.command_trace = []
+        coordinator.controller = MagicMock(requires_notification_channel=True)
+        coordinator.async_start_notify_for_diagnostics = AsyncMock()
 
         async def _connect_through_coordinator(*, reset_timer):
             assert reset_timer is False
@@ -754,7 +756,83 @@ class TestBleDiagnosticsRunner:
         assert report.device["actual_source"] == "proxy_1"
         coordinator.pause_disconnect_timer.assert_called_once()
         coordinator.resume_disconnect_timer.assert_called_once()
+        coordinator.async_start_notify_for_diagnostics.assert_not_called()
+        coordinator.controller.stop_notify.assert_not_called()
         client.disconnect.assert_not_awaited()
+
+    async def test_coordinator_attempts_are_retained_before_standalone_fallback(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,
+    ):
+        """A successful raw fallback must not hide the configured connection failure."""
+        service_info = _build_unknown_service_info(
+            source="proxy_1",
+            connectable=True,
+            rssi=-61,
+        )
+        client = _build_diagnostic_client(_FakeServices([]))
+        coordinator = MagicMock()
+        coordinator.client = None
+        coordinator.is_connected = False
+        coordinator.entry.data = {CONF_PREFERRED_ADAPTER: "proxy_1"}
+        coordinator.adapter_details = {}
+        coordinator.connection_history = {}
+        coordinator.connection_attempt_details = [
+            {
+                "attempt": 1,
+                "result": "failed",
+                "error_category": "PAIRING FAILED",
+            }
+        ]
+        coordinator.command_trace = []
+        coordinator.async_ensure_connected = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.get_service_info_snapshots_by_address",
+                return_value=[(service_info, True)],
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.select_adapter",
+                new=AsyncMock(
+                    return_value=AdapterSelectionResult(
+                        device=service_info.device,
+                        source="proxy_1",
+                        rssi=-61,
+                        connectable=True,
+                        available_sources=["proxy_1 (RSSI: -61)"],
+                    )
+                ),
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.establish_connection",
+                new=AsyncMock(return_value=client),
+            ),
+            patch(
+                "custom_components.adjustable_bed.ble_diagnostics.bluetooth.async_scanner_count",
+                return_value=1,
+            ),
+        ):
+            report = await BLEDiagnosticRunner(
+                hass,
+                service_info.address,
+                capture_duration=0,
+                coordinator=coordinator,
+            ).run_diagnostics()
+
+        assert len(report.connection_attempt_details) == 2
+        configured_attempt, fallback_attempt = report.connection_attempt_details
+        assert configured_attempt["error_category"] == "PAIRING FAILED"
+        assert (
+            configured_attempt["diagnostic_connection_path"]
+            == "configured_coordinator"
+        )
+        assert fallback_attempt["result"] == "connected"
+        assert (
+            fallback_attempt["diagnostic_connection_path"]
+            == "standalone_after_coordinator_failure"
+        )
 
 
 class TestSupportBundle:
@@ -1100,7 +1178,7 @@ class TestSupportBundle:
                     ],
                 }
             ],
-            "command_trace": [],
+            "command_trace": [{"command_origin": "query_config"}],
             "notification_summary": {"total_notifications": 0},
         }
         pairing = _build_pairing_assessment(
@@ -1121,6 +1199,7 @@ class TestSupportBundle:
                 }
             ],
             diagnostic_report=diagnostics,
+            reproduction_command_trace=[],
             pairing=pairing,
             bluetooth_info={"scanners": []},
             configured=True,
@@ -1130,11 +1209,25 @@ class TestSupportBundle:
         assert pairing["status"] == "authentication_failed"
         assert pairing["configured_bond_conflicts_with_capture"] is True
         assert pairing["source"]["matches_preference"] is True
-        assert evidence["command_trace_count"] == 0
+        assert evidence["command_trace_count"] == 1
+        assert evidence["reproduction_command_trace_count"] == 0
+        assert evidence["non_reproduction_command_trace_count"] == 1
         assert evidence["notification_count"] == 0
         assert evidence["log_capture_status"] == "unavailable"
         assert evidence["complete"] is False
         assert any("saved bond marker" in warning for warning in evidence["warnings"])
+        assert any("No user command reproduction" in warning for warning in evidence["warnings"])
+
+        raw_auth_failure = _build_pairing_assessment(
+            {
+                **diagnostics,
+                "detection": {"bed_type": "linak"},
+            },
+            entry=None,
+            coordinator=None,
+        )
+        assert raw_auth_failure["required"] is False
+        assert raw_auth_failure["status"] == "authentication_failed"
 
     async def test_coordinator_records_command_trace(
         self,
@@ -1157,3 +1250,10 @@ class TestSupportBundle:
         assert trace[-1]["payload"]["hex"] == "0102"
         assert trace[-1]["repeat_count"] == 2
         assert trace[-1]["repeat_delay_ms"] == 25
+        assert trace[-1]["operation_name"] is None
+
+        async def _user_command(active_controller):
+            await active_controller.write_command(b"\x03\x04")
+
+        await coordinator.async_execute_controller_command(_user_command)
+        assert coordinator.command_trace[-1]["operation_name"] == "command"


### PR DESCRIPTION
## Summary

- run configured-device captures through the coordinator so diagnostics use the configured adapter, pairing, bond verification, controller startup, and command path
- label standalone fallback captures explicitly when the coordinator cannot connect
- add per-scanner target visibility, RSSI, scanner health, registration details, and compact scanner diagnostics
- include ESPHome proxy firmware, API version, feature flags, pairing capability, availability, and BLE connection-slot status when Home Assistant exposes them
- add an explicit authentication verdict, source consistency, and stale bond-marker detection while preserving the existing pairing diagnostics
- add an `evidence` completeness summary for missing command attempts, notifications, logs, controller initialization, proxy availability, and connection capacity
- surface capture warnings in the completion notification and update the support documentation

## Why

Configured support bundles previously opened a standalone BLE connection whenever the coordinator was idle-disconnected. That bypassed the integration's normal adapter and pairing path, so a bundle could report an unauthenticated proxy connection even when the configured entry had connected differently. The bundle also exposed too little ESPHome proxy state and made maintainers infer missing evidence from raw JSON.

This makes configured captures representative of actual integration behavior and calls out incomplete or contradictory evidence directly. It was motivated by the debugging ambiguity in #368.

## User impact

Users receive immediate warnings when a bundle lacks the failed command, useful logs, notification traffic, or a working controller connection. Maintainers can see which adapter or proxy handled the capture, whether that proxy supports pairing, its firmware and slot health, and whether captured GATT authentication evidence contradicts the saved bond state.

## Validation

- `uvx ruff@0.15.16 check ...`
- `uvx pyright@1.1.410 ...`
- `pytest -q tests/test_support_bundle.py tests/test_diagnostics.py tests/test_init.py` (69 passed)

The full suite will also run in GitHub Actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Support bundles now include richer pairing assessments, BLE scanner details, connection paths, proxy health, command traces, and evidence completeness warnings.
  - Notifications highlight warnings when diagnostic captures or logs are incomplete.
  - Reports include BLE bond status and expanded connection diagnostics.

- **Documentation**
  - Expanded guidance for generating, capturing, and using support bundles, including their additional diagnostic contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->