### PR TITLE
Fix CB24 preset recall overwriting memory

### DIFF
--- a/custom_components/adjustable_bed/beds/okin_cb24.py
+++ b/custom_components/adjustable_bed/beds/okin_cb24.py
@@ -22,21 +22,16 @@ Protocol families detected from the OEM SmartBed app:
 - OLD protocol (CB24/CB27/CB24AB/CB1221/Dacheng): uses 0x05 0x02 packets.
 
 Preset behavior in this integration:
-- NEW protocol profiles use one-shot presets.
-- Legacy profiles (`cb24`, `cb27`, `cb24_ab`, `cb1221`, `dacheng`) use one-shot
-  presets (matching v2.4.0 behavior that worked on known hardware).
-- `cb_old` compatibility variant uses continuous presets at 300ms and sends
-  STOP after completion.
-- Auto-detected legacy profiles can promote to continuous preset mode when the
-  same preset is retried repeatedly in a short window, avoiding manual profile
-  changes.
+- All profiles use one-shot presets. The OEM app repeats legacy preset packets
+  only while the user holds a touchscreen button and treats a 5.2-second hold
+  as a memory-save gesture. A fixed continuous stream can therefore overwrite
+  stored presets instead of recalling them.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import time
 from enum import Enum
 from typing import TYPE_CHECKING
 
@@ -61,16 +56,7 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# Legacy continuous preset timing for the `cb_old` compatibility variant.
-# The OEM app sends continuously at 300ms intervals; the actuator moves
-# incrementally per command.  55 repeats ≈ 16.5s covers typical full-travel
-# preset recalls.  The cancel-event mechanism allows early interruption.
-_PRESET_CONTINUOUS_COUNT = 55
-_PRESET_CONTINUOUS_DELAY_MS = 300
-_ADAPTIVE_PRESET_RETRY_WINDOW_SECONDS = 12.0
-_ADAPTIVE_PRESET_PROMOTION_RETRY_COUNT = 2
-
-# Device profile variants grouped by protocol and preset behavior.
+# Device profile variants grouped by protocol family.
 _LEGACY_PROTOCOL_VARIANTS = frozenset(
     {
         OKIN_CB24_VARIANT_OLD,
@@ -82,7 +68,6 @@ _LEGACY_PROTOCOL_VARIANTS = frozenset(
     }
 )
 _NEW_PROTOCOL_VARIANTS = frozenset({OKIN_CB24_VARIANT_NEW, OKIN_CB24_VARIANT_CB27NEW})
-_CONTINUOUS_PRESET_VARIANTS = frozenset({OKIN_CB24_VARIANT_OLD})
 
 # CBNewProtocol memory command mapping (CB24 integer command -> memory index).
 _CBNEW_MEMORY_BY_COMMAND: dict[int, int] = {
@@ -255,10 +240,7 @@ class OkinCB24Controller(BedController):
         self,
         coordinator: AdjustableBedCoordinator,
         bed_selection: int = 0x00,
-        protocol_variant: str = OKIN_CB24_VARIANT_OLD,
-        *,
-        adaptive_preset_fallback: bool = False,
-        initial_continuous_presets: bool = False,
+        protocol_variant: str = OKIN_CB24_VARIANT_CB24,
     ) -> None:
         """Initialize the Okin CB24 controller.
 
@@ -266,35 +248,17 @@ class OkinCB24Controller(BedController):
             coordinator: The AdjustableBedCoordinator instance
             bed_selection: Bed selection (0x00=default, 0xAA=bed A, 0xBB=bed B)
             protocol_variant: CB24 profile variant (cb24/cb27/cb24_ab/cb1221/dacheng/cb27new)
-            adaptive_preset_fallback: Enable automatic one-shot->continuous preset fallback
-            initial_continuous_presets: Reuse a previously learned continuous preset mode
         """
         super().__init__(coordinator)
         self._motor_state: dict[str, MotorDirection] = {}
         self._bed_selection = bed_selection
         self._protocol_variant = protocol_variant
         self._is_new_protocol = protocol_variant in _NEW_PROTOCOL_VARIANTS
-        self._continuous_presets = (
-            not self._is_new_protocol
-            and (
-                protocol_variant in _CONTINUOUS_PRESET_VARIANTS
-                or initial_continuous_presets
-            )
-        )
-        self._adaptive_preset_fallback = (
-            adaptive_preset_fallback and not self._is_new_protocol and not self._continuous_presets
-        )
-        self._last_one_shot_preset_command: int | None = None
-        self._last_one_shot_preset_monotonic = 0.0
-        self._now = time.monotonic
-        self._same_preset_retry_count = 0
         if not self._is_new_protocol and protocol_variant not in _LEGACY_PROTOCOL_VARIANTS:
             _LOGGER.warning(
-                "Unknown CB24 protocol variant '%s'; defaulting to OLD protocol handling",
+                "Unknown CB24 protocol variant '%s'; defaulting to legacy one-shot handling",
                 protocol_variant,
             )
-            self._continuous_presets = True
-            self._adaptive_preset_fallback = False
 
         self._lights_on = False
         self._massage_on = False
@@ -303,12 +267,10 @@ class OkinCB24Controller(BedController):
         self._massage_mode = 0
 
         _LOGGER.debug(
-            "OkinCB24Controller initialized (bed_selection=%#x, variant=%s, new_protocol=%s, continuous_presets=%s, adaptive_preset_fallback=%s)",
+            "OkinCB24Controller initialized (bed_selection=%#x, variant=%s, new_protocol=%s)",
             bed_selection,
             protocol_variant,
             self._is_new_protocol,
-            self._continuous_presets,
-            self._adaptive_preset_fallback,
         )
 
     @property
@@ -523,96 +485,9 @@ class OkinCB24Controller(BedController):
         )
 
     # Preset methods
