### PR TITLE
Fix Leggett & Platt Gen2 BLE pairing order

### DIFF
--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -120,6 +120,7 @@ from .const import (
     get_richmat_motor_count,
     passive_position_reconciliation_default_enabled,
     requires_pairing,
+    requires_pairing_after_service_discovery,
     supports_passive_position_reconciliation,
 )
 from .detection import (
@@ -429,9 +430,9 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             return await self._get_config_translation(
                 "step.bluetooth_pairing.data_description.pairing_instructions_leggett_gen2",
                 "1. Unplug your bed's power cord and remove any batteries from the power supply.\n"
-                "2. Plug the bed back in. You'll hear a small chime and see a pulsing blue light "
-                "under the bed - the bed stays in pairing mode for about 2 minutes.\n"
-                "3. While the light is pulsing, click 'Pair Now'.",
+                "2. Plug the bed back in. Wait for a small chime and a pulsing blue light "
+                "under the bed.\n"
+                "3. While the light is pulsing, promptly click 'Pair Now'.",
             )
         if bed_type in {
             BED_TYPE_OKIMAT,
@@ -2182,7 +2183,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     async def _attempt_pairing(self, address: str | None) -> bool:
-        """Attempt to pair with the device using establish_connection with pair=True.
+        """Attempt to pair using the protocol's required connection ordering.
 
         Returns:
             True if pairing succeeded, False otherwise
@@ -2245,18 +2246,34 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             getattr(matching_service_info, "connectable", None),
         )
 
-        # Connect with pairing enabled - this handles both built-in HA Bluetooth
-        # (pairing during connection) and ESPHome proxy (pairing after connection)
+        bed_type = self._manual_data.get(CONF_BED_TYPE) if self._manual_data else None
+        protocol_variant = (
+            self._manual_data.get(CONF_PROTOCOL_VARIANT) if self._manual_data else None
+        )
+        pair_after_service_discovery = bool(
+            bed_type and requires_pairing_after_service_discovery(bed_type, protocol_variant)
+        )
+
+        # LP Control first connects and discovers GATT, then asks Android to
+        # create the bond. BlueZ's pair=True path calls Device1.Pair instead of
+        # making the app's ordinary unbonded GATT connection first.
         client = await establish_connection(
             BleakClient,
             device,
             address,
             max_attempts=1,
             timeout=CONNECTION_PROFILES[DEFAULT_CONNECTION_PROFILE].connection_timeout,
-            pair=True,
+            pair=not pair_after_service_discovery,
+            use_services_cache=not pair_after_service_discovery,
         )
         try:
-            # Connection with pair=True succeeded - pairing is complete
+            if pair_after_service_discovery:
+                _LOGGER.info(
+                    "Connected to %s and discovered services; creating the BLE bond now",
+                    address,
+                )
+                await client.pair()
+
             _LOGGER.info("Pairing successful for %s", address)
             return True
         finally:

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -1855,12 +1855,11 @@ BEDS_REQUIRING_PAIRING: Final[set[str]] = {
     BED_TYPE_OKIMAT,
     BED_TYPE_VIBRADORM,
     BED_TYPE_LOGICDATA,
-    # Leggett & Platt Gen2 (LP Comfort Connect, 209-M001): the LP Control app
-    # calls createBond() after service discovery ("Bond Needed...Bonding" in
-    # BLEConnectionViewModel). Issue #385 shows the corresponding hardware
-    # symptom outside its ~2-minute pairing window: unbonded reconnects time out
-    # while the box keeps advertising. The app can re-open that window with its
-    # "PAIR ENABLE" serial command.
+    # Leggett & Platt Gen2 (LP Comfort Connect, 209-M001): LP Control calls
+    # createBond() for an unbonded Gen2 device after service discovery. Issue
+    # #385 shows repeated unbonded BlueZ connection timeouts while the box keeps
+    # advertising. The controller-side reason remains hardware behavior, not
+    # something the APK can prove.
     BED_TYPE_LEGGETT_GEN2,
 }
 
@@ -1890,6 +1889,20 @@ def requires_pairing(bed_type: str, protocol_variant: str | None = None) -> bool
         if protocol_variant in BED_TYPE_VARIANTS_REQUIRING_PAIRING[bed_type]:
             return True
     return False
+
+
+def requires_pairing_after_service_discovery(
+    bed_type: str, protocol_variant: str | None = None
+) -> bool:
+    """Return True when GATT discovery must precede the BLE bond request.
+
+    LP Control connects and discovers services before calling the Android
+    bonding API. BlueZ's usual ``pair=True`` path instead invokes
+    ``Device1.Pair`` without first making the ordinary unbonded GATT connection.
+    """
+    if bed_type == BED_TYPE_LEGGETT_GEN2:
+        return True
+    return bed_type == BED_TYPE_LEGGETT_PLATT and protocol_variant == LEGGETT_VARIANT_GEN2
 
 
 def connection_gated_by_bond(bed_type: str, protocol_variant: str | None = None) -> bool:

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -1232,6 +1232,101 @@ class AdjustableBedCoordinator:
 
         return not self._uses_persistent_connection()
 
+    def _prepare_pairing_attempt(
+        self,
+        device: BLEDevice,
+        pairing_details: dict[str, Any],
+    ) -> tuple[bool, bool, bool]:
+        """Resolve pairing policy and diagnostics for one connection attempt."""
+        bed_requires_pairing = requires_pairing(self._bed_type, self._protocol_variant)
+        bond_marker_before_attempt = self._ble_bond_established
+        transient_skip_was_set = self._skip_pair_next_attempt
+        os_bond_reported = (
+            bed_requires_pairing and self._device_reports_existing_bond(device)
+        )
+        if (
+            bed_requires_pairing
+            and not self._ble_bond_established
+            and os_bond_reported
+        ):
+            _LOGGER.info(
+                "Existing BLE bond detected for %s; skipping pair=True",
+                self._address,
+            )
+            self._mark_ble_bond_established()
+
+        use_pairing = (
+            bed_requires_pairing
+            and not self._ble_bond_established
+            and not self._skip_pair_next_attempt
+            and self._pairing_supported is not False
+        )
+        pair_after_service_discovery = bool(
+            use_pairing
+            and requires_pairing_after_service_discovery(
+                self._bed_type,
+                self._protocol_variant,
+            )
+        )
+        pairing_ordering = "not_requested"
+        if use_pairing:
+            pairing_ordering = (
+                "connect_discover_then_pair"
+                if pair_after_service_discovery
+                else "backend_default"
+            )
+        if not bed_requires_pairing:
+            pairing_decision = "not_required"
+        elif os_bond_reported and not bond_marker_before_attempt:
+            pairing_decision = "existing_os_bond_detected"
+        elif self._ble_bond_established:
+            pairing_decision = "bond_marker_present"
+        elif transient_skip_was_set:
+            pairing_decision = "retry_without_pairing"
+        elif self._pairing_supported is False:
+            pairing_decision = "adapter_pairing_unsupported"
+        else:
+            pairing_decision = "pairing_requested"
+        pairing_details.update(
+            {
+                "required": bed_requires_pairing,
+                "requested": use_pairing,
+                "decision": pairing_decision,
+                "adapter_pairing_supported": self._pairing_supported,
+                "bond_marker_before_attempt": bond_marker_before_attempt,
+                "bond_marker_after_detection": self._ble_bond_established,
+                "os_bond_reported": os_bond_reported,
+                "transient_skip_was_set": transient_skip_was_set,
+                "ordering": pairing_ordering,
+            }
+        )
+        # Consume the transient skip flag: it only suppresses pairing for the
+        # single attempt immediately following a failed pair.
+        self._skip_pair_next_attempt = False
+        return bed_requires_pairing, use_pairing, pair_after_service_discovery
+
+    async def _async_cleanup_failed_connection(self) -> None:
+        """Release a failed-attempt client without scheduling auto-reconnect."""
+        client = self._client
+        if client is None:
+            return
+
+        _LOGGER.debug("Cleaning up failed connection attempt...")
+        self._intentional_disconnect = True
+        try:
+            await client.disconnect()
+            _LOGGER.debug("Disconnect cleanup successful")
+        except Exception as disconnect_err:
+            _LOGGER.debug(
+                "Error during disconnect cleanup: %s (%s)",
+                disconnect_err,
+                type(disconnect_err).__name__,
+            )
+        finally:
+            self._client = None
+            self._controller = None
+            self._intentional_disconnect = False
+
     async def _async_connect_locked(self, reset_timer: bool = True) -> bool:
         """Connect to the bed (must hold lock)."""
         # Clear any prior manual/idle disconnect marker before a fresh connect attempt.
@@ -1521,73 +1616,15 @@ class AdjustableBedCoordinator:
                 # some ESP-IDF/ESPHome stacks respond with auth error 82 and can
                 # leave the proxy stuck in ESTABLISHED state when asked to re-pair
                 # an already-bonded device.
-                bed_requires_pairing = requires_pairing(self._bed_type, self._protocol_variant)
                 pairing_details = attempt_details["pairing"]
-                bond_marker_before_attempt = self._ble_bond_established
-                transient_skip_was_set = self._skip_pair_next_attempt
-                os_bond_reported = (
-                    bed_requires_pairing and self._device_reports_existing_bond(device)
+                (
+                    bed_requires_pairing,
+                    use_pairing,
+                    pair_after_service_discovery,
+                ) = self._prepare_pairing_attempt(
+                    device,
+                    pairing_details,
                 )
-                if (
-                    bed_requires_pairing
-                    and not self._ble_bond_established
-                    and os_bond_reported
-                ):
-                    _LOGGER.info(
-                        "Existing BLE bond detected for %s; skipping pair=True",
-                        self._address,
-                    )
-                    self._mark_ble_bond_established()
-
-                use_pairing = (
-                    bed_requires_pairing
-                    and not self._ble_bond_established
-                    and not self._skip_pair_next_attempt
-                    and self._pairing_supported is not False
-                )
-                pair_after_service_discovery = bool(
-                    use_pairing
-                    and requires_pairing_after_service_discovery(
-                        self._bed_type,
-                        self._protocol_variant,
-                    )
-                )
-                pairing_ordering = "not_requested"
-                if use_pairing:
-                    pairing_ordering = (
-                        "connect_discover_then_pair"
-                        if pair_after_service_discovery
-                        else "backend_default"
-                    )
-                if not bed_requires_pairing:
-                    pairing_decision = "not_required"
-                elif os_bond_reported and not bond_marker_before_attempt:
-                    pairing_decision = "existing_os_bond_detected"
-                elif self._ble_bond_established:
-                    pairing_decision = "bond_marker_present"
-                elif transient_skip_was_set:
-                    pairing_decision = "retry_without_pairing"
-                elif self._pairing_supported is False:
-                    pairing_decision = "adapter_pairing_unsupported"
-                else:
-                    pairing_decision = "pairing_requested"
-                pairing_details.update(
-                    {
-                        "required": bed_requires_pairing,
-                        "requested": use_pairing,
-                        "decision": pairing_decision,
-                        "adapter_pairing_supported": self._pairing_supported,
-                        "bond_marker_before_attempt": bond_marker_before_attempt,
-                        "bond_marker_after_detection": self._ble_bond_established,
-                        "os_bond_reported": os_bond_reported,
-                        "transient_skip_was_set": transient_skip_was_set,
-                        "ordering": pairing_ordering,
-                    }
-                )
-                # Consume the transient skip flag: it only suppresses pairing for
-                # the single attempt immediately following a failed pair, so we
-                # never get stuck skipping pairing forever.
-                self._skip_pair_next_attempt = False
                 keep_connecting_through_startup = self._uses_persistent_connection()
                 if use_pairing:
                     _LOGGER.info(
@@ -2204,23 +2241,7 @@ class AdjustableBedCoordinator:
                     type(err).__name__,
                     err.args,
                 )
-                if self._client:
-                    _LOGGER.debug("Cleaning up failed connection attempt...")
-                    client = self._client
-                    self._intentional_disconnect = True
-                    try:
-                        await client.disconnect()
-                        _LOGGER.debug("Disconnect cleanup successful")
-                    except Exception as disconnect_err:
-                        _LOGGER.debug(
-                            "Error during disconnect cleanup: %s (%s)",
-                            disconnect_err,
-                            type(disconnect_err).__name__,
-                        )
-                    finally:
-                        self._client = None
-                        self._controller = None
-                        self._intentional_disconnect = False
+                await self._async_cleanup_failed_connection()
                 self._connection_attempt_details.append(attempt_details)
                 # Delay is handled at the start of the next iteration with progressive backoff
             except Exception as err:  # noqa: BLE001 - preserve retry diagnostics for unexpected connect failures
@@ -2250,19 +2271,7 @@ class AdjustableBedCoordinator:
                 )
                 # Log full traceback at debug level
                 _LOGGER.debug("Full traceback:\n%s", traceback.format_exc())
-                if self._client:
-                    _LOGGER.debug("Cleaning up failed connection attempt...")
-                    try:
-                        await self._client.disconnect()
-                        _LOGGER.debug("Disconnect cleanup successful")
-                    except Exception as disconnect_err:
-                        _LOGGER.debug(
-                            "Error during disconnect cleanup: %s (%s)",
-                            disconnect_err,
-                            type(disconnect_err).__name__,
-                        )
-                    self._client = None
-                    self._controller = None
+                await self._async_cleanup_failed_connection()
                 self._connection_attempt_details.append(attempt_details)
                 # Delay is handled at the start of the next iteration with progressive backoff
 

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -142,6 +142,7 @@ from .const import (
     get_richmat_motor_count,
     passive_position_reconciliation_default_enabled,
     requires_pairing,
+    requires_pairing_after_service_discovery,
     resolve_richmat_remote_code,
 )
 from .controller_factory import create_controller
@@ -1544,6 +1545,20 @@ class AdjustableBedCoordinator:
                     and not self._skip_pair_next_attempt
                     and self._pairing_supported is not False
                 )
