### PR TITLE
Fix Keeson movement stutter and add current app protocols

### DIFF
--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -75,11 +75,21 @@ _APP_MOTOR_PULSE_DEFAULTS: dict[str, tuple[int, int]] = {
 
 _THREE_MOTOR_BETTERLIVING_PULSES = (5, 200)
 
-# The direct six-byte P2 protocol has no dedicated release/STOP frame. OEM apps
-# stop refreshing the held key and request status three times at 300 ms intervals.
+# The direct six-byte P2 protocol has no dedicated release/STOP frame. Current
+# SFD apps stop refreshing the held key and request status three times at 300 ms
+# intervals. Member's Mark also stops by ceasing refreshes and keeps issuing the
+# same status query on its independent 400 ms timer.
 _KSBT_RELEASE_QUERY = bytes([0x00, 0xB0])
 _KSBT_RELEASE_QUERY_DELAY_SECONDS = 0.3
 _KSBT_RELEASE_QUERY_COUNT = 3
+
+_PURPLE_PLUS_NAME_PREFIX = "ksbt04c"
+_PURPLE_RELEASE_COMMAND = bytes.fromhex("04020000000000")
+_PURPLE_MEMORY_PROGRAM_COUNT = 26
+_PURPLE_MEMORY_PROGRAM_DELAY_SECONDS = 0.2
+
+_SLEEP_HARMONY_BASE_I5_PREFIX = "base-i5."
+_SLEEP_HARMONY_RELEASE_DELAY_SECONDS = 0.2
 
 
 def is_ksbt03c_name(name: str | None) -> bool:
@@ -239,10 +249,24 @@ class KeesonController(BedController):
         # back to the configured name (defaults to the BLE name) when this
         # connection didn't surface a device name, so a stale or user-edited
         # configured name can never override the real hardware name.
-        if device_name:
-            self._is_ksbt03c = is_ksbt03c_name(device_name)
-        else:
-            self._is_ksbt03c = is_ksbt03c_name(getattr(coordinator, "name", None))
+        resolved_device_name = device_name or getattr(coordinator, "name", None)
+        self._is_ksbt03c = (
+            variant == KEESON_VARIANT_KSBT
+            and is_ksbt03c_name(resolved_device_name)
+        )
+        self._is_sleep_harmony_base_i5 = (
+            variant == KEESON_VARIANT_KSBT04C
+            and (resolved_device_name or "")
+            .strip()
+            .lower()
+            .startswith(_SLEEP_HARMONY_BASE_I5_PREFIX)
+        )
+        self._is_purple_plus = variant == KEESON_VARIANT_PURPLE and (
+            (resolved_device_name or "").strip().lower().startswith(
+                _PURPLE_PLUS_NAME_PREFIX
+            )
+            or self._has_ksbt_service()
+        )
         self._notify_callback: Callable[[str, float], None] | None = None
         self._motor_state: dict[str, bool | None] = {}
         self._write_with_response = True
@@ -262,6 +286,10 @@ class KeesonController(BedController):
         # Determine the characteristic UUID
         if char_uuid:
             self._char_uuid = char_uuid
+        elif self._is_sleep_harmony_base_i5:
+            self._char_uuid = self._detect_characteristic_uuid()
+        elif self._is_purple_plus:
+            self._char_uuid = self._detect_ksbt_characteristic_uuid()
         elif variant == KEESON_VARIANT_JSON:
             self._char_uuid = self._detect_json_characteristic_uuid()
         elif variant in {"ksbt", KEESON_VARIANT_KSBT_CR, KEESON_VARIANT_KSBT04C}:
@@ -279,9 +307,22 @@ class KeesonController(BedController):
         )
 
         _LOGGER.debug(
-            "KeesonController initialized (variant: %s, char: %s)",
+            "KeesonController initialized (variant: %s, purple_plus: %s, "
+            "sleep_harmony_base_i5: %s, char: %s)",
             variant,
+            self._is_purple_plus,
+            self._is_sleep_harmony_base_i5,
             self._char_uuid,
+        )
+
+    def _has_ksbt_service(self) -> bool:
+        """Return whether the connected device exposes Nordic UART service."""
+        client = self.client
+        if client is None or client.services is None:
+            return False
+        return any(
+            str(service.uuid).lower() == KEESON_KSBT_SERVICE_UUID.lower()
+            for service in client.services
         )
 
     def _detect_characteristic_uuid(self) -> str:
@@ -436,10 +477,10 @@ class KeesonController(BedController):
     def _single_shot_count(self) -> int:
         """Repeat count for single-shot commands (massage, presets, lights).
 
-        Sleep Harmony sends KSBT04C one-shot commands twice. Ergomotion Sync,
-        Adjustable Lite, and SomosBeds send their KSBT/KSBT03CR one-shots once.
+        Current OEM apps send UI one-shot commands once. Sleep Harmony follows
+        each command with a delayed STOP rather than duplicating the command.
         """
-        return 2 if self._variant == KEESON_VARIANT_KSBT04C else 1
+        return 1
 
     # Capability properties
     @property
@@ -452,7 +493,8 @@ class KeesonController(BedController):
         return (
             self._is_ksbt
             or self._is_json_variant
-            or self._variant in {"ergomotion", KEESON_VARIANT_PURPLE}
+            or self._variant == "ergomotion"
+            or (self._variant == KEESON_VARIANT_PURPLE and not self._is_purple_plus)
         )
 
     @property
@@ -497,7 +539,7 @@ class KeesonController(BedController):
         if self._is_ksbt:
             return 2  # KSBT03CR: Memory 1 and Memory 2 only (unverified beyond that)
         elif self._variant == KEESON_VARIANT_PURPLE:
-            return 2  # Purple Premium has 2. Plus model bed supports 3, but we don't know what path it uses
+            return 3 if self._is_purple_plus else 2
         elif self._variant == "ergomotion":
             return 4  # Ergomotion may support all 4
         else:
@@ -657,12 +699,12 @@ class KeesonController(BedController):
 
     @property
     def supports_massage_off_control(self) -> bool:
-        """Return True only for Sino, the sole variant with a real off command.
+        """Return True for variants with a verified massage-off command.
 
-        Other Keeson variants (KSBT, BaseI4/I5, Ergomotion) can only step
-        massage intensity; massage_off() would raise, so hide the button.
+        Sino sets both zones to intensity zero. Sleep Harmony KSBT04C uses the
+        dedicated 0x02000000 all-zone STOP command.
         """
-        return self._variant == KEESON_VARIANT_SINO
+        return self._variant in {KEESON_VARIANT_SINO, KEESON_VARIANT_KSBT04C}
 
     @property
     def supports_massage_intensity_control(self) -> bool:
@@ -745,6 +787,15 @@ class KeesonController(BedController):
             if command_value == 0:
                 return self._build_json_command(command_value, ctrm=0, km=1, keykt=0)
             return self._build_json_command(command_value, ctrm=1, km=1, keykt=0)
+        if self._is_sleep_harmony_base_i5:
+            # Sleep Harmony base-i5: E6/FE/16 + command_le32 + side 00 + checksum.
+            int_bytes = int_to_bytes(command_value)
+            int_bytes.reverse()
+            data = [0xE6, 0xFE, 0x16] + int_bytes + [0x00]
+            return bytes(data + [(~sum(data)) & 0xFF])
+        if self._is_purple_plus:
+            # Purple Premium Plus P2: [0x04, 0x02, command_be32, 0x00].
+            return bytes([0x04, 0x02] + int_to_bytes(command_value) + [0x00])
         if self._variant == "ksbt":
             # KSBT: [0x04, 0x02, ...int_to_bytes(command)]
             return bytes([0x04, 0x02] + int_to_bytes(command_value))
@@ -1044,15 +1095,33 @@ class KeesonController(BedController):
             except Exception:
                 _LOGGER.debug("Failed to release motor command during cleanup")
 
-    async def _release_motion(self) -> None:
+    async def _release_motion(self, *, delay: bool = True) -> None:
         """Send the protocol-specific motor release sequence.
 
         Direct six-byte KSBT/P2 remotes do not transmit a zero-key frame on
-        release. They stop the 100 ms key refresh and send status query ``00 B0``
-        at +300, +600, and +900 ms. Other variants retain their explicit zero
-        frame, whose packet format is specific to that protocol family.
+        release. Current SFD apps stop the 100 ms key refresh and send status
+        query ``00 B0`` at +300, +600, and +900 ms. The Member's Mark app also
+        stops by ceasing refreshes and continues its independent ``00 B0`` query
+        timer. Other variants retain their explicit zero frame, whose packet
+        format is specific to that protocol family.
         """
         cancel_event = asyncio.Event()
+        if self._variant == KEESON_VARIANT_PURPLE:
+            await self.write_command(
+                _PURPLE_RELEASE_COMMAND,
+                cancel_event=cancel_event,
+            )
+            return
+
+        if self._variant == KEESON_VARIANT_KSBT04C:
+            if delay:
+                await asyncio.sleep(_SLEEP_HARMONY_RELEASE_DELAY_SECONDS)
+            await self.write_command(
+                self._build_command(0),
+                cancel_event=cancel_event,
+            )
+            return
+
         if self._variant == KEESON_VARIANT_KSBT:
             for _ in range(_KSBT_RELEASE_QUERY_COUNT):
                 await asyncio.sleep(_KSBT_RELEASE_QUERY_DELAY_SECONDS)
@@ -1066,6 +1135,12 @@ class KeesonController(BedController):
             self._build_command(0),
             cancel_event=cancel_event,
         )
+
+    async def _write_single_shot(self, command: bytes) -> None:
+        """Write a one-shot action and perform any app-specific release."""
+        await self.write_command(command, repeat_count=self._single_shot_count)
+        if self._variant == KEESON_VARIANT_KSBT04C:
+            await self._release_motion()
 
     async def _write_json_motion_command(
         self,
@@ -1147,7 +1222,7 @@ class KeesonController(BedController):
     async def stop_all(self) -> None:
         """Stop all motors."""
         self._motor_state = {}
-        await self._release_motion()
+        await self._release_motion(delay=False)
 
     # Tilt motor control
     async def move_tilt_up(self) -> None:
@@ -1179,21 +1254,29 @@ class KeesonController(BedController):
     async def preset_flat(self) -> None:
         """Go to flat position."""
         if self._betterliving_presets:
-            await self.write_command(self._build_command(BetterLivingCommands.PRESET_FLAT), repeat_count=self._single_shot_count)
+            await self._write_single_shot(
+                self._build_command(BetterLivingCommands.PRESET_FLAT)
+            )
         else:
-            await self.write_command(self._build_command(KeesonCommands.PRESET_FLAT), repeat_count=self._single_shot_count)
+            await self._write_single_shot(
+                self._build_command(KeesonCommands.PRESET_FLAT)
+            )
 
     async def preset_memory(self, memory_num: int) -> None:
         """Go to memory preset.
 
         Note: Command values vary by protocol variant:
-        - KSBT/KSBT04C (Ergomotion Sync APK): Memory 1 (0x2000) = Read button,
-          Memory 2 (0x4000) = TV button, Memory 3 (0x10000) = M button
+        - KSBT: Memory 1 (0x2000) = Read button, Memory 2 (0x4000) = TV
+          button, Memory 3 (0x10000) = M button
+        - Sleep Harmony KSBT04C: Memory 1/2/3 labels send Read (0x2000),
+          TV (0x4000), and Snore (0x8000)
         - BaseI4/I5: Memory 3 (0x8000) is the only confirmed memory preset
         - Memory 3 (0x8000) on KSBT is actually anti-snore, not memory
         - BetterLiving: Memory 1 (0x01000008), Memory 2 (0x01000009)
         - CB1322: Memory 1 (0x00010000), Memory 2 (0x00040000)
-        - Purple: Memory 1 (0x00010000), Memory 2 (0x00004000)
+        - Purple Premium: Memory 1 (0x00010000), Memory 2 (0x00004000)
+        - Purple Premium Plus: Memory 1 (0x00010000), Memory 2 (0x00002000),
+          Memory 3 (0x00004000)
         """
         if self._betterliving_presets:
             commands = {
@@ -1201,7 +1284,7 @@ class KeesonController(BedController):
                 2: BetterLivingCommands.PRESET_MEMORY_2,
             }
             if command := commands.get(memory_num):
-                await self.write_command(self._build_command(command), repeat_count=self._single_shot_count)
+                await self._write_single_shot(self._build_command(command))
             else:
                 _LOGGER.warning(
                     "BetterLiving memory %d not supported (valid: %s)",
@@ -1216,7 +1299,7 @@ class KeesonController(BedController):
                 2: CB1322Commands.PRESET_MEMORY_2,
             }
             if command := commands.get(memory_num):
-                await self.write_command(self._build_command(command), repeat_count=self._single_shot_count)
+                await self._write_single_shot(self._build_command(command))
             else:
                 _LOGGER.warning(
                     "CB1322 memory %d not supported (valid: %s)",
@@ -1225,18 +1308,47 @@ class KeesonController(BedController):
                 )
             return
 
-        # KSBT/KSBT04C remotes (Ergomotion Sync APK): memory slot 3 is the
-        # "M" button (0x10000), not 0x8000 which triggers anti-snore there.
-        if self._variant in {"ksbt", KEESON_VARIANT_KSBT04C}:
-            commands = {
-                1: KeesonCommands.PRESET_MEMORY_1,
-                2: KeesonCommands.PRESET_MEMORY_2,
-                3: KeesonCommands.PRESET_MEMORY_4,
-            }
+        if self._variant == KEESON_VARIANT_PURPLE:
+            commands = (
+                {
+                    1: KeesonCommands.PRESET_MEMORY_4,
+                    2: KeesonCommands.PRESET_MEMORY_1,
+                    3: KeesonCommands.PRESET_MEMORY_2,
+                }
+                if self._is_purple_plus
+                else {
+                    1: KeesonCommands.PRESET_MEMORY_4,
+                    2: KeesonCommands.PRESET_MEMORY_2,
+                }
+            )
             if command := commands.get(memory_num):
-                await self.write_command(
-                    self._build_command(command), repeat_count=self._single_shot_count
+                await self._write_single_shot(self._build_command(command))
+            else:
+                _LOGGER.warning(
+                    "Purple memory %d not supported (valid: %s)",
+                    memory_num,
+                    sorted(commands.keys()),
                 )
+            return
+
+        if self._variant in {"ksbt", KEESON_VARIANT_KSBT04C}:
+            # Sleep Harmony labels Reading/TV/Snore as M1/M2/M3. Direct
+            # six-byte KSBT instead maps its third M button to 0x10000.
+            commands = (
+                {
+                    1: KeesonCommands.PRESET_MEMORY_1,
+                    2: KeesonCommands.PRESET_MEMORY_2,
+                    3: KeesonCommands.PRESET_ANTI_SNORE,
+                }
+                if self._variant == KEESON_VARIANT_KSBT04C
+                else {
+                    1: KeesonCommands.PRESET_MEMORY_1,
+                    2: KeesonCommands.PRESET_MEMORY_2,
+                    3: KeesonCommands.PRESET_MEMORY_4,
+                }
+            )
+            if command := commands.get(memory_num):
+                await self._write_single_shot(self._build_command(command))
             else:
                 _LOGGER.warning(
                     "KSBT memory %d not supported (valid: %s)",
@@ -1257,10 +1369,6 @@ class KeesonController(BedController):
                 memory_num,
             )
 
-        #Purple treats Memory 4 as memory 1
-        if self._variant == KEESON_VARIANT_PURPLE and memory_num == 1:
-            memory_num = 4
-
         commands = {
             1: KeesonCommands.PRESET_MEMORY_1,
             2: KeesonCommands.PRESET_MEMORY_2,
@@ -1268,14 +1376,15 @@ class KeesonController(BedController):
             4: KeesonCommands.PRESET_MEMORY_4,
         }
         if command := commands.get(memory_num):
-            await self.write_command(self._build_command(command), repeat_count=self._single_shot_count)
+            await self._write_single_shot(self._build_command(command))
 
     async def program_memory(self, memory_num: int) -> None:
         """Program current position to memory.
 
         BetterLiving BED_DEFAULT has dedicated save commands.
