### PR TITLE
Fix Jura BlueFrog false-positive bed detection

### DIFF
--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -613,9 +613,11 @@ MANUFACTURER_ID_DEWERTOKIN: Final = 1643  # 0x066B
 # Used by SmartBed devices that advertise manufacturer data instead of service UUIDs
 MANUFACTURER_ID_OKIN: Final = 89  # 0x0059
 
-# DewertOkin service UUID (unique to FurniMove/DewertOkin devices)
-# This UUID can uniquely identify DewertOkin beds regardless of device name
+# Primary DewertOkin service UUID. The Jura TT214H BlueFrog coffee-machine
+# dongle also advertises this UUID, so detection excludes that exact known
+# non-bed name before treating the UUID as a DewertOkin signal (issue #450).
 DEWERTOKIN_SERVICE_UUID: Final = "00001523-0000-1000-8000-00805f9b34fb"
+DEWERTOKIN_EXCLUDED_DEVICE_NAMES: Final = frozenset({"tt214h bluefrog"})
 
 # DewertOkin RF Gateway settings service. Devices with BLE Device Information
 # model "Bluetooth RF-Gateway" expose this name characteristic as the app's

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -86,6 +86,7 @@ from .const import (
     COMFORT_MOTION_SERVICE_UUID,
     COOLBASE_NAME_PATTERNS,
     DEVICE_INFO_SERVICE_UUID,
+    DEWERTOKIN_EXCLUDED_DEVICE_NAMES,
     DEWERTOKIN_NAME_PATTERNS,
     DEWERTOKIN_RF_GATEWAY_DEVICE_NAME_CHAR_UUID,
     DEWERTOKIN_RF_GATEWAY_SERVICE_UUID,
@@ -908,6 +909,25 @@ def detect_bed_type_detailed(service_info: BluetoothServiceInfoBleak) -> Detecti
     # Parse Kaidi metadata up front so validated Kaidi advertisements are not
     # discarded by the generic "mouse" exclusion before protocol detection.
     kaidi_adv = extract_kaidi_advertisement(service_info.manufacturer_data)
+
+    # The Jura TT214H BlueFrog coffee-machine dongle advertises the same 1523
+    # service UUID as DewertOkin beds. Its exact model/name is authoritative
+    # enough to reject before the otherwise high-confidence UUID check (#450).
+    if (
+        device_name in DEWERTOKIN_EXCLUDED_DEVICE_NAMES
+        and DEWERTOKIN_SERVICE_UUID.lower() in service_uuids
+    ):
+        _LOGGER.debug(
+            "Device %s excluded: known Jura BlueFrog dongle '%s' advertises "
+            "the shared DewertOkin service UUID",
+            service_info.address,
+            service_info.name,
+        )
+        return DetectionResult(
+            bed_type=None,
+            confidence=0.0,
+            signals=["excluded:jura_bluefrog"],
+        )
 
     # Exclude devices that are clearly not beds based on name, but only when
     # they have generic/shared UUIDs. This preserves UUID-based detection for

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -61,6 +61,7 @@ from custom_components.adjustable_bed.const import (
     DEVICE_INFO_SERVICE_UUID,
     DEWERTOKIN_RF_GATEWAY_DEVICE_NAME_CHAR_UUID,
     DEWERTOKIN_RF_GATEWAY_SERVICE_UUID,
+    DEWERTOKIN_SERVICE_UUID,
     JENSEN_SERVICE_UUID,
     KAIDI_DISCOVERY_SERVICE_UUID,
     KAIDI_MESH_SERVICE_UUID,
@@ -1970,6 +1971,23 @@ class TestExcludedDevicePatterns:
     are also used by legitimate beds, causing false positive discovery.
     See: https://github.com/kristofferR/ha-adjustable-bed/issues/187
     """
+
+    def test_jura_bluefrog_is_not_detected_as_dewertokin(self):
+        """The TT214H coffee-machine dongle shares DewertOkin's UUID (#450)."""
+        service_info = _make_service_info(
+            name="TT214H BlueFrog",
+            address="CC:2D:04:34:E9:4A",
+            service_uuids=[
+                DEWERTOKIN_SERVICE_UUID,
+                "00001623-0000-1000-8000-00805f9b34fb",
+            ],
+        )
+
+        result = detect_bed_type_detailed(service_info)
+
+        assert result.bed_type is None
+        assert result.confidence == 0.0
+        assert result.signals == ["excluded:jura_bluefrog"]
 
     @pytest.mark.parametrize(
         "name",


### PR DESCRIPTION
## Summary

- exclude the Jura TT214H BlueFrog coffee-machine dongle when it advertises DewertOkin's shared `1523` service UUID
- preserve UUID-based discovery for genuine DewertOkin beds
- add regression coverage for the exact advertisement reported in issue #450

## Root cause

The DewertOkin `1523` service UUID was treated as bed-unique, but the Jura BlueFrog dongle advertises the same UUID. The detector therefore classified it as DewertOkin at 90% confidence without considering its authoritative model name.

## Validation

- `ruff check custom_components/adjustable_bed/const.py custom_components/adjustable_bed/detection.py tests/test_detection.py`
- `pytest -q tests/test_detection.py` (257 passed)
- `pytest -q tests/test_config_flow.py::TestBluetoothDiscoveryFlow::test_bluetooth_discovery_not_supported` (1 passed)

Closes #450