### PR TITLE
Improve OCTO notification handling and add TV lift support

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ To adjust settings after setup, click the **gear icon** on your device in Settin
 
 | Setting | Description |
 |---------|-------------|
-| Motor Count | 2 (back/legs), 3 (adds head), or 4 (adds feet) |
+| Motor Count | 2 (back/legs), 3 (adds head), or 4 (adds feet); Standard Octo RTV TV lifts use 1 |
 | Has Massage | Enable if your bed has massage |
 | Protocol Variant | Usually auto-detected, override if needed |
 | Motor Pulse Settings | Fine-tune movement timing |

--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -80,6 +80,7 @@ ATTR_INCLUDE_LOGS = "include_logs"
 ATTR_DIRECTION = "direction"
 ATTR_DURATION_MS = "duration_ms"
 TIMED_MOVE_MOTOR_OPTIONS = (
+    "tv_lift",
     "back",
     "legs",
     "head",

--- a/custom_components/adjustable_bed/beds/octo.py
+++ b/custom_components/adjustable_bed/beds/octo.py
@@ -64,6 +64,11 @@ OCTO_DRIVEMODE_TIMEOUT = 3.0
 # Feature discovery timeout
 OCTO_FEATURE_TIMEOUT = 5.0
 
+# Maximum encoded OCTO packet size: two delimiters plus the worst case where
+# every byte in the five-byte header and 16-bit-length data field is escaped.
+# This retains every protocol-valid packet while bounding a missing delimiter.
+OCTO_MAX_RESPONSE_BUFFER_SIZE = 2 + (2 * (5 + 0xFFFF))
+
 # Byte stuffing constants
 OCTO_PACKET_CHAR = 0x40
 OCTO_ESCAPE_CHAR = 0x3C
@@ -91,6 +96,7 @@ class OctoController(BedController):
         self._pin: str = pin
         self._keepalive_task: asyncio.Task[None] | None = None
         self._notifications_started: bool = False  # Track if BLE notifications are active
+        self._response_buffer = bytearray()
 
         # Feature discovery state
         self._has_pin: bool | None = None  # None = not yet discovered
@@ -191,7 +197,7 @@ class OctoController(BedController):
         # Build final packet with unescaped delimiters
         return bytes([OCTO_PACKET_CHAR, *escaped_payload, OCTO_PACKET_CHAR])
 
-    def _parse_response_packet(self, message: bytes) -> dict | None:
+    def _parse_response_packet(self, message: bytes) -> dict[str, list[int]] | None:
         """Parse a response packet from the bed.
 
         Format: [0x40, escaped(...), 0x40]
@@ -235,6 +241,51 @@ class OctoController(BedController):
             return None
 
         return {"command": command, "data": data}
+
+    def _extract_response_packets(self, data: bytes) -> list[dict[str, list[int]]]:
+        """Buffer notified values and return every complete, valid response packet.
+
+        BLE notification boundaries are not OCTO packet boundaries. In particular,
+        the controller may emit a protocol packet across multiple notifications when
+        it does not fit in one notified characteristic value. Raw ``0x40`` bytes
+        cannot occur inside a packet because the OCTO serializer escapes them, so
+        delimiter pairs provide an unambiguous framing boundary.
+        """
+        self._response_buffer.extend(data)
+        packets: list[dict[str, list[int]]] = []
+
+        while self._response_buffer:
+            start = self._response_buffer.find(OCTO_PACKET_CHAR)
+            if start < 0:
+                # Bytes before a start delimiter cannot become part of a later packet.
+                self._response_buffer.clear()
+                break
+            if start:
+                del self._response_buffer[:start]
+
+            end = self._response_buffer.find(OCTO_PACKET_CHAR, 1)
+            if end < 0:
+                # Retain the incomplete packet for the next notification.
+                break
+
+            packet = self._parse_response_packet(bytes(self._response_buffer[: end + 1]))
+            if packet is None:
+                # The end delimiter may also be the start of the next valid packet.
+                # Retain it while discarding the malformed candidate before it.
+                del self._response_buffer[:end]
+                continue
+
+            packets.append(packet)
+            del self._response_buffer[: end + 1]
+
+        if len(self._response_buffer) > OCTO_MAX_RESPONSE_BUFFER_SIZE:
+            _LOGGER.debug(
+                "Discarding oversized incomplete Octo response (%d bytes)",
+                len(self._response_buffer),
+            )
+            self._response_buffer.clear()
+
+        return packets
 
     def _extract_feature_value_pair(
         self, data: list[int]
@@ -351,36 +402,33 @@ class OctoController(BedController):
         _LOGGER.debug("Received notification: %s", data.hex())
         self.forward_raw_notification(OCTO_CHAR_UUID, bytes(data))
 
-        packet = self._parse_response_packet(bytes(data))
-        if packet is None:
-            return
+        for packet in self._extract_response_packets(bytes(data)):
+            command = packet["command"]
+            packet_data = packet["data"]
 
-        command = packet["command"]
-        packet_data = packet["data"]
+            # Handle feature response (0x21 0x71)
+            if command[0] == 0x21 and command[1] == 0x71:
+                self._handle_feature_response(packet_data)
 
-        # Handle feature response (0x21 0x71)
-        if command[0] == 0x21 and command[1] == 0x71:
-            self._handle_feature_response(packet_data)
-
-        # Handle CONFIG responses (0x11 = response to CONFIG 0x10)
-        if command[0] == 0x11:
-            if command[1] == 0x72:
-                # CONFIG_GET_DRIVEMODE response
-                if packet_data:
-                    self._synchro_active = packet_data[0] == OCTO_DRIVEMODE_SYNC
-                    _LOGGER.debug(
-                        "Drivemode response: %s",
-                        "sync" if self._synchro_active else "single",
-                    )
-                    self._drivemode_event.set()
-            elif command[1] == 0x71:
-                # CONFIG_SET_DRIVEMODE acknowledgment
-                if packet_data:
-                    self._synchro_active = packet_data[0] == OCTO_DRIVEMODE_SYNC
-                    _LOGGER.debug(
-                        "Drivemode set acknowledged: %s",
-                        "sync" if self._synchro_active else "single",
-                    )
+            # Handle CONFIG responses (0x11 = response to CONFIG 0x10)
+            if command[0] == 0x11:
+                if command[1] == 0x72:
+                    # CONFIG_GET_DRIVEMODE response
+                    if packet_data:
+                        self._synchro_active = packet_data[0] == OCTO_DRIVEMODE_SYNC
+                        _LOGGER.debug(
+                            "Drivemode response: %s",
+                            "sync" if self._synchro_active else "single",
+                        )
+                        self._drivemode_event.set()
+                elif command[1] == 0x71:
+                    # CONFIG_SET_DRIVEMODE acknowledgment
+                    if packet_data:
+                        self._synchro_active = packet_data[0] == OCTO_DRIVEMODE_SYNC
+                        _LOGGER.debug(
+                            "Drivemode set acknowledged: %s",
+                            "sync" if self._synchro_active else "single",
+                        )
 
     async def write_command(
         self,
@@ -431,9 +479,7 @@ class OctoController(BedController):
         packet = self._build_packet(command, data)
         await self.write_command(packet, repeat_count, repeat_delay_ms, cancel_event)
 
-    async def start_notify(
-        self, callback: Callable[[str, float], None] | None = None
-    ) -> None:
+    async def start_notify(self, callback: Callable[[str, float], None] | None = None) -> None:
         """Start listening for notifications.
 
         Octo beds don't support position notifications, but we use notifications
@@ -441,6 +487,7 @@ class OctoController(BedController):
         """
         self._notify_callback = callback
         if self.client is not None and self.client.is_connected:
+            self._response_buffer.clear()
             try:
                 async with self._ble_lock:
                     await self.client.start_notify(OCTO_CHAR_UUID, self._on_notification)
@@ -452,6 +499,7 @@ class OctoController(BedController):
     async def stop_notify(self) -> None:
         """Stop listening for notifications."""
         self._notifications_started = False
+        self._response_buffer.clear()
         if self.client is not None and self.client.is_connected:
             with contextlib.suppress(BleakError):
                 async with self._ble_lock:
@@ -620,6 +668,7 @@ class OctoController(BedController):
         # skip notification setup when disable_angle_sensing is true, but Octo still
         # needs notifications for feature discovery (PIN/lights detection)
         if not self._notifications_started:
+            self._response_buffer.clear()
             try:
                 async with self._ble_lock:
                     await self.client.start_notify(OCTO_CHAR_UUID, self._on_notification)
@@ -1191,9 +1240,7 @@ class OctoStar2Controller(BedController):
             if i < repeat_count - 1:
                 await asyncio.sleep(repeat_delay_ms / 1000)
 
-    async def start_notify(
-        self, callback: Callable[[str, float], None] | None = None
-    ) -> None:
+    async def start_notify(self, callback: Callable[[str, float], None] | None = None) -> None:
         """Start listening for notifications.
 
         Star2 doesn't support position notifications, so this only stores the callback.

--- a/custom_components/adjustable_bed/beds/octo.py
+++ b/custom_components/adjustable_bed/beds/octo.py
@@ -253,37 +253,42 @@ class OctoController(BedController):
         """
         self._response_buffer.extend(data)
         packets: list[dict[str, list[int]]] = []
+        buffer = self._response_buffer
+        trim_at = 0
 
-        while self._response_buffer:
-            start = self._response_buffer.find(OCTO_PACKET_CHAR)
+        while True:
+            start = buffer.find(OCTO_PACKET_CHAR, trim_at)
             if start < 0:
                 # Bytes before a start delimiter cannot become part of a later packet.
-                self._response_buffer.clear()
+                trim_at = len(buffer)
                 break
-            if start:
-                del self._response_buffer[:start]
 
-            end = self._response_buffer.find(OCTO_PACKET_CHAR, 1)
+            end = buffer.find(OCTO_PACKET_CHAR, start + 1)
             if end < 0:
-                # Retain the incomplete packet for the next notification.
+                # Discard leading noise but retain the incomplete packet.
+                trim_at = start
                 break
 
-            packet = self._parse_response_packet(bytes(self._response_buffer[: end + 1]))
+            packet = self._parse_response_packet(bytes(buffer[start : end + 1]))
             if packet is None:
                 # The end delimiter may also be the start of the next valid packet.
-                # Retain it while discarding the malformed candidate before it.
-                del self._response_buffer[:end]
+                # Scan from it without shifting the bytearray on every candidate.
+                trim_at = end
                 continue
 
             packets.append(packet)
-            del self._response_buffer[: end + 1]
+            trim_at = end + 1
 
-        if len(self._response_buffer) > OCTO_MAX_RESPONSE_BUFFER_SIZE:
+        # Front-delete at most once per callback. Repeated bytearray shifts during
+        # malformed-stream resynchronization would otherwise have quadratic cost.
+        del buffer[:trim_at]
+
+        if len(buffer) > OCTO_MAX_RESPONSE_BUFFER_SIZE:
             _LOGGER.debug(
                 "Discarding oversized incomplete Octo response (%d bytes)",
-                len(self._response_buffer),
+                len(buffer),
             )
-            self._response_buffer.clear()
+            buffer.clear()
 
         return packets
 

--- a/custom_components/adjustable_bed/beds/octo.py
+++ b/custom_components/adjustable_bed/beds/octo.py
@@ -524,6 +524,11 @@ class OctoController(BedController):
         return bool(self._pin)
 
     @property
+    def _is_one_motor_lift(self) -> bool:
+        """Return whether this controller represents an OCTO one-motor lift."""
+        return self._coordinator.motor_count == 1
+
+    @property
     def supports_lights(self) -> bool:
         """Check if the bed has under-bed lights.
 
@@ -534,6 +539,8 @@ class OctoController(BedController):
         Returns False if:
         - Features were discovered but light feature was not present
         """
+        if self._is_one_motor_lift:
+            return False
         if self._has_lights is not None:
             return self._has_lights
         # Features not discovered - assume lights exist for backward compatibility
@@ -542,26 +549,26 @@ class OctoController(BedController):
     @property
     def supports_light_color_control(self) -> bool:
         """Return True if bed supports RGBWI light color control."""
-        return self._has_rgbwi
+        return not self._is_one_motor_lift and self._has_rgbwi
 
     @property
     def supported_color_mode(self) -> str | None:
         """Return 'rgbw' for RGBWI beds, None otherwise."""
-        if self._has_rgbwi:
+        if self.supports_light_color_control:
             return "rgbw"
         return None
 
     @property
     def default_light_rgb_color(self) -> tuple[int, int, int] | None:
         """Return default white color for RGBWI beds."""
-        if self._has_rgbwi:
+        if self.supports_light_color_control:
             return (255, 255, 255)
         return None
 
     @property
     def supports_explicit_light_on_control(self) -> bool:
         """Return True if bed has a dedicated light-on command."""
-        if self._has_rgbwi:
+        if self.supports_light_color_control:
             return True
         return self.supports_discrete_light_control
 
@@ -569,6 +576,11 @@ class OctoController(BedController):
     def supports_discrete_light_control(self) -> bool:
         """Return True if bed has separate on/off light commands."""
         return self.supports_lights
+
+    @property
+    def supports_light_toggle_control(self) -> bool:
+        """Return whether this OCTO controller exposes bed-light toggling."""
+        return not self._is_one_motor_lift and super().supports_light_toggle_control
 
     @property
     def light_auto_off_seconds(self) -> int | None:
@@ -580,6 +592,8 @@ class OctoController(BedController):
     @property
     def supports_memory_presets(self) -> bool:
         """Return True if bed supports memory presets (CAP_MEMCOUNT > 0)."""
+        if self._is_one_motor_lift:
+            return False
         if self._memory_count is not None:
             return self._memory_count > 0
         # Features not discovered - assume no memory presets for safety
@@ -588,6 +602,8 @@ class OctoController(BedController):
     @property
     def memory_slot_count(self) -> int:
         """Return number of memory preset slots."""
+        if self._is_one_motor_lift:
+            return 0
         return self._memory_count if self._memory_count is not None else 0
 
     @property
@@ -601,6 +617,8 @@ class OctoController(BedController):
 
         Returns True only if CAP_SYNCHRO (0x000101) was detected during discovery.
         """
+        if self._is_one_motor_lift:
+            return False
         if self._has_synchro is not None:
             return self._has_synchro
         return False
@@ -861,6 +879,18 @@ class OctoController(BedController):
         """Stop fourth motor."""
         await self._stop_motors()
 
+    async def _move_tv_lift_up(self) -> None:
+        """Raise an OCTO one-motor TV lift."""
+        await self._octo_move_with_stop(OCTO_MOTOR_HEAD, "up")
+
+    async def _move_tv_lift_down(self) -> None:
+        """Lower an OCTO one-motor TV lift."""
+        await self._octo_move_with_stop(OCTO_MOTOR_HEAD, "down")
+
+    async def _move_tv_lift_stop(self) -> None:
+        """Stop an OCTO one-motor TV lift."""
+        await self._stop_motors()
+
     async def stop_all(self) -> None:
         """Stop all motors."""
         await self._stop_motors()
@@ -879,6 +909,17 @@ class OctoController(BedController):
         standard cover entity naming convention.
         """
         motor_count = self._coordinator.motor_count
+
+        if motor_count == 1:
+            return (
+                MotorControlSpec(
+                    key="tv_lift",
+                    translation_key="tv_lift",
+                    open_fn=lambda ctrl: cast(OctoController, ctrl)._move_tv_lift_up(),
+                    close_fn=lambda ctrl: cast(OctoController, ctrl)._move_tv_lift_down(),
+                    stop_fn=lambda ctrl: cast(OctoController, ctrl)._move_tv_lift_stop(),
+                ),
+            )
 
         specs: list[MotorControlSpec] = [
             MotorControlSpec(
@@ -925,8 +966,20 @@ class OctoController(BedController):
 
     @property
     def supports_preset_both_up(self) -> bool:
-        """Return True - Octo beds support moving both head and legs up."""
-        return True
+        """Return whether this OCTO controller has both bed motors."""
+        return not self._is_one_motor_lift
+
+    @property
+    def supports_preset_flat(self) -> bool:
+        """Return whether this OCTO controller represents a bed."""
+        return not self._is_one_motor_lift
+
+    @property
+    def stale_motor_entity_keys(self) -> frozenset[str]:
+        """Return entity keys belonging to the other OCTO actuator layout."""
+        if self._is_one_motor_lift:
+            return frozenset({"back", "legs", "head", "feet"})
+        return frozenset({"tv_lift"})
 
     # Preset methods
     async def preset_both_up(self) -> None:

--- a/custom_components/adjustable_bed/beds/octo.py
+++ b/custom_components/adjustable_bed/beds/octo.py
@@ -1238,6 +1238,11 @@ class OctoStar2Controller(BedController):
         _LOGGER.debug("OctoStar2Controller initialized")
 
     @property
+    def stale_motor_entity_keys(self) -> frozenset[str]:
+        """Return stale OCTO motor entities to remove for Star2."""
+        return frozenset({"tv_lift"})
+
+    @property
     def supports_lights(self) -> bool:
         """Star2 protocol doesn't support light control."""
         return False

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -109,6 +109,7 @@ from .const import (
     MALOUF_LAYOUTS,
     MALOUF_MEMORY_SLOT_OPTIONS,
     MALOUF_MEMORY_SLOTS_AUTO,
+    OCTO_VARIANT_STAR2,
     POSITION_MODE_ACCURACY,
     POSITION_MODE_SPEED,
     RICHMAT_REMOTE_AUTO,
@@ -164,6 +165,39 @@ BED_TYPE_AUTO_DETECT = "auto_detect"
 # such as OKIN receivers) — we keep "Auto-detect" selected and ask the user to
 # choose, rather than silently configuring a guessed protocol.
 _AUTO_DETECT_MIN_CONFIDENCE = 0.7
+
+
+def _motor_count_options(
+    bed_type: str | None,
+    protocol_variant: str = DEFAULT_PROTOCOL_VARIANT,
+) -> list[int]:
+    """Return motor counts supported by the selected protocol."""
+    if bed_type == BED_TYPE_OCTO and protocol_variant != OCTO_VARIANT_STAR2:
+        return [1, 2, 3, 4]
+    return [2, 3, 4]
+
+
+def _is_valid_motor_count(
+    bed_type: str | None,
+    protocol_variant: str,
+    motor_count: int,
+) -> bool:
+    """Return whether a motor count is valid for the selected protocol."""
+    return motor_count in _motor_count_options(bed_type, protocol_variant)
+
+
+def _default_motor_count(
+    bed_type: str | None,
+    device_name: str | None = None,
+) -> int:
+    """Return the motor-count default, recognizing OCTO RTV one-motor lifts."""
+    if (
+        bed_type == BED_TYPE_OCTO
+        and device_name is not None
+        and device_name.strip().lower().startswith("rtv")
+    ):
+        return 1
+    return DEFAULT_MOTOR_COUNT
 
 
 def _confident_auto_detect(result: DetectionResult) -> str | None:
@@ -769,6 +803,12 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             preferred_adapter = user_input.get(CONF_PREFERRED_ADAPTER, ADAPTER_AUTO)
             protocol_variant = user_input.get(CONF_PROTOCOL_VARIANT, DEFAULT_PROTOCOL_VARIANT)
 
+            motor_count = user_input.get(CONF_MOTOR_COUNT, DEFAULT_MOTOR_COUNT)
+            if selected_bed_type and not _is_valid_motor_count(
+                selected_bed_type, protocol_variant, motor_count
+            ):
+                errors[CONF_MOTOR_COUNT] = "invalid_motor_count_for_bed_type"
+
             # Validate protocol variant is valid for selected bed type
             if selected_bed_type and not is_valid_variant_for_bed_type(
                 selected_bed_type, protocol_variant
@@ -904,7 +944,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         default_pulse_count, default_pulse_delay = pulse_defaults
 
         # Auto-detect motor count for Richmat beds based on remote code features
-        default_motor_count = DEFAULT_MOTOR_COUNT
+        default_motor_count = _default_motor_count(bed_type, self._discovery_info.name)
         detected_remote = detection_result.detected_remote
         if bed_type == BED_TYPE_RICHMAT:
             # Use detected_remote from detection result, or try to extract from name
@@ -950,7 +990,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             vol.Optional(CONF_BED_TYPE, default=bed_type_default): bed_type_selector,
             vol.Optional(CONF_NAME, default=self._discovery_info.name or "Adjustable Bed"): str,
             vol.Optional(CONF_MOTOR_COUNT, default=default_motor_count): vol.All(
-                vol.Coerce(int), vol.In([2, 3, 4])
+                vol.Coerce(int), vol.In([1, 2, 3, 4])
             ),
             vol.Optional(CONF_HAS_MASSAGE, default=DEFAULT_HAS_MASSAGE): bool,
             vol.Optional(CONF_DISABLE_ANGLE_SENSING, default=default_disable_angle): bool,
@@ -1441,6 +1481,12 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             preferred_adapter = user_input.get(CONF_PREFERRED_ADAPTER, str(discovery_source))
             protocol_variant = user_input.get(CONF_PROTOCOL_VARIANT, DEFAULT_PROTOCOL_VARIANT)
 
+            motor_count = user_input.get(CONF_MOTOR_COUNT, DEFAULT_MOTOR_COUNT)
+            if bed_type != BED_TYPE_AUTO_DETECT and not _is_valid_motor_count(
+                bed_type, protocol_variant, motor_count
+            ):
+                errors[CONF_MOTOR_COUNT] = "invalid_motor_count_for_bed_type"
+
             # Validate protocol variant is valid for bed type
             if bed_type != BED_TYPE_AUTO_DETECT and not is_valid_variant_for_bed_type(
                 bed_type, protocol_variant
@@ -1615,9 +1661,10 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 vol.Optional(
                     CONF_NAME, default=device_name if device_name != "Unknown" else "Adjustable Bed"
                 ): str,
-                vol.Optional(CONF_MOTOR_COUNT, default=DEFAULT_MOTOR_COUNT): vol.All(
-                    vol.Coerce(int), vol.In([2, 3, 4])
-                ),
+                vol.Optional(
+                    CONF_MOTOR_COUNT,
+                    default=_default_motor_count(defaults_bed_type, device_name),
+                ): vol.All(vol.Coerce(int), vol.In([1, 2, 3, 4])),
                 vol.Optional(CONF_HAS_MASSAGE, default=DEFAULT_HAS_MASSAGE): bool,
                 vol.Optional(CONF_DISABLE_ANGLE_SENSING, default=default_disable_angle): bool,
                 vol.Optional(CONF_PREFERRED_ADAPTER, default=discovery_source): vol.In(adapters),
@@ -1665,6 +1712,10 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 preferred_adapter = user_input.get(CONF_PREFERRED_ADAPTER, ADAPTER_AUTO)
                 protocol_variant = user_input.get(CONF_PROTOCOL_VARIANT, DEFAULT_PROTOCOL_VARIANT)
+
+                motor_count = user_input.get(CONF_MOTOR_COUNT, DEFAULT_MOTOR_COUNT)
+                if not _is_valid_motor_count(bed_type, protocol_variant, motor_count):
+                    errors[CONF_MOTOR_COUNT] = "invalid_motor_count_for_bed_type"
 
                 # Validate protocol variant is valid for bed type
                 if not is_valid_variant_for_bed_type(bed_type, protocol_variant):
@@ -1816,7 +1867,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             {
                 vol.Optional(CONF_NAME, default="Adjustable Bed"): str,
                 vol.Optional(CONF_MOTOR_COUNT, default=DEFAULT_MOTOR_COUNT): vol.All(
-                    vol.Coerce(int), vol.In([2, 3, 4])
+                    vol.Coerce(int), vol.In([1, 2, 3, 4])
                 ),
                 vol.Optional(CONF_HAS_MASSAGE, default=DEFAULT_HAS_MASSAGE): bool,
                 vol.Optional(CONF_DISABLE_ANGLE_SENSING, default=default_disable_angle): bool,
@@ -2523,7 +2574,15 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
             vol.Optional(
                 CONF_MOTOR_COUNT,
                 default=current_data.get(CONF_MOTOR_COUNT, DEFAULT_MOTOR_COUNT),
-            ): vol.All(vol.Coerce(int), vol.In([2, 3, 4])),
+            ): vol.All(
+                vol.Coerce(int),
+                vol.In(
+                    _motor_count_options(
+                        bed_type,
+                        current_data.get(CONF_PROTOCOL_VARIANT, DEFAULT_PROTOCOL_VARIANT),
+                    )
+                ),
+            ),
             vol.Optional(
                 CONF_HAS_MASSAGE,
                 default=current_data.get(CONF_HAS_MASSAGE, DEFAULT_HAS_MASSAGE),
@@ -2668,6 +2727,24 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
             discovery_disabled_input: bool | None = None
             if CONF_DISABLE_DISCOVERY in user_input:
                 discovery_disabled_input = bool(user_input.pop(CONF_DISABLE_DISCOVERY))
+            requested_variant = user_input.get(
+                CONF_PROTOCOL_VARIANT,
+                current_data.get(CONF_PROTOCOL_VARIANT, DEFAULT_PROTOCOL_VARIANT),
+            )
+            requested_motor_count = user_input.get(
+                CONF_MOTOR_COUNT,
+                current_data.get(CONF_MOTOR_COUNT, DEFAULT_MOTOR_COUNT),
+            )
+            if not _is_valid_motor_count(
+                bed_type,
+                requested_variant,
+                requested_motor_count,
+            ):
+                return self.async_show_form(
+                    step_id="init",
+                    data_schema=vol.Schema(schema_dict),
+                    errors={CONF_MOTOR_COUNT: "invalid_motor_count_for_bed_type"},
+                )
             if bed_type == BED_TYPE_OCTO and CONF_OCTO_PIN in user_input:
                 octo_pin = normalize_octo_pin(user_input.get(CONF_OCTO_PIN, DEFAULT_OCTO_PIN))
                 if not is_valid_octo_pin(octo_pin):

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -177,6 +177,20 @@ def _motor_count_options(
     return [2, 3, 4]
 
 
+def _motor_count_options_for_all_variants(bed_type: str | None) -> list[int]:
+    """Return the union of motor counts selectable across protocol variants."""
+    variants = get_variants_for_bed_type(bed_type)
+    if variants is None:
+        return _motor_count_options(bed_type)
+    return sorted(
+        {
+            motor_count
+            for variant in variants
+            for motor_count in _motor_count_options(bed_type, variant)
+        }
+    )
+
+
 def _is_valid_motor_count(
     bed_type: str | None,
     protocol_variant: str,
@@ -2576,12 +2590,7 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
                 default=current_data.get(CONF_MOTOR_COUNT, DEFAULT_MOTOR_COUNT),
             ): vol.All(
                 vol.Coerce(int),
-                vol.In(
-                    _motor_count_options(
-                        bed_type,
-                        current_data.get(CONF_PROTOCOL_VARIANT, DEFAULT_PROTOCOL_VARIANT),
-                    )
-                ),
+                vol.In(_motor_count_options_for_all_variants(bed_type)),
             ),
             vol.Optional(
                 CONF_HAS_MASSAGE,

--- a/custom_components/adjustable_bed/cover.py
+++ b/custom_components/adjustable_bed/cover.py
@@ -54,6 +54,16 @@ class AdjustableBedCoverEntityDescription(CoverEntityDescription):
 # - 4 motors: back, legs, head, feet
 COVER_DESCRIPTIONS: tuple[AdjustableBedCoverEntityDescription, ...] = (
     AdjustableBedCoverEntityDescription(
+        key="tv_lift",
+        translation_key="tv_lift",
+        icon="mdi:television-classic",
+        device_class=CoverDeviceClass.DAMPER,
+        open_fn=lambda ctrl: ctrl.move_back_up(),
+        close_fn=lambda ctrl: ctrl.move_back_down(),
+        stop_fn=lambda ctrl: ctrl.move_back_stop(),
+        min_motors=1,
+    ),
+    AdjustableBedCoverEntityDescription(
         key="back",
         translation_key="back",
         icon="mdi:human-handsup",

--- a/custom_components/adjustable_bed/services.yaml
+++ b/custom_components/adjustable_bed/services.yaml
@@ -70,6 +70,8 @@ set_position:
       selector:
         select:
           options:
+            - label: TV Lift
+              value: tv_lift
             - label: Back
               value: back
             - label: Legs

--- a/custom_components/adjustable_bed/services.yaml
+++ b/custom_components/adjustable_bed/services.yaml
@@ -70,8 +70,6 @@ set_position:
       selector:
         select:
           options:
-            - label: TV Lift
-              value: tv_lift
             - label: Back
               value: back
             - label: Legs
@@ -108,6 +106,8 @@ timed_move:
       selector:
         select:
           options:
+            - label: TV Lift
+              value: tv_lift
             - label: Back
               value: back
             - label: Legs

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -286,6 +286,7 @@
       "invalid_number": "Please enter valid numbers for motor pulse count and delay.",
       "invalid_pin": "PIN must be empty or exactly 4 digits.",
       "invalid_variant_for_bed_type": "The selected protocol variant is not compatible with the selected bed type.",
+      "invalid_motor_count_for_bed_type": "One motor is supported only for Standard OCTO TV lift controllers.",
       "pairing_not_confirmed": "Please confirm that you have paired the bed before continuing.",
       "pairing_failed": "Pairing failed. Make sure the bed is in pairing mode and try again.",
       "pairing_not_supported": "Pairing not supported by this Bluetooth adapter. If using ESPHome proxy, update to ESPHome >= 2024.3.0.",
@@ -345,6 +346,7 @@
     "error": {
       "invalid_number": "Please enter valid numbers for motor pulse count and delay.",
       "invalid_pin": "PIN must be empty or exactly 4 digits.",
+      "invalid_motor_count_for_bed_type": "One motor is supported only for Standard OCTO TV lift controllers.",
       "invalid_angle": "Angle must be a positive number between 0 and 180 degrees."
     }
   },
@@ -505,6 +507,9 @@
       }
     },
     "cover": {
+      "tv_lift": {
+        "name": "TV Lift"
+      },
       "head": {
         "name": "Head"
       },
@@ -767,7 +772,7 @@
         },
         "motor": {
           "name": "Motor",
-          "description": "The motor to move (back, legs, head, feet, or stair)."
+          "description": "The motor to move (TV lift, back, legs, head, feet, or another supported actuator)."
         },
         "direction": {
           "name": "Direction",

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -286,6 +286,7 @@
       "invalid_number": "Please enter valid numbers for motor pulse count and delay.",
       "invalid_pin": "PIN must be empty or exactly 4 digits.",
       "invalid_variant_for_bed_type": "The selected protocol variant is not compatible with the selected bed type.",
+      "invalid_motor_count_for_bed_type": "One motor is supported only for Standard OCTO TV lift controllers.",
       "pairing_not_confirmed": "Please confirm that you have paired the bed before continuing.",
       "pairing_failed": "Pairing failed. Make sure the bed is in pairing mode and try again.",
       "pairing_not_supported": "Pairing not supported by this Bluetooth adapter. If using ESPHome proxy, update to ESPHome >= 2024.3.0.",
@@ -345,6 +346,7 @@
     "error": {
       "invalid_number": "Please enter valid numbers for motor pulse count and delay.",
       "invalid_pin": "PIN must be empty or exactly 4 digits.",
+      "invalid_motor_count_for_bed_type": "One motor is supported only for Standard OCTO TV lift controllers.",
       "invalid_angle": "Angle must be a positive number between 0 and 180 degrees."
     }
   },
@@ -505,6 +507,9 @@
       }
     },
     "cover": {
+      "tv_lift": {
+        "name": "TV Lift"
+      },
       "head": {
         "name": "Head"
       },
@@ -767,7 +772,7 @@
         },
         "motor": {
           "name": "Motor",
-          "description": "The motor to move (back, legs, head, feet, or stair)."
+          "description": "The motor to move (TV lift, back, legs, head, feet, or another supported actuator)."
         },
         "direction": {
           "name": "Direction",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -39,7 +39,7 @@ To adjust settings after setup:
 
 | Setting | Options | Default | Description |
 |---------|---------|---------|-------------|
-| **Motor Count** | 2, 3, 4 | 2 | Number of controllable motor sections |
+| **Motor Count** | 2, 3, 4; 1 for Standard OCTO TV lifts | 2 | Number of controllable motor sections |
 | **Has Massage** | On/Off | Off | Enable massage controls if your bed supports it |
 | **Preferred Adapter** | Auto / Specific adapter | Auto | Which Bluetooth adapter or proxy to use |
 
@@ -47,11 +47,12 @@ To adjust settings after setup:
 
 | Motors | Controllable Sections |
 |--------|----------------------|
+| 1 | TV Lift (Standard OCTO `RTV` only) |
 | 2 | Back + Legs |
 | 3 | Head + Back + Legs |
 | 4 | Head + Back + Legs + Feet |
 
-**Tip:** Count the distinct moving sections when using your physical remote to determine the correct setting.
+**Tip:** Count the distinct moving sections when using your physical remote to determine the correct setting. An OCTO device named `RTV` is detected automatically as a one-motor TV lift.
 
 ### Malouf/Lucid Layout and Memory
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -39,7 +39,7 @@ To adjust settings after setup:
 
 | Setting | Options | Default | Description |
 |---------|---------|---------|-------------|
-| **Motor Count** | 2, 3, 4; 1 for Standard OCTO TV lifts | 2 | Number of controllable motor sections |
+| **Motor Count** | 2, 3, 4; 1 for one-motor Standard OCTO lifts | 2 | Number of controllable motor sections |
 | **Has Massage** | On/Off | Off | Enable massage controls if your bed supports it |
 | **Preferred Adapter** | Auto / Specific adapter | Auto | Which Bluetooth adapter or proxy to use |
 
@@ -47,12 +47,12 @@ To adjust settings after setup:
 
 | Motors | Controllable Sections |
 |--------|----------------------|
-| 1 | TV Lift (Standard OCTO `RTV` only) |
+| 1 | TV/bed lift (Standard OCTO; `RTV` is detected automatically) |
 | 2 | Back + Legs |
 | 3 | Head + Back + Legs |
 | 4 | Head + Back + Legs + Feet |
 
-**Tip:** Count the distinct moving sections when using your physical remote to determine the correct setting. An OCTO device named `RTV` is detected automatically as a one-motor TV lift.
+**Tip:** Count the distinct moving sections when using your physical remote to determine the correct setting. A one-motor Standard OCTO controller can be selected manually; an OCTO device named `RTV` is detected automatically as a one-motor TV lift.
 
 ### Malouf/Lucid Layout and Memory
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -103,7 +103,7 @@ This guide covers common issues and their solutions when using the Adjustable Be
 
 **Solutions:**
 1. **Verify features:** Check if your bed actually has the feature (massage, lights, etc.)
-2. **Update motor count:** Set the correct number of motors in options (2, 3, or 4; use 1 only for a Standard OCTO `RTV` TV lift)
+2. **Update motor count:** Set the correct number of motors in options (2, 3, or 4; use 1 only for a one-motor Standard OCTO lift, with `RTV` detected automatically)
 3. **Enable massage:** If bed has massage, enable it in integration options
 
 ### Commands are slow or delayed

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -103,7 +103,7 @@ This guide covers common issues and their solutions when using the Adjustable Be
 
 **Solutions:**
 1. **Verify features:** Check if your bed actually has the feature (massage, lights, etc.)
-2. **Update motor count:** Set correct number of motors in options (2, 3, or 4)
+2. **Update motor count:** Set the correct number of motors in options (2, 3, or 4; use 1 only for a Standard OCTO `RTV` TV lift)
 3. **Enable massage:** If bed has massage, enable it in integration options
 
 ### Commands are slow or delayed

--- a/docs/beds/octo.md
+++ b/docs/beds/octo.md
@@ -1,13 +1,18 @@
 # Octo
 
-**Status:** ✅ Tested
+**Status:** ✅ Protocol tested for supported 2-4 motor bed receivers
 
 **Credit:** Reverse engineering by [kristofferR](https://github.com/kristofferR/ha-adjustable-bed), [_pm](https://community.home-assistant.io/t/how-to-setup-esphome-to-control-my-bluetooth-controlled-octocontrol-bed/540790), [goedh452](https://community.home-assistant.io/t/how-to-setup-esphome-to-control-my-bluetooth-controlled-octocontrol-bed/540790/10), Murp, and [Brokkert](https://github.com/Brokkert)
 
 ## Known Models
+
 - Octo-branded adjustable beds
 - Beka
 - Cozyworld Cozy2Go
+
+OCTO Smart Control also recognizes non-bed and one-motor products that use the
+same protocol family. Recognition of an OCTO BLE name does not by itself mean
+that the device's actuator layout is supported by this integration.
 
 ## Apps
 
@@ -31,19 +36,35 @@ Some Octo beds require a 4-digit PIN to maintain the Bluetooth connection. Witho
 
 ### Finding Your PIN
 
-The PIN is typically found in your Octo physical remote's settings menu, or in the documentation that came with your bed. If you don't know your PIN and the bed works without one, leave it empty.
+This is the receiver's OCTO app PIN, not a Bluetooth pairing code. If you set a
+four-digit PIN in OCTO Smart Control, enter the same code here. If the receiver
+works without a PIN, leave this field empty. Follow the manufacturer's reset
+instructions if a configured PIN has been lost.
 
 ## Features
 
 | Feature | Supported |
 |---------|-----------|
-| Motor Control | ✅ (2-4 motors, auto-detected via CAP_MOTORCOUNT) |
+| Bed Motor Control | ✅ (2-4 motors; configured during setup and checked against CAP_MOTORCOUNT) |
+| One-motor TV/Bed Lift | ❌ (recognized as OCTO, but no dedicated lift entity yet) |
 | Position Feedback | ❌ |
 | Memory Presets | ✅ (dynamically detected, Standard variant only) |
 | Both Up Preset | ✅ (Standard variant: moves head + legs together) |
 | Under-bed Lights | ✅ (Standard variant only; RGBW color picker on beds with CAP_LIGHT_RGBWI) |
 | Synchro/Linked Mode | ✅ (Standard variant, split-king beds with CAP_SYNCHRO) |
 | PIN Authentication | ✅ (Standard variant only) |
+
+### One-motor and TV lift limitation
+
+The official OCTO device list identifies `RTV` as **Lift 1M**. Other OCTO
+products can also report a single motor through `CAP_MOTORCOUNT`. The integration
+currently allows only 2, 3, or 4 motors and always creates bed-oriented motor
+entities, beginning with Back and Legs. It therefore does not currently provide
+a correct or safe representation of a one-motor TV/bed lift.
+
+An `RTV` device may be detected as OCTO because it shares the protocol and an
+official name prefix. Detection is not a claim of TV lift support. Do not
+configure it as a two-motor bed merely to make it pass setup.
 
 ## Split Beds
 
@@ -60,6 +81,11 @@ The official Octo app handles this by storing separate left/right device
 addresses and switching between them. Also note that the `Back + Legs Up`
 preset only moves both motors on the currently connected controller; it does
 not mean both bed sides.
+
+The integration does not merge the two BLE addresses and a separate `RTV`
+controller into one Home Assistant device. Each supported bed receiver is a
+separate config entry. `Synchro Mode`, when advertised by the receiver, is a
+hardware capability and is not software grouping across arbitrary entries.
 
 ## Protocol Variants
 
@@ -78,6 +104,18 @@ Octo beds have at least two protocol variants. The integration auto-detects the 
 ```
 
 **Checksum:** `((sum_of_all_bytes XOR 0xFF) + 1) & 0xFF`
+
+Bytes `0x40`, `0x3C`, `0x4F`, and `0x41` inside the frame payload are escaped.
+The delimiters themselves remain unescaped.
+
+#### Notification framing
+
+An OCTO packet and a BLE notification are not the same boundary. A complete
+packet can span multiple notified characteristic values, and one notified value
+can contain multiple packets. The integration keeps an incomplete response
+between callbacks, extracts every complete `0x40 ... 0x40` frame, then verifies
+its unescaped length and checksum before dispatching it. Malformed data is
+discarded up to the next possible frame delimiter.
 
 #### Motor Commands
 
@@ -120,7 +158,7 @@ The integration queries capabilities via `[0x20, 0x71]`. Known feature IDs:
 
 | Feature ID | Name | Value |
 |------------|------|-------|
-| `0x000001` | CAP_MOTORCOUNT | Motor count (2-4) |
+| `0x000001` | CAP_MOTORCOUNT | Motor count reported by the device (1-4; integration supports 2-4) |
 | `0x000002` | CAP_MEMCOUNT | Memory preset count |
 | `0x000003` | CAP_PIN | PIN requirement + lock state |
 | `0x000101` | CAP_SYNCHRO | Synchro/linked mode support |
@@ -172,7 +210,31 @@ To configure PIN, enter your 4-digit PIN during setup or in the integration opti
 
 ## Detection
 
-- **Standard variant:** Detected by device name containing `octo`
+- **Standard variant:** Detected by an official OCTO device-name prefix. The
+  shared `FFE0` service UUID alone is not sufficient because other protocol
+  families also use it.
 - **Star2 variant:** Auto-detected by service UUID `0000aa5c-0000-1000-8000-00805f9b34fb`
 
 You can also manually select the variant in the integration options.
+
+Recognized Standard-variant name prefixes are:
+
+| Prefix | OCTO description |
+|--------|------------------|
+| `RTV` | Lift 1M (detected, but one-motor lift control is not supported) |
+| `RC2` | Receiver II |
+| `MC2` | Micro 2 |
+| `OCTOBrick` | Brick 1 (`OCTOBrick2` is covered by the same prefix) |
+| `MC1` | Micro 1 |
+| `L2M` | Lift 2M |
+| `CLI` | Cosy Lift |
+| `OCTOIQ` | IQ Redesign |
+| `RC3` | Receiver II 3M |
+| `BMB` | BrickMini Basic |
+| `BMS` | BrickMini Memo |
+| `BM3` | BrickMini Basic 3M |
+| `DA1458x` | Legacy receiver/SoC name |
+
+These names select the likely protocol implementation. Features are still
+limited by the device capabilities and the support table above, and every OEM
+combination is not necessarily hardware-tested.

--- a/docs/beds/octo.md
+++ b/docs/beds/octo.md
@@ -100,7 +100,10 @@ hardware capability and is not software grouping across arbitrary entries.
 
 ## Protocol Variants
 
-Octo beds have at least two protocol variants. The integration auto-detects the variant based on the service UUID.
+Octo beds have at least two protocol variants. Standard OCTO requires a
+recognized official device-name prefix because its `FFE0` service UUID is
+shared with other protocols. Star2 is auto-detected by its dedicated
+`0000aa5c-0000-1000-8000-00805f9b34fb` service UUID.
 
 ### Standard Variant (Most Common)
 

--- a/docs/beds/octo.md
+++ b/docs/beds/octo.md
@@ -1,6 +1,6 @@
 # Octo
 
-**Status:** ✅ Protocol tested for supported 2-4 motor bed receivers
+**Status:** ✅ Protocol tested for 2-4 motor bed receivers; one-motor RTV TV lift implementation is based on the official app and needs hardware validation
 
 **Credit:** Reverse engineering by [kristofferR](https://github.com/kristofferR/ha-adjustable-bed), [_pm](https://community.home-assistant.io/t/how-to-setup-esphome-to-control-my-bluetooth-controlled-octocontrol-bed/540790), [goedh452](https://community.home-assistant.io/t/how-to-setup-esphome-to-control-my-bluetooth-controlled-octocontrol-bed/540790/10), Murp, and [Brokkert](https://github.com/Brokkert)
 
@@ -10,9 +10,9 @@
 - Beka
 - Cozyworld Cozy2Go
 
-OCTO Smart Control also recognizes non-bed and one-motor products that use the
-same protocol family. Recognition of an OCTO BLE name does not by itself mean
-that the device's actuator layout is supported by this integration.
+OCTO Smart Control also recognizes one-motor products that use the same
+protocol family. The integration supports the official `RTV` **Lift 1M** as a
+separate TV Lift device.
 
 ## Apps
 
@@ -46,7 +46,7 @@ instructions if a configured PIN has been lost.
 | Feature | Supported |
 |---------|-----------|
 | Bed Motor Control | ✅ (2-4 motors; configured during setup and checked against CAP_MOTORCOUNT) |
-| One-motor TV/Bed Lift | ❌ (recognized as OCTO, but no dedicated lift entity yet) |
+| One-motor TV/Bed Lift | ✅ (Standard variant; dedicated TV Lift entity, hardware validation pending) |
 | Position Feedback | ❌ |
 | Memory Presets | ✅ (dynamically detected, Standard variant only) |
 | Both Up Preset | ✅ (Standard variant: moves head + legs together) |
@@ -54,17 +54,19 @@ instructions if a configured PIN has been lost.
 | Synchro/Linked Mode | ✅ (Standard variant, split-king beds with CAP_SYNCHRO) |
 | PIN Authentication | ✅ (Standard variant only) |
 
-### One-motor and TV lift limitation
+### One-motor TV lift
 
-The official OCTO device list identifies `RTV` as **Lift 1M**. Other OCTO
-products can also report a single motor through `CAP_MOTORCOUNT`. The integration
-currently allows only 2, 3, or 4 motors and always creates bed-oriented motor
-entities, beginning with Back and Legs. It therefore does not currently provide
-a correct or safe representation of a one-motor TV/bed lift.
+The official OCTO device list identifies `RTV` as **Lift 1M**, and the official
+app controls it through Standard OCTO motor 1 (`0x02`). An automatically
+discovered `RTV` defaults to one motor and exposes one **TV Lift** cover with
+Raise, Lower, and Stop controls. You can also select one motor manually for a
+Standard OCTO controller.
 
-An `RTV` device may be detected as OCTO because it shares the protocol and an
-official name prefix. Detection is not a claim of TV lift support. Do not
-configure it as a two-motor bed merely to make it pass setup.
+The lift is deliberately not presented as an adjustable bed. Bed-only controls
+such as Flat, Back + Legs Up, memory positions, lights, and synchro mode are
+suppressed even if a malformed or unexpected capability response advertises
+them. Position feedback is not available. The packet implementation is derived
+from the official OCTO app; physical RTV hardware testing is still required.
 
 ## Split Beds
 
@@ -82,9 +84,18 @@ addresses and switching between them. Also note that the `Back + Legs Up`
 preset only moves both motors on the currently connected controller; it does
 not mean both bed sides.
 
-The integration does not merge the two BLE addresses and a separate `RTV`
-controller into one Home Assistant device. Each supported bed receiver is a
-separate config entry. `Synchro Mode`, when advertised by the receiver, is a
+In the current release, each receiver is a separate config entry. The upcoming
+4.0 release adds first-class pairing for the two bed-side receivers. OCTO pairs
+use conservative one-link switching: Left, Right, or Both commands connect to
+one side at a time, and Both visits the two sides sequentially. The separate
+one-motor `RTV` remains its own TV Lift device and must not be added as a bed
+side. Pairing requires compatible bed-side actuator layouts, so a one-motor RTV
+cannot be paired with a two-motor RC2.
+
+This design matches three-device installations such as two `RC2` bed sides plus
+one `RTV` TV lift. The 4.0 dual-bed implementation has extensive failure,
+cancellation, and one-link ordering tests, but still needs validation on real
+dual OCTO hardware. `Synchro Mode`, when advertised by a receiver, remains a
 hardware capability and is not software grouping across arbitrary entries.
 
 ## Protocol Variants
@@ -158,7 +169,7 @@ The integration queries capabilities via `[0x20, 0x71]`. Known feature IDs:
 
 | Feature ID | Name | Value |
 |------------|------|-------|
-| `0x000001` | CAP_MOTORCOUNT | Motor count reported by the device (1-4; integration supports 2-4) |
+| `0x000001` | CAP_MOTORCOUNT | Motor count reported by the device (1-4; Standard OCTO supports 1-4) |
 | `0x000002` | CAP_MEMCOUNT | Memory preset count |
 | `0x000003` | CAP_PIN | PIN requirement + lock state |
 | `0x000101` | CAP_SYNCHRO | Synchro/linked mode support |
@@ -221,7 +232,7 @@ Recognized Standard-variant name prefixes are:
 
 | Prefix | OCTO description |
 |--------|------------------|
-| `RTV` | Lift 1M (detected, but one-motor lift control is not supported) |
+| `RTV` | Lift 1M (defaults to the dedicated one-motor TV Lift layout) |
 | `RC2` | Receiver II |
 | `MC2` | Micro 2 |
 | `OCTOBrick` | Brick 1 (`OCTOBrick2` is covered by the same prefix) |

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -70,6 +70,7 @@ from custom_components.adjustable_bed.const import (
     CONF_MOTOR_PULSE_COUNT,
     CONF_PASSIVE_POSITION_RECONCILIATION,
     CONF_PREFERRED_ADAPTER,
+    CONF_PROTOCOL_VARIANT,
     DOMAIN,
     KAIDI_VARIANT_SEAT_1,
     MALOUF_LAYOUT_HILO,
@@ -1948,6 +1949,43 @@ class TestUserFlow:
 
 class TestOptionsFlow:
     """Test options flow."""
+
+    async def test_octo_options_can_switch_variant_and_one_motor_together(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,
+    ):
+        """A Star2 entry can switch to Standard and one motor in one save."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="OCTO Star2",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:97",
+                CONF_NAME: "OCTO Star2",
+                CONF_BED_TYPE: BED_TYPE_OCTO,
+                CONF_MOTOR_COUNT: 2,
+                CONF_PROTOCOL_VARIANT: OCTO_VARIANT_STAR2,
+            },
+            unique_id="AA:BB:CC:DD:EE:97",
+        )
+        entry.add_to_hass(hass)
+        await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["type"] == FlowResultType.FORM
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_MOTOR_COUNT: 1,
+                CONF_PROTOCOL_VARIANT: OCTO_VARIANT_STANDARD,
+            },
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert entry.data[CONF_MOTOR_COUNT] == 1
+        assert entry.data[CONF_PROTOCOL_VARIANT] == OCTO_VARIANT_STANDARD
 
     async def test_options_flow(
         self,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -20,7 +20,11 @@ from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adjustable_bed.adapter import AdapterSelectionResult
-from custom_components.adjustable_bed.config_flow import AdjustableBedConfigFlow
+from custom_components.adjustable_bed.config_flow import (
+    AdjustableBedConfigFlow,
+    _default_motor_count,
+    _is_valid_motor_count,
+)
 from custom_components.adjustable_bed.const import (
     BED_TYPE_COOLBASE,
     BED_TYPE_DEWERTOKIN,
@@ -69,6 +73,8 @@ from custom_components.adjustable_bed.const import (
     DOMAIN,
     KAIDI_VARIANT_SEAT_1,
     MALOUF_LAYOUT_HILO,
+    OCTO_VARIANT_STANDARD,
+    OCTO_VARIANT_STAR2,
     RICHMAT_WILINKE_SERVICE_UUIDS,
     SUTA_SERVICE_UUID,
     TIMOTION_AHF_SERVICE_UUID,
@@ -100,6 +106,17 @@ def test_skips_setup_connection_probe_for_pairing_window_beds() -> None:
     # Unrelated beds are unaffected.
     assert _skips_setup_connection_probe(BED_TYPE_KEESON, "auto") is False
     assert _skips_setup_connection_probe(None, None) is False
+
+
+def test_octo_one_motor_count_is_limited_to_standard_tv_lifts() -> None:
+    """Only Standard OCTO supports the one-motor TV lift layout."""
+    assert _default_motor_count(BED_TYPE_OCTO, "RTV") == 1
+    assert _default_motor_count(BED_TYPE_OCTO, "RTV-1234") == 1
+    assert _default_motor_count(BED_TYPE_OCTO, "RC2") == 2
+    assert _is_valid_motor_count(BED_TYPE_OCTO, OCTO_VARIANT_STANDARD, 1)
+    assert _is_valid_motor_count(BED_TYPE_OCTO, "auto", 1)
+    assert not _is_valid_motor_count(BED_TYPE_OCTO, OCTO_VARIANT_STAR2, 1)
+    assert not _is_valid_motor_count(BED_TYPE_LINAK, "auto", 1)
 
 
 class TestPairingInstructions:
@@ -660,6 +677,29 @@ class TestBluetoothDiscoveryFlow:
 
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "bluetooth_confirm"
+
+    async def test_octo_rtv_discovery_defaults_to_one_motor(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info_octo_rc2: MagicMock,
+        enable_custom_integrations,
+    ):
+        """The official RTV name should select the safe one-motor lift layout."""
+        mock_bluetooth_service_info_octo_rc2.name = "RTV"
+        mock_bluetooth_service_info_octo_rc2.address = "EC:4E:1A:B5:39:98"
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_BLUETOOTH},
+            data=mock_bluetooth_service_info_octo_rc2,
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "bluetooth_confirm"
+        motor_count_marker = next(
+            marker for marker in result["data_schema"].schema if marker.schema == CONF_MOTOR_COUNT
+        )
+        assert motor_count_marker.default() == 1
 
     async def test_bluetooth_discovery_confirm(
         self,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -183,22 +183,17 @@ class TestCoverEntities:
 
         registry = er.async_get(hass)
         address = "AA:BB:CC:DD:EE:98"
-        assert registry.async_get_entity_id("cover", DOMAIN, f"{address}_tv_lift")
-        for key in ("back", "legs", "head", "feet"):
-            assert registry.async_get_entity_id("cover", DOMAIN, f"{address}_{key}") is None
-
-        assert registry.async_get_entity_id("button", DOMAIN, f"{address}_stop")
-        for key in (
-            "preset_flat",
-            "preset_both_up",
-            "preset_memory_1",
-            "program_memory_1",
-            "toggle_light",
-        ):
-            assert registry.async_get_entity_id("button", DOMAIN, f"{address}_{key}") is None
-        assert registry.async_get_entity_id("switch", DOMAIN, f"{address}_under_bed_lights") is None
-        assert registry.async_get_entity_id("switch", DOMAIN, f"{address}_synchro_mode") is None
-        assert registry.async_get_entity_id("light", DOMAIN, f"{address}_under_bed_lights") is None
+        entry_entities = er.async_entries_for_config_entry(registry, entry.entry_id)
+        assert {
+            (registered.entity_id.partition(".")[0], registered.unique_id)
+            for registered in entry_entities
+        } == {
+            ("binary_sensor", f"{address}_ble_connection"),
+            ("button", f"{address}_connect"),
+            ("button", f"{address}_disconnect"),
+            ("button", f"{address}_stop"),
+            ("cover", f"{address}_tv_lift"),
+        }
 
     async def test_malouf_hilo_cover_setup_removes_stale_head_and_feet(
         self,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -20,6 +20,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_LEGGETT_GEN2,
     BED_TYPE_MALOUF_LEGACY_OKIN,
     BED_TYPE_MALOUF_NEW_OKIN,
+    BED_TYPE_OCTO,
     BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_RF_ECO_BT,
     BED_TYPE_OKIN_UUID,
@@ -40,6 +41,7 @@ from custom_components.adjustable_bed.const import (
     KAIDI_VARIANT_SEAT_1,
     LEGGETT_GEN2_WRITE_CHAR_UUID,
     MALOUF_LAYOUT_HILO,
+    OCTO_VARIANT_STANDARD,
     OKIN_FOOT_MAX_ANGLE,
     OKIN_HEAD_MAX_ANGLE,
     SLEEP_NUMBER_VARIANT_LEFT,
@@ -148,6 +150,55 @@ class TestCoverEntities:
             assert (
                 registry.async_get_entity_id("button", DOMAIN, f"AA:BB:CC:DD:EE:44_{key}") is None
             )
+
+    async def test_octo_rtv_exposes_only_tv_lift_cover_and_stop(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """OCTO RTV should expose a lift, never bed-only entities."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="RTV",
+            data={
+                "address": "AA:BB:CC:DD:EE:98",
+                "name": "RTV",
+                CONF_BED_TYPE: BED_TYPE_OCTO,
+                CONF_MOTOR_COUNT: 1,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+                CONF_PROTOCOL_VARIANT: OCTO_VARIANT_STANDARD,
+            },
+            unique_id="AA:BB:CC:DD:EE:98",
+            entry_id="octo_rtv_entity_entry",
+        )
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        address = "AA:BB:CC:DD:EE:98"
+        assert registry.async_get_entity_id("cover", DOMAIN, f"{address}_tv_lift")
+        for key in ("back", "legs", "head", "feet"):
+            assert registry.async_get_entity_id("cover", DOMAIN, f"{address}_{key}") is None
+
+        assert registry.async_get_entity_id("button", DOMAIN, f"{address}_stop")
+        for key in (
+            "preset_flat",
+            "preset_both_up",
+            "preset_memory_1",
+            "program_memory_1",
+            "toggle_light",
+        ):
+            assert registry.async_get_entity_id("button", DOMAIN, f"{address}_{key}") is None
+        assert registry.async_get_entity_id("switch", DOMAIN, f"{address}_under_bed_lights") is None
+        assert registry.async_get_entity_id("switch", DOMAIN, f"{address}_synchro_mode") is None
+        assert registry.async_get_entity_id("light", DOMAIN, f"{address}_under_bed_lights") is None
 
     async def test_malouf_hilo_cover_setup_removes_stale_head_and_feet(
         self,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -28,6 +28,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_LEGGETT_GEN2,
     BED_TYPE_LINAK,
     BED_TYPE_MALOUF_LEGACY_OKIN,
+    BED_TYPE_OCTO,
     BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_RF_ECO_BT,
     BED_TYPE_REVERIE,
@@ -52,6 +53,7 @@ from custom_components.adjustable_bed.const import (
     DOMAIN,
     KAIDI_VARIANT_SEAT_1,
     MALOUF_LAYOUT_HILO,
+    OCTO_VARIANT_STANDARD,
     OKIN_HEAD_MAX_ANGLE,
 )
 
@@ -1290,6 +1292,63 @@ class TestServices:
             bytes.fromhex("040200000000"),
             bytes.fromhex("040200000000"),
         ]
+
+    async def test_timed_move_service_accepts_octo_tv_lift(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+        enable_custom_integrations,
+    ):
+        """Timed move should accept the one-motor OCTO TV Lift surface."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="RTV",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:98",
+                CONF_NAME: "RTV",
+                CONF_BED_TYPE: BED_TYPE_OCTO,
+                CONF_MOTOR_COUNT: 1,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+                CONF_PROTOCOL_VARIANT: OCTO_VARIANT_STANDARD,
+                CONF_MOTOR_PULSE_COUNT: 1,
+                CONF_MOTOR_PULSE_DELAY_MS: 100,
+            },
+            unique_id="AA:BB:CC:DD:EE:98",
+            entry_id="octo_rtv_timed_move_entry",
+        )
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        from homeassistant.helpers import device_registry as dr
+
+        device_registry = dr.async_get(hass)
+        devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+        assert len(devices) == 1
+        device_id = devices[0].id
+        controller = hass.data[DOMAIN][entry.entry_id].controller
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TIMED_MOVE,
+            {
+                "device_id": [device_id],
+                "motor": "tv_lift",
+                "direction": "up",
+                "duration_ms": 200,
+            },
+            blocking=True,
+        )
+
+        move_packet = controller._build_packet([0x02, 0x70], [0x02])
+        stop_packet = controller._build_packet([0x02, 0x73])
+        payloads = [call.args[1] for call in mock_bleak_client.write_gatt_char.call_args_list]
+        assert payloads == [move_packet, move_packet, stop_packet, stop_packet]
 
     async def test_timed_move_service_rejects_bed_height_for_standard_layout(
         self,

--- a/tests/test_octo.py
+++ b/tests/test_octo.py
@@ -16,7 +16,9 @@ from custom_components.adjustable_bed.beds.octo import (
     OCTO_FEATURE_END,
     OCTO_FEATURE_LIGHT,
     OCTO_FEATURE_LIGHT_RGBWI,
+    OCTO_MAX_RESPONSE_BUFFER_SIZE,
     OCTO_MOTOR_HEAD,
+    OCTO_PACKET_CHAR,
     OctoController,
     OctoStar2Controller,
 )
@@ -99,6 +101,43 @@ def mock_octo_star2_config_entry(
     return entry
 
 
+@pytest.fixture
+def octo_stream_controller() -> OctoController:
+    """Return a lightweight Octo controller for response-stream tests."""
+    coordinator = MagicMock()
+    coordinator.address = "AA:BB:CC:DD:EE:FF"
+    coordinator.client = None
+    return OctoController(coordinator)
+
+
+def _build_octo_response(
+    controller: OctoController,
+    command: tuple[int, int],
+    data: list[int] | None = None,
+) -> bytes:
+    """Build a from-device OCTO response with escaping and checksum."""
+    packet_data = data or []
+    data_len_high = (len(packet_data) >> 8) & 0xFF
+    data_len_low = len(packet_data) & 0xFF
+    checksum = controller._calculate_checksum(
+        [0x80, *command, data_len_high, data_len_low, *packet_data]
+    )
+    payload = [
+        *command,
+        data_len_high,
+        data_len_low,
+        checksum,
+        *packet_data,
+    ]
+    return bytes(
+        [
+            OCTO_PACKET_CHAR,
+            *controller._escape_bytes(payload),
+            OCTO_PACKET_CHAR,
+        ]
+    )
+
+
 class TestOctoVariantSelection:
     """Test Octo variant selection in controller creation."""
 
@@ -125,6 +164,129 @@ class TestOctoVariantSelection:
         await coordinator.async_connect()
 
         assert isinstance(coordinator.controller, OctoStar2Controller)
+
+
+class TestOctoNotificationStream:
+    """Test OCTO packet reassembly across notified characteristic values."""
+
+    def test_reassembles_at_every_encoded_byte_boundary(
+        self, octo_stream_controller: OctoController
+    ) -> None:
+        """Every split point, including escaped pairs, should reassemble."""
+        packet_data = [0x40, 0x3C, 0x4F, 0x41, 0x01]
+        response = _build_octo_response(
+            octo_stream_controller,
+            (0x21, 0x71),
+            packet_data,
+        )
+        expected = {"command": [0x21, 0x71], "data": packet_data}
+
+        for split_at in range(1, len(response)):
+            controller = OctoController(octo_stream_controller._coordinator)
+            assert controller._extract_response_packets(response[:split_at]) == []
+            assert controller._extract_response_packets(response[split_at:]) == [expected]
+            assert controller._response_buffer == bytearray()
+
+    def test_reassembles_one_byte_notifications(
+        self, octo_stream_controller: OctoController
+    ) -> None:
+        """A response should survive the most fragmented possible delivery."""
+        response = _build_octo_response(octo_stream_controller, (0x21, 0x7F))
+        packets: list[dict[str, list[int]]] = []
+
+        for byte in response:
+            packets.extend(octo_stream_controller._extract_response_packets(bytes([byte])))
+
+        assert packets == [{"command": [0x21, 0x7F], "data": []}]
+        assert octo_stream_controller._response_buffer == bytearray()
+
+    def test_extracts_multiple_packets_from_one_notification(
+        self, octo_stream_controller: OctoController
+    ) -> None:
+        """One notified value may contain multiple complete protocol packets."""
+        first = _build_octo_response(octo_stream_controller, (0x21, 0x7F))
+        second = _build_octo_response(octo_stream_controller, (0x11, 0x72), [0x01])
+
+        assert octo_stream_controller._extract_response_packets(first + second) == [
+            {"command": [0x21, 0x7F], "data": []},
+            {"command": [0x11, 0x72], "data": [0x01]},
+        ]
+
+    def test_resynchronizes_after_noise_and_a_malformed_frame(
+        self, octo_stream_controller: OctoController
+    ) -> None:
+        """A bad candidate should not consume the next valid start delimiter."""
+        malformed = bytearray(_build_octo_response(octo_stream_controller, (0x21, 0x7F)))
+        malformed[-2] ^= 0x01
+        valid = _build_octo_response(octo_stream_controller, (0x11, 0x72), [0x01])
+
+        assert octo_stream_controller._extract_response_packets(
+            b"\x00\xff" + malformed + valid
+        ) == [{"command": [0x11, 0x72], "data": [0x01]}]
+        assert octo_stream_controller._response_buffer == bytearray()
+
+    def test_bounds_incomplete_response_and_recovers(
+        self, octo_stream_controller: OctoController
+    ) -> None:
+        """A missing end delimiter must not grow retained state indefinitely."""
+        incomplete = bytes([OCTO_PACKET_CHAR]) + bytes([0x01] * OCTO_MAX_RESPONSE_BUFFER_SIZE)
+
+        assert octo_stream_controller._extract_response_packets(incomplete) == []
+        assert octo_stream_controller._response_buffer == bytearray()
+
+        valid = _build_octo_response(octo_stream_controller, (0x21, 0x7F))
+        assert octo_stream_controller._extract_response_packets(valid) == [
+            {"command": [0x21, 0x7F], "data": []}
+        ]
+
+    def test_notification_dispatches_reassembled_packets_and_preserves_raw_chunks(
+        self, octo_stream_controller: OctoController
+    ) -> None:
+        """Reassembly should dispatch all packets without altering diagnostics."""
+        light_data = [0x00, 0x01, 0x02, 0x00, 0x00, 0x01, 0x01]
+        end_data = [0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00]
+        responses = _build_octo_response(
+            octo_stream_controller,
+            (0x21, 0x71),
+            light_data,
+        ) + _build_octo_response(
+            octo_stream_controller,
+            (0x21, 0x71),
+            end_data,
+        )
+        first_chunk = bytearray(responses[:5])
+        second_chunk = bytearray(responses[5:])
+        raw_callback = MagicMock()
+        octo_stream_controller.set_raw_notify_callback(raw_callback)
+
+        octo_stream_controller._on_notification(MagicMock(), first_chunk)
+        assert octo_stream_controller._has_lights is None
+        octo_stream_controller._on_notification(MagicMock(), second_chunk)
+
+        assert octo_stream_controller._has_lights is True
+        assert octo_stream_controller._features_complete.is_set()
+        assert raw_callback.call_args_list == [
+            ((OCTO_CHAR_UUID, bytes(first_chunk)),),
+            ((OCTO_CHAR_UUID, bytes(second_chunk)),),
+        ]
+
+    async def test_notification_lifecycle_clears_incomplete_data(
+        self, octo_stream_controller: OctoController
+    ) -> None:
+        """Stale fragments must not cross notification subscriptions."""
+        client = MagicMock()
+        client.is_connected = True
+        client.start_notify = AsyncMock()
+        client.stop_notify = AsyncMock()
+        octo_stream_controller._coordinator.client = client
+        octo_stream_controller._response_buffer.extend(b"\x40\x21")
+
+        await octo_stream_controller.start_notify()
+        assert octo_stream_controller._response_buffer == bytearray()
+
+        octo_stream_controller._response_buffer.extend(b"\x40\x21")
+        await octo_stream_controller.stop_notify()
+        assert octo_stream_controller._response_buffer == bytearray()
 
 
 class TestOctoPinAuth:

--- a/tests/test_octo.py
+++ b/tests/test_octo.py
@@ -343,6 +343,68 @@ class TestOctoPinAuth:
 class TestOctoCommands:
     """Test Octo motor, light, and stop commands."""
 
+    async def test_one_motor_lift_exposes_only_tv_lift_and_uses_motor_one(
+        self,
+        hass: HomeAssistant,
+        mock_octo_config_entry_data: dict,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """A one-motor OCTO controller should safely model an RTV TV lift."""
+        lift_data = {
+            **mock_octo_config_entry_data,
+            CONF_NAME: "RTV",
+            CONF_MOTOR_COUNT: 1,
+            CONF_OCTO_PIN: "",
+        }
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="RTV",
+            data=lift_data,
+            unique_id="AA:BB:CC:DD:EE:98",
+            entry_id="octo_rtv_entry",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        await coordinator.async_connect()
+        controller = cast(OctoController, coordinator.controller)
+
+        controller._has_lights = True
+        controller._has_rgbwi = True
+        controller._memory_count = 4
+        controller._has_synchro = True
+
+        assert [spec.key for spec in controller.motor_control_specs] == ["tv_lift"]
+        assert controller.supports_preset_flat is False
+        assert controller.supports_preset_both_up is False
+        assert controller.supports_lights is False
+        assert controller.supports_light_color_control is False
+        assert controller.supports_memory_presets is False
+        assert controller.memory_slot_count == 0
+        assert controller.supports_synchro is False
+        assert controller.stale_motor_entity_keys == frozenset({"back", "legs", "head", "feet"})
+
+        mock_bleak_client.write_gatt_char.reset_mock()
+        await controller.motor_control_specs[0].open_fn(controller)
+
+        payloads = [call.args[1] for call in mock_bleak_client.write_gatt_char.call_args_list]
+        assert payloads == [
+            controller._build_packet([0x02, 0x70], [OCTO_MOTOR_HEAD]),
+            controller._build_packet([0x02, 0x73]),
+        ]
+
+    async def test_bed_layout_marks_tv_lift_entity_as_stale(
+        self,
+        hass: HomeAssistant,
+        mock_octo_config_entry,
+    ):
+        """Normal OCTO beds should clean up a former TV lift entity."""
+        coordinator = AdjustableBedCoordinator(hass, mock_octo_config_entry)
+        controller = OctoController(coordinator)
+
+        assert controller.stale_motor_entity_keys == frozenset({"tv_lift"})
+
     async def test_move_head_up_sends_move_then_stop(
         self,
         hass: HomeAssistant,

--- a/tests/test_octo.py
+++ b/tests/test_octo.py
@@ -419,6 +419,17 @@ class TestOctoCommands:
 
         assert controller.stale_motor_entity_keys == frozenset({"tv_lift"})
 
+    async def test_star2_layout_marks_tv_lift_entity_as_stale(
+        self,
+        hass: HomeAssistant,
+        mock_octo_star2_config_entry,
+    ):
+        """Star2 should clean up a former one-motor TV lift entity."""
+        coordinator = AdjustableBedCoordinator(hass, mock_octo_star2_config_entry)
+        controller = OctoStar2Controller(coordinator)
+
+        assert controller.stale_motor_entity_keys == frozenset({"tv_lift"})
+
     async def test_move_head_up_sends_move_then_stop(
         self,
         hass: HomeAssistant,

--- a/tests/test_octo.py
+++ b/tests/test_octo.py
@@ -225,6 +225,20 @@ class TestOctoNotificationStream:
         ) == [{"command": [0x11, 0x72], "data": [0x01]}]
         assert octo_stream_controller._response_buffer == bytearray()
 
+    def test_resynchronizes_long_delimiter_run_without_losing_valid_start(
+        self, octo_stream_controller: OctoController
+    ) -> None:
+        """Many malformed candidates should retain the final possible start."""
+        delimiters = bytes([OCTO_PACKET_CHAR]) * 4096
+        assert octo_stream_controller._extract_response_packets(delimiters) == []
+        assert octo_stream_controller._response_buffer == bytearray([OCTO_PACKET_CHAR])
+
+        valid = _build_octo_response(octo_stream_controller, (0x21, 0x7F))
+        assert octo_stream_controller._extract_response_packets(valid) == [
+            {"command": [0x21, 0x7F], "data": []}
+        ]
+        assert octo_stream_controller._response_buffer == bytearray()
+
     def test_bounds_incomplete_response_and_recovers(
         self, octo_stream_controller: OctoController
     ) -> None:


### PR DESCRIPTION
## Summary

- reassemble Standard OCTO protocol packets across fragmented BLE notifications and process multiple packets per callback
- resynchronize after malformed data, bound retained fragments, and clear the stream buffer at notification lifecycle boundaries
- add explicit one-motor Standard OCTO TV lift support for official `RTV` / Lift 1M controllers
- default discovered `RTV` devices to one motor and expose a dedicated **TV Lift** cover plus Stop All
- suppress bed-only presets, memory, lighting, and synchro entities on the lift layout
- add `tv_lift` support to `adjustable_bed.timed_move`
- document OCTO notification framing, RTV behavior, and the upcoming 4.0 dual-bed architecture

## Notification root cause

`OctoController._on_notification()` previously passed each Bleak callback directly to a parser that requires one complete `0x40 ... 0x40` frame. OCTO application packets can span multiple notified characteristic values, so fragmented capability, PIN, or configuration replies were rejected and feature discovery timed out.

The controller now treats callbacks as a byte stream. It retains incomplete fragments, extracts every complete delimiter-bounded frame, validates unescaped length and checksum, and preserves raw diagnostic callbacks exactly as received.

## TV lift implementation

The recovered official OCTO app identifies `RTV` as **Lift 1M** and controls it through Standard OCTO motor 1:

- raise: command `[0x02, 0x70]`, motor mask `[0x02]`
- lower: command `[0x02, 0x71]`, motor mask `[0x02]`
- stop: command `[0x02, 0x73]`

A one-motor OCTO entry is represented as a TV lift, not as a one-motor bed. It therefore cannot accidentally expose Flat, Back + Legs Up, memory, lights, or synchro controls even if an unexpected capability response advertises them. Explicit Star2 configurations still reject one motor.

## 4.0 dual-bed audit

`release/4.0` has first-class paired OCTO support for two compatible bed-side receivers. Its default OCTO mode conservatively connects, commands, and disconnects one side before visiting the other. A **Both** command is therefore sequential, not simultaneous.

The paired coordinator covers connection switching, partial failures, cancellation, STOP cleanup, capability snapshots, and one-link capture. A separate one-motor RTV has an incompatible actuator layout and cannot be paired as a bed side, so a two-RC2-plus-RTV installation is modeled as one paired bed plus one separate TV Lift device.

Real dual-OCTO and RTV hardware validation is still pending.

## Validation

- changed-file Ruff formatting and lint checks passed
- Pyright: 0 errors
- focused OCTO notification/controller suite: 38 passed
- full PR branch suite: 2,236 passed
- `release/4.0` OCTO and pairing suites in an isolated worktree: 201 passed
- both actionable review threads were fixed and resolved; GitHub validation reruns on every push

## Sources

- [Bluetooth Core Specification, ATT notifications](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host/attribute-protocol--att-.html)
- [Android BluetoothGattCallback](https://developer.android.com/reference/android/bluetooth/BluetoothGattCallback)
- [Bleak notification callback documentation](https://bleak.readthedocs.io/en/latest/api/client.html#bleak.BleakClient.start_notify)
- #63
- #66
- #440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for one-motor OCTO TV lifts, including dedicated TV Lift cover, timed-move/position options, and updated motor-count handling across setup and options.
  * Improved handling of fragmented/combined BLE notifications with robust packet reassembly.

* **Documentation**
  * Expanded OCTO configuration, detection, PIN guidance, and troubleshooting; added notification framing and updated motor count references.

* **Bug Fixes**
  * Prevented malformed/stale notification fragments from impacting future communication and ensured correct per-packet command handling.

* **Tests**
  * Added extensive coverage for OCTO packet reassembly, lifecycle cleanup, and TV Lift entity/service behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->