-    def _should_promote_presets_to_continuous(
-        self, command_value: int, *, _now: float | None = None
-    ) -> bool:
-        """Promote auto legacy presets after repeated quick retries."""
-        if not self._adaptive_preset_fallback:
-            return False
-
-        now = _now if _now is not None else self._now()
-        if (
-            self._last_one_shot_preset_command == command_value
-            and now - self._last_one_shot_preset_monotonic
-            <= _ADAPTIVE_PRESET_RETRY_WINDOW_SECONDS
-        ):
-            self._same_preset_retry_count += 1
-            if self._same_preset_retry_count < _ADAPTIVE_PRESET_PROMOTION_RETRY_COUNT:
-                _LOGGER.debug(
-                    "CB24 adaptive retry %d/%d for preset %#x before continuous promotion",
-                    self._same_preset_retry_count,
-                    _ADAPTIVE_PRESET_PROMOTION_RETRY_COUNT,
-                    command_value,
-                )
-                self._last_one_shot_preset_monotonic = now
-                return False
-
-            retry_count = self._same_preset_retry_count
-            self._continuous_presets = True
-            self._adaptive_preset_fallback = False
-            self._same_preset_retry_count = 0
-            self._coordinator.remember_cb24_continuous_presets()
-            _LOGGER.debug(
-                "CB24 preset mode auto-promoted to continuous after %d retries for preset %#x",
-                retry_count,
-                command_value,
-            )
-            return True
-
-        self._same_preset_retry_count = 0
-        self._last_one_shot_preset_command = command_value
-        self._last_one_shot_preset_monotonic = now
-        return False
-
-    async def _send_continuous_preset(self, preset_command: bytes) -> None:
-        """Send a continuous legacy preset stream followed by STOP."""
-        try:
-            await self.write_command(
-                preset_command,
-                repeat_count=_PRESET_CONTINUOUS_COUNT,
-                repeat_delay_ms=_PRESET_CONTINUOUS_DELAY_MS,
-            )
-        finally:
-            # Send STOP to signal preset completion, shielded from
-            # cancellation (same pattern as _move_motor).
-            try:
-                await asyncio.shield(
-                    self.write_command(
-                        self._build_stop_command(),
-                        cancel_event=asyncio.Event(),
-                    )
-                )
-            except asyncio.CancelledError:
-                raise
-            except (BleakError, ConnectionError):
-                _LOGGER.debug("Failed to send stop after preset", exc_info=True)
-
     async def _send_preset(self, command_value: int) -> None:
-        """Send a preset command using the appropriate protocol.
-
-        NEW_PROTOCOL (CB27New/CBNew): One-shot — the actuator receives the
-        command once and moves to the saved position autonomously.
-
-        LEGACY profiles:
-        - `cb_old`: Continuous — the actuator moves incrementally per command
-          and needs repeated sends at 300ms intervals; STOP is sent afterward.
-        - `cb24`/`cb27`/`cb24_ab`/`cb1221`/`dacheng`: one-shot by default.
-        - Auto mode can promote legacy presets to continuous when a preset is
-          retried repeatedly in a short window, avoiding manual compatibility
-          changes.
-        """
+        """Send one preset packet without simulating a destructive long press."""
         preset_command = self._build_preset_command(command_value)
-
-        if self._is_new_protocol:
-            await self.write_command(preset_command)
-            return
-
-        if self._continuous_presets or self._should_promote_presets_to_continuous(
-            command_value
-        ):
-            await self._send_continuous_preset(preset_command)
-            return
-
         await self.write_command(preset_command)
 
     async def preset_flat(self) -> None:

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -998,7 +998,7 @@ OKIN_CB24_VARIANT_DACHENG: Final = "dacheng"
 OKIN_CB24_VARIANT_CB27NEW: Final = "cb27new"
 OKIN_CB24_VARIANTS: Final = {
     VARIANT_AUTO: "Auto-detect (recommended)",
-    OKIN_CB24_VARIANT_OLD: "OLD protocol compatibility (continuous presets)",
+    OKIN_CB24_VARIANT_OLD: "OLD protocol compatibility (safe one-shot presets)",
     OKIN_CB24_VARIANT_NEW: "NEW protocol (CB27New)",
     OKIN_CB24_VARIANT_CB24: "CB24 profile (legacy packets, one-shot presets)",
     OKIN_CB24_VARIANT_CB27: "CB27 profile (legacy packets, one-shot presets)",

--- a/custom_components/adjustable_bed/controller_factory.py
+++ b/custom_components/adjustable_bed/controller_factory.py
@@ -397,36 +397,10 @@ async def create_controller(
                 manufacturer_data=manufacturer_data,
             )
 
-        # OLD uses unconditional continuous presets so adaptive fallback is
-        # unnecessary; NEW/CB27NEW are new-protocol one-shot (no legacy path).
-        adaptive_preset_fallback = (
-            not explicit_variant_selected
-            and profile_variant
-            in {
-                OKIN_CB24_VARIANT_CB24,
-                OKIN_CB24_VARIANT_CB27,
-                OKIN_CB24_VARIANT_CB24_AB,
-                OKIN_CB24_VARIANT_CB1221,
-                OKIN_CB24_VARIANT_DACHENG,
-            }
-        )
-        initial_continuous_presets = (
-            adaptive_preset_fallback
-            and getattr(coordinator, "cb24_continuous_presets_learned", False)
-        )
-
-        if initial_continuous_presets:
-            _LOGGER.debug(
-                "Reusing learned CB24 continuous preset mode for %s",
-                coordinator.address,
-            )
-
         return OkinCB24Controller(
             coordinator,
             bed_selection=cb24_bed_selection,
             protocol_variant=profile_variant,
-            adaptive_preset_fallback=adaptive_preset_fallback,
-            initial_continuous_presets=initial_continuous_presets,
         )
 
     if bed_type == BED_TYPE_OKIN_ORE:

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -279,7 +279,6 @@ class AdjustableBedCoordinator:
 
         # CB24-specific configuration (SmartBed by Okin split beds)
         self._cb24_bed_selection: int = entry.data.get(CONF_CB24_BED_SELECTION, 0x00)
-        self._cb24_continuous_presets_learned = False
 
         self._client: BleakClient | None = None
         self._controller: BedController | None = None
@@ -578,11 +577,6 @@ class AdjustableBedCoordinator:
     def motor_pulse_delay_ms(self) -> int:
         """Return the motor pulse delay in milliseconds."""
         return self._motor_pulse_delay_ms
-
-    @property
-    def cb24_continuous_presets_learned(self) -> bool:
-        """Return whether CB24 auto mode has learned continuous preset sends."""
-        return self._cb24_continuous_presets_learned
 
     @property
     def controller(self) -> BedController | None:
@@ -1141,17 +1135,6 @@ class AdjustableBedCoordinator:
                     "retrying on the next connection.",
                     self._address,
                 )