+                pair_after_service_discovery = bool(
+                    use_pairing
+                    and requires_pairing_after_service_discovery(
+                        self._bed_type,
+                        self._protocol_variant,
+                    )
+                )
+                pairing_ordering = "not_requested"
+                if use_pairing:
+                    pairing_ordering = (
+                        "connect_discover_then_pair"
+                        if pair_after_service_discovery
+                        else "backend_default"
+                    )
                 if not bed_requires_pairing:
                     pairing_decision = "not_required"
                 elif os_bond_reported and not bond_marker_before_attempt:
@@ -1566,6 +1581,7 @@ class AdjustableBedCoordinator:
                         "bond_marker_after_detection": self._ble_bond_established,
                         "os_bond_reported": os_bond_reported,
                         "transient_skip_was_set": transient_skip_was_set,
+                        "ordering": pairing_ordering,
                     }
                 )
                 # Consume the transient skip flag: it only suppresses pairing for
@@ -1575,11 +1591,12 @@ class AdjustableBedCoordinator:
                 keep_connecting_through_startup = self._uses_persistent_connection()
                 if use_pairing:
                     _LOGGER.info(
-                        "Pairing enabled for %s (bed type: %s, variant: %s) - "
+                        "Pairing enabled for %s (bed type: %s, variant: %s, ordering: %s) - "
                         "GATT services cache disabled to force fresh discovery",
                         self._name,
                         self._bed_type,
                         self._protocol_variant,
+                        pairing_details["ordering"],
                     )
 
                 # Mark that we're connecting to suppress spurious disconnect warnings
