### PR TITLE
Make Diagnostic bed type selectable in the confirm dialog and fix diagnostic docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -68,7 +68,7 @@ body:
         4. Click the **download link** in the notification that appears
         5. Drag and drop the JSON file here
 
-        **Alternative:** Download diagnostics from Settings → Integrations → Adjustable Bed → ⋮ → Download diagnostics
+        **Alternative:** Download diagnostics from Settings → Devices & Services → Adjustable Bed → ⋮ → Download diagnostics
       placeholder: "Drag and drop the support bundle JSON file here"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/new-bed-support.yml
+++ b/.github/ISSUE_TEMPLATE/new-bed-support.yml
@@ -55,11 +55,14 @@ body:
       description: |
         **The support bundle captures all BLE data needed to implement your bed's protocol** (service UUIDs, GATT structure, device name, advertisements). Without it, we cannot begin implementation.
 
-        1. Add the Adjustable Bed integration and select "Diagnostic (unknown bed)" as the bed type
+        1. Find your bed's MAC address: Settings → Devices & Services → Add Integration → Adjustable Bed → "Browse unsupported BLE devices", then select your bed (this only inspects the device, it doesn't add anything)
         2. Go to Developer Tools → Actions
-        3. Search for `adjustable_bed.generate_support_bundle` and select the device
-        4. Click the **download link** in the notification that appears
-        5. Drag and drop the JSON file here
+        3. Search for `adjustable_bed.generate_support_bundle`, leave the device empty, and enter the MAC address in "Target Address"
+        4. Click "Perform action" and operate your physical remote during the capture
+        5. Click the **download link** in the notification that appears
+        6. Drag and drop the JSON file here
+
+        Note: the bundle records what your bed transmits (notifications and GATT structure) plus this integration's own commands. It cannot see commands sent by the official app or remote. If you have nRF Connect, an app-traffic capture is a valuable supplement, see [Capturing App Traffic](https://github.com/kristofferR/ha-adjustable-bed/blob/master/docs/GETTING_HELP.md#capturing-app-traffic-for-new-bed-support).
       placeholder: "Drag and drop the support bundle JSON file here"
     validations:
       required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ The supported-protocol list lives in the README's "Supported Beds" table — tha
 
 ## Adding a New Bed Type
 