-
-    def remember_cb24_continuous_presets(self) -> None:
-        """Persist the learned CB24 continuous preset mode across reconnects."""
-        if self._cb24_continuous_presets_learned:
-            return
-
-        self._cb24_continuous_presets_learned = True
-        _LOGGER.info(
-            "Learned CB24 continuous preset mode for %s; reusing it on reconnects",
-            self._address,
-        )
 
     def record_command_trace(
         self,

--- a/docs/beds/okimat.md
+++ b/docs/beds/okimat.md
@@ -211,6 +211,15 @@ The app supports multiple protocol versions based on device name:
 | `okin-ble` | CB.13/CB.15 (FFE5) | 9-byte: `[0xE6, 0xFE, 0x16, cmd(4), side, checksum]` |
 | `smartbed` | CB.24 (Nordic UART) | 7-byte: `[0x05, 0x02, cmd(4), 0x00]` (no checksum) |
 
+### CB.24 Preset Safety
+
+CB.24 preset recalls are sent as a single packet. The SmartBed app repeats the
+same packet every 300 ms only while a touchscreen button remains held, and a
+5.2-second hold is the controller's memory-save gesture. Fixed-duration or
+automatically learned repeat streams can therefore overwrite the remote's
+stored presets. All CB.24 profile variants, including the legacy `cb_old`
+compatibility alias, use safe one-shot preset recall.
+
 ### Additional Motors Supported
 
 | Motor | Up | Down |

--- a/tests/test_okin_cb24.py
+++ b/tests/test_okin_cb24.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
 from custom_components.adjustable_bed.beds.okin_cb24 import (
-    _PRESET_CONTINUOUS_COUNT,
-    _PRESET_CONTINUOUS_DELAY_MS,
     OkinCB24Commands,
     OkinCB24Controller,
 )
@@ -38,7 +35,6 @@ def _make_factory_coordinator() -> SimpleNamespace:
     return SimpleNamespace(
         client=None,
         cancel_command=None,
-        cb24_continuous_presets_learned=False,
         motor_pulse_count=10,
         motor_pulse_delay_ms=100,
         address="AA:BB:CC:DD:EE:FF",
@@ -110,8 +106,8 @@ class TestOkinCB24Controller:
         )
 
     @pytest.mark.asyncio
-    async def test_old_protocol_preset_sends_continuously_then_stop(self) -> None:
-        """`cb_old` compatibility presets should send repeatedly at 300ms then STOP."""
+    async def test_old_protocol_compatibility_preset_is_one_shot(self) -> None:
+        """The legacy alias must not turn preset recall into a memory-save hold."""
         coordinator = MagicMock()
         coordinator.address = "AA:BB:CC:DD:EE:FF"
         controller = OkinCB24Controller(coordinator, protocol_variant=OKIN_CB24_VARIANT_OLD)
@@ -119,15 +115,9 @@ class TestOkinCB24Controller:
 
         await controller._send_preset(OkinCB24Commands.PRESET_FLAT)
 
-        assert controller.write_command.await_count == 2
-        first_call = controller.write_command.await_args_list[0]
-        assert first_call == call(
+        controller.write_command.assert_awaited_once_with(
             controller._build_command(OkinCB24Commands.PRESET_FLAT),
-            repeat_count=_PRESET_CONTINUOUS_COUNT,
-            repeat_delay_ms=_PRESET_CONTINUOUS_DELAY_MS,
         )
-        second_call = controller.write_command.await_args_list[1]
-        assert second_call.args[0] == controller._build_command(0)
 
     @pytest.mark.asyncio
     async def test_cb24_profile_preset_is_one_shot(self) -> None:
@@ -144,115 +134,26 @@ class TestOkinCB24Controller:
         )
 
     @pytest.mark.asyncio
-    async def test_adaptive_cb24_promotes_to_continuous_after_retry(self) -> None:
-        """Auto legacy mode should switch after repeated quick same-preset retries."""
-        coordinator = MagicMock()
-        coordinator.address = "AA:BB:CC:DD:EE:FF"
-        coordinator.remember_cb24_continuous_presets = MagicMock()
-        controller = OkinCB24Controller(
-            coordinator,
-            protocol_variant=OKIN_CB24_VARIANT_CB24,
-            adaptive_preset_fallback=True,
-        )
-        controller.write_command = AsyncMock()
-        current_time = 1.0
-
-        def fake_now() -> float:
-            nonlocal current_time
-            value = current_time
-            current_time += 1.0
-            return value
-
-        controller._now = fake_now
-
-        await controller._send_preset(OkinCB24Commands.PRESET_MEMORY_1)
-        await controller._send_preset(OkinCB24Commands.PRESET_MEMORY_1)
-        await controller._send_preset(OkinCB24Commands.PRESET_MEMORY_1)
-
-        assert controller.write_command.await_count == 4
-        assert controller.write_command.await_args_list[0] == call(
-            controller._build_command(OkinCB24Commands.PRESET_MEMORY_1),
-        )
-        assert controller.write_command.await_args_list[1] == call(
-            controller._build_command(OkinCB24Commands.PRESET_MEMORY_1),
-        )
-        assert controller.write_command.await_args_list[2] == call(
-            controller._build_command(OkinCB24Commands.PRESET_MEMORY_1),
-            repeat_count=_PRESET_CONTINUOUS_COUNT,
-            repeat_delay_ms=_PRESET_CONTINUOUS_DELAY_MS,
-        )
-        assert controller.write_command.await_args_list[3].args[0] == controller._build_command(0)
-        coordinator.remember_cb24_continuous_presets.assert_called_once_with()
-        assert controller._continuous_presets is True
-        assert controller._adaptive_preset_fallback is False
-
-    @pytest.mark.asyncio
-    async def test_adaptive_cb24_stays_one_shot_for_different_preset(self) -> None:
-        """Adaptive fallback should not promote when different presets are tapped."""
+    async def test_repeated_cb24_presets_remain_one_shot(self) -> None:
+        """Repeated retries must never be learned as a destructive long press."""
         coordinator = MagicMock()
         coordinator.address = "AA:BB:CC:DD:EE:FF"
         controller = OkinCB24Controller(
             coordinator,
             protocol_variant=OKIN_CB24_VARIANT_CB24,
-            adaptive_preset_fallback=True,
         )
         controller.write_command = AsyncMock()
 
         await controller._send_preset(OkinCB24Commands.PRESET_MEMORY_1)
-        await controller._send_preset(OkinCB24Commands.PRESET_MEMORY_2)
+        await controller._send_preset(OkinCB24Commands.PRESET_MEMORY_1)
+        await controller._send_preset(OkinCB24Commands.PRESET_MEMORY_1)
 
-        assert controller.write_command.await_count == 2
-        assert controller.write_command.await_args_list[0] == call(
-            controller._build_command(OkinCB24Commands.PRESET_MEMORY_1),
-        )
-        assert controller.write_command.await_args_list[1] == call(
-            controller._build_command(OkinCB24Commands.PRESET_MEMORY_2),
-        )
-        assert controller._continuous_presets is False
-        assert controller._adaptive_preset_fallback is True
-
-    def test_adaptive_cb24_stays_one_shot_after_window_expires(self) -> None:
-        """Adaptive fallback should not promote when retry is outside the 12-second window."""
-        coordinator = MagicMock()
-        coordinator.address = "AA:BB:CC:DD:EE:FF"
-        controller = OkinCB24Controller(
-            coordinator,
-            protocol_variant=OKIN_CB24_VARIANT_CB24,
-            adaptive_preset_fallback=True,
-        )
-
-        # First tap at t=1000 records the preset and timestamp
-        result1 = controller._should_promote_presets_to_continuous(
-            OkinCB24Commands.PRESET_MEMORY_1, _now=1000.0
-        )
-        assert result1 is False
-
-        # Retry same preset after window has expired (13s > 12s) — treated as fresh tap
-        result2 = controller._should_promote_presets_to_continuous(
-            OkinCB24Commands.PRESET_MEMORY_1, _now=1013.0
-        )
-        assert result2 is False
-        assert controller._continuous_presets is False
-        assert controller._adaptive_preset_fallback is True
+        expected_call = call(controller._build_command(OkinCB24Commands.PRESET_MEMORY_1))
+        assert controller.write_command.await_args_list == [expected_call] * 3
 
     @pytest.mark.asyncio
-    async def test_old_protocol_preset_sends_stop_on_cancellation(self) -> None:
-        """`cb_old` compatibility profile should still attempt STOP on cancellation."""
-        coordinator = MagicMock()
-        coordinator.address = "AA:BB:CC:DD:EE:FF"
-        controller = OkinCB24Controller(coordinator, protocol_variant=OKIN_CB24_VARIANT_OLD)
-        controller.write_command = AsyncMock(side_effect=[asyncio.CancelledError(), None])
-
-        with pytest.raises(asyncio.CancelledError):
-            await controller._send_preset(OkinCB24Commands.PRESET_FLAT)
-
-        assert controller.write_command.await_count == 2
-        second_call = controller.write_command.await_args_list[1]
-        assert second_call.args[0] == controller._build_command(0)
-
-    @pytest.mark.asyncio
-    async def test_default_is_old_protocol(self) -> None:
-        """Default variant should use OLD protocol behavior."""
+    async def test_default_is_cb24_one_shot(self) -> None:
+        """Direct controller construction should default to safe CB24 behavior."""
         coordinator = MagicMock()
         coordinator.address = "AA:BB:CC:DD:EE:FF"
         controller = OkinCB24Controller(coordinator)
@@ -260,12 +161,9 @@ class TestOkinCB24Controller:
 
         await controller._send_preset(OkinCB24Commands.PRESET_MEMORY_1)
 
-        assert controller.write_command.await_count == 2
-        first_call = controller.write_command.await_args_list[0]
-        assert first_call == call(
+        assert controller._protocol_variant == OKIN_CB24_VARIANT_CB24
+        controller.write_command.assert_awaited_once_with(
             controller._build_command(OkinCB24Commands.PRESET_MEMORY_1),
-            repeat_count=_PRESET_CONTINUOUS_COUNT,
-            repeat_delay_ms=_PRESET_CONTINUOUS_DELAY_MS,
         )
 
     @pytest.mark.asyncio
@@ -320,7 +218,6 @@ class TestOkinCB24FactoryProfiles:
         assert isinstance(controller, OkinCB24Controller)
         assert controller._protocol_variant == OKIN_CB24_VARIANT_CB24
         assert controller._is_new_protocol is False
-        assert controller._adaptive_preset_fallback is True
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -351,7 +248,6 @@ class TestOkinCB24FactoryProfiles:
 
         assert isinstance(controller, OkinCB24Controller)
         assert controller._protocol_variant == expected_variant
-        assert controller._adaptive_preset_fallback is True
 
     @pytest.mark.asyncio
     async def test_unknown_manufacturer_payload_falls_back_to_name_heuristic(self) -> None:
@@ -368,13 +264,12 @@ class TestOkinCB24FactoryProfiles:
 
         assert isinstance(controller, OkinCB24Controller)
         assert controller._protocol_variant == OKIN_CB24_VARIANT_CB27NEW
-        assert controller._adaptive_preset_fallback is False
 
     @pytest.mark.asyncio
-    async def test_auto_detect_reuses_learned_continuous_preset_mode_after_reconnect(
+    async def test_obsolete_learned_continuous_flag_cannot_change_safe_behavior(
         self,
     ) -> None:
-        """Factory should preserve learned CB24 continuous preset mode across reconnects."""
+        """A stale runtime flag must not restore destructive preset repeats."""
         coordinator = _make_factory_coordinator()
         coordinator.cb24_continuous_presets_learned = True
         controller = await create_controller(
@@ -387,8 +282,13 @@ class TestOkinCB24FactoryProfiles:
 
         assert isinstance(controller, OkinCB24Controller)
         assert controller._protocol_variant == OKIN_CB24_VARIANT_CB24
-        assert controller._continuous_presets is True
-        assert controller._adaptive_preset_fallback is False
+        controller.write_command = AsyncMock()
+
+        await controller._send_preset(OkinCB24Commands.PRESET_ZERO_G)
+
+        controller.write_command.assert_awaited_once_with(
+            controller._build_command(OkinCB24Commands.PRESET_ZERO_G),
+        )
 
     @pytest.mark.asyncio
     async def test_manufacturer_payload_takes_precedence_over_cb27new_name(self) -> None:
@@ -406,7 +306,6 @@ class TestOkinCB24FactoryProfiles:
         assert isinstance(controller, OkinCB24Controller)
         assert controller._protocol_variant == OKIN_CB24_VARIANT_CB24_AB
         assert controller._is_new_protocol is False
-        assert controller._adaptive_preset_fallback is True
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -440,7 +339,6 @@ class TestOkinCB24FactoryProfiles:
         assert isinstance(controller, OkinCB24Controller)
         assert controller._protocol_variant == profile_variant
         assert controller._is_new_protocol is is_new_protocol
-        assert controller._adaptive_preset_fallback is False
 
 
 class TestOkinCB24VariantValidation:


### PR DESCRIPTION
## Summary

- send CB24 preset recall commands exactly once for every supported profile
- remove the adaptive and learned continuous-preset behavior
- retain `cb_old` as a safe one-shot compatibility option
- add regression coverage and document the CB24 preset safety constraint

## Root cause

The SmartBed APK sends the same preset command every 300 ms while the control is held. At roughly 5.2 seconds, that gesture becomes a memory-save operation. The integration's adaptive fallback sent 55 repeats over about 16.3 seconds, crossing that threshold and overwriting the stored preset.

This is the OEM preset-programming gesture, not evidence of a separate protocol variant.

## Impact

Preset recall no longer risks reprogramming or wiping the user's saved CB24 positions. Existing configurations that select `cb_old` remain accepted, but use the safe one-shot behavior.

Fixes #441

## Validation

- `.venv/bin/pytest -q tests/test_okin_cb24.py` (28 passed)
- Ruff checks passed
- Pyright passed with 0 errors and 0 warnings
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Safety Improvements**
  * Preset recall now uses a single, safe command across all supported CB24 profile variants.
  * Prevented repeated or automatically learned preset transmissions that could overwrite stored bed presets.

* **Documentation**
  * Added guidance explaining CB.24 preset behavior, including touchscreen hold timing and memory-save gestures.
  * Updated profile labels to identify legacy compatibility mode as using safe one-shot presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->