@@ -1612,9 +1629,21 @@ class AdjustableBedCoordinator:
                             max_attempts=1,
                             timeout=self._connection_timeout,
                             ble_device_callback=ble_device_callback,
-                            pair=use_pairing,
+                            pair=use_pairing and not pair_after_service_discovery,
                             use_services_cache=not disable_cache,
                         )
+                        # LP Control requests the Android bond only after the
+                        # unbonded GATT link has reported SERVICES_DISCOVERED.
+                        # establish_connection() returns after Bleak has loaded
+                        # the service collection, so pairing here preserves that
+                        # proven application ordering on BlueZ as well.
+                        if pair_after_service_discovery:
+                            _LOGGER.info(
+                                "Connected to %s and discovered services; "
+                                "creating the BLE bond now",
+                                self._address,
+                            )
+                            await self._client.pair()
                         # If we get here with pairing enabled, mark it as supported
                         if use_pairing:
                             self._pairing_supported = True
@@ -1627,6 +1656,18 @@ class AdjustableBedCoordinator:
                         # NotImplementedError: ESPHome < 2024.3.0 doesn't support pairing
                         # TypeError: older bleak-retry-connector doesn't have pair kwarg
                         if use_pairing:
+                            # A post-discovery pair() failure leaves a live
+                            # unbonded client, unlike a failed pair=True connect.
+                            # Release it before the compatibility retry.
+                            if self._client is not None:
+                                client = self._client
+                                self._intentional_disconnect = True
+                                try:
+                                    with contextlib.suppress(Exception):
+                                        await client.disconnect()
+                                finally:
+                                    self._client = None
+                                    self._intentional_disconnect = False
                             _LOGGER.warning(
                                 "Pairing not supported by Bluetooth adapter: %s. "
                                 "If using ESPHome proxy, update to ESPHome >= 2024.3.0. "
@@ -2165,8 +2206,10 @@ class AdjustableBedCoordinator:
                 )
                 if self._client:
                     _LOGGER.debug("Cleaning up failed connection attempt...")
+                    client = self._client
+                    self._intentional_disconnect = True
                     try:
-                        await self._client.disconnect()
+                        await client.disconnect()
                         _LOGGER.debug("Disconnect cleanup successful")
                     except Exception as disconnect_err:
                         _LOGGER.debug(
@@ -2174,8 +2217,10 @@ class AdjustableBedCoordinator:
                             disconnect_err,
                             type(disconnect_err).__name__,
                         )
-                    self._client = None
-                    self._controller = None
+                    finally:
+                        self._client = None
+                        self._controller = None
+                        self._intentional_disconnect = False
                 self._connection_attempt_details.append(attempt_details)
                 # Delay is handled at the start of the next iteration with progressive backoff
             except Exception as err:  # noqa: BLE001 - preserve retry diagnostics for unexpected connect failures

--- a/custom_components/adjustable_bed/repairs.py
+++ b/custom_components/adjustable_bed/repairs.py
@@ -1,9 +1,9 @@
 """Repair flows for the Adjustable Bed integration.
 
 Currently provides a guided fix for the ``pairing_required`` issue: it walks the
-user through putting an OKIN-style base into Bluetooth pairing mode (by
-power-cycling the control box), pairs with ``pair=True``, and verifies the bond
-by reading an auth-gated characteristic before resolving the issue.
+user through putting the base into Bluetooth pairing mode, follows the
+controller-specific connection/bond ordering, and verifies the bond by reading
+an auth-gated characteristic before resolving the issue.
 """
 
 from __future__ import annotations
@@ -21,9 +21,12 @@ from .adapter import get_discovered_service_info
 from .ble_auth import is_ble_authentication_error
 from .const import (
     ADAPTER_AUTO,
+    CONF_BED_TYPE,
     CONF_BLE_BOND_ESTABLISHED,
     CONF_PREFERRED_ADAPTER,
+    CONF_PROTOCOL_VARIANT,
     DEVICE_INFO_CHARS,
+    requires_pairing_after_service_discovery,
 )
 
 if TYPE_CHECKING:
@@ -95,7 +98,7 @@ class PairingRequiredRepairFlow(RepairsFlow):
         return None
 
     async def _async_try_pair(self) -> bool:
-        """Connect with pair=True and verify the encrypted link is bonded."""
+        """Create a bond with the controller-specific ordering and verify it."""
         from bleak import BleakClient
         from bleak.exc import BleakError
         from bleak_retry_connector import establish_connection
@@ -108,65 +111,89 @@ class PairingRequiredRepairFlow(RepairsFlow):
             )
             return False
 