-        CB1322 and Purple emulates save by sending the recall command repeated 30x at 100ms
-        (simulating a long press on the physical remote).
+        CB1322 emulates save by sending the recall command repeated 30x at 100ms.
+        Purple's dedicated send-memory flow performs 26 writes, each after a
+        200ms delay (approximately 5.2 seconds total).
         Other Keeson variants don't support programming.
         """
         if self._betterliving_presets:
@@ -1293,17 +1402,42 @@ class KeesonController(BedController):
                 )
             return
 
-        if self._cb1322_presets or self._variant == KEESON_VARIANT_PURPLE:
-            if self._variant == KEESON_VARIANT_PURPLE:
-                commands = {
+        if self._variant == KEESON_VARIANT_PURPLE:
+            commands = (
+                {
+                    1: KeesonCommands.PRESET_MEMORY_4,
+                    2: KeesonCommands.PRESET_MEMORY_1,
+                    3: KeesonCommands.PRESET_MEMORY_2,
+                }
+                if self._is_purple_plus
+                else {
                     1: KeesonCommands.PRESET_MEMORY_4,
                     2: KeesonCommands.PRESET_MEMORY_2,
                 }
+            )
+            if command := commands.get(memory_num):
+                cancel_event = self._coordinator.cancel_command
+                for _ in range(_PURPLE_MEMORY_PROGRAM_COUNT):
+                    if cancel_event.is_set():
+                        return
+                    await asyncio.sleep(_PURPLE_MEMORY_PROGRAM_DELAY_SECONDS)
+                    await self.write_command(
+                        self._build_command(command),
+                        cancel_event=cancel_event,
+                    )
             else:
-                commands = {
-                    1: CB1322Commands.PRESET_MEMORY_1,
-                    2: CB1322Commands.PRESET_MEMORY_2,
-                }
+                _LOGGER.warning(
+                    "Purple save memory %d not supported (valid: %s)",
+                    memory_num,
+                    sorted(commands.keys()),
+                )
+            return
+
+        if self._cb1322_presets:
+            commands = {
+                1: CB1322Commands.PRESET_MEMORY_1,
+                2: CB1322Commands.PRESET_MEMORY_2,
+            }
             if command := commands.get(memory_num):
                 await self.write_command(
                     self._build_command(command),
@@ -1312,8 +1446,7 @@ class KeesonController(BedController):
                 )
             else:
                 _LOGGER.warning(
-                    "%s save memory %d not supported (valid: %s)",
-                    self._variant,
+                    "CB1322 save memory %d not supported (valid: %s)",
                     memory_num,
                     sorted(commands.keys()),
                 )
@@ -1326,32 +1459,43 @@ class KeesonController(BedController):
     async def preset_zero_g(self) -> None:
         """Go to zero gravity position."""
         if self._betterliving_presets:
-            await self.write_command(self._build_command(BetterLivingCommands.PRESET_ZERO_G), repeat_count=self._single_shot_count)
+            await self._write_single_shot(
+                self._build_command(BetterLivingCommands.PRESET_ZERO_G)
+            )
         else:
-            await self.write_command(self._build_command(KeesonCommands.PRESET_ZERO_G), repeat_count=self._single_shot_count)
+            await self._write_single_shot(
+                self._build_command(KeesonCommands.PRESET_ZERO_G)
+            )
 
     async def preset_lounge(self) -> None:
         """Go to lounge position (KSBT 'Read' button / Memory 1, Lounge on Purple)."""
         if (
             not self._is_ksbt
             and not self._is_json_variant
-            and self._variant not in {"ergomotion", KEESON_VARIANT_PURPLE}
+            and self._variant != "ergomotion"
+            and (
+                self._variant != KEESON_VARIANT_PURPLE or self._is_purple_plus
+            )
         ):
             _LOGGER.warning("Lounge preset is not available on %s beds", self._variant)
             return
-        await self.write_command(self._build_command(KeesonCommands.PRESET_LOUNGE), repeat_count=self._single_shot_count)
+        await self._write_single_shot(
+            self._build_command(KeesonCommands.PRESET_LOUNGE)
+        )
 
     async def preset_tv(self) -> None:
         """Go to TV position (KSBT/Ergomotion only)."""
         if self._variant in ["base",KEESON_VARIANT_PURPLE]:
             _LOGGER.warning("TV preset is not available on %s beds", self._variant)
             return
-        await self.write_command(self._build_command(KeesonCommands.PRESET_TV), repeat_count=self._single_shot_count)
+        await self._write_single_shot(self._build_command(KeesonCommands.PRESET_TV))
 
     async def preset_anti_snore(self) -> None:
         """Go to anti-snore position."""
         if self._betterliving_presets:
-            await self.write_command(self._build_command(BetterLivingCommands.PRESET_ANTI_SNORE), repeat_count=self._single_shot_count)
+            await self._write_single_shot(
+                self._build_command(BetterLivingCommands.PRESET_ANTI_SNORE)
+            )
             return
         if (
             not self._is_ksbt
@@ -1360,7 +1504,9 @@ class KeesonController(BedController):
         ):
             _LOGGER.warning("Anti-snore preset is not available on %s beds", self._variant)
             return
-        await self.write_command(self._build_command(KeesonCommands.PRESET_ANTI_SNORE), repeat_count=self._single_shot_count)
+        await self._write_single_shot(
+            self._build_command(KeesonCommands.PRESET_ANTI_SNORE)
+        )
 
     # Light methods
     async def lights_on(self) -> None:
@@ -1417,7 +1563,9 @@ class KeesonController(BedController):
                     repeat_count=self._single_shot_count,
                 )
         else:
-            await self.write_command(self._build_command(KeesonCommands.MASSAGE_STEP), repeat_count=self._single_shot_count)
+            await self._write_single_shot(
+                self._build_command(KeesonCommands.MASSAGE_STEP)
+            )
 
     async def massage_off(self) -> None:
         """Turn off all massage."""
@@ -1427,6 +1575,10 @@ class KeesonController(BedController):
             await self.write_command(self._build_command(SinoCommands.MASSAGE_FOOT_INTENSITY_BASE), repeat_count=self._single_shot_count)
             self._head_massage = 0
             self._foot_massage = 0
+        elif self._variant == KEESON_VARIANT_KSBT04C:
+            await self._write_single_shot(
+                self._build_command(KeesonCommands.MASSAGE_ALL_STOP)
+            )
         else:
             # Standard Keeson doesn't have a dedicated off command
             await super().massage_off()
@@ -1442,7 +1594,9 @@ class KeesonController(BedController):
                 repeat_count=self._single_shot_count,
             )
         else:
-            await self.write_command(self._build_command(KeesonCommands.MASSAGE_HEAD_UP), repeat_count=self._single_shot_count)
+            await self._write_single_shot(
+                self._build_command(KeesonCommands.MASSAGE_HEAD_UP)
+            )
 
     async def massage_head_down(self) -> None:
         """Decrease head massage intensity."""
@@ -1455,7 +1609,9 @@ class KeesonController(BedController):
                 repeat_count=self._single_shot_count,
             )
         else:
-            await self.write_command(self._build_command(KeesonCommands.MASSAGE_HEAD_DOWN), repeat_count=self._single_shot_count)
+            await self._write_single_shot(
+                self._build_command(KeesonCommands.MASSAGE_HEAD_DOWN)
+            )
 
     async def massage_foot_up(self) -> None:
         """Increase foot massage intensity."""
@@ -1468,7 +1624,9 @@ class KeesonController(BedController):
                 repeat_count=self._single_shot_count,
             )
         else:
-            await self.write_command(self._build_command(KeesonCommands.MASSAGE_FOOT_UP), repeat_count=self._single_shot_count)
+            await self._write_single_shot(
+                self._build_command(KeesonCommands.MASSAGE_FOOT_UP)
+            )
 
     async def massage_foot_down(self) -> None:
         """Decrease foot massage intensity."""
@@ -1481,7 +1639,9 @@ class KeesonController(BedController):
                 repeat_count=self._single_shot_count,
             )
         else:
-            await self.write_command(self._build_command(KeesonCommands.MASSAGE_FOOT_DOWN), repeat_count=self._single_shot_count)
+            await self._write_single_shot(
+                self._build_command(KeesonCommands.MASSAGE_FOOT_DOWN)
+            )
 
     async def massage_intensity_up(self) -> None:
         """Increase all massage intensity."""
@@ -1550,7 +1710,9 @@ class KeesonController(BedController):
                 repeat_count=self._single_shot_count,
             )
         else:
-            await self.write_command(self._build_command(KeesonCommands.MASSAGE_TIMER_STEP), repeat_count=self._single_shot_count)
+            await self._write_single_shot(
+                self._build_command(KeesonCommands.MASSAGE_TIMER_STEP)
+            )
 
     async def massage_head_toggle(self) -> None:
         """Toggle head massage zone on/off."""
@@ -1569,9 +1731,8 @@ class KeesonController(BedController):
                 )
         else:
             # Standard Keeson: step through head massage intensity (wraps max→0)
-            await self.write_command(
-                self._build_command(KeesonCommands.MASSAGE_HEAD_UP),
-                repeat_count=self._single_shot_count,
+            await self._write_single_shot(
+                self._build_command(KeesonCommands.MASSAGE_HEAD_UP)
             )
 
     async def massage_foot_toggle(self) -> None:
@@ -1591,9 +1752,8 @@ class KeesonController(BedController):
                 )
         else:
             # Standard Keeson: step through foot massage intensity (wraps max→0)
-            await self.write_command(
-                self._build_command(KeesonCommands.MASSAGE_FOOT_UP),
-                repeat_count=self._single_shot_count,
+            await self._write_single_shot(
+                self._build_command(KeesonCommands.MASSAGE_FOOT_UP)
             )
 
     async def sound_toggle(self) -> None:

--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -856,6 +856,15 @@ class KeesonController(BedController):
         cancel_event: asyncio.Event | None = None,
     ) -> None:
         """Write a command to the bed."""
+        selected_cancel_event = (
+            cancel_event
+            if cancel_event is not None
+            else self._coordinator.cancel_command
+        )
+        if selected_cancel_event.is_set():
+            _LOGGER.debug("Skipping Keeson write because command was cancelled")
+            return
+
         self._refresh_write_mode()
         _LOGGER.debug(
             "Writing command to Keeson bed: %s (repeat: %d, delay: %dms)",
@@ -868,7 +877,7 @@ class KeesonController(BedController):
             command,
             repeat_count=repeat_count,
             repeat_delay_ms=repeat_delay_ms,
-            cancel_event=cancel_event,
+            cancel_event=selected_cancel_event,
             response=self._write_with_response,
         )
 
@@ -1578,9 +1587,8 @@ class KeesonController(BedController):
             )
             self._led_on = not self._led_on
         else:
-            await self.write_command(
-                self._build_command(KeesonCommands.TOGGLE_SAFETY_LIGHTS),
-                repeat_count=self._single_shot_count,
+            await self._write_single_shot(
+                self._build_command(KeesonCommands.TOGGLE_SAFETY_LIGHTS)
             )
 
     # Massage methods

--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -581,7 +581,7 @@ class KeesonController(BedController):
             return False
         if self._variant == KEESON_VARIANT_PURPLE:
             # Plus model has massage and lighting; Premium base has neither
-            return self._coordinator.has_massage
+            return self._is_purple_plus
         return True
 
     @property

--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -63,7 +63,7 @@ _LOGGER = logging.getLogger(__name__)
 _APP_MOTOR_PULSE_DEFAULTS: dict[str, tuple[int, int]] = {
     KEESON_VARIANT_BASE: (3, 400),
     KEESON_VARIANT_JSON: (10, 100),
-    KEESON_VARIANT_KSBT: (4, 300),
+    KEESON_VARIANT_KSBT: (10, 100),
     KEESON_VARIANT_KSBT_CR: (4, 300),
     KEESON_VARIANT_KSBT04C: (4, 300),
     KEESON_VARIANT_ERGOMOTION: (10, 100),
@@ -74,6 +74,12 @@ _APP_MOTOR_PULSE_DEFAULTS: dict[str, tuple[int, int]] = {
 }
 
 _THREE_MOTOR_BETTERLIVING_PULSES = (5, 200)
+
+# The direct six-byte P2 protocol has no dedicated release/STOP frame. OEM apps
+# stop refreshing the held key and request status three times at 300 ms intervals.
+_KSBT_RELEASE_QUERY = bytes([0x00, 0xB0])
+_KSBT_RELEASE_QUERY_DELAY_SECONDS = 0.3
+_KSBT_RELEASE_QUERY_COUNT = 3
 
 
 def is_ksbt03c_name(name: str | None) -> bool:
@@ -1011,7 +1017,7 @@ class KeesonController(BedController):
         return _APP_MOTOR_PULSE_DEFAULTS.get(self._variant, configured)
 
     async def _move_motor(self, motor: str, direction: bool | None) -> None:
-        """Move a motor in a direction or stop it, always sending STOP at the end."""
+        """Move a motor in a direction or stop it, always releasing at the end."""
         self._motor_state[motor] = direction
         command = self._get_move_command()
         repeat_count, repeat_delay_ms = self._motor_pulse_settings()
@@ -1031,15 +1037,35 @@ class KeesonController(BedController):
                         repeat_delay_ms=repeat_delay_ms,
                     )
         finally:
-            # Always send stop with a fresh event so it's not affected by cancellation
+            # Always release with a fresh event so it is not affected by cancellation.
             self._motor_state = {}
             try:
-                await self.write_command(
-                    self._build_command(0),
-                    cancel_event=asyncio.Event(),
-                )
+                await self._release_motion()
             except Exception:
-                _LOGGER.debug("Failed to send STOP command during cleanup")
+                _LOGGER.debug("Failed to release motor command during cleanup")
+
+    async def _release_motion(self) -> None:
+        """Send the protocol-specific motor release sequence.
+
+        Direct six-byte KSBT/P2 remotes do not transmit a zero-key frame on
+        release. They stop the 100 ms key refresh and send status query ``00 B0``
+        at +300, +600, and +900 ms. Other variants retain their explicit zero
+        frame, whose packet format is specific to that protocol family.
+        """
+        cancel_event = asyncio.Event()
+        if self._variant == KEESON_VARIANT_KSBT:
+            for _ in range(_KSBT_RELEASE_QUERY_COUNT):
+                await asyncio.sleep(_KSBT_RELEASE_QUERY_DELAY_SECONDS)
+                await self.write_command(
+                    _KSBT_RELEASE_QUERY,
+                    cancel_event=cancel_event,
+                )
+            return
+
+        await self.write_command(
+            self._build_command(0),
+            cancel_event=cancel_event,
+        )
 
     async def _write_json_motion_command(
         self,
@@ -1121,10 +1147,7 @@ class KeesonController(BedController):
     async def stop_all(self) -> None:
         """Stop all motors."""
         self._motor_state = {}
-        await self.write_command(
-            self._build_command(0),
-            cancel_event=asyncio.Event(),
-        )
+        await self._release_motion()
 
     # Tilt motor control
     async def move_tilt_up(self) -> None:

--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -47,6 +47,7 @@ from ..const import (
     KEESON_VARIANT_PURPLE,
     KEESON_VARIANT_SERTA,
     KEESON_VARIANT_SINO,
+    KEESON_VARIANT_SLEEP_HARMONY,
 )
 from .base import BedController, MotorControlSpec
 from .okin_protocol import int_to_bytes
@@ -66,6 +67,7 @@ _APP_MOTOR_PULSE_DEFAULTS: dict[str, tuple[int, int]] = {
     KEESON_VARIANT_KSBT: (10, 100),
     KEESON_VARIANT_KSBT_CR: (4, 300),
     KEESON_VARIANT_KSBT04C: (4, 300),
+    KEESON_VARIANT_SLEEP_HARMONY: (4, 300),
     KEESON_VARIANT_ERGOMOTION: (10, 100),
     KEESON_VARIANT_OKIN: (10, 100),
     KEESON_VARIANT_SERTA: (10, 100),
@@ -160,6 +162,7 @@ class KeesonCommands:
     TOGGLE_SAFETY_LIGHTS = 0x20000
     TOGGLE_LIGHTS = 0x20000  # Alias for Ergomotion compatibility
 
+
 class SinoCommands:
     """Sino (Dynasty, INNOVA) specific command constants.
 