-1. **Document the BLE protocol** - Use APK reverse engineering (see `disassembly/AGENTS.md`) to extract UUIDs and command bytes. The `run_diagnostics` service captures GATT structure and device responses. User-provided nRF Connect logs can supplement APK analysis with real traffic captures.
+1. **Document the BLE protocol** - Use APK reverse engineering (see `disassembly/AGENTS.md`) to extract UUIDs and command bytes. The `generate_support_bundle` service captures GATT structure and device responses. User-provided nRF Connect logs can supplement APK analysis with real traffic captures.
 
 2. **Add constants to `const.py`**:
    ```python
@@ -181,8 +181,7 @@ The supported-protocol list lives in the README's "Supported Beds" table — tha
 | `adjustable_bed.stop_all` | Immediately stop all motors |
 | `adjustable_bed.set_position` | Move motor to a specific position |
 | `adjustable_bed.timed_move` | Move motor for a specified duration |
-| `adjustable_bed.run_diagnostics` | Capture BLE protocol data for debugging |
-| `adjustable_bed.generate_support_bundle` | Generate JSON support bundle with diagnostics (params: device_id, include_logs) |
+| `adjustable_bed.generate_support_bundle` | Capture the full JSON support bundle (BLE diagnostics, GATT details, pairing evidence, command trace, logs). Params: `device_id` or `target_address` (exactly one), `capture_duration`, `include_logs` |
 
 ## Critical Implementation Details
 
@@ -260,11 +259,11 @@ under `custom_components/adjustable_bed/frontend/`.
 
 ### Using BLE Diagnostics
 
-The `run_diagnostics` service captures protocol data for debugging and adding new bed support:
-1. Call the service with either a configured device or a raw MAC address
-2. Operate the physical remote during the capture period
-3. Find the JSON report in your HA config directory
-4. The report contains GATT services, characteristics, and captured notifications
+The `generate_support_bundle` service captures protocol data for debugging and adding new bed support:
+1. Call the service with either a configured device (`device_id`) or a raw MAC address (`target_address`) - exactly one of the two
+2. Operate the physical remote during the capture period (default 120 seconds)
+3. A persistent notification provides a download link; the JSON report is also saved in the HA config directory as `adjustable_bed_support_bundle_*.json`
+4. The report contains GATT services, characteristics, captured notifications, advertisements per source, pairing evidence, and the recent command trace
 
 ### Common Issues
 

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -114,7 +114,6 @@ from .const import (
     POSITION_MODE_SPEED,
     RICHMAT_REMOTE_AUTO,
     RICHMAT_REMOTES,
-    SUPPORTED_BED_TYPES,
     VARIANT_AUTO,
     DetectionResult,
     get_richmat_features,
@@ -998,7 +997,28 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 or BED_TYPE_AUTO_DETECT
             )
         else:
-            bed_type_selector = vol.In(SUPPORTED_BED_TYPES)
+            # Same display-name dropdown as the full list, so users see
+            # "Diagnostic (unknown bed)" etc. instead of raw type slugs
+            # (issue #385). Detection may return a legacy alias (e.g.
+            # dewertokin) that the display list omits; prepend it so the
+            # detected default stays selectable.
+            options = get_bed_type_options()
+            if isinstance(bed_type_default, str) and bed_type_default not in {
+                option["value"] for option in options
+            }:
+                options.insert(
+                    0,
+                    SelectOptionDict(
+                        value=bed_type_default,
+                        label=BED_TYPE_DISPLAY_NAMES.get(bed_type_default, bed_type_default),
+                    ),
+                )
+            bed_type_selector = SelectSelector(
+                SelectSelectorConfig(
+                    options=options,
+                    mode=SelectSelectorMode.DROPDOWN,
+                )
+            )
 
         schema_dict: dict[vol.Marker, Any] = {
             vol.Optional(CONF_BED_TYPE, default=bed_type_default): bed_type_selector,

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -62,7 +62,7 @@
           "auto_detect_option": "Auto-detect (recommended)"
         },
         "data_description": {
-          "bed_type": "Auto-detected bed type. Change if detection was incorrect.",
+          "bed_type": "Auto-detected bed type. Change if detection was incorrect. Options are controller protocols, not mattress brands; example beds are shown in parentheses. See the Supported Actuators guide if unsure.",
           "motor_count": "Number of physical actuators. Malouf/Lucid beds use the separate actuator-layout setting below.",
           "malouf_layout": "Physical controls on the remote. This is independent of BLE protocol: Lucid L600 beds have shipped with multiple protocols.",
           "malouf_memory_slots": "Number of memory buttons on the physical remote. Auto exposes one for a two-motor L600-style layout and two for other layouts.",
@@ -104,6 +104,7 @@
           "idle_disconnect_seconds": "Idle disconnect timeout (seconds)"
         },
         "data_description": {
+          "bed_type": "Options are controller protocols, not mattress brands; example beds are shown in parentheses. See the Supported Actuators guide if unsure.",
           "protocol_variant": "Leave as 'auto' unless you know the specific protocol. Keeson: base (Member's Mark/Purple) or ksbt (KSBT03/KSBT04, including some Ergomotion Sync beds). Leggett: gen2 (most common) or okin. Richmat: auto-detected.",
           "motor_count": "Number of physical actuators. Malouf/Lucid beds use the separate actuator-layout setting below.",
           "malouf_layout": "Physical controls on the remote. This is independent of BLE protocol: Lucid L600 beds have shipped with multiple protocols.",
@@ -137,6 +138,7 @@
         },
         "data_description": {
           "address": "MAC address in format XX:XX:XX:XX:XX:XX (found in the bed's Bluetooth settings or on a label).",
+          "bed_type": "Options are controller protocols, not mattress brands; example beds are shown in parentheses. See the Supported Actuators guide if unsure.",
           "protocol_variant": "Leave as 'auto' unless you know the specific protocol. Keeson: base (Member's Mark/Purple) or ksbt (KSBT03/KSBT04, including some Ergomotion Sync beds). Leggett: gen2 (most common) or okin. Richmat: auto-detected.",
           "motor_count": "Number of physical actuators. Malouf/Lucid beds use the separate actuator-layout setting below.",
           "malouf_layout": "Physical controls on the remote. This is independent of BLE protocol: Lucid L600 beds have shipped with multiple protocols.",

--- a/docs/GETTING_HELP.md
+++ b/docs/GETTING_HELP.md
@@ -55,7 +55,7 @@ The support bundle includes everything we need in one file:
 1. Go to **Developer Tools** → **Actions**
 2. Search for `adjustable_bed.generate_support_bundle`
 3. For a control problem, first try the failing Home Assistant command so it is present in the command trace.
-4. Select that same bed device, or enter `target_address` for an unconfigured device, then click **Perform action**.
+4. Select that same bed device, or leave the device empty and enter `target_address` for an unconfigured device, then click **Perform action**.
 5. (Optional) Adjust `capture_duration` to change how long notifications are captured (default: 120 seconds). Operate the physical remote during capture to generate useful traffic.
 6. A notification will appear with a **download link** — click it to save the file.
 7. Attach the JSON file to your GitHub issue. Check its `evidence.warnings` section for anything that could not be captured.
@@ -76,7 +76,7 @@ The support bundle includes:
 
 If you prefer to gather information separately:
 
-1. Go to **Settings** → **Integrations** → **Adjustable Bed**
+1. Go to **Settings** → **Devices & Services** → **Adjustable Bed**
 2. Click the **⋮** menu → **Download diagnostics**
 3. Attach the downloaded JSON file to your issue
 
@@ -98,11 +98,16 @@ If your bed isn't supported yet, file a [New Bed Support Request](https://github
 
 **Start by generating a support bundle** — it captures all the BLE data (service UUIDs, device name, GATT structure) needed to implement a new protocol. Without it, we cannot begin implementation.
 
-1. Add the Adjustable Bed integration and select **"Diagnostic (unknown bed)"** as the bed type
+You don't need to configure anything first — the support bundle action works directly on any BLE device your Home Assistant can see:
+
+1. **Find your bed's MAC address:** go to **Settings** → **Devices & Services** → **Add Integration** → **Adjustable Bed**, choose **"Browse unsupported BLE devices"**, and select your bed from the list (or pick **"Enter address manually"** if you already know the address). The wizard shows the device's MAC address and scanner details — note the address. This step only inspects the device; it doesn't add anything.
 2. Go to **Developer Tools** → **Actions** → `adjustable_bed.generate_support_bundle`
-3. Select the device and click **Perform action**
-4. A notification will appear with a **download link** — click it to save the file
-5. Attach the JSON file to your issue
+3. Leave the **Device** field empty and enter the MAC address in **Target Address**
+4. Click **Perform action**, then operate your physical remote during the capture (120 seconds by default) so the bundle records useful traffic
+5. A notification will appear with a **download link** — click it to save the file. The same JSON file is also written to your Home Assistant config folder as `adjustable_bed_support_bundle_*.json`.
+6. Attach the JSON file to your issue
+
+**Alternative — add the bed as a diagnostic device:** if you'd rather have a persistent entry (for example, to re-run captures easily), open the same wizard, choose **"Show all BLE devices"**, select your bed, and set **Bed type** to **"Diagnostic (unknown bed)"**. You can then run `generate_support_bundle` with that device selected in the **Device** field. Note that "Diagnostic (unknown bed)" only appears in the bed type dropdown on this path — it is not listed under "Select by actuator brand", and it is not in the shorter bed type list shown when a bed was auto-detected.
 
 Then fill in the rest of the template with your bed manufacturer/model, remote model number, and any other details.
 
@@ -129,7 +134,7 @@ Let us know if you can:
 | Scenario | Recommended Tool |
 |----------|------------------|
 | Troubleshooting a configured bed | Support bundle or diagnostics download |
-| Finding your bed's MAC address | Integration shows discovered MACs when manually adding |
+| Finding your bed's MAC address | **"Browse unsupported BLE devices"** in the add-integration wizard |
 | Identifying bed type/service UUIDs | `generate_support_bundle` with `target_address` |
 | New bed support - capture what app sends | nRF Connect logging (see below) |
 | Device not visible to HA at all | nRF Connect to verify it exists |
@@ -147,10 +152,10 @@ The `generate_support_bundle` action captures GATT structure, device info, scann
 1. Go to **Developer Tools** → **Actions**
 2. Search for `adjustable_bed.generate_support_bundle`
 3. Try the failing Home Assistant control once if you are troubleshooting commands.
-4. Select that same bed device (or enter `target_address` for unconfigured devices).
+4. Select that same bed device, or leave the device empty and enter `target_address` for an unconfigured device (provide exactly one of the two).
 5. Click **Perform action**.
 6. Optionally operate your physical remote during capture to record notifications.
-7. Find the JSON report in your `/config/` folder.
+7. A notification will appear with a **download link**; the JSON report is also saved in your Home Assistant config folder as `adjustable_bed_support_bundle_*.json`.
 
 This captures:
 - All GATT services and characteristics

--- a/docs/GETTING_HELP.md
+++ b/docs/GETTING_HELP.md
@@ -107,7 +107,7 @@ You don't need to configure anything first — the support bundle action works d
 5. A notification will appear with a **download link** — click it to save the file. The same JSON file is also written to your Home Assistant config folder as `adjustable_bed_support_bundle_*.json`.
 6. Attach the JSON file to your issue
 
-**Alternative — add the bed as a diagnostic device:** if you'd rather have a persistent entry (for example, to re-run captures easily), open the same wizard, choose **"Show all BLE devices"**, select your bed, and set **Bed type** to **"Diagnostic (unknown bed)"**. You can then run `generate_support_bundle` with that device selected in the **Device** field. Note that "Diagnostic (unknown bed)" only appears in the bed type dropdown on this path — it is not listed under "Select by actuator brand", and it is not in the shorter bed type list shown when a bed was auto-detected.
+**Alternative — add the bed as a diagnostic device:** if you'd rather have a persistent entry (for example, to re-run captures easily), open the same wizard, choose **"Show all BLE devices"**, select your bed, and set **Bed type** to **"Diagnostic (unknown bed)"**. You can then run `generate_support_bundle` with that device selected in the **Device** field. "Diagnostic (unknown bed)" appears in every bed type dropdown, including the confirm dialog for an auto-detected bed; only the "Select by actuator brand" list does not offer it.
 
 Then fill in the rest of the template with your bed manufacturer/model, remote model number, and any other details.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -73,7 +73,7 @@ This guide covers common issues and their solutions when using the Adjustable Be
 **Solutions:**
 1. **Verify BLE advertising:** Use a BLE scanner app to confirm the bed is visible
 2. **Check MAC address:** Verify the MAC address matches what's shown in your BLE scanner
-3. **Try manual configuration:** Use manual setup if auto-discovery doesn't find the bed
+3. **Try manual configuration:** If auto-discovery doesn't find the bed, use **Settings** → **Devices & Services** → **Add Integration** → **Adjustable Bed** and choose **"Select by actuator brand"** or **"Show all BLE devices"**
 
 ---
 
@@ -192,7 +192,7 @@ the next command from Home Assistant — no action is needed.
 2. OEM bed using different manufacturer's controller
 
 **Solutions:**
-1. **Manual configuration:** Remove and re-add the bed using manual setup
+1. **Manual configuration:** Remove and re-add the bed, choosing the bed type yourself via **"Select by actuator brand"** or **"Show all BLE devices"** instead of accepting the auto-detected type
 2. **Try different types:** If one type doesn't work, try related types (e.g., Okimat ↔ Leggett Okin)
 
 ### Keeson Variant Selection

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -28,6 +28,7 @@ from custom_components.adjustable_bed.config_flow import (
 from custom_components.adjustable_bed.const import (
     BED_TYPE_COOLBASE,
     BED_TYPE_DEWERTOKIN,
+    BED_TYPE_DIAGNOSTIC,
     BED_TYPE_ERGOMOTION,
     BED_TYPE_JIECANG,
     BED_TYPE_KAIDI,
@@ -81,7 +82,7 @@ from custom_components.adjustable_bed.const import (
     TIMOTION_AHF_SERVICE_UUID,
     requires_pairing,
 )
-from custom_components.adjustable_bed.detection import detect_bed_type
+from custom_components.adjustable_bed.detection import BED_TYPE_DISPLAY_NAMES, detect_bed_type
 from custom_components.adjustable_bed.discovery_settings import (
     async_is_discovery_disabled,
     async_set_discovery_disabled,
@@ -743,6 +744,102 @@ class TestBluetoothDiscoveryFlow:
         assert result["data"][CONF_MOTOR_COUNT] == 4
         assert result["data"][CONF_HAS_MASSAGE] is True
         assert result["data"][CONF_DISABLE_ANGLE_SENSING] is False
+
+    async def test_bluetooth_confirm_bed_type_dropdown_uses_display_names(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info: BluetoothServiceInfoBleak,
+        enable_custom_integrations,
+    ):
+        """Regression for #385: the confirm dropdown showed raw type slugs from
+        SUPPORTED_BED_TYPES, with no "Diagnostic (unknown bed)" entry. It must use
+        the same display-name options as the other selection paths."""
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_BLUETOOTH},
+            data=mock_bluetooth_service_info,
+        )
+        assert result["step_id"] == "bluetooth_confirm"
+
+        bed_type_marker = next(
+            marker for marker in result["data_schema"].schema if marker.schema == CONF_BED_TYPE
+        )
+        selector = result["data_schema"].schema[bed_type_marker]
+        options = selector.config["options"]
+        options_by_value = {option["value"]: option["label"] for option in options}
+
+        assert bed_type_marker.default() == BED_TYPE_LINAK
+        assert options_by_value[BED_TYPE_LINAK] == BED_TYPE_DISPLAY_NAMES[BED_TYPE_LINAK]
+        assert options_by_value[BED_TYPE_DIAGNOSTIC] == "Diagnostic (unknown bed)"
+
+    async def test_bluetooth_confirm_legacy_alias_default_stays_selectable(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info_ambiguous_okin: MagicMock,
+        enable_custom_integrations,
+    ):
+        """A legacy-alias bed type (absent from the display-name list) chosen via
+        disambiguation must be prepended so the dropdown default stays valid."""
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_BLUETOOTH},
+            data=mock_bluetooth_service_info_ambiguous_okin,
+        )
+        assert result["step_id"] == "bluetooth_disambiguate"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"bed_type_choice": BED_TYPE_OKIMAT},
+        )
+        assert result["step_id"] == "bluetooth_confirm"
+
+        bed_type_marker = next(
+            marker for marker in result["data_schema"].schema if marker.schema == CONF_BED_TYPE
+        )
+        selector = result["data_schema"].schema[bed_type_marker]
+        option_values = [option["value"] for option in selector.config["options"]]
+
+        assert bed_type_marker.default() == BED_TYPE_OKIMAT
+        assert option_values[0] == BED_TYPE_OKIMAT
+        assert option_values.count(BED_TYPE_OKIMAT) == 1
+
+    async def test_bluetooth_confirm_diagnostic_bed_type_creates_entry(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info: BluetoothServiceInfoBleak,
+        enable_custom_integrations,
+    ):
+        """Selecting "Diagnostic (unknown bed)" on the confirm step must create
+        an entry so users can capture a support bundle (#385)."""
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_BLUETOOTH},
+            data=mock_bluetooth_service_info,
+        )
+        assert result["step_id"] == "bluetooth_confirm"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_BED_TYPE: BED_TYPE_DIAGNOSTIC,
+                CONF_NAME: "Mystery Bed",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+        )
+
+        # A connectable scanner is mocked, so the verify_connection step appears.
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "verify_connection"
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={},
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_BED_TYPE] == BED_TYPE_DIAGNOSTIC
 
     async def test_bluetooth_discovery_confirm_coerces_string_motor_count(
         self,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -841,6 +841,51 @@ class TestBluetoothDiscoveryFlow:
         assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_BED_TYPE] == BED_TYPE_DIAGNOSTIC
 
+    async def test_bluetooth_confirm_diagnostic_entry_created_when_probe_fails(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info: BluetoothServiceInfoBleak,
+        enable_custom_integrations,
+    ):
+        """A failed connection probe must not block a diagnostic entry: the
+        whole point is capturing bundles for beds we cannot reach (#385)."""
+        from custom_components.adjustable_bed.config_flow import CapabilityReport
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_BLUETOOTH},
+            data=mock_bluetooth_service_info,
+        )
+        assert result["step_id"] == "bluetooth_confirm"
+
+        with patch.object(
+            AdjustableBedConfigFlow,
+            "_probe_capabilities",
+            AsyncMock(return_value=CapabilityReport(device_found=False)),
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={
+                    CONF_BED_TYPE: BED_TYPE_DIAGNOSTIC,
+                    CONF_NAME: "Unreachable Bed",
+                    CONF_MOTOR_COUNT: 2,
+                    CONF_HAS_MASSAGE: False,
+                    CONF_DISABLE_ANGLE_SENSING: True,
+                    CONF_PREFERRED_ADAPTER: "auto",
+                },
+            )
+
+            # The probe failed, but the verify step is informational only.
+            assert result["type"] == FlowResultType.FORM
+            assert result["step_id"] == "verify_connection"
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={},
+            )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_BED_TYPE] == BED_TYPE_DIAGNOSTIC
+
     async def test_bluetooth_discovery_confirm_coerces_string_motor_count(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## Problem

A user following our instructions to "add a Diagnostic bed" could not find the option anywhere (Ref #385, confirmed by their screencast):

- The bed type dropdown on the discovery **confirm dialog** was built from raw `SUPPORTED_BED_TYPES` slugs, so it showed internal identifiers like `okin_7byte` / `sleepys_box24` and had **no** "Diagnostic (unknown bed)" entry (`diagnostic` is not in that list).
- The "Select by actuator brand" list has no diagnostic entry either.
- `docs/GETTING_HELP.md` and the new-bed issue template still described the pre-3.3 flow ("select Diagnostic (unknown bed) as the bed type"), and `AGENTS.md` documented a `run_diagnostics` service that no longer exists.

## Changes

**Config flow**
- The confirm-step dropdown now uses the same display-name `SelectSelector` (`get_bed_type_options()`) as the other selection paths, so users see "Linak", "Okin (handle remote)", "Diagnostic (unknown bed)" instead of raw slugs, and the diagnostic type is actually selectable.
- Detection can return a legacy alias (e.g. `dewertokin`) that the display list intentionally omits; the detected default is prepended to the options so it stays valid.
- The verify-connection step never blocks entry creation, so selecting Diagnostic for an unreachable bed still creates the entry (it sets up offline).

**Docs and templates**
- `docs/GETTING_HELP.md`: new-bed section rewritten around the actual flow (find the MAC via "Browse unsupported BLE devices", then `generate_support_bundle` with `target_address`), with the diagnostic-entry path as a documented alternative; corrected bundle output location and stale "Settings → Integrations" naming.
- `.github/ISSUE_TEMPLATE/new-bed-support.yml`: same correction, plus a note that the bundle cannot capture app/remote commands (nRF Connect supplement).
- `docs/TROUBLESHOOTING.md`: vague "use manual setup" tips now name the real wizard options.
- `AGENTS.md`: `run_diagnostics` references replaced with the actual `generate_support_bundle` service and parameters.

## Testing

- 3 new tests: display-name options + Diagnostic present on the confirm form, legacy-alias default injection via disambiguation, and end-to-end entry creation with the diagnostic type.
- Full `tests/test_config_flow.py` suite: 107 passed.
- `crq preflight` run before commit; its one finding (template capture-limitation note) addressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Bluetooth setup with a clearer bed-type dropdown and support for diagnostic device selection.
  * Added guidance for generating support bundles for configured and unconfigured beds, including MAC-address lookup.
* **Documentation**
  * Updated troubleshooting, support, and diagnostic instructions with clearer navigation and setup steps.
  * Clarified support bundle contents and available diagnostic workflows.
* **Bug Fixes**
  * Preserved legacy bed-type selections in the setup menu.
  * Enabled selecting diagnostic devices for support bundle capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->