-        try:
-            client = await establish_connection(
-                BleakClient,
-                device,
-                self._name,
-                max_attempts=1,
-                pair=True,
-                use_services_cache=False,
-            )
-        except Exception as err:  # noqa: BLE001 - any failure means "not paired"
-            _LOGGER.warning("Repair: pairing failed for %s: %s", self._address, err)
-            return False
-
-        bonded = False
-        try:
-            # Verify the bond by reading a known auth-gated characteristic. A
-            # still-unbonded link fails with GATT error=5; non-auth errors
-            # (e.g. the characteristic is absent) are inconclusive, not failures.
-            await client.read_gatt_char(DEVICE_INFO_CHARS["model_number"])
-            bonded = True
-        except BleakError as err:
-            if is_ble_authentication_error(err):
-                _LOGGER.warning(
-                    "Repair: bond verification failed for %s: %s", self._address, err
+        pair_after_service_discovery = False
+        if self._entry_id is not None:
+            entry = self.hass.config_entries.async_get_entry(self._entry_id)
+            if entry is not None:
+                bed_type = entry.data.get(CONF_BED_TYPE)
+                pair_after_service_discovery = bool(
+                    bed_type
+                    and requires_pairing_after_service_discovery(
+                        bed_type,
+                        entry.data.get(CONF_PROTOCOL_VARIANT),
+                    )
                 )
-            else:
+
+        client: BleakClient | None = None
+        reload_entry_id: str | None = None
+        try:
+            try:
+                client = await establish_connection(
+                    BleakClient,
+                    device,
+                    self._name,
+                    max_attempts=1,
+                    pair=not pair_after_service_discovery,
+                    use_services_cache=False,
+                )
+                if pair_after_service_discovery:
+                    await client.pair()
+            except Exception as err:  # noqa: BLE001 - any failure means "not paired"
+                _LOGGER.warning("Repair: pairing failed for %s: %s", self._address, err)
+                return False
+
+            bonded = False
+            try:
+                # Verify the bond by reading a known auth-gated characteristic. A
+                # still-unbonded link fails with GATT error=5; non-auth errors
+                # (e.g. the characteristic is absent) are inconclusive, not failures.
+                await client.read_gatt_char(DEVICE_INFO_CHARS["model_number"])
+                bonded = True
+            except BleakError as err:
+                if is_ble_authentication_error(err):
+                    _LOGGER.warning(
+                        "Repair: bond verification failed for %s: %s",
+                        self._address,
+                        err,
+                    )
+                else:
+                    _LOGGER.debug(
+                        "Repair: bond verification inconclusive for %s: %s",
+                        self._address,
+                        err,
+                    )
+                    bonded = True
+            except Exception as err:  # noqa: BLE001
                 _LOGGER.debug(
                     "Repair: bond verification inconclusive for %s: %s",
                     self._address,
                     err,
                 )
                 bonded = True
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.debug(
-                "Repair: bond verification inconclusive for %s: %s",
-                self._address,
-                err,
-            )
-            bonded = True
+
+            if not bonded:
+                return False
+
+            # Persist the confirmed bond and reload so the coordinator reuses it
+            # (and does not try to re-pair on top of the existing bond).
+            if self._entry_id is not None:
+                entry = self.hass.config_entries.async_get_entry(self._entry_id)
+                if entry is not None:
+                    if not entry.data.get(CONF_BLE_BOND_ESTABLISHED):
+                        self.hass.config_entries.async_update_entry(
+                            entry,
+                            data={**entry.data, CONF_BLE_BOND_ESTABLISHED: True},
+                        )
+                    reload_entry_id = self._entry_id
         finally:
-            try:
-                await client.disconnect()
-            except Exception:  # noqa: BLE001
-                pass
+            if client is not None:
+                try:
+                    await client.disconnect()
+                except Exception:  # noqa: BLE001
+                    pass
 
-        if not bonded:
-            return False
-
-        # Persist the confirmed bond and reload so the coordinator reuses it
-        # (and does not try to re-pair on top of the existing bond).
-        if self._entry_id is not None:
-            entry = self.hass.config_entries.async_get_entry(self._entry_id)
-            if entry is not None:
-                if not entry.data.get(CONF_BLE_BOND_ESTABLISHED):
-                    self.hass.config_entries.async_update_entry(
-                        entry,
-                        data={**entry.data, CONF_BLE_BOND_ESTABLISHED: True},
-                    )
-                await self.hass.config_entries.async_reload(self._entry_id)
+        if reload_entry_id is not None:
+            await self.hass.config_entries.async_reload(reload_entry_id)
 
         _LOGGER.info("Repair: pairing succeeded for %s", self._address)
         return True

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -227,7 +227,7 @@
           "pairing_instructions_generic": "1. Put your bed in pairing mode (hold lamp button until blue light blinks, or unplug for 30+ seconds)\n2. Click 'Pair Now'",
           "pairing_instructions_okin": "1. Put the OKIN base into Bluetooth pairing mode by power-cycling the control box: unplug it for ~30 seconds, then plug it back in. The status light blinks blue, then turns green after ~20 seconds. (Some models instead use the under-bed lamp/light button - hold it until the light blinks blue.) There is no separate Bluetooth pairing button; any Pair/Learn button on the box only syncs the RF remote.\n2. While the light is active, click 'Pair Now'.",
           "pairing_instructions_sleep_number": "1. Put your bed in pairing mode (hold the side pairing button until the blue light blinks)\n2. Click 'Pair Now'",
-          "pairing_instructions_leggett_gen2": "1. Unplug your bed's power cord and remove any batteries from the power supply.\n2. Plug the bed back in. You'll hear a small chime and see a pulsing blue light under the bed - the bed stays in pairing mode for about 2 minutes.\n3. While the light is pulsing, click 'Pair Now'."
+          "pairing_instructions_leggett_gen2": "1. Unplug your bed's power cord and remove any batteries from the power supply.\n2. Plug the bed back in. Wait for a small chime and a pulsing blue light under the bed.\n3. While the light is pulsing, promptly click 'Pair Now'."
         }
       },
       "manual_pairing": {
@@ -857,7 +857,7 @@
         "step": {
           "confirm": {
             "title": "Pair your adjustable bed",
-            "description": "**{name}** ({address}) requires a Bluetooth bond before it can be controlled.\n\n1. Put the bed into pairing mode. **OKIN bases** (Okimat, Okin CST, Nectar OKIN-*, Mattress Firm 900-O): power-cycle the control box — unplug it for ~30 seconds, then plug it back in (the light blinks blue, then turns green); they have no Bluetooth pairing button. **Leggett & Platt Smart Bed (LP Comfort Connect)**: unplug the bed's power cord, remove any batteries from the power supply, then plug it back in — you'll hear a chime and see a pulsing blue light under the bed, and the bed stays in pairing mode for about 2 minutes. **Other beds**: hold the pairing button on the control box or remote until its light blinks.\n2. While the bed is in pairing mode, press **Submit** to pair.\n\nPairing happens on your Home Assistant host or Bluetooth proxy — not your phone. ESPHome proxies must run ESPHome 2024.3.0 or newer."
+            "description": "**{name}** ({address}) requires a Bluetooth bond before it can be controlled.\n\n1. Put the bed into pairing mode. **OKIN bases** (Okimat, Okin CST, Nectar OKIN-*, Mattress Firm 900-O): power-cycle the control box — unplug it for ~30 seconds, then plug it back in (the light blinks blue, then turns green); they have no Bluetooth pairing button. **Leggett & Platt Smart Bed (LP Comfort Connect)**: unplug the bed's power cord, remove any batteries from the power supply, then plug it back in — wait for a chime and a pulsing blue light under the bed. **Other beds**: hold the pairing button on the control box or remote until its light blinks.\n2. While the bed is in pairing mode, promptly press **Submit** to pair.\n\nPairing happens on your Home Assistant host or Bluetooth proxy — not your phone. ESPHome proxies must run ESPHome 2024.3.0 or newer."
           }
         },
         "abort": {

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -229,7 +229,7 @@
           "pairing_instructions_generic": "1. Put your bed in pairing mode (hold lamp button until blue light blinks, or unplug for 30+ seconds)\n2. Click 'Pair Now'",
           "pairing_instructions_okin": "1. Put the OKIN base into Bluetooth pairing mode by power-cycling the control box: unplug it for ~30 seconds, then plug it back in. The status light blinks blue, then turns green after ~20 seconds. (Some models instead use the under-bed lamp/light button - hold it until the light blinks blue.) There is no separate Bluetooth pairing button; any Pair/Learn button on the box only syncs the RF remote.\n2. While the light is active, click 'Pair Now'.",
           "pairing_instructions_sleep_number": "1. Put your bed in pairing mode (hold the side pairing button until the blue light blinks)\n2. Click 'Pair Now'",
-          "pairing_instructions_leggett_gen2": "1. Unplug your bed's power cord and remove any batteries from the power supply.\n2. Plug the bed back in. You'll hear a small chime and see a pulsing blue light under the bed - the bed stays in pairing mode for about 2 minutes.\n3. While the light is pulsing, click 'Pair Now'."
+          "pairing_instructions_leggett_gen2": "1. Unplug your bed's power cord and remove any batteries from the power supply.\n2. Plug the bed back in. Wait for a small chime and a pulsing blue light under the bed.\n3. While the light is pulsing, promptly click 'Pair Now'."
         }
       },
       "manual_pairing": {
@@ -862,7 +862,7 @@
         "step": {
           "confirm": {
             "title": "Pair your adjustable bed",
-            "description": "**{name}** ({address}) requires a Bluetooth bond before it can be controlled.\n\n1. Put the bed into pairing mode. **OKIN bases** (Okimat, Okin CST, Nectar OKIN-*, Mattress Firm 900-O): power-cycle the control box — unplug it for ~30 seconds, then plug it back in (the light blinks blue, then turns green); they have no Bluetooth pairing button. **Leggett & Platt Smart Bed (LP Comfort Connect)**: unplug the bed's power cord, remove any batteries from the power supply, then plug it back in — you'll hear a chime and see a pulsing blue light under the bed, and the bed stays in pairing mode for about 2 minutes. **Other beds**: hold the pairing button on the control box or remote until its light blinks.\n2. While the bed is in pairing mode, press **Submit** to pair.\n\nPairing happens on your Home Assistant host or Bluetooth proxy — not your phone. ESPHome proxies must run ESPHome 2024.3.0 or newer."
+            "description": "**{name}** ({address}) requires a Bluetooth bond before it can be controlled.\n\n1. Put the bed into pairing mode. **OKIN bases** (Okimat, Okin CST, Nectar OKIN-*, Mattress Firm 900-O): power-cycle the control box — unplug it for ~30 seconds, then plug it back in (the light blinks blue, then turns green); they have no Bluetooth pairing button. **Leggett & Platt Smart Bed (LP Comfort Connect)**: unplug the bed's power cord, remove any batteries from the power supply, then plug it back in — wait for a chime and a pulsing blue light under the bed. **Other beds**: hold the pairing button on the control box or remote until its light blinks.\n2. While the bed is in pairing mode, promptly press **Submit** to pair.\n\nPairing happens on your Home Assistant host or Bluetooth proxy — not your phone. ESPHome proxies must run ESPHome 2024.3.0 or newer."
           }
         },
         "abort": {

--- a/docs/beds/leggett-platt.md
+++ b/docs/beds/leggett-platt.md
@@ -43,33 +43,36 @@ Leggett & Platt beds have three protocol variants with different detection metho
   from that prefix, matching the LP Control app's `isGen2Box()` check.
 - Detection: automatic by service UUID **or** the `XP`/`CP` manufacturer prefix.
 
-> **Connection & bonding (LP Comfort Connect):** the ESP32 controller requires a
-> **BLE bond** (issue #385). Outside its pairing window, the reported unbonded
-> connection attempts time out while the box keeps advertising. The LP Control
-> app bonds after service discovery
+> **Connection & bonding (LP Comfort Connect):** LP Control requests an Android
+> **BLE bond** for an unbonded Gen2 device, but only after service discovery
 > (`BLEConnectionViewModel`: bond state `BOND_NONE` + Gen2 → `createBond()`),
-> which is why the app can reconnect at any time.
+> while the Gen2 controller concurrently configures its GATT receive paths.
 >
-> The APK proves that the app requires a bond; the controller firmware is not
-> present in the APK, so the exact link-layer filtering mechanism is inferred
-> from the observed timeout-while-advertising behavior.
+> The issue #385 support bundles show the unbonded BlueZ connection timing out
+> before GATT discovery while the box remains visible. They do not reach a
+> pairing attempt, so the exact controller-side reason remains hardware
+> behavior that the APK cannot prove.
 >
-> The integration therefore pairs (`pair=True`) on the first connection, which
-> must happen during the pairing window:
+> The integration therefore mirrors the app's ordering on the first connection:
+> connect without a bond, discover the live GATT services, then create the BLE
+> bond while that link is active. This must happen during the pairing window:
 >
 > - **Entering pairing mode** (per the LP Control app): unplug the bed, remove
 >   any batteries from the power supply, plug it back in — a small chime plays
->   and a pulsing blue light shows under the bed. The window lasts ~2 minutes.
+>   and a pulsing blue light shows under the bed. Pair promptly while it pulses;
+>   the APK does not state the duration of this initial power-cycle window.
 >   A connected client can also re-open the window with the `PAIR ENABLE`
->   serial command (the app's "pair another phone" feature).
+>   serial command; for that "Pair Another Phone" flow, the app states that
+>   pairing mode remains active for 2 minutes.
 > - `DWIPE` is the app's Gen2 factory-reset command. Whether it specifically
 >   clears the controller's bond table is firmware behavior and is not required
 >   by this integration flow.
 >
-> Once bonded, reconnects are accepted outside the pairing window. The
-> integration still holds the link open for this bed type (no idle disconnect).
-> While Home Assistant is connected the physical remote cannot be used (same
-> limitation as the app: the box allows one active client).
+> After BlueZ confirms the bond, the integration records it and reconnects
+> without trying to pair again. Hardware confirmation of the initial bond and
+> subsequent reconnect remains pending. The integration holds the link open for
+> this bed type (no idle disconnect); LP Control's own UI warns that the remote
+> does not function while the app is connected.
 
 ### Okin Variant
 - **Service UUID:** `62741523-...` (shared with Okimat and Nectar)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,6 +6,7 @@ import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from bleak.exc import BleakError
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.config_entries import (
     SOURCE_BLUETOOTH,
@@ -264,6 +265,112 @@ class TestPairingPersistence:
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_BLE_BOND_ESTABLISHED] is True
+
+    async def test_leggett_gen2_pairs_after_service_discovery(self, hass: HomeAssistant) -> None:
+        """LP Comfort Connect must connect and discover GATT before bonding."""
+        flow = self._new_pairing_flow(hass)
+        flow._manual_data[CONF_BED_TYPE] = BED_TYPE_LEGGETT_GEN2
+
+        service_info = MagicMock()
+        service_info.address = flow._manual_data[CONF_ADDRESS]
+        service_info.source = "local"
+        service_info.connectable = True
+        service_info.device = MagicMock()
+
+        events: list[str] = []
+        client = MagicMock()
+
+        async def pair() -> None:
+            events.append("pair")
+
+        async def disconnect() -> None:
+            events.append("disconnect")
+
+        client.pair = AsyncMock(side_effect=pair)
+        client.disconnect = AsyncMock(side_effect=disconnect)
+
+        async def establish(*_args: object, **_kwargs: object) -> MagicMock:
+            events.append("connect")
+            return client
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
+                return_value=[service_info],
+            ),
+            patch(
+                "bleak_retry_connector.establish_connection",
+                new=AsyncMock(side_effect=establish),
+            ) as mock_establish,
+        ):
+            assert await flow._attempt_pairing(flow._manual_data[CONF_ADDRESS]) is True
+
+        assert events == ["connect", "pair", "disconnect"]
+        assert mock_establish.await_args.kwargs["pair"] is False
+        assert mock_establish.await_args.kwargs["use_services_cache"] is False
+
+    async def test_leggett_gen2_pair_failure_disconnects(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A failed post-discovery bond must not leave the GATT link open."""
+        flow = self._new_pairing_flow(hass)
+        flow._manual_data[CONF_BED_TYPE] = BED_TYPE_LEGGETT_GEN2
+
+        service_info = MagicMock()
+        service_info.address = flow._manual_data[CONF_ADDRESS]
+        service_info.source = "local"
+        service_info.connectable = True
+        service_info.device = MagicMock()
+
+        client = MagicMock()
+        client.pair = AsyncMock(side_effect=BleakError("pairing rejected"))
+        client.disconnect = AsyncMock()
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
+                return_value=[service_info],
+            ),
+            patch(
+                "bleak_retry_connector.establish_connection",
+                new=AsyncMock(return_value=client),
+            ),
+            pytest.raises(BleakError, match="pairing rejected"),
+        ):
+            await flow._attempt_pairing(flow._manual_data[CONF_ADDRESS])
+
+        client.disconnect.assert_awaited_once_with()
+
+    async def test_other_beds_keep_pair_during_connection(self, hass: HomeAssistant) -> None:
+        """Existing pairing-required protocols keep the standard Bleak path."""
+        flow = self._new_pairing_flow(hass)
+
+        service_info = MagicMock()
+        service_info.address = flow._manual_data[CONF_ADDRESS]
+        service_info.source = "local"
+        service_info.connectable = True
+        service_info.device = MagicMock()
+
+        client = MagicMock()
+        client.pair = AsyncMock()
+        client.disconnect = AsyncMock()
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.config_flow.get_discovered_service_info",
+                return_value=[service_info],
+            ),
+            patch(
+                "bleak_retry_connector.establish_connection",
+                new=AsyncMock(return_value=client),
+            ) as mock_establish,
+        ):
+            assert await flow._attempt_pairing(flow._manual_data[CONF_ADDRESS]) is True
+
+        assert mock_establish.await_args.kwargs["pair"] is True
+        assert mock_establish.await_args.kwargs["use_services_cache"] is True
+        client.pair.assert_not_awaited()
+        client.disconnect.assert_awaited_once()
 
 
 class TestDetectBedType:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1663,6 +1663,32 @@ class TestCoordinatorDisconnectTimer:
         assert coordinator._reconnect_timer is None
         assert coordinator._intentional_disconnect is False
 
+    async def test_failed_connection_cleanup_is_intentional(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """Failure cleanup must not let the callback schedule auto-reconnect."""
+        coordinator = AdjustableBedCoordinator(hass, mock_config_entry)
+        coordinator._client = mock_bleak_client
+        coordinator._controller = MagicMock()
+        intentional_during_disconnect: list[bool] = []
+
+        async def disconnect() -> None:
+            intentional_during_disconnect.append(coordinator._intentional_disconnect)
+            coordinator._on_disconnect(mock_bleak_client)
+
+        mock_bleak_client.disconnect = AsyncMock(side_effect=disconnect)
+
+        await coordinator._async_cleanup_failed_connection()
+
+        assert intentional_during_disconnect == [True]
+        assert coordinator._client is None
+        assert coordinator._controller is None
+        assert coordinator._reconnect_timer is None
+        assert coordinator._intentional_disconnect is False
+
     async def test_sleep_number_mcr_skips_disconnect_timer_on_connect(
         self,
         hass: HomeAssistant,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -16,6 +16,7 @@ from custom_components.adjustable_bed.const import (
     BED_MOTOR_PULSE_DEFAULTS,
     BED_TYPE_BEDTECH,
     BED_TYPE_KEESON,
+    BED_TYPE_LEGGETT_GEN2,
     BED_TYPE_LEGGETT_OKIN,
     BED_TYPE_LINAK,
     BED_TYPE_MALOUF_LEGACY_OKIN,
@@ -280,6 +281,217 @@ class TestCoordinatorConnection:
         )
         assert pairing["connection_attempts"][0]["pairing"]["os_bond_reported"] is True
         assert pairing["connection_attempts"][0]["pairing"]["requested"] is False
+
+    async def test_leggett_gen2_connects_discovers_then_pairs(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_adapters,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """Gen2 coordinator pairing must follow the LP Control app ordering."""
+        del mock_bluetooth_adapters
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Unpaired LP Gen2 Bed",
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: TEST_NAME,
+                CONF_BED_TYPE: BED_TYPE_LEGGETT_GEN2,
+                CONF_MOTOR_COUNT: 4,
+                CONF_HAS_MASSAGE: True,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id="leggett_gen2_pair_order_test",
+        )
+        entry.add_to_hass(hass)
+
+        adapter_result = MagicMock()
+        adapter_result.device = MagicMock()
+        adapter_result.device.address = TEST_ADDRESS
+        adapter_result.device.name = TEST_NAME
+        adapter_result.device.details = {"source": "local"}
+        adapter_result.source = "local"
+        adapter_result.rssi = -60
+        adapter_result.connectable = True
+        adapter_result.available_sources = ["local"]
+
+        events: list[str] = []
+
+        async def establish(*_args: object, **_kwargs: object) -> MagicMock:
+            events.append("connect_and_discover")
+            return mock_bleak_client
+
+        async def pair() -> None:
+            events.append("pair")
+
+        mock_bleak_client.pair = AsyncMock(side_effect=pair)
+
+        controller = MagicMock()
+        controller.requires_persistent_connection = True
+        controller.requires_notification_channel = False
+        controller.supports_under_bed_lights = False
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.coordinator.select_adapter",
+                new_callable=AsyncMock,
+                return_value=adapter_result,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.establish_connection",
+                new=AsyncMock(side_effect=establish),
+            ) as mock_establish_connection,
+            patch(
+                "custom_components.adjustable_bed.coordinator.discover_services",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.read_ble_device_info",
+                new_callable=AsyncMock,
+                return_value=(None, None),
+            ),
+            patch.object(
+                AdjustableBedCoordinator,
+                "_async_verify_bonded",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.create_controller",
+                new_callable=AsyncMock,
+                return_value=controller,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.asyncio.sleep",
+                new=AsyncMock(),
+            ),
+        ):
+            coordinator = AdjustableBedCoordinator(hass, entry)
+            coordinator._max_retries = 1
+            result = await coordinator.async_connect()
+
+        assert result is True
+        assert events == ["connect_and_discover", "pair"]
+        assert mock_establish_connection.await_args.kwargs["pair"] is False
+        assert mock_establish_connection.await_args.kwargs["use_services_cache"] is False
+        mock_bleak_client.pair.assert_awaited_once_with()
+        assert entry.data[CONF_BLE_BOND_ESTABLISHED] is True
+
+        pairing = coordinator.pairing_diagnostics["connection_attempts"][0]["pairing"]
+        assert pairing["requested"] is True
+        assert pairing["ordering"] == "connect_discover_then_pair"
+        assert pairing["connection_result"] == "pairing_connection_succeeded"
+
+    @pytest.mark.parametrize(
+        ("pair_error", "max_retries", "fallback_pair"),
+        [
+            (NotImplementedError("pairing unavailable"), 1, None),
+            (BleakError("pairing rejected"), 2, False),
+        ],
+    )
+    async def test_leggett_gen2_pair_fallback_disconnect_is_intentional(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_adapters,
+        mock_bleak_client: MagicMock,
+        pair_error: Exception,
+        max_retries: int,
+        fallback_pair: bool | None,
+    ) -> None:
+        """Pairing failures intentionally release Gen2 before no-pair fallback."""
+        del mock_bluetooth_adapters
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Unpaired LP Gen2 Bed",
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: TEST_NAME,
+                CONF_BED_TYPE: BED_TYPE_LEGGETT_GEN2,
+                CONF_MOTOR_COUNT: 4,
+                CONF_HAS_MASSAGE: True,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id="leggett_gen2_pair_fallback_test",
+        )
+        entry.add_to_hass(hass)
+
+        adapter_result = MagicMock()
+        adapter_result.device = MagicMock()
+        adapter_result.device.address = TEST_ADDRESS
+        adapter_result.device.name = TEST_NAME
+        adapter_result.device.details = {"source": "local"}
+        adapter_result.source = "local"
+        adapter_result.rssi = -60
+        adapter_result.connectable = True
+        adapter_result.available_sources = ["local"]
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        intentional_during_disconnect: list[bool] = []
+
+        async def disconnect() -> None:
+            intentional_during_disconnect.append(coordinator._intentional_disconnect)
+            coordinator._on_disconnect(mock_bleak_client)
+
+        mock_bleak_client.pair = AsyncMock(side_effect=pair_error)
+        mock_bleak_client.disconnect = AsyncMock(side_effect=disconnect)
+
+        controller = MagicMock()
+        controller.requires_persistent_connection = True
+        controller.requires_notification_channel = False
+        controller.supports_under_bed_lights = False
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.coordinator.select_adapter",
+                new_callable=AsyncMock,
+                return_value=adapter_result,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.establish_connection",
+                new_callable=AsyncMock,
+                return_value=mock_bleak_client,
+            ) as mock_establish_connection,
+            patch(
+                "custom_components.adjustable_bed.coordinator.discover_services",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.read_ble_device_info",
+                new_callable=AsyncMock,
+                return_value=(None, None),
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.create_controller",
+                new_callable=AsyncMock,
+                return_value=controller,
+            ),
+            patch(
+                "custom_components.adjustable_bed.coordinator.asyncio.sleep",
+                new=AsyncMock(),
+            ),
+        ):
+            coordinator._max_retries = max_retries
+            result = await coordinator.async_connect()
+
+        assert result is True
+        assert mock_establish_connection.await_count == 2
+        assert mock_establish_connection.await_args_list[0].kwargs["pair"] is False
+        fallback_kwargs = mock_establish_connection.await_args_list[1].kwargs
+        if fallback_pair is None:
+            assert "pair" not in fallback_kwargs
+        else:
+            assert fallback_kwargs["pair"] is fallback_pair
+        assert intentional_during_disconnect == [True]
+        assert coordinator._intentional_disconnect is False
+        mock_bleak_client.disconnect.assert_awaited_once_with()
 
     async def test_initial_position_read_prepares_controller_before_hydration(
         self,

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -35,6 +35,7 @@ from custom_components.adjustable_bed.const import (
     VARIANT_AUTO,
     connection_gated_by_bond,
     requires_pairing,
+    requires_pairing_after_service_discovery,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
 
@@ -261,6 +262,7 @@ class TestLeggettGen2Connection:
         ("bed_type", "variant", "expected"),
         [
             (BED_TYPE_LEGGETT_GEN2, None, True),
+            (BED_TYPE_LEGGETT_GEN2, VARIANT_AUTO, True),
             (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_GEN2, True),
             # Okin-style pairing beds accept the connection and only gate GATT
             # access, so a connect timeout there is not a pairing symptom.
@@ -274,6 +276,22 @@ class TestLeggettGen2Connection:
     ):
         """Only Gen2 showed the bond-gated timeout signature in issue #385."""
         assert connection_gated_by_bond(bed_type, variant) is expected
+
+    @pytest.mark.parametrize(
+        ("bed_type", "variant", "expected"),
+        [
+            (BED_TYPE_LEGGETT_GEN2, None, True),
+            (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_GEN2, True),
+            (BED_TYPE_LEGGETT_PLATT, LEGGETT_VARIANT_OKIN, False),
+            (BED_TYPE_LEGGETT_PLATT, VARIANT_AUTO, False),
+            (BED_TYPE_OKIMAT, None, False),
+        ],
+    )
+    async def test_pairing_order(
+        self, bed_type: str, variant: str | None, expected: bool
+    ) -> None:
+        """Only LP Gen2 connects and discovers GATT before requesting a bond."""
+        assert requires_pairing_after_service_discovery(bed_type, variant) is expected
 
     async def test_gen2_unexpected_disconnect_schedules_auto_reconnect(
         self,

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from bleak.exc import BleakError
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
 from homeassistant.core import HomeAssistant
@@ -11,6 +13,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adjustable_bed.const import (
+    BED_TYPE_LEGGETT_GEN2,
     CONF_BED_TYPE,
     CONF_BLE_BOND_ESTABLISHED,
     DOMAIN,
@@ -103,12 +106,13 @@ async def test_try_pair_succeeds_and_clears_marker(hass: HomeAssistant) -> None:
     flow.hass = hass
 
     client = MagicMock()
+    client.pair = AsyncMock()
     client.read_gatt_char = AsyncMock(return_value=b"Model X")
     client.disconnect = AsyncMock()
 
     with (
         patch(BLEAK_DEVICE, return_value=MagicMock()),
-        patch(ESTABLISH, new=AsyncMock(return_value=client)),
+        patch(ESTABLISH, new=AsyncMock(return_value=client)) as mock_establish,
         patch.object(
             hass.config_entries, "async_reload", new=AsyncMock()
         ) as mock_reload,
@@ -117,8 +121,133 @@ async def test_try_pair_succeeds_and_clears_marker(hass: HomeAssistant) -> None:
 
     assert result is True
     assert entry.data[CONF_BLE_BOND_ESTABLISHED] is True
+    assert mock_establish.await_args.kwargs["pair"] is True
+    client.pair.assert_not_awaited()
     mock_reload.assert_awaited_once_with(entry.entry_id)
     client.disconnect.assert_awaited_once()
+
+
+async def test_leggett_gen2_repair_pairs_after_service_discovery(
+    hass: HomeAssistant,
+) -> None:
+    """The repair path must mirror the LP app's connect-then-bond ordering."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=TEST_NAME,
+        data={
+            CONF_ADDRESS: TEST_ADDRESS,
+            CONF_NAME: TEST_NAME,
+            CONF_BED_TYPE: BED_TYPE_LEGGETT_GEN2,
+            CONF_BLE_BOND_ESTABLISHED: False,
+        },
+        unique_id=TEST_ADDRESS,
+        entry_id="repair_leggett_gen2_entry",
+    )
+    entry.add_to_hass(hass)
+
+    flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, entry.entry_id)
+    flow.hass = hass
+
+    cleanup_order: list[str] = []
+
+    async def disconnect() -> None:
+        cleanup_order.append("disconnect")
+
+    async def reload_entry(_entry_id: str) -> None:
+        cleanup_order.append("reload")
+
+    client = MagicMock()
+    client.pair = AsyncMock()
+    client.read_gatt_char = AsyncMock(return_value=b"209-M001")
+    client.disconnect = AsyncMock(side_effect=disconnect)
+
+    with (
+        patch(BLEAK_DEVICE, return_value=MagicMock()),
+        patch(ESTABLISH, new=AsyncMock(return_value=client)) as mock_establish,
+        patch.object(
+            hass.config_entries,
+            "async_reload",
+            new=AsyncMock(side_effect=reload_entry),
+        ),
+    ):
+        assert await flow._async_try_pair() is True
+
+    assert mock_establish.await_args.kwargs["pair"] is False
+    assert mock_establish.await_args.kwargs["use_services_cache"] is False
+    client.pair.assert_awaited_once()
+    client.disconnect.assert_awaited_once()
+    assert cleanup_order == ["disconnect", "reload"]
+
+
+async def test_leggett_gen2_repair_disconnects_when_pairing_fails(
+    hass: HomeAssistant,
+) -> None:
+    """A failed post-discovery repair bond must release its connected client."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=TEST_NAME,
+        data={
+            CONF_ADDRESS: TEST_ADDRESS,
+            CONF_NAME: TEST_NAME,
+            CONF_BED_TYPE: BED_TYPE_LEGGETT_GEN2,
+            CONF_BLE_BOND_ESTABLISHED: False,
+        },
+        unique_id=TEST_ADDRESS,
+        entry_id="repair_leggett_gen2_failure_entry",
+    )
+    entry.add_to_hass(hass)
+
+    flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, entry.entry_id)
+    flow.hass = hass
+
+    client = MagicMock()
+    client.pair = AsyncMock(side_effect=BleakError("pairing rejected"))
+    client.disconnect = AsyncMock()
+
+    with (
+        patch(BLEAK_DEVICE, return_value=MagicMock()),
+        patch(ESTABLISH, new=AsyncMock(return_value=client)),
+    ):
+        assert await flow._async_try_pair() is False
+
+    assert entry.data[CONF_BLE_BOND_ESTABLISHED] is False
+    client.disconnect.assert_awaited_once_with()
+
+
+async def test_leggett_gen2_repair_disconnects_when_pairing_is_cancelled(
+    hass: HomeAssistant,
+) -> None:
+    """Cancelling post-discovery pairing must still release the live client."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=TEST_NAME,
+        data={
+            CONF_ADDRESS: TEST_ADDRESS,
+            CONF_NAME: TEST_NAME,
+            CONF_BED_TYPE: BED_TYPE_LEGGETT_GEN2,
+            CONF_BLE_BOND_ESTABLISHED: False,
+        },
+        unique_id=TEST_ADDRESS,
+        entry_id="repair_leggett_gen2_cancelled_entry",
+    )
+    entry.add_to_hass(hass)
+
+    flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, entry.entry_id)
+    flow.hass = hass
+
+    client = MagicMock()
+    client.pair = AsyncMock(side_effect=asyncio.CancelledError())
+    client.disconnect = AsyncMock()
+
+    with (
+        patch(BLEAK_DEVICE, return_value=MagicMock()),
+        patch(ESTABLISH, new=AsyncMock(return_value=client)),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await flow._async_try_pair()
+
+    assert entry.data[CONF_BLE_BOND_ESTABLISHED] is False
+    client.disconnect.assert_awaited_once_with()
 
 
 async def test_try_pair_treats_non_auth_read_error_as_success(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Summary

- mirror LP Control's proven Gen2 sequence: connect, discover live GATT services, then request the Android/BlueZ bond
- apply the ordering consistently during initial setup, repair, and coordinator recovery without changing other pairing-required protocols
- clean up live clients safely across unsupported pairing, ordinary pairing failures, cancellation, and repair reloads
- improve pairing diagnostics, user instructions, protocol documentation, and focused regression coverage

## Root cause

BlueZ pairing through `establish_connection(pair=True)` requests `Device1.Pair` before the normal unbonded connection and service-discovery path. A clean-room analysis of LP Control 2.9.0 shows that its Gen2 implementation first connects and reaches `SERVICES_DISCOVERED`, then calls Android `createBond()`.

The support bundle attached to #385 timed out before GATT discovery and did not exercise pairing. It therefore identifies the failing pre-GATT path but cannot by itself validate pairing order or hardware success.

## Validation

- 305 relevant tests pass across config flow, coordinator, Leggett protocol, and repair coverage
- Ruff passes for all changed Python and test files
- scoped mypy passes for all changed integration modules
- JSON and staged-diff validation pass
- local CodeRabbit preflight converged with zero findings after addressing two review rounds
- frozen Phase 4 report passes 44 protocol assertions, 66 evidence-path checks, and 20 completion gates

Hardware confirmation remains deferred until a Gen2 user tests the corrected sequence while the base is in pairing mode.

Ref #385
See #447


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth pairing for Leggett & Platt Gen2 beds by completing service discovery before creating the bond.
  * Added safer cleanup and retry handling when pairing or connections fail.
  * Confirmed successful bonds are saved and reused, avoiding unnecessary re-pairing.

* **User Experience**
  * Updated pairing instructions to prompt users to select **Pair Now** or **Submit** while pairing mode is active.
  * Clarified Gen2 connection and pairing behavior in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->