@@ -250,21 +253,13 @@ class KeesonController(BedController):
         # connection didn't surface a device name, so a stale or user-edited
         # configured name can never override the real hardware name.
         resolved_device_name = device_name or getattr(coordinator, "name", None)
-        self._is_ksbt03c = (
-            variant == KEESON_VARIANT_KSBT
-            and is_ksbt03c_name(resolved_device_name)
-        )
-        self._is_sleep_harmony_base_i5 = (
-            variant == KEESON_VARIANT_KSBT04C
-            and (resolved_device_name or "")
-            .strip()
-            .lower()
-            .startswith(_SLEEP_HARMONY_BASE_I5_PREFIX)
-        )
+        self._is_ksbt03c = variant == KEESON_VARIANT_KSBT and is_ksbt03c_name(resolved_device_name)
+        self._is_sleep_harmony = variant == KEESON_VARIANT_SLEEP_HARMONY
+        self._is_sleep_harmony_base_i5 = self._is_sleep_harmony and (
+            resolved_device_name or ""
+        ).strip().lower().startswith(_SLEEP_HARMONY_BASE_I5_PREFIX)
         self._is_purple_plus = variant == KEESON_VARIANT_PURPLE and (
-            (resolved_device_name or "").strip().lower().startswith(
-                _PURPLE_PLUS_NAME_PREFIX
-            )
+            (resolved_device_name or "").strip().lower().startswith(_PURPLE_PLUS_NAME_PREFIX)
             or self._has_ksbt_service()
         )
         self._notify_callback: Callable[[str, float], None] | None = None
@@ -292,7 +287,12 @@ class KeesonController(BedController):
             self._char_uuid = self._detect_ksbt_characteristic_uuid()
         elif variant == KEESON_VARIANT_JSON:
             self._char_uuid = self._detect_json_characteristic_uuid()
-        elif variant in {"ksbt", KEESON_VARIANT_KSBT_CR, KEESON_VARIANT_KSBT04C}:
+        elif variant in {
+            "ksbt",
+            KEESON_VARIANT_KSBT_CR,
+            KEESON_VARIANT_KSBT04C,
+            KEESON_VARIANT_SLEEP_HARMONY,
+        }:
             # For KSBT variants, try to find a working characteristic UUID
             self._char_uuid = self._detect_ksbt_characteristic_uuid()
         else:
@@ -465,8 +465,13 @@ class KeesonController(BedController):
 
     @property
     def _is_ksbt(self) -> bool:
-        """Return True if this is any KSBT variant (ksbt, ksbt_cr, or ksbt04c)."""
-        return self._variant in {"ksbt", KEESON_VARIANT_KSBT_CR, KEESON_VARIANT_KSBT04C}
+        """Return True if this controller uses a KSBT-family protocol."""
+        return self._variant in {
+            "ksbt",
+            KEESON_VARIANT_KSBT_CR,
+            KEESON_VARIANT_KSBT04C,
+            KEESON_VARIANT_SLEEP_HARMONY,
+        }
 
     @property
     def _is_json_variant(self) -> bool:
@@ -521,8 +526,9 @@ class KeesonController(BedController):
     def memory_slot_count(self) -> int:
         """Return memory slot count based on variant.
 
-        KSBT/KSBT04C: Slots 1-3 (Read = slot 1, TV = slot 2, M = slot 3, from
-            Ergomotion Sync APK remotes A/B/C)
+        KSBT/KSBT04C: Slots 1-3 (Read = slot 1, TV = slot 2, M = slot 3,
+            from Ergomotion Sync APK remotes A/B/C)
+        Sleep Harmony: Slots 1-3 (Read = slot 1, TV = slot 2, Snore = slot 3)
         KSBT03CR: Slots 1-2 (not covered by Ergomotion Sync, keep legacy)
         BetterLiving/CB1322: Slots 1-2 (from APK analysis)
         BaseI4/I5: Slot 3 only (from APK analysis)
@@ -534,7 +540,11 @@ class KeesonController(BedController):
             return 4
         if self._betterliving_presets or self._cb1322_presets:
             return 2  # BetterLiving and CB1322 both have Memory 1 and Memory 2
-        if self._variant in {"ksbt", KEESON_VARIANT_KSBT04C}:
+        if self._variant in {
+            "ksbt",
+            KEESON_VARIANT_KSBT04C,
+            KEESON_VARIANT_SLEEP_HARMONY,
+        }:
             return 3  # Read (0x2000), TV (0x4000), M (0x10000) buttons
         if self._is_ksbt:
             return 2  # KSBT03CR: Memory 1 and Memory 2 only (unverified beyond that)
@@ -550,7 +560,11 @@ class KeesonController(BedController):
     @property
     def supports_memory_programming(self) -> bool:
         """Return True for BetterLiving (save commands) and CB1322 (long-press save)."""
-        return self._betterliving_presets or self._cb1322_presets or self._variant == KEESON_VARIANT_PURPLE
+        return (
+            self._betterliving_presets
+            or self._cb1322_presets
+            or self._variant == KEESON_VARIANT_PURPLE
+        )
 
     @property
     def supports_lights(self) -> bool:
@@ -558,7 +572,10 @@ class KeesonController(BedController):
 
         Purple Premium Smart Base lacks lighting; Purple Plus (with massage) has it.
         """
-        if self._variant == KEESON_VARIANT_KSBT04C:
+        if self._variant in {
+            KEESON_VARIANT_KSBT04C,
+            KEESON_VARIANT_SLEEP_HARMONY,
+        }:
             # The guessed KSBT04C light/audio mappings are not verified and field
             # reports showed they were wrong or unsafe. Hide them until captured.
             return False
@@ -575,7 +592,10 @@ class KeesonController(BedController):
     @property
     def supports_light_toggle_control(self) -> bool:
         """Return whether the toggle-light button should be exposed."""
-        if self._variant == KEESON_VARIANT_KSBT04C:
+        if self._variant in {
+            KEESON_VARIANT_KSBT04C,
+            KEESON_VARIANT_SLEEP_HARMONY,
+        }:
             return False
         return super().supports_light_toggle_control
 
@@ -704,7 +724,10 @@ class KeesonController(BedController):
         Sino sets both zones to intensity zero. Sleep Harmony KSBT04C uses the
         dedicated 0x02000000 all-zone STOP command.
         """
-        return self._variant in {KEESON_VARIANT_SINO, KEESON_VARIANT_KSBT04C}
+        return self._variant in {
+            KEESON_VARIANT_SINO,
+            KEESON_VARIANT_SLEEP_HARMONY,
+        }
 
     @property
     def supports_massage_intensity_control(self) -> bool:
@@ -802,7 +825,10 @@ class KeesonController(BedController):
         elif self._variant == KEESON_VARIANT_KSBT_CR:
             # KSBT03CR: [0x05, 0x02, ...int_to_bytes(command), 0x00]
             return bytes([0x05, 0x02] + int_to_bytes(command_value) + [0x00])
-        elif self._variant == KEESON_VARIANT_KSBT04C:
+        elif self._variant in {
+            KEESON_VARIANT_KSBT04C,
+            KEESON_VARIANT_SLEEP_HARMONY,
+        }:
             # KSBT04C: [0x04, 0x02, ...int_to_bytes(command), checksum]
             # Source: com.keeson.ssbaudio (Sleep Harmony) BleClient.buildInstruct0()
             data = [0x04, 0x02] + int_to_bytes(command_value)
@@ -846,9 +872,7 @@ class KeesonController(BedController):
             response=self._write_with_response,
         )
 
-    async def start_notify(
-        self, callback: Callable[[str, float], None] | None = None
-    ) -> None:
+    async def start_notify(self, callback: Callable[[str, float], None] | None = None) -> None:
         """Start listening for position notifications (ergomotion variant only)."""
         self._notify_callback = callback
 
@@ -1090,10 +1114,7 @@ class KeesonController(BedController):
         finally:
             # Always release with a fresh event so it is not affected by cancellation.
             self._motor_state = {}
-            try:
-                await self._release_motion()
-            except Exception:
-                _LOGGER.debug("Failed to release motor command during cleanup")
+            await self._release_motion()
 
     async def _release_motion(self, *, delay: bool = True) -> None:
         """Send the protocol-specific motor release sequence.
@@ -1113,7 +1134,7 @@ class KeesonController(BedController):
             )
             return
 
-        if self._variant == KEESON_VARIANT_KSBT04C:
+        if self._variant == KEESON_VARIANT_SLEEP_HARMONY:
             if delay:
                 await asyncio.sleep(_SLEEP_HARMONY_RELEASE_DELAY_SECONDS)
             await self.write_command(
@@ -1123,6 +1144,10 @@ class KeesonController(BedController):
             return
 
         if self._variant == KEESON_VARIANT_KSBT:
+            if not delay:
+                # Direct P2 motion stops when the held-key refresh ends. The
+                # app's delayed 00 B0 frames are status queries, not STOP.
+                return
             for _ in range(_KSBT_RELEASE_QUERY_COUNT):
                 await asyncio.sleep(_KSBT_RELEASE_QUERY_DELAY_SECONDS)
                 await self.write_command(
@@ -1138,9 +1163,14 @@ class KeesonController(BedController):
 
     async def _write_single_shot(self, command: bytes) -> None:
         """Write a one-shot action and perform any app-specific release."""
-        await self.write_command(command, repeat_count=self._single_shot_count)
-        if self._variant == KEESON_VARIANT_KSBT04C:
-            await self._release_motion()
+        try:
+            await self.write_command(command, repeat_count=self._single_shot_count)
+        finally:
+            if self._variant in {
+                KEESON_VARIANT_PURPLE,
+                KEESON_VARIANT_SLEEP_HARMONY,
+            }:
+                await self._release_motion()
 
     async def _write_json_motion_command(
         self,
@@ -1254,13 +1284,9 @@ class KeesonController(BedController):
     async def preset_flat(self) -> None:
         """Go to flat position."""
         if self._betterliving_presets:
-            await self._write_single_shot(
-                self._build_command(BetterLivingCommands.PRESET_FLAT)
-            )
+            await self._write_single_shot(self._build_command(BetterLivingCommands.PRESET_FLAT))
         else:
-            await self._write_single_shot(
-                self._build_command(KeesonCommands.PRESET_FLAT)
-            )
+            await self._write_single_shot(self._build_command(KeesonCommands.PRESET_FLAT))
 
     async def preset_memory(self, memory_num: int) -> None:
         """Go to memory preset.
@@ -1331,16 +1357,20 @@ class KeesonController(BedController):
                 )
             return
 
-        if self._variant in {"ksbt", KEESON_VARIANT_KSBT04C}:
+        if self._variant in {
+            "ksbt",
+            KEESON_VARIANT_KSBT04C,
+            KEESON_VARIANT_SLEEP_HARMONY,
+        }:
             # Sleep Harmony labels Reading/TV/Snore as M1/M2/M3. Direct
-            # six-byte KSBT instead maps its third M button to 0x10000.
+            # and generic KSBT04C instead map their third M button to 0x10000.
             commands = (
                 {
                     1: KeesonCommands.PRESET_MEMORY_1,
                     2: KeesonCommands.PRESET_MEMORY_2,
                     3: KeesonCommands.PRESET_ANTI_SNORE,
                 }
-                if self._variant == KEESON_VARIANT_KSBT04C
+                if self._variant == KEESON_VARIANT_SLEEP_HARMONY
                 else {
                     1: KeesonCommands.PRESET_MEMORY_1,
                     2: KeesonCommands.PRESET_MEMORY_2,
@@ -1459,13 +1489,9 @@ class KeesonController(BedController):
     async def preset_zero_g(self) -> None:
         """Go to zero gravity position."""
         if self._betterliving_presets:
-            await self._write_single_shot(
-                self._build_command(BetterLivingCommands.PRESET_ZERO_G)
-            )
+            await self._write_single_shot(self._build_command(BetterLivingCommands.PRESET_ZERO_G))
         else:
-            await self._write_single_shot(
-                self._build_command(KeesonCommands.PRESET_ZERO_G)
-            )
+            await self._write_single_shot(self._build_command(KeesonCommands.PRESET_ZERO_G))
 
     async def preset_lounge(self) -> None:
         """Go to lounge position (KSBT 'Read' button / Memory 1, Lounge on Purple)."""
@@ -1473,19 +1499,15 @@ class KeesonController(BedController):
             not self._is_ksbt
             and not self._is_json_variant
             and self._variant != "ergomotion"
-            and (
-                self._variant != KEESON_VARIANT_PURPLE or self._is_purple_plus
-            )
+            and (self._variant != KEESON_VARIANT_PURPLE or self._is_purple_plus)
         ):
             _LOGGER.warning("Lounge preset is not available on %s beds", self._variant)
             return
-        await self._write_single_shot(
-            self._build_command(KeesonCommands.PRESET_LOUNGE)
-        )
+        await self._write_single_shot(self._build_command(KeesonCommands.PRESET_LOUNGE))
 
     async def preset_tv(self) -> None:
         """Go to TV position (KSBT/Ergomotion only)."""
-        if self._variant in ["base",KEESON_VARIANT_PURPLE]:
+        if self._variant in ["base", KEESON_VARIANT_PURPLE]:
             _LOGGER.warning("TV preset is not available on %s beds", self._variant)
             return
         await self._write_single_shot(self._build_command(KeesonCommands.PRESET_TV))
@@ -1504,18 +1526,21 @@ class KeesonController(BedController):
         ):
             _LOGGER.warning("Anti-snore preset is not available on %s beds", self._variant)
             return
-        await self._write_single_shot(
-            self._build_command(KeesonCommands.PRESET_ANTI_SNORE)
-        )
+        await self._write_single_shot(self._build_command(KeesonCommands.PRESET_ANTI_SNORE))
 
     # Light methods
     async def lights_on(self) -> None:
         """Turn on safety lights."""
-        if self._variant == KEESON_VARIANT_KSBT04C:
+        if self._variant in {
+            KEESON_VARIANT_KSBT04C,
+            KEESON_VARIANT_SLEEP_HARMONY,
+        }:
             raise NotImplementedError("KSBT04C light control is not yet verified")
         if self._variant == KEESON_VARIANT_SINO:
             # ORE variant has discrete on/off commands
-            await self.write_command(self._build_command(SinoCommands.LIGHT_ON), repeat_count=self._single_shot_count)
+            await self.write_command(
+                self._build_command(SinoCommands.LIGHT_ON), repeat_count=self._single_shot_count
+            )
             self._led_on = True
         else:
             # Other variants only have toggle
@@ -1523,11 +1548,16 @@ class KeesonController(BedController):
 
     async def lights_off(self) -> None:
         """Turn off safety lights."""
-        if self._variant == KEESON_VARIANT_KSBT04C:
+        if self._variant in {
+            KEESON_VARIANT_KSBT04C,
+            KEESON_VARIANT_SLEEP_HARMONY,
+        }:
             raise NotImplementedError("KSBT04C light control is not yet verified")
         if self._variant == KEESON_VARIANT_SINO:
             # ORE variant has discrete on/off commands
-            await self.write_command(self._build_command(SinoCommands.LIGHT_OFF), repeat_count=self._single_shot_count)
+            await self.write_command(
+                self._build_command(SinoCommands.LIGHT_OFF), repeat_count=self._single_shot_count
+            )
             self._led_on = False
         else:
             # Other variants only have toggle
@@ -1535,15 +1565,23 @@ class KeesonController(BedController):
 
     async def lights_toggle(self) -> None:
         """Toggle safety lights."""
-        if self._variant == KEESON_VARIANT_KSBT04C:
+        if self._variant in {
+            KEESON_VARIANT_KSBT04C,
+            KEESON_VARIANT_SLEEP_HARMONY,
+        }:
             raise NotImplementedError("KSBT04C light control is not yet verified")
         if self._variant == KEESON_VARIANT_SINO:
             # ORE doesn't have a toggle command; emulate it with tracked state.
             command = SinoCommands.LIGHT_OFF if self._led_on else SinoCommands.LIGHT_ON
-            await self.write_command(self._build_command(command), repeat_count=self._single_shot_count)
+            await self.write_command(
+                self._build_command(command), repeat_count=self._single_shot_count
+            )
             self._led_on = not self._led_on
         else:
-            await self.write_command(self._build_command(KeesonCommands.TOGGLE_SAFETY_LIGHTS), repeat_count=self._single_shot_count)
+            await self.write_command(
+                self._build_command(KeesonCommands.TOGGLE_SAFETY_LIGHTS),
+                repeat_count=self._single_shot_count,
+            )
 
     # Massage methods
     async def massage_toggle(self) -> None:
@@ -1563,22 +1601,24 @@ class KeesonController(BedController):
                     repeat_count=self._single_shot_count,
                 )
         else:
-            await self._write_single_shot(
-                self._build_command(KeesonCommands.MASSAGE_STEP)
-            )
+            await self._write_single_shot(self._build_command(KeesonCommands.MASSAGE_STEP))
 
     async def massage_off(self) -> None:
         """Turn off all massage."""
         if self._variant == KEESON_VARIANT_SINO:
             # Dynasty/INNOVA apps stop massage by setting both zones to intensity 0.
-            await self.write_command(self._build_command(SinoCommands.MASSAGE_HEAD_INTENSITY_BASE), repeat_count=self._single_shot_count)
-            await self.write_command(self._build_command(SinoCommands.MASSAGE_FOOT_INTENSITY_BASE), repeat_count=self._single_shot_count)
+            await self.write_command(
+                self._build_command(SinoCommands.MASSAGE_HEAD_INTENSITY_BASE),
+                repeat_count=self._single_shot_count,
+            )
+            await self.write_command(
+                self._build_command(SinoCommands.MASSAGE_FOOT_INTENSITY_BASE),
+                repeat_count=self._single_shot_count,
+            )
             self._head_massage = 0
             self._foot_massage = 0
-        elif self._variant == KEESON_VARIANT_KSBT04C:
-            await self._write_single_shot(
-                self._build_command(KeesonCommands.MASSAGE_ALL_STOP)
-            )
+        elif self._variant == KEESON_VARIANT_SLEEP_HARMONY:
+            await self._write_single_shot(self._build_command(KeesonCommands.MASSAGE_ALL_STOP))
         else:
             # Standard Keeson doesn't have a dedicated off command
             await super().massage_off()
@@ -1588,60 +1628,44 @@ class KeesonController(BedController):
         if self._variant == KEESON_VARIANT_SINO:
             self._head_massage = min(10, self._head_massage + 1)
             await self.write_command(
-                self._build_command(
-                    SinoCommands.MASSAGE_HEAD_INTENSITY_BASE + self._head_massage
-                ),
+                self._build_command(SinoCommands.MASSAGE_HEAD_INTENSITY_BASE + self._head_massage),
                 repeat_count=self._single_shot_count,
             )
         else:
-            await self._write_single_shot(
-                self._build_command(KeesonCommands.MASSAGE_HEAD_UP)
-            )
+            await self._write_single_shot(self._build_command(KeesonCommands.MASSAGE_HEAD_UP))
 
     async def massage_head_down(self) -> None:
         """Decrease head massage intensity."""
         if self._variant == KEESON_VARIANT_SINO:
             self._head_massage = max(0, self._head_massage - 1)
             await self.write_command(
-                self._build_command(
-                    SinoCommands.MASSAGE_HEAD_INTENSITY_BASE + self._head_massage
-                ),
+                self._build_command(SinoCommands.MASSAGE_HEAD_INTENSITY_BASE + self._head_massage),
                 repeat_count=self._single_shot_count,
             )
         else:
-            await self._write_single_shot(
-                self._build_command(KeesonCommands.MASSAGE_HEAD_DOWN)
-            )
+            await self._write_single_shot(self._build_command(KeesonCommands.MASSAGE_HEAD_DOWN))
 
     async def massage_foot_up(self) -> None:
         """Increase foot massage intensity."""
         if self._variant == KEESON_VARIANT_SINO:
             self._foot_massage = min(10, self._foot_massage + 1)
             await self.write_command(
-                self._build_command(
-                    SinoCommands.MASSAGE_FOOT_INTENSITY_BASE + self._foot_massage
-                ),
+                self._build_command(SinoCommands.MASSAGE_FOOT_INTENSITY_BASE + self._foot_massage),
                 repeat_count=self._single_shot_count,
             )
         else:
-            await self._write_single_shot(
-                self._build_command(KeesonCommands.MASSAGE_FOOT_UP)
-            )
+            await self._write_single_shot(self._build_command(KeesonCommands.MASSAGE_FOOT_UP))
 
     async def massage_foot_down(self) -> None:
         """Decrease foot massage intensity."""
         if self._variant == KEESON_VARIANT_SINO:
             self._foot_massage = max(0, self._foot_massage - 1)
             await self.write_command(
-                self._build_command(
-                    SinoCommands.MASSAGE_FOOT_INTENSITY_BASE + self._foot_massage
-                ),
+                self._build_command(SinoCommands.MASSAGE_FOOT_INTENSITY_BASE + self._foot_massage),
                 repeat_count=self._single_shot_count,
             )
         else:
-            await self._write_single_shot(
-                self._build_command(KeesonCommands.MASSAGE_FOOT_DOWN)
-            )
+            await self._write_single_shot(self._build_command(KeesonCommands.MASSAGE_FOOT_DOWN))
 
     async def massage_intensity_up(self) -> None:
         """Increase all massage intensity."""
@@ -1649,27 +1673,17 @@ class KeesonController(BedController):
             self._head_massage = min(10, self._head_massage + 1)
             self._foot_massage = min(10, self._foot_massage + 1)
             await self.write_command(
-                self._build_command(
-                    SinoCommands.MASSAGE_HEAD_INTENSITY_BASE + self._head_massage
-                ),
+                self._build_command(SinoCommands.MASSAGE_HEAD_INTENSITY_BASE + self._head_massage),
                 repeat_count=self._single_shot_count,
             )
             await self.write_command(
-                self._build_command(
-                    SinoCommands.MASSAGE_FOOT_INTENSITY_BASE + self._foot_massage
-                ),
+                self._build_command(SinoCommands.MASSAGE_FOOT_INTENSITY_BASE + self._foot_massage),
                 repeat_count=self._single_shot_count,
             )
         else:
             # Standard Keeson: step both zones up
-            await self.write_command(
-                self._build_command(KeesonCommands.MASSAGE_HEAD_UP),
-                repeat_count=self._single_shot_count,
-            )
-            await self.write_command(
-                self._build_command(KeesonCommands.MASSAGE_FOOT_UP),
-                repeat_count=self._single_shot_count,
-            )
+            await self._write_single_shot(self._build_command(KeesonCommands.MASSAGE_HEAD_UP))
+            await self._write_single_shot(self._build_command(KeesonCommands.MASSAGE_FOOT_UP))
 
     async def massage_intensity_down(self) -> None:
         """Decrease all massage intensity."""
@@ -1677,42 +1691,28 @@ class KeesonController(BedController):
             self._head_massage = max(0, self._head_massage - 1)
             self._foot_massage = max(0, self._foot_massage - 1)
             await self.write_command(
-                self._build_command(
-                    SinoCommands.MASSAGE_HEAD_INTENSITY_BASE + self._head_massage
-                ),
+                self._build_command(SinoCommands.MASSAGE_HEAD_INTENSITY_BASE + self._head_massage),
                 repeat_count=self._single_shot_count,
             )
             await self.write_command(
-                self._build_command(
-                    SinoCommands.MASSAGE_FOOT_INTENSITY_BASE + self._foot_massage
-                ),
+                self._build_command(SinoCommands.MASSAGE_FOOT_INTENSITY_BASE + self._foot_massage),
                 repeat_count=self._single_shot_count,
             )
         else:
             # Standard Keeson: step both zones down
-            await self.write_command(
-                self._build_command(KeesonCommands.MASSAGE_HEAD_DOWN),
-                repeat_count=self._single_shot_count,
-            )
-            await self.write_command(
-                self._build_command(KeesonCommands.MASSAGE_FOOT_DOWN),
-                repeat_count=self._single_shot_count,
-            )
+            await self._write_single_shot(self._build_command(KeesonCommands.MASSAGE_HEAD_DOWN))
+            await self._write_single_shot(self._build_command(KeesonCommands.MASSAGE_FOOT_DOWN))
 
     async def massage_mode_step(self) -> None:
         """Step through massage wave patterns."""
         if self._variant == KEESON_VARIANT_SINO:
             self._wave_massage = (self._wave_massage % 10) + 1
             await self.write_command(
-                self._build_command(
-                    SinoCommands.MASSAGE_HEAD_WAVE_BASE + self._wave_massage
-                ),
+                self._build_command(SinoCommands.MASSAGE_HEAD_WAVE_BASE + self._wave_massage),
                 repeat_count=self._single_shot_count,
             )
         else:
-            await self._write_single_shot(
-                self._build_command(KeesonCommands.MASSAGE_TIMER_STEP)
-            )
+            await self._write_single_shot(self._build_command(KeesonCommands.MASSAGE_TIMER_STEP))
 
     async def massage_head_toggle(self) -> None:
         """Toggle head massage zone on/off."""
@@ -1731,9 +1731,7 @@ class KeesonController(BedController):
                 )
         else:
             # Standard Keeson: step through head massage intensity (wraps max→0)
-            await self._write_single_shot(
-                self._build_command(KeesonCommands.MASSAGE_HEAD_UP)
-            )
+            await self._write_single_shot(self._build_command(KeesonCommands.MASSAGE_HEAD_UP))
 
     async def massage_foot_toggle(self) -> None:
         """Toggle foot massage zone on/off."""
@@ -1752,9 +1750,7 @@ class KeesonController(BedController):
                 )
         else:
             # Standard Keeson: step through foot massage intensity (wraps max→0)
-            await self._write_single_shot(
-                self._build_command(KeesonCommands.MASSAGE_FOOT_UP)
-            )
+            await self._write_single_shot(self._build_command(KeesonCommands.MASSAGE_FOOT_UP))
 
     async def sound_toggle(self) -> None:
         """Raise until KSBT04C sound control is verified from captured traffic."""

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -1027,13 +1027,13 @@ KEESON_VARIANTS: Final = {
     KEESON_VARIANT_JSON: "JSON/A00A (Juna, Linx, Ergo Health)",
     KEESON_VARIANT_KSBT: "KSBT (Nordic UART, some Ergomotion Sync beds)",
     KEESON_VARIANT_KSBT_CR: "KSBT03CR (7-byte, 0x05 prefix)",
-    KEESON_VARIANT_KSBT04C: "KSBT04C (7-byte with checksum, Beautyrest Baselogic)",
+    KEESON_VARIANT_KSBT04C: "Sleep Harmony (KSBT04C / base-i5)",
     KEESON_VARIANT_ERGOMOTION: "Ergomotion (with position feedback)",
     KEESON_VARIANT_OKIN: "OKIN FFE (OKIN 13/15 series, 0xE6 prefix)",
     KEESON_VARIANT_SERTA: "Serta (Serta MP Remote)",
     KEESON_VARIANT_SINO: "Sino (Dynasty, INNOVA, BetterLiving - big-endian)",
     "ore": "ORE (deprecated alias for Sino)",
-    KEESON_VARIANT_PURPLE: "Purple Premium Smart Base",
+    KEESON_VARIANT_PURPLE: "Purple Smart Base (Premium / Premium Plus)",
 }
 
 # Leggett & Platt variants

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -1019,6 +1019,7 @@ KEESON_VARIANT_SERTA: Final = "serta"
 KEESON_VARIANT_SINO: Final = "sino"
 KEESON_VARIANT_PURPLE: Final = "purple"
 KEESON_VARIANT_KSBT04C: Final = "ksbt04c"
+KEESON_VARIANT_SLEEP_HARMONY: Final = "sleep_harmony"
 # Deprecated alias kept for compatibility with older references.
 KEESON_VARIANT_ORE: Final = KEESON_VARIANT_SINO
 KEESON_VARIANTS: Final = {
@@ -1027,7 +1028,8 @@ KEESON_VARIANTS: Final = {
     KEESON_VARIANT_JSON: "JSON/A00A (Juna, Linx, Ergo Health)",
     KEESON_VARIANT_KSBT: "KSBT (Nordic UART, some Ergomotion Sync beds)",
     KEESON_VARIANT_KSBT_CR: "KSBT03CR (7-byte, 0x05 prefix)",
-    KEESON_VARIANT_KSBT04C: "Sleep Harmony (KSBT04C / base-i5)",
+    KEESON_VARIANT_KSBT04C: "KSBT04C (generic 7-byte checksum)",
+    KEESON_VARIANT_SLEEP_HARMONY: "Sleep Harmony (KSBT04C / base-i5)",
     KEESON_VARIANT_ERGOMOTION: "Ergomotion (with position feedback)",
     KEESON_VARIANT_OKIN: "OKIN FFE (OKIN 13/15 series, 0xE6 prefix)",
     KEESON_VARIANT_SERTA: "Serta (Serta MP Remote)",
@@ -1756,6 +1758,7 @@ ALL_PROTOCOL_VARIANTS: Final = [
     KEESON_VARIANT_JSON,
     KEESON_VARIANT_KSBT,
     KEESON_VARIANT_KSBT04C,
+    KEESON_VARIANT_SLEEP_HARMONY,
     KEESON_VARIANT_ERGOMOTION,
     KEESON_VARIANT_OKIN,
     KEESON_VARIANT_SERTA,
@@ -1857,6 +1860,7 @@ def connection_gated_by_bond(bed_type: str, protocol_variant: str | None = None)
     if bed_type == BED_TYPE_LEGGETT_GEN2:
         return True
     return bed_type == BED_TYPE_LEGGETT_PLATT and protocol_variant == LEGGETT_VARIANT_GEN2
+
 
 # Bed types that support angle sensing (position feedback)
 BEDS_WITH_ANGLE_SENSING: Final = frozenset(

--- a/custom_components/adjustable_bed/controller_factory.py
+++ b/custom_components/adjustable_bed/controller_factory.py
@@ -625,7 +625,9 @@ async def create_controller(
             return KeesonController(coordinator, variant="serta")
         elif keeson_variant == KEESON_VARIANT_PURPLE:
             _LOGGER.debug("Using Purple Keeson variant")
-            return KeesonController(coordinator, variant="purple")
+            return KeesonController(
+                coordinator, variant="purple", device_name=device_name
+            )
         elif keeson_variant == KEESON_VARIANT_SINO:
             _LOGGER.debug("Using Sino Keeson variant (big-endian)")
             return KeesonController(
@@ -636,7 +638,9 @@ async def create_controller(
         else:
             # Auto or base variant
             _LOGGER.debug("Using Base Keeson variant")
-            return KeesonController(coordinator, variant="base")
+            return KeesonController(
+                coordinator, variant="base", device_name=device_name
+            )
 
     if bed_type == BED_TYPE_OKIN_FFE:
         from .beds.keeson import KeesonController

--- a/custom_components/adjustable_bed/controller_factory.py
+++ b/custom_components/adjustable_bed/controller_factory.py
@@ -83,6 +83,7 @@ from .const import (
     KEESON_VARIANT_PURPLE,
     KEESON_VARIANT_SERTA,
     KEESON_VARIANT_SINO,
+    KEESON_VARIANT_SLEEP_HARMONY,
     LEGGETT_VARIANT_MLRM,
     LEGGETT_VARIANT_OKIN,
     MANUFACTURER_ID_OKIN,
@@ -570,8 +571,7 @@ async def create_controller(
                         keeson_cb1322_presets = True
                     else:
                         _LOGGER.info(
-                            "Auto-detected Keeson Sino variant for %s "
-                            "(name: %s, services: %s)",
+                            "Auto-detected Keeson Sino variant for %s (name: %s, services: %s)",
                             coordinator.address,
                             device_name or "unknown",
                             sorted(service_uuids),
@@ -590,8 +590,10 @@ async def create_controller(
                 )
                 keeson_variant = KEESON_VARIANT_KSBT_CR
             elif normalized_name.startswith("ksbt04c") or normalized_name == "smart_dfu":
-                _LOGGER.info(
-                    "Auto-detected KSBT04C variant for %s (name: %s)",
+                _LOGGER.warning(
+                    "Device %s advertises the ambiguous name %s; using the "
+                    "legacy generic KSBT04C profile. Select Purple or Sleep "
+                    "Harmony explicitly if that is the matching app family.",
                     coordinator.address,
                     device_name,
                 )
@@ -610,8 +612,19 @@ async def create_controller(
             _LOGGER.debug("Using KSBT03CR Keeson variant (7-byte, 0x05 prefix)")
             return KeesonController(coordinator, variant="ksbt_cr", device_name=device_name)
         elif keeson_variant == KEESON_VARIANT_KSBT04C:
-            _LOGGER.debug("Using KSBT04C Keeson variant (7-byte with checksum)")
-            return KeesonController(coordinator, variant="ksbt04c", device_name=device_name)
+            _LOGGER.debug("Using generic KSBT04C Keeson variant (7-byte with checksum)")
+            return KeesonController(
+                coordinator,
+                variant=KEESON_VARIANT_KSBT04C,
+                device_name=device_name,
+            )
+        elif keeson_variant == KEESON_VARIANT_SLEEP_HARMONY:
+            _LOGGER.debug("Using explicit Sleep Harmony Keeson variant")
+            return KeesonController(
+                coordinator,
+                variant=KEESON_VARIANT_SLEEP_HARMONY,
+                device_name=device_name,
+            )
         elif keeson_variant == KEESON_VARIANT_ERGOMOTION:
             _LOGGER.debug("Using Ergomotion Keeson variant (with position feedback)")
             return KeesonController(coordinator, variant="ergomotion")
@@ -625,9 +638,7 @@ async def create_controller(
             return KeesonController(coordinator, variant="serta")
         elif keeson_variant == KEESON_VARIANT_PURPLE:
             _LOGGER.debug("Using Purple Keeson variant")
-            return KeesonController(
-                coordinator, variant="purple", device_name=device_name
-            )
+            return KeesonController(coordinator, variant="purple", device_name=device_name)
         elif keeson_variant == KEESON_VARIANT_SINO:
             _LOGGER.debug("Using Sino Keeson variant (big-endian)")
             return KeesonController(
@@ -638,9 +649,7 @@ async def create_controller(
         else:
             # Auto or base variant
             _LOGGER.debug("Using Base Keeson variant")
-            return KeesonController(
-                coordinator, variant="base", device_name=device_name
-            )
+            return KeesonController(coordinator, variant="base", device_name=device_name)
 
     if bed_type == BED_TYPE_OKIN_FFE:
         from .beds.keeson import KeesonController
@@ -914,7 +923,11 @@ async def create_controller(
         from .beds.sbi import SBIController
 
         # Use configured variant or default to "both" for dual-bed control
-        variant = protocol_variant if protocol_variant and protocol_variant != "auto" else SBI_VARIANT_BOTH
+        variant = (
+            protocol_variant
+            if protocol_variant and protocol_variant != "auto"
+            else SBI_VARIANT_BOTH
+        )
         _LOGGER.debug("Using SBI controller with variant: %s", variant)
         return SBIController(coordinator, variant=variant)
 

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -37,8 +37,11 @@ Brands using Keeson/Ergomotion actuators:
 | Analyzed | App | Package ID |
 |----------|-----|------------|
 | ✅ | [Ergomotion 4.0](https://play.google.com/store/apps/details?id=com.sfd.hump) | `com.sfd.hump` |
+| ✅ | [1500 Tilt Base Remote](https://play.google.com/store/apps/details?id=com.sfd.rondure_hump) | `com.sfd.rondure_hump` |
+| ✅ | [Q-Plus Adjustable Remote](https://play.google.com/store/apps/details?id=com.sbi.costco) | `com.sbi.costco` |
 | ✅ | [Ergomotion](https://play.google.com/store/apps/details?id=com.sfd.ergomotion) | `com.sfd.ergomotion` |
 | ✅ | [Tempur Zero G Bed Base](https://play.google.com/store/apps/details?id=com.sfd.row) | `com.sfd.row` |
+| ✅ | Tempur Curve | `com.ore.tempur` |
 | ✅ | [Member's Mark Base Remote](https://play.google.com/store/apps/details?id=com.sfd.mm) | `com.sfd.mm` |
 | ✅ | Ergomotion Sync | `cn.com.mancini` |
 | ✅ | Linx | `com.keeson.connectedbed` |
@@ -96,10 +99,16 @@ One-shot buttons use `ctrm=1, km=1, keykt=0`. Held motion is not fully uniform:
 
 The integration treats `0000a00a` as a distinct Keeson variant and uses the shared 32-bit command values, while accommodating the split held-motion metadata from the Juna/Linx app family.
 
-### KSBT Variant (Older Remotes)
+### KSBT Variant (Direct P2 Remotes)
 
 **Primary Service UUID:** `6e400001-b5a3-f393-e0a9-e50e24dcca9e` (Nordic UART Service)
 **Format:** 6 bytes `[0x04, 0x02, ...int_bytes]` (big-endian)
+
+Held movement keys are written immediately and refreshed every 100 ms. Releasing
+a key cancels that refresh and writes the two-byte status query `[0x00, 0xB0]`
+at +300, +600 and +900 ms. The current Ergomotion 4.0, Q-Plus and 1500 Tilt
+Base apps all prove this behavior independently. They do not write the six-byte
+zero-key packet as the P2 release sequence.
 
 Some Ergomotion-branded beds also use this variant. A confirmed Rio 6.0 support bundle advertises as `KSBT04...` and works correctly with the standard KSBT 6-byte protocol.
 Juna's `LVrestore` and `LVrelax` remotes also use this direct 6-byte framing rather than the JSON/A00A path.
@@ -194,7 +203,7 @@ app/protocol family, not to the shared 32-bit command values:
 |---------------------|------------------|-------------------|-------------------------|
 | BaseI4/BaseI5 | Member's Mark | 400ms fixed-delay scheduler | 3 writes, 400ms apart |
 | JSON/A00A | Juna / Linx | Requests every 5ms / 3ms, but drops requests while a write-with-response is pending | Existing safe 10 writes, 100ms apart |
-| KSBT | Ergomotion Sync / Adjustable Lite | 300ms `Timer.schedule` | 4 writes, 300ms apart |
+| KSBT direct P2 | Ergomotion 4.0 / Q-Plus / 1500 Tilt Base | 100ms handler loop | 10 writes, 100ms apart |
 | KSBT03CR | SomosBeds | 300ms `Timer.schedule` | 4 writes, 300ms apart |
 | KSBT04C | Sleep Harmony | 300ms handler loop | 4 writes, 300ms apart |
 | Ergomotion | Ergomotion / Ergomotion 4.0 / Tempur Zero G | 100ms handler loop | 10 writes, 100ms apart |
@@ -216,11 +225,12 @@ BetterLiving devices use the BetterLiving cadence whenever that app profile is
 detected, even if a future factory path pairs the profile flag with a different
 base Keeson variant.
 
-Release behavior also varies. Ergomotion and Purple send an explicit zero frame;
-standard KSBT and Member's Mark merely cancel their repeat timer; Sleep Harmony
-sends two delayed zero frames. The integration intentionally sends an immediate
-zero frame after every movement for hardware safety. One-shot commands are sent
-once on KSBT and KSBT03CR, while Sleep Harmony's KSBT04C variant sends them twice.
+Release behavior also varies. Direct six-byte KSBT/P2 stops its 100 ms refresh
+and sends `00 B0` queries at +300/+600/+900 ms; it does not send a zero-key
+frame. Base/Ergomotion/Purple families use their own explicit zero frame, while
+checksum and KSBT03CR variants retain their independently derived release
+behavior. One-shot commands are sent once on KSBT and KSBT03CR, while Sleep
+Harmony's KSBT04C variant sends them twice.
 
 ## Split-Bed Support (Member's Mark)
 

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -43,6 +43,7 @@ Brands using Keeson/Ergomotion actuators:
 | ✅ | [Tempur Zero G Bed Base](https://play.google.com/store/apps/details?id=com.sfd.row) | `com.sfd.row` |
 | ✅ | Tempur Curve | `com.ore.tempur` |
 | ✅ | [Member's Mark Base Remote](https://play.google.com/store/apps/details?id=com.sfd.mm) | `com.sfd.mm` |
+| ✅ | [Sleep Harmony](https://play.google.com/store/apps/details?id=com.keeson.ssbaudio) | `com.keeson.ssbaudio` |
 | ✅ | Ergomotion Sync | `cn.com.mancini` |
 | ✅ | Linx | `com.keeson.connectedbed` |
 | ✅ | Juna Sleep | `com.keeson.junasleep` |
@@ -52,15 +53,15 @@ Brands using Keeson/Ergomotion actuators:
 
 | Feature | BaseI4/I5 | JSON/A00A | KSBT | Ergomotion | Okin | Serta | Sino | Purple (Premium) | Purple (Premium Plus) |
 |---------|-----------|------------|------|------------|------|-------|------|------------------|-----------------------|
-| Motor Control | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❓ |
-| Position Feedback | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❓ |
-| Memory Presets | ✅ (slots 3-4) | ✅ (remote-dependent 0x2000/0x4000/0x8000/0x10000) | ✅ (slots 1-3: Read/TV/M) | ✅ (4 slots) | ✅ | ✅ | ✅ | ✅ | ❓ |
-| TV Preset | ❌ | ✅ (remote-dependent) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❓ |
-| Anti-Snore Preset | ❌ | ✅ (remote-dependent) | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ❓ |
-| Lounge Preset | ❌ | ✅ (remote-dependent) | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❓ |
-| Massage | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❓ |
-| Safety Lights | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❓ |
-| Zero-G | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❓ |
+| Motor Control | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Position Feedback | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Memory Presets | ✅ (slots 3-4) | ✅ (remote-dependent 0x2000/0x4000/0x8000/0x10000) | ✅ (slots 1-3: Read/TV/M) | ✅ (4 slots) | ✅ | ✅ | ✅ | ✅ (2 slots) | ✅ (3 slots) |
+| TV Preset | ❌ | ✅ (remote-dependent) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Anti-Snore Preset | ❌ | ✅ (remote-dependent) | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| Lounge Preset | ❌ | ✅ (remote-dependent) | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Massage | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Safety Lights | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Zero-G | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ## Protocol Variants
 
@@ -104,11 +105,14 @@ The integration treats `0000a00a` as a distinct Keeson variant and uses the shar
 **Primary Service UUID:** `6e400001-b5a3-f393-e0a9-e50e24dcca9e` (Nordic UART Service)
 **Format:** 6 bytes `[0x04, 0x02, ...int_bytes]` (big-endian)
 
-Held movement keys are written immediately and refreshed every 100 ms. Releasing
-a key cancels that refresh and writes the two-byte status query `[0x00, 0xB0]`
-at +300, +600 and +900 ms. The current Ergomotion 4.0, Q-Plus and 1500 Tilt
-Base apps all prove this behavior independently. They do not write the six-byte
-zero-key packet as the P2 release sequence.
+Ergomotion 4.0, Q-Plus and 1500 Tilt Base write held movement keys immediately
+and refresh them every 100 ms. Releasing a key cancels that refresh and writes
+the two-byte status query `[0x00, 0xB0]` at +300, +600 and +900 ms. Member's
+Mark uses a 400 ms movement refresh and runs the same query on an independent
+400 ms timer. None of these P2 paths writes the six-byte zero-key packet on
+release. The integration uses the 100 ms compatibility cadence needed by
+KSBT03C beds such as the issue #408 device; explicit per-device pulse settings
+remain authoritative.
 
 Some Ergomotion-branded beds also use this variant. A confirmed Rio 6.0 support bundle advertises as `KSBT04...` and works correctly with the standard KSBT 6-byte protocol.
 Juna's `LVrestore` and `LVrelax` remotes also use this direct 6-byte framing rather than the JSON/A00A path.
@@ -116,6 +120,10 @@ Juna's `LVrestore` and `LVrelax` remotes also use this direct 6-byte framing rat
 **Ergomotion Sync remotes (from `cn.com.mancini` APK):** the app has three remote layouts — A and C target `KSBT04C` devices, B targets `KSBT03C` (e.g. Rio 5.0). All three share the same preset buttons: Read = `0x2000`, TV = `0x4000`, M = `0x10000`, Zero-G = `0x1000`, Flat = `0x8000000`, light toggle = `0x20000`, and massage steps head `0x800` / foot `0x400` / timer `0x200` (no all-off command). The Anti-Snore button (`0x8000`) appears on layouts B/C only; that describes the remote UIs, not command support — the integration exposes anti-snore on all KSBT variants. Read/TV/M are exposed as memory slots 1-3 on KSBT variants.
 
 **KSBT03C motor layout:** the KSBT03C remote (layout B) drives only three motors — head/back (`0x1`/`0x2`), feet/legs (`0x4`/`0x8`) and lumbar (`0x40`/`0x80`). There are no head-tilt (`0x10`/`0x20`) buttons, so KSBT03C beds have no tilt motor and the integration maps the third configured motor to lumbar. KSBT04C remotes (layouts A/C) additionally have the head-tilt buttons.
+
+That three-motor rule belongs to the direct six-byte KSBT profile. Sleep Harmony
+also accepts a `KSBT03C` name but uses its separate explicit profile and exposes
+head, foot, tilt/EJ and lumbar controls.
 
 **Status:** the KSBT03C command values and 3-motor layout are APK-derived (Ergomotion Sync 1.0.2) and not yet confirmed on hardware; the Rio 5.0 report in issue #408 confirms the lumbar motor responds to `0x40`/`0x80` and that no tilt motor exists.
 
@@ -130,6 +138,27 @@ Juna's `LVrestore` and `LVrelax` remotes also use this direct 6-byte framing rat
 
 Auto-detected from device name prefix `ksbt03cr`. Uses the same 32-bit command values as standard KSBT; only the framing differs (7-byte packet with `0x05` prefix and trailing `0x00` byte instead of 6-byte packet with `0x04` prefix). Falls back to the same alternative service UUIDs as standard KSBT.
 
+### Sleep Harmony Variant
+
+Sleep Harmony 1.0.1 has two name-selected packet families behind the explicit
+`Sleep Harmony (KSBT04C / base-i5)` profile:
+
+| Name prefix | GATT | Frame |
+|-------------|------|-------|
+| `KSBT04C` / `KSBT03C` | Nordic UART 6E400001 / 2 / 3 | `04 02 + command_be32 + complement checksum` |
+| `base-i5.` | FFE5 / FFE9, notify FFE4 | `E6 FE 16 + command_le32 + side 00 + complement checksum` |
+
+Motor commands start immediately and repeat every 300 ms. Releasing a motor or
+one-shot button waits 200 ms and sends one protocol-specific zero command. The
+integration preserves that UI release delay but keeps the safety `stop_all`
+service immediate. Sleep Harmony's popup M1/M2/M3 sends Reading `0x2000`, TV
+`0x4000`, and Snore `0x8000`; it has no memory-save action. Its dedicated
+massage-off command is `0x02000000`.
+
+These prefixes overlap Purple Smart Base while the packet endings differ. Select
+the explicit Purple or Sleep Harmony profile; a name alone cannot distinguish
+the ecosystems safely.
+
 ### Sino Variant (Dynasty, INNOVA, BetterLiving)
 **Primary Service UUID:** `0000ffe5-0000-1000-8000-00805f9b34fb`
 **Format:** 8 bytes `[0xE5, 0xFE, 0x16, b4, b5, b6, b7, checksum]` (big-endian byte order)
@@ -140,24 +169,33 @@ Used by BetterLiving/OKIN-BLE devices. Same packet structure as Base variant but
 Same protocol as Base variant but with real-time position updates via BLE notifications.
 
 ### Purple Variant
-Same protocol as Base variant, but with support for Lounge and Anti-Snore presets. Additionally, Memory 1 is mapped to the typical Memory 4 address. Also supports saving memory presets by sending the recall command repeated 30x at 100ms. Note that only the "Premium" model bed has been tested, no functionality has been verified for the "Premium Plus" model.
 
-**Notify Characteristic:** `0000ffe4-0000-1000-8000-00805f9b34fb`
+Purple Smart Base 1.0.8 has two explicitly selected products:
 
-Position data formats (by header byte):
+| Product | Name prefix | GATT | Command frame |
+|---------|-------------|------|---------------|
+| Premium | `base-i5` | FFE5 / FFE9, notify FFE4 | `E5 FE 16 + mask_le32 + complement checksum` |
+| Premium Plus | `KSBT04C` | Nordic UART 6E400001 / 2 / 3 | `04 02 + mask_be32 + 00` |
 
-| Header | Length | Description |
-|--------|--------|-------------|
-| `0xED` | 16 bytes | Basic position data |
-| `0xF0` | 19 bytes | Extended position data |
-| `0xF1` | 20 bytes | Full status data |
+Both repeat movement every 100 ms. On release, the app writes the Premium Plus
+zero-mask frame `04 02 00 00 00 00 00`, including when Premium's FFE9 target is
+selected. Premium has lounge, anti-snore and two memory slots. Premium Plus has
+pillow and lumbar motors, anti-snore, three memory slots, massage, underbed and
+motion lighting, and no lounge action.
 
-Position data includes:
-- Head position (16-bit, 0-100 scale)
-- Foot position (16-bit, 0-100 scale)
-- Movement status flags
-- Massage levels (0-6)
-- LED status
+Memory recall/save masks differ:
+
+| Slot | Premium | Premium Plus |
+|------|---------|--------------|
+| 1 | `0x00010000` | `0x00010000` |
+| 2 | `0x00004000` | `0x00002000` |
+| 3 | unavailable | `0x00004000` |
+
+The dedicated save flow performs 26 writes, each after 200 ms, for about 5.2
+seconds. Notifications report massage time/strength, light state, motion-light
+state/duration and version; the app contains no bed-position feedback parser.
+Select the explicit Purple profile because `base-i5` and `KSBT04C` names are
+also used by other Keeson app families with different packet endings.
 
 ### Commands (32-bit Values)
 
@@ -177,8 +215,8 @@ Position data includes:
 | Massage Foot Up | `0x00000400` | Increase foot massage |
 | Massage Head Up | `0x00000800` | Increase head massage |
 | Zero-G | `0x00001000` | Zero-G preset |
-| Memory 1 / Lounge | `0x00002000` | KSBT "Read" button, Lounge on Purple, not available on BaseI4/I5 |
-| Memory 2 / TV | `0x00004000` | KSBT TV button, Purple Memory 2, not available on BaseI4/I5  |
+| Memory 1 / Lounge | `0x00002000` | KSBT "Read" button; Purple Premium lounge; Purple Plus memory 2 |
+| Memory 2 / TV | `0x00004000` | KSBT TV button; Purple Premium memory 2; Purple Plus memory 3 |
 | Memory 3 / Anti-Snore | `0x00008000` | Memory 3 on BaseI4/I5, Anti-Snore on KSBT and Purple |
 | Memory 4 / M | `0x00010000` | KSBT "M" button (memory slot 3), Maps to Memory 1 on Purple |
 | Toggle Lights | `0x00020000` | Toggle safety lights |
@@ -203,9 +241,9 @@ app/protocol family, not to the shared 32-bit command values:
 |---------------------|------------------|-------------------|-------------------------|
 | BaseI4/BaseI5 | Member's Mark | 400ms fixed-delay scheduler | 3 writes, 400ms apart |
 | JSON/A00A | Juna / Linx | Requests every 5ms / 3ms, but drops requests while a write-with-response is pending | Existing safe 10 writes, 100ms apart |
-| KSBT direct P2 | Ergomotion 4.0 / Q-Plus / 1500 Tilt Base | 100ms handler loop | 10 writes, 100ms apart |
+| KSBT direct P2 | Ergomotion 4.0 / Q-Plus / 1500 Tilt Base; Member's Mark | 100ms in the SFD apps, 400ms in Member's Mark | 10 writes, 100ms apart; explicit user overrides are preserved |
 | KSBT03CR | SomosBeds | 300ms `Timer.schedule` | 4 writes, 300ms apart |
-| KSBT04C | Sleep Harmony | 300ms handler loop | 4 writes, 300ms apart |
+| Sleep Harmony (`KSBT04C` / `base-i5.`) | Sleep Harmony | 300ms handler loop | 4 writes, 300ms apart |
 | Ergomotion | Ergomotion / Ergomotion 4.0 / Tempur Zero G | 100ms handler loop | 10 writes, 100ms apart |
 | Serta | Serta MP Remote | 100ms handler loop | 10 writes, 100ms apart |
 | Sino / BetterLiving OKIN | BetterLiving | 100ms on the two-motor screen, 200ms on the three-motor screen | 10 x 100ms or 5 x 200ms |
@@ -225,12 +263,15 @@ BetterLiving devices use the BetterLiving cadence whenever that app profile is
 detected, even if a future factory path pairs the profile flag with a different
 base Keeson variant.
 
-Release behavior also varies. Direct six-byte KSBT/P2 stops its 100 ms refresh
-and sends `00 B0` queries at +300/+600/+900 ms; it does not send a zero-key
-frame. Base/Ergomotion/Purple families use their own explicit zero frame, while
-checksum and KSBT03CR variants retain their independently derived release
-behavior. One-shot commands are sent once on KSBT and KSBT03CR, while Sleep
-Harmony's KSBT04C variant sends them twice.
+Release behavior also varies. The current SFD direct-six-byte P2 apps stop their
+100 ms refresh and send `00 B0` queries at +300/+600/+900 ms. Member's Mark
+stops its 400 ms refresh without a dedicated release write, while its independent
+timer continues sending `00 B0`. None sends a zero-key frame. Base/Ergomotion/
+Serta families retain their family-specific zero frames. Purple uses the explicit
+seven-byte P2 zero frame. Sleep Harmony waits 200 ms and sends one zero frame
+after both movement and one-shot actions. KSBT03CR retains its independently
+derived release behavior. One-shot commands themselves are sent once before any
+profile-specific release.
 
 ## Split-Bed Support (Member's Mark)
 
@@ -254,8 +295,9 @@ Unique service UUID auto-detection:
 
 | Device Name Prefix | Protocol |
 |-------------------|----------|
-| `base` | Standard FFE5/FFE9 (8-byte) |
+| `base` / `base-i5` | Profile-dependent: Purple Premium uses E5/8-byte; Sleep Harmony uses E6/9-byte; select the explicit profile |
 | `KSBT03C` | Nordic UART with 6-byte packets (3 motors: no head tilt; e.g. Ergomotion Rio 5.0) |
-| `KSBT04C` | Nordic UART with 6-byte packets (used by some Ergomotion Sync beds, including Rio 6.0) |
+| `KSBT04` | Nordic UART with 6-byte packets (confirmed Rio 6.0 family) |
+| `KSBT04C` | Profile-dependent: Purple Plus uses a trailing zero, Sleep Harmony uses a checksum; select the matching explicit profile |
 | `ksbt03cr` | Nordic UART with 7-byte packets (KSBT03CR variant) |
 | `EH` | Mattress variant (E0FF service) |

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -55,7 +55,7 @@ Brands using Keeson/Ergomotion actuators:
 |---------|-----------|------------|------|------------|------|-------|------|------------------|-----------------------|
 | Motor Control | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Position Feedback | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Memory Presets | ✅ (slots 3-4) | ✅ (remote-dependent 0x2000/0x4000/0x8000/0x10000) | ✅ (slots 1-3: Read/TV/M) | ✅ (4 slots) | ✅ | ✅ | ✅ | ✅ (2 slots) | ✅ (3 slots) |
+| Memory Presets | ⚠️ 4 exposed (slot 3 app-confirmed) | ✅ (remote-dependent 0x2000/0x4000/0x8000/0x10000) | ✅ (slots 1-3: Read/TV/M) | ⚠️ 4 exposed (verification needed) | ✅ | ✅ | ✅ | ✅ (2 slots) | ✅ (3 slots) |
 | TV Preset | ❌ | ✅ (remote-dependent) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Anti-Snore Preset | ❌ | ✅ (remote-dependent) | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ |
 | Lounge Preset | ❌ | ✅ (remote-dependent) | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
@@ -141,7 +141,7 @@ Auto-detected from device name prefix `ksbt03cr`. Uses the same 32-bit command v
 ### Sleep Harmony Variant
 
 Sleep Harmony 1.0.1 has two name-selected packet families behind the explicit
-`Sleep Harmony (KSBT04C / base-i5)` profile:
+`sleep_harmony` (`Sleep Harmony (KSBT04C / base-i5)`) profile:
 
 | Name prefix | GATT | Frame |
 |-------------|------|-------|
@@ -295,9 +295,9 @@ Unique service UUID auto-detection:
 
 | Device Name Prefix | Protocol |
 |-------------------|----------|
-| `base` / `base-i5` | Profile-dependent: Purple Premium uses E5/8-byte; Sleep Harmony uses E6/9-byte; select the explicit profile |
+| `base` / `base-i5` | Ambiguous: Auto keeps the Base profile; Purple Premium uses E5/8-byte and Sleep Harmony uses E6/9-byte, so select either profile explicitly |
 | `KSBT03C` | Nordic UART with 6-byte packets (3 motors: no head tilt; e.g. Ergomotion Rio 5.0) |
 | `KSBT04` | Nordic UART with 6-byte packets (confirmed Rio 6.0 family) |
-| `KSBT04C` | Profile-dependent: Purple Plus uses a trailing zero, Sleep Harmony uses a checksum; select the matching explicit profile |
+| `KSBT04C` | Ambiguous: Auto keeps the legacy generic checksum profile; Purple Plus uses a trailing zero and Sleep Harmony uses app-specific checksum/release behavior, so select either profile explicitly |
 | `ksbt03cr` | Nordic UART with 7-byte packets (KSBT03CR variant) |
 | `EH` | Mattress variant (E0FF service) |

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -140,6 +140,9 @@ Auto-detected from device name prefix `ksbt03cr`. Uses the same 32-bit command v
 
 ### Sleep Harmony Variant
 
+**Validation status:** Clean-room APK analysis complete; physical Sleep Harmony
+hardware has not yet been tested.
+
 Sleep Harmony 1.0.1 has two name-selected packet families behind the explicit
 `sleep_harmony` (`Sleep Harmony (KSBT04C / base-i5)`) profile:
 

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -1025,8 +1025,10 @@ class TestPurpleSmartBaseProtocol:
 
         assert premium.memory_slot_count == 2
         assert premium.supports_preset_lounge
+        assert not premium.supports_lights
         assert plus.memory_slot_count == 3
         assert not plus.supports_preset_lounge
+        assert plus.supports_lights
 
         for memory_num in (1, 2, 3):
             await plus.preset_memory(memory_num)

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -28,6 +28,7 @@ from custom_components.adjustable_bed.const import (
     DOMAIN,
     KEESON_BASE_WRITE_CHAR_UUID,
     KEESON_JSON_WRITE_CHAR_UUID,
+    KEESON_KSBT_CHAR_UUID,
     KEESON_VARIANT_JSON,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
@@ -995,6 +996,238 @@ class TestKeesonPositionNotifications:
         assert coordinator.controller._notify_callback is callback
 
 
+class TestPurpleSmartBaseProtocol:
+    """Test current Purple Premium and Premium Plus protocol variants."""
+
+    async def test_premium_and_plus_build_distinct_packets(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test Premium uses checksummed P1 and Plus uses zero-suffixed P2."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+
+        premium = KeesonController(
+            coordinator, variant="purple", device_name="base-i5.123456"
+        )
+        plus = KeesonController(
+            coordinator, variant="purple", device_name="KSBT04C123456789"
+        )
+
+        assert premium._build_command(KeesonCommands.MOTOR_HEAD_UP) == bytes.fromhex(
+            "e5fe160100000005"
+        )
+        assert plus._build_command(KeesonCommands.MOTOR_HEAD_UP) == bytes.fromhex(
+            "04020000000100"
+        )
+        assert plus.control_characteristic_uuid == KEESON_KSBT_CHAR_UUID
+
+    async def test_plus_capabilities_and_memory_map(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test Purple Plus exposes three proven slots and no lounge action."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        premium = KeesonController(
+            coordinator, variant="purple", device_name="base-i5.123456"
+        )
+        plus = KeesonController(
+            coordinator, variant="purple", device_name="KSBT04C123456789"
+        )
+        plus.write_command = AsyncMock()
+
+        assert premium.memory_slot_count == 2
+        assert premium.supports_preset_lounge
+        assert plus.memory_slot_count == 3
+        assert not plus.supports_preset_lounge
+
+        for memory_num in (1, 2, 3):
+            await plus.preset_memory(memory_num)
+
+        assert [call.args[0] for call in plus.write_command.await_args_list] == [
+            bytes.fromhex("04020001000000"),
+            bytes.fromhex("04020000200000"),
+            bytes.fromhex("04020000400000"),
+        ]
+
+    @pytest.mark.parametrize("device_name", ["base-i5.123456", "KSBT04C123456789"])
+    async def test_purple_release_uses_p2_zero_frame(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        device_name: str,
+    ):
+        """Test both Purple surfaces release with the artifact's P2 STOP."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        controller = KeesonController(
+            coordinator, variant="purple", device_name=device_name
+        )
+        controller.write_command = AsyncMock()
+
+        await controller.stop_all()
+
+        assert controller.write_command.await_args.args == (
+            bytes.fromhex("04020000000000"),
+        )
+        cancel_event = controller.write_command.await_args.kwargs["cancel_event"]
+        assert isinstance(cancel_event, asyncio.Event)
+        assert not cancel_event.is_set()
+
+    async def test_plus_program_memory_matches_send_memory_sequence(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test Plus memory 2 save performs 26 delayed P2 writes."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        coordinator.cancel_command.clear()
+        controller = KeesonController(
+            coordinator, variant="purple", device_name="KSBT04C123456789"
+        )
+        controller.write_command = AsyncMock()
+        sleep = AsyncMock()
+        monkeypatch.setattr(
+            "custom_components.adjustable_bed.beds.keeson.asyncio.sleep",
+            sleep,
+        )
+
+        await controller.program_memory(2)
+
+        assert controller.write_command.await_count == 26
+        assert all(
+            call.args == (bytes.fromhex("04020000200000"),)
+            for call in controller.write_command.await_args_list
+        )
+        assert [call.args for call in sleep.await_args_list] == [(0.2,)] * 26
+
+
+class TestSleepHarmonyProtocol:
+    """Test current Sleep Harmony protocol routing and release behavior."""
+
+    async def test_base_i5_uses_side_zero_p2_packet(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test explicit Sleep Harmony base-i5 uses E6 plus side zero."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        controller = KeesonController(
+            coordinator, variant="ksbt04c", device_name="base-i5.123456"
+        )
+
+        assert controller._build_command(KeesonCommands.MOTOR_HEAD_UP) == bytes.fromhex(
+            "e6fe16010000000004"
+        )
+        assert controller._build_command(0) == bytes.fromhex(
+            "e6fe16000000000005"
+        )
+        assert controller.control_characteristic_uuid == KEESON_BASE_WRITE_CHAR_UUID
+
+    async def test_motor_hold_and_delayed_release_match_remote(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test Sleep Harmony repeats at 300 ms and stops after 200 ms."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        controller = KeesonController(
+            coordinator, variant="ksbt04c", device_name="KSBT04C123456789"
+        )
+        controller.write_command = AsyncMock()
+        sleep = AsyncMock()
+        monkeypatch.setattr(
+            "custom_components.adjustable_bed.beds.keeson.asyncio.sleep",
+            sleep,
+        )
+
+        await controller.move_head_up()
+
+        calls = controller.write_command.await_args_list
+        assert calls[0].args == (bytes.fromhex("040200000001f8"),)
+        assert calls[0].kwargs == {
+            "repeat_count": 4,
+            "repeat_delay_ms": 300,
+        }
+        assert calls[1].args == (bytes.fromhex("040200000000f9"),)
+        assert isinstance(calls[1].kwargs["cancel_event"], asyncio.Event)
+        sleep.assert_awaited_once_with(0.2)
+
+    async def test_memory_three_and_massage_off_append_delayed_stop(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test recovered M3 and massage-off actions each release with STOP."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        controller = KeesonController(
+            coordinator, variant="ksbt04c", device_name="KSBT04C123456789"
+        )
+        controller.write_command = AsyncMock()
+        sleep = AsyncMock()
+        monkeypatch.setattr(
+            "custom_components.adjustable_bed.beds.keeson.asyncio.sleep",
+            sleep,
+        )
+
+        assert controller.supports_massage_off_control
+        await controller.preset_memory(3)
+        await controller.massage_off()
+
+        assert [call.args[0] for call in controller.write_command.await_args_list] == [
+            bytes.fromhex("04020000800079"),
+            bytes.fromhex("040200000000f9"),
+            bytes.fromhex("040202000000f7"),
+            bytes.fromhex("040200000000f9"),
+        ]
+        assert [call.args for call in sleep.await_args_list] == [(0.2,), (0.2,)]
+
+    async def test_stop_all_sends_immediate_sleep_harmony_stop(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test the safety stop bypasses the UI release delay."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        controller = KeesonController(
+            coordinator, variant="ksbt04c", device_name="KSBT04C123456789"
+        )
+        controller.write_command = AsyncMock()
+        sleep = AsyncMock()
+        monkeypatch.setattr(
+            "custom_components.adjustable_bed.beds.keeson.asyncio.sleep",
+            sleep,
+        )
+
+        await controller.stop_all()
+
+        controller.write_command.assert_awaited_once()
+        assert controller.write_command.await_args.args == (
+            bytes.fromhex("040200000000f9"),
+        )
+        sleep.assert_not_awaited()
+
+
 class TestKsbt03cMotorLayout:
     """Test KSBT03C (Ergomotion RIO 5.0) motor layout handling (issue #408)."""
 
@@ -1300,7 +1533,7 @@ class TestKsbt03cMotorLayout:
         [
             ("ksbt", 1),
             ("ksbt_cr", 1),
-            ("ksbt04c", 2),
+            ("ksbt04c", 1),
         ],
     )
     def test_ksbt_single_shot_count_matches_oem_app(
@@ -1310,7 +1543,7 @@ class TestKsbt03cMotorLayout:
         variant: str,
         expected: int,
     ):
-        """Test only Sleep Harmony's KSBT04C one-shots are duplicated."""
+        """Test OEM app one-shots are sent once before any release sequence."""
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         controller = KeesonController(coordinator, variant=variant)
 
@@ -1334,7 +1567,7 @@ class TestKsbt03cMotorLayout:
 class TestKeesonMassageOffGating:
     """Test massage-off capability gating (issue #408)."""
 
-    @pytest.mark.parametrize("variant", ["base", "ksbt", "ksbt04c", "ergomotion"])
+    @pytest.mark.parametrize("variant", ["base", "ksbt", "ergomotion"])
     async def test_non_sino_variants_hide_massage_off(
         self,
         hass: HomeAssistant,
@@ -1385,15 +1618,18 @@ class TestKsbtMemoryPresets:
 
         assert controller.memory_slot_count == slots
 
-    @pytest.mark.parametrize("variant", ["ksbt", "ksbt04c"])
     @pytest.mark.parametrize(
-        "memory_num,expected_value",
+        "variant,memory_num,expected_value",
         [
             # Literal protocol values from the Ergomotion Sync APK, pinned so a
             # bad edit to the KeesonCommands constants cannot self-verify.
-            (1, 0x2000),  # Read button
-            (2, 0x4000),  # TV button
-            (3, 0x10000),  # M button
+            ("ksbt", 1, 0x2000),  # Read button
+            ("ksbt", 2, 0x4000),  # TV button
+            ("ksbt", 3, 0x10000),  # M button
+            # Sleep Harmony labels Reading/TV/Snore as M1/M2/M3.
+            ("ksbt04c", 1, 0x2000),
+            ("ksbt04c", 2, 0x4000),
+            ("ksbt04c", 3, 0x8000),
         ],
     )
     async def test_ksbt_preset_memory_mapping(
@@ -1406,7 +1642,7 @@ class TestKsbtMemoryPresets:
         memory_num: int,
         expected_value: int,
     ):
-        """Test KSBT/KSBT04C memory slots map to the Read/TV/M remote buttons."""
+        """Test direct KSBT and Sleep Harmony use their proven memory labels."""
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         await coordinator.async_connect()
         controller = KeesonController(coordinator, variant=variant)

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -1173,7 +1174,7 @@ class TestKsbt03cMotorLayout:
         [
             ("base", 2, (3, 400)),
             ("json", 2, (10, 100)),
-            ("ksbt", 2, (4, 300)),
+            ("ksbt", 2, (10, 100)),
             ("ksbt_cr", 2, (4, 300)),
             ("ksbt04c", 2, (4, 300)),
             ("ergomotion", 2, (10, 100)),
@@ -1228,6 +1229,7 @@ class TestKsbt03cMotorLayout:
         hass: HomeAssistant,
         mock_keeson_config_entry,
         mock_coordinator_connected,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """Test per-device pulse tuning overrides the OEM app default."""
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
@@ -1238,12 +1240,60 @@ class TestKsbt03cMotorLayout:
             coordinator, variant="ksbt", device_name="KSBT03C300039050"
         )
         controller.write_command = AsyncMock()
+        monkeypatch.setattr(
+            "custom_components.adjustable_bed.beds.keeson.asyncio.sleep",
+            AsyncMock(),
+        )
 
         await controller.move_head_up()
 
         first_call = controller.write_command.await_args_list[0]
         assert first_call.kwargs["repeat_count"] == 6
         assert first_call.kwargs["repeat_delay_ms"] == 250
+
+    async def test_ksbt_motion_uses_p2_hold_and_release_sequence(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test direct P2 motion refreshes at 100 ms and releases with queries."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        controller = KeesonController(
+            coordinator, variant="ksbt", device_name="KSBT03C300039050"
+        )
+        controller.write_command = AsyncMock()
+        sleep = AsyncMock()
+        monkeypatch.setattr(
+            "custom_components.adjustable_bed.beds.keeson.asyncio.sleep",
+            sleep,
+        )
+
+        await controller.move_head_up()
+
+        calls = controller.write_command.await_args_list
+        assert len(calls) == 4
+        assert calls[0].args == (bytes.fromhex("040200000001"),)
+        assert calls[0].kwargs == {
+            "repeat_count": 10,
+            "repeat_delay_ms": 100,
+        }
+        assert [call.args for call in calls[1:]] == [
+            (bytes.fromhex("00b0"),),
+            (bytes.fromhex("00b0"),),
+            (bytes.fromhex("00b0"),),
+        ]
+        release_events = [call.kwargs["cancel_event"] for call in calls[1:]]
+        assert all(isinstance(event, asyncio.Event) for event in release_events)
+        assert release_events[0] is release_events[1] is release_events[2]
+        assert not release_events[0].is_set()
+        assert [call.args for call in sleep.await_args_list] == [
+            (0.3,),
+            (0.3,),
+            (0.3,),
+        ]
 
     @pytest.mark.parametrize(
         ("variant", "expected"),

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -30,6 +30,10 @@ from custom_components.adjustable_bed.const import (
     KEESON_JSON_WRITE_CHAR_UUID,
     KEESON_KSBT_CHAR_UUID,
     KEESON_VARIANT_JSON,
+    KEESON_VARIANT_KSBT04C,
+    KEESON_VARIANT_PURPLE,
+    KEESON_VARIANT_SLEEP_HARMONY,
+    VARIANT_AUTO,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
 
@@ -798,9 +802,7 @@ class TestSinoMassage:
         mock_bleak_client: MagicMock,
     ):
         """Test massage_toggle sends zero intensity to both zones when active."""
-        coordinator = await self._make_coordinator(
-            hass, sino_config_entry_data, "sino_toggle_off"
-        )
+        coordinator = await self._make_coordinator(hass, sino_config_entry_data, "sino_toggle_off")
         coordinator.controller._head_massage = 3
 
         await coordinator.controller.massage_toggle()
@@ -851,9 +853,7 @@ class TestSinoMassage:
         await coordinator.controller.massage_head_toggle()
 
         assert coordinator.controller._head_massage == 0
-        expected = coordinator.controller._build_command(
-            SinoCommands.MASSAGE_HEAD_INTENSITY_BASE
-        )
+        expected = coordinator.controller._build_command(SinoCommands.MASSAGE_HEAD_INTENSITY_BASE)
         mock_bleak_client.write_gatt_char.assert_called_with(
             coordinator.controller._char_uuid, expected, response=True
         )
@@ -896,9 +896,7 @@ class TestSinoMassage:
         await coordinator.controller.massage_foot_toggle()
 
         assert coordinator.controller._foot_massage == 0
-        expected = coordinator.controller._build_command(
-            SinoCommands.MASSAGE_FOOT_INTENSITY_BASE
-        )
+        expected = coordinator.controller._build_command(SinoCommands.MASSAGE_FOOT_INTENSITY_BASE)
         mock_bleak_client.write_gatt_char.assert_called_with(
             coordinator.controller._char_uuid, expected, response=True
         )
@@ -937,9 +935,7 @@ class TestSinoMassage:
         await coordinator.controller.massage_head_down()
 
         assert coordinator.controller._head_massage == 0
-        expected = coordinator.controller._build_command(
-            SinoCommands.MASSAGE_HEAD_INTENSITY_BASE
-        )
+        expected = coordinator.controller._build_command(SinoCommands.MASSAGE_HEAD_INTENSITY_BASE)
         mock_bleak_client.write_gatt_char.assert_called_with(
             coordinator.controller._char_uuid, expected, response=True
         )
@@ -956,9 +952,7 @@ class TestSinoMassage:
 
         await coordinator.controller.massage_mode_step()
         assert coordinator.controller._wave_massage == 1
-        expected = coordinator.controller._build_command(
-            SinoCommands.MASSAGE_HEAD_WAVE_BASE + 1
-        )
+        expected = coordinator.controller._build_command(SinoCommands.MASSAGE_HEAD_WAVE_BASE + 1)
         mock_bleak_client.write_gatt_char.assert_called_with(
             coordinator.controller._char_uuid, expected, response=True
         )
@@ -969,9 +963,7 @@ class TestSinoMassage:
         await coordinator.controller.massage_mode_step()
         assert coordinator.controller._wave_massage == 1
         assert coordinator.controller._head_massage == 4
-        expected = coordinator.controller._build_command(
-            SinoCommands.MASSAGE_HEAD_WAVE_BASE + 1
-        )
+        expected = coordinator.controller._build_command(SinoCommands.MASSAGE_HEAD_WAVE_BASE + 1)
         mock_bleak_client.write_gatt_char.assert_called_with(
             coordinator.controller._char_uuid, expected, response=True
         )
@@ -1009,19 +1001,13 @@ class TestPurpleSmartBaseProtocol:
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         await coordinator.async_connect()
 
-        premium = KeesonController(
-            coordinator, variant="purple", device_name="base-i5.123456"
-        )
-        plus = KeesonController(
-            coordinator, variant="purple", device_name="KSBT04C123456789"
-        )
+        premium = KeesonController(coordinator, variant="purple", device_name="base-i5.123456")
+        plus = KeesonController(coordinator, variant="purple", device_name="KSBT04C123456789")
 
         assert premium._build_command(KeesonCommands.MOTOR_HEAD_UP) == bytes.fromhex(
             "e5fe160100000005"
         )
-        assert plus._build_command(KeesonCommands.MOTOR_HEAD_UP) == bytes.fromhex(
-            "04020000000100"
-        )
+        assert plus._build_command(KeesonCommands.MOTOR_HEAD_UP) == bytes.fromhex("04020000000100")
         assert plus.control_characteristic_uuid == KEESON_KSBT_CHAR_UUID
 
     async def test_plus_capabilities_and_memory_map(
@@ -1033,12 +1019,8 @@ class TestPurpleSmartBaseProtocol:
         """Test Purple Plus exposes three proven slots and no lounge action."""
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         await coordinator.async_connect()
-        premium = KeesonController(
-            coordinator, variant="purple", device_name="base-i5.123456"
-        )
-        plus = KeesonController(
-            coordinator, variant="purple", device_name="KSBT04C123456789"
-        )
+        premium = KeesonController(coordinator, variant="purple", device_name="base-i5.123456")
+        plus = KeesonController(coordinator, variant="purple", device_name="KSBT04C123456789")
         plus.write_command = AsyncMock()
 
         assert premium.memory_slot_count == 2
@@ -1051,8 +1033,11 @@ class TestPurpleSmartBaseProtocol:
 
         assert [call.args[0] for call in plus.write_command.await_args_list] == [
             bytes.fromhex("04020001000000"),
+            bytes.fromhex("04020000000000"),
             bytes.fromhex("04020000200000"),
+            bytes.fromhex("04020000000000"),
             bytes.fromhex("04020000400000"),
+            bytes.fromhex("04020000000000"),
         ]
 
     @pytest.mark.parametrize("device_name", ["base-i5.123456", "KSBT04C123456789"])
@@ -1066,19 +1051,70 @@ class TestPurpleSmartBaseProtocol:
         """Test both Purple surfaces release with the artifact's P2 STOP."""
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         await coordinator.async_connect()
-        controller = KeesonController(
-            coordinator, variant="purple", device_name=device_name
-        )
+        controller = KeesonController(coordinator, variant="purple", device_name=device_name)
         controller.write_command = AsyncMock()
 
         await controller.stop_all()
 
-        assert controller.write_command.await_args.args == (
-            bytes.fromhex("04020000000000"),
-        )
+        assert controller.write_command.await_args.args == (bytes.fromhex("04020000000000"),)
         cancel_event = controller.write_command.await_args.kwargs["cancel_event"]
         assert isinstance(cancel_event, asyncio.Event)
         assert not cancel_event.is_set()
+
+    @pytest.mark.parametrize(
+        ("variant", "device_name", "expected_release", "expected_delays"),
+        [
+            (
+                KEESON_VARIANT_PURPLE,
+                "KSBT04C123456789",
+                bytes.fromhex("04020000000000"),
+                [],
+            ),
+            (
+                KEESON_VARIANT_SLEEP_HARMONY,
+                "KSBT04C123456789",
+                bytes.fromhex("040200000000f9"),
+                [(0.2,)],
+            ),
+        ],
+    )
+    async def test_one_shot_cleanup_runs_after_write_failure(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        monkeypatch: pytest.MonkeyPatch,
+        variant: str,
+        device_name: str,
+        expected_release: bytes,
+        expected_delays: list[tuple[float]],
+    ):
+        """Test app-required one-shot releases run from a finally block."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        controller = KeesonController(
+            coordinator,
+            variant=variant,
+            device_name=device_name,
+        )
+        controller.write_command = AsyncMock(side_effect=[RuntimeError("write failed"), None])
+        sleep = AsyncMock()
+        monkeypatch.setattr(
+            "custom_components.adjustable_bed.beds.keeson.asyncio.sleep",
+            sleep,
+        )
+
+        with pytest.raises(RuntimeError, match="write failed"):
+            await controller.preset_zero_g()
+
+        calls = controller.write_command.await_args_list
+        assert len(calls) == 2
+        assert calls[1].args == (expected_release,)
+        release_event = calls[1].kwargs["cancel_event"]
+        assert isinstance(release_event, asyncio.Event)
+        assert release_event is not coordinator.cancel_command
+        assert not release_event.is_set()
+        assert [call.args for call in sleep.await_args_list] == expected_delays
 
     async def test_plus_program_memory_matches_send_memory_sequence(
         self,
@@ -1091,9 +1127,7 @@ class TestPurpleSmartBaseProtocol:
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         await coordinator.async_connect()
         coordinator.cancel_command.clear()
-        controller = KeesonController(
-            coordinator, variant="purple", device_name="KSBT04C123456789"
-        )
+        controller = KeesonController(coordinator, variant="purple", device_name="KSBT04C123456789")
         controller.write_command = AsyncMock()
         sleep = AsyncMock()
         monkeypatch.setattr(
@@ -1124,15 +1158,15 @@ class TestSleepHarmonyProtocol:
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         await coordinator.async_connect()
         controller = KeesonController(
-            coordinator, variant="ksbt04c", device_name="base-i5.123456"
+            coordinator,
+            variant=KEESON_VARIANT_SLEEP_HARMONY,
+            device_name="base-i5.123456",
         )
 
         assert controller._build_command(KeesonCommands.MOTOR_HEAD_UP) == bytes.fromhex(
             "e6fe16010000000004"
         )
-        assert controller._build_command(0) == bytes.fromhex(
-            "e6fe16000000000005"
-        )
+        assert controller._build_command(0) == bytes.fromhex("e6fe16000000000005")
         assert controller.control_characteristic_uuid == KEESON_BASE_WRITE_CHAR_UUID
 
     async def test_motor_hold_and_delayed_release_match_remote(
@@ -1146,7 +1180,9 @@ class TestSleepHarmonyProtocol:
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         await coordinator.async_connect()
         controller = KeesonController(
-            coordinator, variant="ksbt04c", device_name="KSBT04C123456789"
+            coordinator,
+            variant=KEESON_VARIANT_SLEEP_HARMONY,
+            device_name="KSBT04C123456789",
         )
         controller.write_command = AsyncMock()
         sleep = AsyncMock()
@@ -1178,7 +1214,9 @@ class TestSleepHarmonyProtocol:
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         await coordinator.async_connect()
         controller = KeesonController(
-            coordinator, variant="ksbt04c", device_name="KSBT04C123456789"
+            coordinator,
+            variant=KEESON_VARIANT_SLEEP_HARMONY,
+            device_name="KSBT04C123456789",
         )
         controller.write_command = AsyncMock()
         sleep = AsyncMock()
@@ -1199,6 +1237,38 @@ class TestSleepHarmonyProtocol:
         ]
         assert [call.args for call in sleep.await_args_list] == [(0.2,), (0.2,)]
 
+    async def test_all_zone_massage_steps_each_append_delayed_stop(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test aggregate massage controls release each Sleep Harmony key."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        controller = KeesonController(
+            coordinator,
+            variant=KEESON_VARIANT_SLEEP_HARMONY,
+            device_name="KSBT04C123456789",
+        )
+        controller.write_command = AsyncMock()
+        sleep = AsyncMock()
+        monkeypatch.setattr(
+            "custom_components.adjustable_bed.beds.keeson.asyncio.sleep",
+            sleep,
+        )
+
+        await controller.massage_intensity_up()
+
+        assert [call.args[0] for call in controller.write_command.await_args_list] == [
+            bytes.fromhex("040200000800f1"),
+            bytes.fromhex("040200000000f9"),
+            bytes.fromhex("040200000400f5"),
+            bytes.fromhex("040200000000f9"),
+        ]
+        assert [call.args for call in sleep.await_args_list] == [(0.2,), (0.2,)]
+
     async def test_stop_all_sends_immediate_sleep_harmony_stop(
         self,
         hass: HomeAssistant,
@@ -1210,7 +1280,9 @@ class TestSleepHarmonyProtocol:
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         await coordinator.async_connect()
         controller = KeesonController(
-            coordinator, variant="ksbt04c", device_name="KSBT04C123456789"
+            coordinator,
+            variant=KEESON_VARIANT_SLEEP_HARMONY,
+            device_name="KSBT04C123456789",
         )
         controller.write_command = AsyncMock()
         sleep = AsyncMock()
@@ -1222,9 +1294,7 @@ class TestSleepHarmonyProtocol:
         await controller.stop_all()
 
         controller.write_command.assert_awaited_once()
-        assert controller.write_command.await_args.args == (
-            bytes.fromhex("040200000000f9"),
-        )
+        assert controller.write_command.await_args.args == (bytes.fromhex("040200000000f9"),)
         sleep.assert_not_awaited()
 
 
@@ -1254,9 +1324,7 @@ class TestKsbt03cMotorLayout:
         await coordinator.async_connect()
         coordinator._motor_count = 3
 
-        controller = KeesonController(
-            coordinator, variant="ksbt", device_name="KSBT03C300039050"
-        )
+        controller = KeesonController(coordinator, variant="ksbt", device_name="KSBT03C300039050")
 
         assert not controller.has_tilt_support
         keys = [spec.key for spec in controller.motor_control_specs]
@@ -1273,9 +1341,7 @@ class TestKsbt03cMotorLayout:
         await coordinator.async_connect()
         coordinator._motor_count = 4
 
-        controller = KeesonController(
-            coordinator, variant="ksbt", device_name="KSBT03C300039050"
-        )
+        controller = KeesonController(coordinator, variant="ksbt", device_name="KSBT03C300039050")
 
         keys = [spec.key for spec in controller.motor_control_specs]
         assert keys == ["head", "feet", "lumbar"]
@@ -1350,6 +1416,56 @@ class TestKsbt03cMotorLayout:
             "lumbar",
         ]
 
+    async def test_ambiguous_ksbt04c_name_keeps_legacy_generic_profile(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        caplog,
+    ):
+        """Test an ambiguous name does not silently select Sleep Harmony."""
+        from custom_components.adjustable_bed.controller_factory import create_controller
+
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+
+        controller = await create_controller(
+            coordinator=coordinator,
+            bed_type=BED_TYPE_KEESON,
+            protocol_variant=VARIANT_AUTO,
+            client=coordinator.client,
+            device_name="KSBT04C123456789",
+        )
+
+        assert isinstance(controller, KeesonController)
+        assert controller._variant == KEESON_VARIANT_KSBT04C
+        assert not controller._is_sleep_harmony
+        assert "ambiguous name" in caplog.text
+
+    async def test_factory_selects_sleep_harmony_only_when_explicit(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test the Sleep Harmony profile requires explicit selection."""
+        from custom_components.adjustable_bed.controller_factory import create_controller
+
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+
+        controller = await create_controller(
+            coordinator=coordinator,
+            bed_type=BED_TYPE_KEESON,
+            protocol_variant=KEESON_VARIANT_SLEEP_HARMONY,
+            client=coordinator.client,
+            device_name="KSBT04C123456789",
+        )
+
+        assert isinstance(controller, KeesonController)
+        assert controller._variant == KEESON_VARIANT_SLEEP_HARMONY
+        assert controller._is_sleep_harmony
+
     async def test_present_device_name_overrides_configured_name(
         self,
         hass: HomeAssistant,
@@ -1369,9 +1485,7 @@ class TestKsbt03cMotorLayout:
         coordinator = AdjustableBedCoordinator(hass, entry)
         await coordinator.async_connect()
 
-        controller = KeesonController(
-            coordinator, variant="ksbt_cr", device_name="KSBT03CR12345"
-        )
+        controller = KeesonController(coordinator, variant="ksbt_cr", device_name="KSBT03CR12345")
 
         assert controller.has_tilt_support
 
@@ -1410,6 +1524,7 @@ class TestKsbt03cMotorLayout:
             ("ksbt", 2, (10, 100)),
             ("ksbt_cr", 2, (4, 300)),
             ("ksbt04c", 2, (4, 300)),
+            ("sleep_harmony", 2, (4, 300)),
             ("ergomotion", 2, (10, 100)),
             ("okin", 2, (10, 100)),
             ("okin", 3, (5, 200)),
@@ -1451,9 +1566,7 @@ class TestKsbt03cMotorLayout:
         """Test BetterLiving cadence follows the explicit preset flag."""
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         coordinator._motor_count = motor_count
-        controller = KeesonController(
-            coordinator, variant="base", betterliving_presets=True
-        )
+        controller = KeesonController(coordinator, variant="base", betterliving_presets=True)
 
         assert controller._motor_pulse_settings() == expected
 
@@ -1469,9 +1582,7 @@ class TestKsbt03cMotorLayout:
         await coordinator.async_connect()
         coordinator._motor_pulse_count = 6
         coordinator._motor_pulse_delay_ms = 250
-        controller = KeesonController(
-            coordinator, variant="ksbt", device_name="KSBT03C300039050"
-        )
+        controller = KeesonController(coordinator, variant="ksbt", device_name="KSBT03C300039050")
         controller.write_command = AsyncMock()
         monkeypatch.setattr(
             "custom_components.adjustable_bed.beds.keeson.asyncio.sleep",
@@ -1484,6 +1595,28 @@ class TestKsbt03cMotorLayout:
         assert first_call.kwargs["repeat_count"] == 6
         assert first_call.kwargs["repeat_delay_ms"] == 250
 
+    async def test_motor_release_failure_is_propagated(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test a failed safety release is visible to command callers."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        controller = KeesonController(coordinator, variant="base")
+        controller.write_command = AsyncMock(side_effect=[None, RuntimeError("release failed")])
+
+        with pytest.raises(RuntimeError, match="release failed"):
+            await controller.move_head_up()
+
+        calls = controller.write_command.await_args_list
+        assert len(calls) == 2
+        release_event = calls[1].kwargs["cancel_event"]
+        assert isinstance(release_event, asyncio.Event)
+        assert release_event is not coordinator.cancel_command
+        assert not release_event.is_set()
+
     async def test_ksbt_motion_uses_p2_hold_and_release_sequence(
         self,
         hass: HomeAssistant,
@@ -1494,9 +1627,7 @@ class TestKsbt03cMotorLayout:
         """Test direct P2 motion refreshes at 100 ms and releases with queries."""
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         await coordinator.async_connect()
-        controller = KeesonController(
-            coordinator, variant="ksbt", device_name="KSBT03C300039050"
-        )
+        controller = KeesonController(coordinator, variant="ksbt", device_name="KSBT03C300039050")
         controller.write_command = AsyncMock()
         sleep = AsyncMock()
         monkeypatch.setattr(
@@ -1528,12 +1659,36 @@ class TestKsbt03cMotorLayout:
             (0.3,),
         ]
 
+    async def test_ksbt_stop_all_does_not_wait_for_status_queries(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test direct P2 safety stop ends refresh without a 900 ms delay."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        controller = KeesonController(coordinator, variant="ksbt", device_name="KSBT03C300039050")
+        controller.write_command = AsyncMock()
+        sleep = AsyncMock()
+        monkeypatch.setattr(
+            "custom_components.adjustable_bed.beds.keeson.asyncio.sleep",
+            sleep,
+        )
+
+        await controller.stop_all()
+
+        controller.write_command.assert_not_awaited()
+        sleep.assert_not_awaited()
+
     @pytest.mark.parametrize(
         ("variant", "expected"),
         [
             ("ksbt", 1),
             ("ksbt_cr", 1),
             ("ksbt04c", 1),
+            ("sleep_harmony", 1),
         ],
     )
     def test_ksbt_single_shot_count_matches_oem_app(
@@ -1559,15 +1714,16 @@ class TestKsbt03cMotorLayout:
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         await coordinator.async_connect()
 
-        assert coordinator.controller.stale_motor_entity_keys == frozenset(
-            {"tilt", "lumbar"}
-        )
+        assert coordinator.controller.stale_motor_entity_keys == frozenset({"tilt", "lumbar"})
 
 
 class TestKeesonMassageOffGating:
     """Test massage-off capability gating (issue #408)."""
 
-    @pytest.mark.parametrize("variant", ["base", "ksbt", "ergomotion"])
+    @pytest.mark.parametrize(
+        "variant",
+        ["base", "ksbt", "ksbt04c", "ergomotion"],
+    )
     async def test_non_sino_variants_hide_massage_off(
         self,
         hass: HomeAssistant,
@@ -1601,7 +1757,15 @@ class TestKeesonMassageOffGating:
 class TestKsbtMemoryPresets:
     """Test KSBT memory presets from Ergomotion Sync APK (issue #408)."""
 
-    @pytest.mark.parametrize("variant,slots", [("ksbt", 3), ("ksbt04c", 3), ("ksbt_cr", 2)])
+    @pytest.mark.parametrize(
+        ("variant", "slots"),
+        [
+            ("ksbt", 3),
+            ("ksbt04c", 3),
+            ("sleep_harmony", 3),
+            ("ksbt_cr", 2),
+        ],
+    )
     async def test_memory_slot_count(
         self,
         hass: HomeAssistant,
@@ -1626,10 +1790,13 @@ class TestKsbtMemoryPresets:
             ("ksbt", 1, 0x2000),  # Read button
             ("ksbt", 2, 0x4000),  # TV button
             ("ksbt", 3, 0x10000),  # M button
+            ("ksbt04c", 1, 0x2000),  # Generic checksum profile: Read
+            ("ksbt04c", 2, 0x4000),  # Generic checksum profile: TV
+            ("ksbt04c", 3, 0x10000),  # Generic checksum profile: M
             # Sleep Harmony labels Reading/TV/Snore as M1/M2/M3.
-            ("ksbt04c", 1, 0x2000),
-            ("ksbt04c", 2, 0x4000),
-            ("ksbt04c", 3, 0x8000),
+            ("sleep_harmony", 1, 0x2000),
+            ("sleep_harmony", 2, 0x4000),
+            ("sleep_harmony", 3, 0x8000),
         ],
     )
     async def test_ksbt_preset_memory_mapping(

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -257,6 +257,46 @@ class TestKeesonController:
         with pytest.raises(ConnectionError):
             await coordinator.controller.write_command(coordinator.controller._build_command(0))
 
+    async def test_write_command_honors_default_cancellation(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test an omitted event uses the coordinator cancellation state."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        coordinator.cancel_command.set()
+        controller = coordinator.controller
+        controller._write_gatt_with_retry = AsyncMock()
+
+        await controller.write_command(controller._build_command(0))
+
+        controller._write_gatt_with_retry.assert_not_awaited()
+
+    async def test_write_command_preserves_explicit_release_event(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test a fresh explicit event bypasses stale command cancellation."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        coordinator.cancel_command.set()
+        controller = coordinator.controller
+        controller._write_gatt_with_retry = AsyncMock()
+        release_event = asyncio.Event()
+        command = controller._build_command(0)
+
+        await controller.write_command(command, cancel_event=release_event)
+
+        controller._write_gatt_with_retry.assert_awaited_once()
+        assert (
+            controller._write_gatt_with_retry.await_args.kwargs["cancel_event"]
+            is release_event
+        )
+
 
 class TestKeesonMovement:
     """Test Keeson movement commands."""
@@ -1062,6 +1102,29 @@ class TestPurpleSmartBaseProtocol:
         cancel_event = controller.write_command.await_args.kwargs["cancel_event"]
         assert isinstance(cancel_event, asyncio.Event)
         assert not cancel_event.is_set()
+
+    async def test_plus_light_toggle_appends_release(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Test Purple Plus light toggles append the required zero-mask frame."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        controller = KeesonController(
+            coordinator,
+            variant=KEESON_VARIANT_PURPLE,
+            device_name="KSBT04C123456789",
+        )
+        controller.write_command = AsyncMock()
+
+        await controller.lights_toggle()
+
+        assert [call.args[0] for call in controller.write_command.await_args_list] == [
+            bytes.fromhex("04020002000000"),
+            bytes.fromhex("04020000000000"),
+        ]
 
     @pytest.mark.parametrize(
         ("variant", "device_name", "expected_release", "expected_delays"),


### PR DESCRIPTION
## Summary

- fix direct KSBT movement stutter by using the app-proven 100 ms hold cadence and `00 B0` release queries
- add explicit current Purple Premium, Purple Premium Plus, and Sleep Harmony protocol profiles
- document the seven clean-room Phase 4 APK analyses completed ahead of the #447 bulk run
- expand Keeson protocol coverage for packet framing, releases, presets, memory programming, massage, and model capabilities

## Root cause

The direct KSBT controller refreshed movement every 300 ms and finished with a six-byte zero packet. Current SFD P2 apps hold movement every 100 ms and release with three `00 B0` status queries. The longer gap made affected bases repeatedly stop and restart.

Purple and Sleep Harmony also share advertised names with other Keeson bases while using different packet endings and release behavior. Explicit profiles avoid guessing across those ambiguous advertisements.

## Validation

- `uv run ruff check custom_components/adjustable_bed/beds/keeson.py custom_components/adjustable_bed/controller_factory.py custom_components/adjustable_bed/const.py tests/test_keeson.py`
- `uv run pytest -q tests/test_keeson.py` (94 passed)
- `uv run pytest -q` (2315 passed)
- `git diff --check origin/master...HEAD`
- all seven reusable Phase 4 reports validate as `COMPLETE` with frozen checksums

Fixes #408
Related to #447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded Keeson adjustable bed protocol support with Sleep Harmony and clearer Purple Smart Base handling for Premium vs Premium Plus.
  - Added/updated variant selection and capability coverage (e.g., presets, memory slots, and massage/off behaviors) based on the chosen protocol.

- **Bug Fixes**
  - Improved motion release/stop sequencing for more reliable held vs release timing and safer stop-all behavior.

- **Documentation**
  - Refreshed Keeson documentation with updated remotes, clarified variant behavior (including profile selection for overlapping names), and revised command/timing details.

- **Tests**
  - Strengthened protocol and sequencing assertions, especially for Purple Plus and Sleep Harmony.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->