### PR TITLE
Fix KSBT03C movement stutter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ The supported-protocol list lives in the README's "Supported Beds" table — tha
 
 **IMPORTANT: Protocol values are hardware-specific.** Timing values (repeat counts, delays), command bytes, and packet formats vary between bed types. Do NOT copy values from one bed's protocol documentation to another. Each bed type's parameters must come from actual device testing or reverse engineering - never guess or extrapolate from other implementations.
 
-1. **Always send STOP after movement** - Movement methods use `try/finally` to guarantee STOP is sent even if cancelled. The STOP command uses a fresh `asyncio.Event()` so it's not affected by the cancel signal.
+1. **Always perform protocol-specific STOP/release cleanup after movement** - Movement methods use `try/finally` so cleanup runs even if cancelled. When the protocol defines a STOP or release frame, send it with a fresh `asyncio.Event()` so the cancel signal cannot suppress it. If complete artifact evidence proves that a protocol stops solely by ending its held-command refresh and defines no release frame (for example, KSBT03C), ending that cancellable refresh is the required cleanup; never invent or extrapolate a hardware command merely to send an extra packet.
 
 2. **Command serialization** - All entities must use `coordinator.async_execute_controller_command()` instead of calling controller methods directly. This ensures proper locking and prevents concurrent BLE writes.
 

--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -1058,7 +1058,7 @@ async def _async_register_services(hass: HomeAssistant) -> None:
             # Execute timed movement
             # Calculate repeat count: duration_ms / pulse_delay_ms
             # Example: 3500ms on Octo (350ms delay) = 10 repeats
-            pulse_delay_ms = coordinator.motor_pulse_delay_ms
+            _, pulse_delay_ms = controller.motor_pulse_settings()
             if pulse_delay_ms <= 0:
                 _LOGGER.warning(
                     "Invalid motor_pulse_delay_ms (%d) for device %s, using default 100ms",
@@ -1076,8 +1076,9 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                 calculated_repeat_count,
             )
 
-            # Store original pulse count to restore after
+            # Store original pulse settings to restore after
             original_pulse_count = coordinator.motor_pulse_count
+            original_pulse_delay_ms = coordinator.motor_pulse_delay_ms
 
             # Bind closure variables as defaults to avoid late-binding bugs
             async def timed_movement(
@@ -1087,19 +1088,23 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                 _move_fn: Callable[..., Coroutine[Any, Any, None]] = move_fn,
                 _stop_fn: Callable[..., Coroutine[Any, Any, None]] = stop_fn,
                 _calculated_repeat_count: int = calculated_repeat_count,
+                _pulse_delay_ms: int = pulse_delay_ms,
                 _original_pulse_count: int = original_pulse_count,
+                _original_pulse_delay_ms: int = original_pulse_delay_ms,
             ) -> None:
                 """Execute movement for specified duration, always sending stop."""
                 try:
-                    # Temporarily set pulse count to calculated value
+                    # Temporarily set the effective pulse settings
                     # This is safe because we're inside the command lock
                     _coordinator._motor_pulse_count = _calculated_repeat_count
+                    _coordinator._motor_pulse_delay_ms = _pulse_delay_ms
 
                     # Call the movement function (uses coordinator's pulse settings)
                     await _move_fn(ctrl)
                 finally:
-                    # Restore original pulse count
+                    # Restore original pulse settings
                     _coordinator._motor_pulse_count = _original_pulse_count
+                    _coordinator._motor_pulse_delay_ms = _original_pulse_delay_ms
 
                     # Always send stop command
                     await asyncio.shield(_stop_fn(ctrl))

--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -1066,8 +1066,12 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                     coordinator.name,
                 )
                 pulse_delay_ms = 100  # DEFAULT_MOTOR_PULSE_DELAY_MS
-            # Round up to honor requested duration as minimum
-            calculated_repeat_count = max(1, (duration_ms + pulse_delay_ms - 1) // pulse_delay_ms)
+            # The first write is immediate, so one additional repeat is needed
+            # after the requested number of delay intervals.
+            calculated_repeat_count = max(
+                2,
+                (duration_ms + pulse_delay_ms - 1) // pulse_delay_ms + 1,
+            )
 
             _LOGGER.debug(
                 "Timed move: duration=%dms, pulse_delay=%dms, repeat_count=%d",

--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -490,6 +490,13 @@ class BedController(ABC):
         """
         raise NotImplementedError("Subclass must implement _send_stop or override _move_with_stop")
 
+    def motor_pulse_settings(self) -> tuple[int, int]:
+        """Return the effective repeat count and delay for motor movement."""
+        return (
+            self._coordinator.motor_pulse_count,
+            self._coordinator.motor_pulse_delay_ms,
+        )
+
     async def _move_with_stop(self, command: bytes) -> None:
         """Execute a movement command with guaranteed STOP at end.
 
@@ -501,8 +508,7 @@ class BedController(ABC):
             command: The movement command bytes to send repeatedly.
         """
         try:
-            pulse_count = self._coordinator.motor_pulse_count
-            pulse_delay = self._coordinator.motor_pulse_delay_ms
+            pulse_count, pulse_delay = self.motor_pulse_settings()
             await self.write_command(command, repeat_count=pulse_count, repeat_delay_ms=pulse_delay)
         finally:
             try:

--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -76,11 +76,12 @@ _APP_MOTOR_PULSE_DEFAULTS: dict[str, tuple[int, int]] = {
 }
 
 _THREE_MOTOR_BETTERLIVING_PULSES = (5, 200)
+_ERGOMOTION_SYNC_KSBT03C_PULSES = (4, 300)
 
 # The direct six-byte P2 protocol has no dedicated release/STOP frame. Current
 # SFD apps stop refreshing the held key and request status three times at 300 ms
-# intervals. Member's Mark also stops by ceasing refreshes and keeps issuing the
-# same status query on its independent 400 ms timer.
+# intervals. Ergomotion Sync and Member's Mark instead run status queries on
+# independent timers; movement release only stops their held-key refresh.
 _KSBT_RELEASE_QUERY = bytes([0x00, 0xB0])
 _KSBT_RELEASE_QUERY_DELAY_SECONDS = 0.3
 _KSBT_RELEASE_QUERY_COUNT = 3
@@ -742,7 +743,7 @@ class KeesonController(BedController):
         return 6  # Keeson/Ergomotion use 0-6 scale
 
     def _refresh_write_mode(self) -> None:
-        """Resolve whether the selected characteristic prefers write-with-response."""
+        """Resolve the write mode required by the selected Keeson profile."""
         if self._write_mode_initialized:
             return
 
@@ -756,7 +757,15 @@ class KeesonController(BedController):
                     continue
 
                 props = {prop.lower() for prop in getattr(char, "properties", [])}
-                if "write" in props:
+                if self._is_ksbt03c and "write-without-response" in props:
+                    # Ergomotion Sync leaves the Android characteristic write
+                    # type unchanged. Android initializes dual-mode
+                    # characteristics to WRITE_TYPE_NO_RESPONSE, so mirror that
+                    # behavior for the identified KSBT03C profile. Waiting for
+                    # an acknowledgement here stretches every 300 ms refresh by
+                    # a full BLE/proxy round trip and makes motion stutter.
+                    self._write_with_response = False
+                elif "write" in props:
                     self._write_with_response = True
                 elif "write-without-response" in props:
                     self._write_with_response = False
@@ -1098,6 +1107,9 @@ class KeesonController(BedController):
             if self._coordinator.motor_count == 3:
                 return _THREE_MOTOR_BETTERLIVING_PULSES
 
+        if self._is_ksbt03c:
+            return _ERGOMOTION_SYNC_KSBT03C_PULSES
+
         return _APP_MOTOR_PULSE_DEFAULTS.get(self._variant, configured)
 
     async def _move_motor(self, motor: str, direction: bool | None) -> None:
@@ -1129,11 +1141,11 @@ class KeesonController(BedController):
         """Send the protocol-specific motor release sequence.
 
         Direct six-byte KSBT/P2 remotes do not transmit a zero-key frame on
-        release. Current SFD apps stop the 100 ms key refresh and send status
-        query ``00 B0`` at +300, +600, and +900 ms. The Member's Mark app also
-        stops by ceasing refreshes and continues its independent ``00 B0`` query
-        timer. Other variants retain their explicit zero frame, whose packet
-        format is specific to that protocol family.
+        release. Ergomotion Sync stops KSBT03C motion solely by cancelling its
+        300 ms repeat timer; its ``00 B0`` status queries run independently.
+        Current SFD apps stop the 100 ms key refresh and send status query
+        ``00 B0`` at +300, +600, and +900 ms. Other variants retain their
+        explicit zero frame, whose packet format is specific to that family.
         """
         cancel_event = asyncio.Event()
         if self._variant == KEESON_VARIANT_PURPLE:
@@ -1153,6 +1165,8 @@ class KeesonController(BedController):
             return
 
         if self._variant == KEESON_VARIANT_KSBT:
+            if self._is_ksbt03c:
+                return
             if not delay:
                 # Direct P2 motion stops when the held-key refresh ends. The
                 # app's delayed 00 B0 frames are status queries, not STOP.

--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -80,8 +80,9 @@ _ERGOMOTION_SYNC_KSBT03C_PULSES = (4, 300)
 
 # The direct six-byte P2 protocol has no dedicated release/STOP frame. Current
 # SFD apps stop refreshing the held key and request status three times at 300 ms
-# intervals. Ergomotion Sync instead runs status queries on an independent
-# timer; movement release only stops its held-key refresh.
+# intervals. Complete clean-room analysis of Ergomotion Sync found no release
+# write: its independent status timer continues while release stops the held-key
+# refresh. Do not substitute an unverified zero-key frame for KSBT03C.
 _KSBT_RELEASE_QUERY = bytes([0x00, 0xB0])
 _KSBT_RELEASE_QUERY_DELAY_SECONDS = 0.3
 _KSBT_RELEASE_QUERY_COUNT = 3
@@ -1168,6 +1169,8 @@ class KeesonController(BedController):
 
         if self._variant == KEESON_VARIANT_KSBT:
             if self._is_ksbt03c:
+                # Timer cessation is the app-proven KSBT03C stop mechanism. No
+                # release frame was found, and inventing one would be unsafe.
                 return
             if not delay:
                 # Direct P2 motion stops when the held-key refresh ends. The

--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -1082,7 +1082,7 @@ class KeesonController(BedController):
             command += KeesonCommands.MOTOR_LUMBAR_DOWN
         return command
 
-    def _motor_pulse_settings(self) -> tuple[int, int]:
+    def motor_pulse_settings(self) -> tuple[int, int]:
         """Return the effective movement cadence for this controller.
 
         Keeson app families use different hold intervals even when their packet
@@ -1117,7 +1117,7 @@ class KeesonController(BedController):
         """Move a motor and always run the protocol-specific release cleanup."""
         self._motor_state[motor] = direction
         command = self._get_move_command()
-        repeat_count, repeat_delay_ms = self._motor_pulse_settings()
+        repeat_count, repeat_delay_ms = self.motor_pulse_settings()
 
         try:
             if command:

--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -80,8 +80,8 @@ _ERGOMOTION_SYNC_KSBT03C_PULSES = (4, 300)
 
 # The direct six-byte P2 protocol has no dedicated release/STOP frame. Current
 # SFD apps stop refreshing the held key and request status three times at 300 ms
-# intervals. Ergomotion Sync and Member's Mark instead run status queries on
-# independent timers; movement release only stops their held-key refresh.
+# intervals. Ergomotion Sync instead runs status queries on an independent
+# timer; movement release only stops its held-key refresh.
 _KSBT_RELEASE_QUERY = bytes([0x00, 0xB0])
 _KSBT_RELEASE_QUERY_DELAY_SECONDS = 0.3
 _KSBT_RELEASE_QUERY_COUNT = 3
@@ -1113,7 +1113,7 @@ class KeesonController(BedController):
         return _APP_MOTOR_PULSE_DEFAULTS.get(self._variant, configured)
 
     async def _move_motor(self, motor: str, direction: bool | None) -> None:
-        """Move a motor in a direction or stop it, always releasing at the end."""
+        """Move a motor and always run the protocol-specific release cleanup."""
         self._motor_state[motor] = direction
         command = self._get_move_command()
         repeat_count, repeat_delay_ms = self._motor_pulse_settings()
@@ -1133,7 +1133,8 @@ class KeesonController(BedController):
                         repeat_delay_ms=repeat_delay_ms,
                     )
         finally:
-            # Always release with a fresh event so it is not affected by cancellation.
+            # Release writes use a fresh event so cancellation cannot suppress them.
+            # KSBT03C has no release write; ending the cancellable refresh is its stop.
             self._motor_state = {}
             await self._release_motion()
 
@@ -1142,7 +1143,8 @@ class KeesonController(BedController):
 
         Direct six-byte KSBT/P2 remotes do not transmit a zero-key frame on
         release. Ergomotion Sync stops KSBT03C motion solely by cancelling its
-        300 ms repeat timer; its ``00 B0`` status queries run independently.
+        300 ms repeat timer, which observes the coordinator cancellation event
+        between writes; its ``00 B0`` status queries run independently.
         Current SFD apps stop the 100 ms key refresh and send status query
         ``00 B0`` at +300, +600, and +900 ms. Other variants retain their
         explicit zero frame, whose packet format is specific to that family.

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -110,8 +110,8 @@ and refresh them every 100 ms. Releasing a key cancels that refresh and writes
 the two-byte status query `[0x00, 0xB0]` at +300, +600 and +900 ms. None of
 these P2 paths writes the six-byte zero-key packet on release.
 
-Ergomotion Sync 1.0.5 is distinct: all three remote layouts write immediately
-and use a 300 ms fixed-delay timer. Release only cancels that timer; its status
+Ergomotion Sync 1.0.5's KSBT03C layout B is distinct: it writes immediately and
+uses a 300 ms fixed-delay timer. Release only cancels that timer; its status
 queries run in a separate background loop. The app leaves Android's
 characteristic write type unchanged. Android defaults a characteristic that
 advertises write-without-response to that mode, so detected `KSBT03C` beds use
@@ -119,7 +119,8 @@ unacknowledged writes when the characteristic supports them. This prevents a
 BLE proxy acknowledgement round trip from stretching every refresh interval.
 Explicit per-device pulse settings remain authoritative. No KSBT03C release
 frame was found in the complete clean-room analysis, so the integration does
-not guess or substitute a zero-key frame.
+not guess or substitute a zero-key frame. Sync's KSBT04C layouts use their
+separate integration profile, including its existing zero-frame release.
 
 Some Ergomotion-branded beds also use this variant. A confirmed Rio 6.0 support bundle advertises as `KSBT04...` and works correctly with the standard KSBT 6-byte protocol.
 Juna's `LVrestore` and `LVrelax` remotes also use this direct 6-byte framing rather than the JSON/A00A path.

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -107,10 +107,8 @@ The integration treats `0000a00a` as a distinct Keeson variant and uses the shar
 
 Ergomotion 4.0, Q-Plus and 1500 Tilt Base write held movement keys immediately
 and refresh them every 100 ms. Releasing a key cancels that refresh and writes
-the two-byte status query `[0x00, 0xB0]` at +300, +600 and +900 ms. Member's
-Mark uses a 400 ms movement refresh and runs the same query on an independent
-400 ms timer. None of these P2 paths writes the six-byte zero-key packet on
-release.
+the two-byte status query `[0x00, 0xB0]` at +300, +600 and +900 ms. None of
+these P2 paths writes the six-byte zero-key packet on release.
 
 Ergomotion Sync 1.0.5 is distinct: all three remote layouts write immediately
 and use a 300 ms fixed-delay timer. Release only cancels that timer; its status
@@ -249,9 +247,9 @@ app/protocol family, not to the shared 32-bit command values:
 
 | Integration variant | OEM app evidence | App hold behavior | Effective default burst |
 |---------------------|------------------|-------------------|-------------------------|
-| BaseI4/BaseI5 | Member's Mark | 400ms fixed-delay scheduler | 3 writes, 400ms apart |
+| BaseI4/BaseI5 | Member's Mark | 400ms fixed-delay scheduler | 3 writes, 400ms apart; Base-family zero frame on release |
 | JSON/A00A | Juna / Linx | Requests every 5ms / 3ms, but drops requests while a write-with-response is pending | Existing safe 10 writes, 100ms apart |
-| KSBT direct P2 | Ergomotion 4.0 / Q-Plus / 1500 Tilt Base; Member's Mark | 100ms in the SFD apps, 400ms in Member's Mark | 10 writes, 100ms apart; explicit user overrides are preserved |
+| KSBT direct P2 | Ergomotion 4.0 / Q-Plus / 1500 Tilt Base | 100ms in the SFD apps | 10 writes, 100ms apart; explicit user overrides are preserved |
 | KSBT03C | Ergomotion Sync 1.0.5, Rio 5 layout | Immediate write plus 300ms `Timer.schedule`; release only cancels the timer | 4 writes, 300ms apart, with no release packet |
 | KSBT03CR | SomosBeds | 300ms `Timer.schedule` | 4 writes, 300ms apart |
 | Sleep Harmony (`KSBT04C` / `base-i5.`) | Sleep Harmony | 300ms handler loop | 4 writes, 300ms apart |
@@ -276,13 +274,13 @@ base Keeson variant.
 
 Release behavior also varies. The current SFD direct-six-byte P2 apps stop their
 100 ms refresh and send `00 B0` queries at +300/+600/+900 ms. Ergomotion Sync
-and Member's Mark stop their movement refresh without a dedicated release write;
-their independent status timers continue sending `00 B0`. None sends a zero-key
-frame. Base/Ergomotion/Serta families retain their family-specific zero frames.
-Purple uses the explicit seven-byte P2 zero frame. Sleep Harmony waits 200 ms
-and sends one zero frame after both movement and one-shot actions. KSBT03CR
-retains its independently derived release behavior. One-shot commands themselves
-are sent once before any profile-specific release.
+stops its movement refresh without a dedicated release write; its independent
+status timer continues sending `00 B0`. Base (including the integration's
+Member's Mark route), Ergomotion, and Serta retain their family-specific zero
+frames. Purple uses the explicit seven-byte P2 zero frame. Sleep Harmony waits
+200 ms and sends one zero frame after both movement and one-shot actions.
+KSBT03CR retains its independently derived release behavior. One-shot commands
+themselves are sent once before any profile-specific release.
 
 ## Split-Bed Support (Member's Mark)
 

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -117,7 +117,9 @@ characteristic write type unchanged. Android defaults a characteristic that
 advertises write-without-response to that mode, so detected `KSBT03C` beds use
 unacknowledged writes when the characteristic supports them. This prevents a
 BLE proxy acknowledgement round trip from stretching every refresh interval.
-Explicit per-device pulse settings remain authoritative.
+Explicit per-device pulse settings remain authoritative. No KSBT03C release
+frame was found in the complete clean-room analysis, so the integration does
+not guess or substitute a zero-key frame.
 
 Some Ergomotion-branded beds also use this variant. A confirmed Rio 6.0 support bundle advertises as `KSBT04...` and works correctly with the standard KSBT 6-byte protocol.
 Juna's `LVrestore` and `LVrelax` remotes also use this direct 6-byte framing rather than the JSON/A00A path.
@@ -131,6 +133,12 @@ also accepts a `KSBT03C` name but uses its separate explicit profile and exposes
 head, foot, tilt/EJ and lumbar controls.
 
 **Status:** the KSBT03C command values and 3-motor layout are APK-derived (Ergomotion Sync 1.0.2) and not yet confirmed on hardware; the Rio 5.0 report in issue #408 confirms the lumbar motor responds to `0x40`/`0x80` and that no tilt motor exists.
+
+The 300 ms cadence, unacknowledged write mode, and timer-cessation release are
+statically verified from Ergomotion Sync 1.0.5 but remain hardware-unverified.
+The timer cessation is intentional: no release packet exists in the analyzed
+app, and a replacement STOP frame must not be guessed without new protocol
+evidence or a hardware capture.
 
 **Fallback Service UUIDs:** Some KSBT devices use different service UUIDs. The integration automatically tries these if the primary isn't found:
 - `6e400020-b5a3-f393-e0a9-e50e24dcca9e` (characteristic: `6e400021`) - Extended Nordic UART, used by some Ergomotion/SFD beds

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -110,9 +110,16 @@ and refresh them every 100 ms. Releasing a key cancels that refresh and writes
 the two-byte status query `[0x00, 0xB0]` at +300, +600 and +900 ms. Member's
 Mark uses a 400 ms movement refresh and runs the same query on an independent
 400 ms timer. None of these P2 paths writes the six-byte zero-key packet on
-release. The integration uses the 100 ms compatibility cadence needed by
-KSBT03C beds such as the issue #408 device; explicit per-device pulse settings
-remain authoritative.
+release.
+
+Ergomotion Sync 1.0.5 is distinct: all three remote layouts write immediately
+and use a 300 ms fixed-delay timer. Release only cancels that timer; its status
+queries run in a separate background loop. The app leaves Android's
+characteristic write type unchanged. Android defaults a characteristic that
+advertises write-without-response to that mode, so detected `KSBT03C` beds use
+unacknowledged writes when the characteristic supports them. This prevents a
+BLE proxy acknowledgement round trip from stretching every refresh interval.
+Explicit per-device pulse settings remain authoritative.
 
 Some Ergomotion-branded beds also use this variant. A confirmed Rio 6.0 support bundle advertises as `KSBT04...` and works correctly with the standard KSBT 6-byte protocol.
 Juna's `LVrestore` and `LVrelax` remotes also use this direct 6-byte framing rather than the JSON/A00A path.
@@ -245,6 +252,7 @@ app/protocol family, not to the shared 32-bit command values:
 | BaseI4/BaseI5 | Member's Mark | 400ms fixed-delay scheduler | 3 writes, 400ms apart |
 | JSON/A00A | Juna / Linx | Requests every 5ms / 3ms, but drops requests while a write-with-response is pending | Existing safe 10 writes, 100ms apart |
 | KSBT direct P2 | Ergomotion 4.0 / Q-Plus / 1500 Tilt Base; Member's Mark | 100ms in the SFD apps, 400ms in Member's Mark | 10 writes, 100ms apart; explicit user overrides are preserved |
+| KSBT03C | Ergomotion Sync 1.0.5, Rio 5 layout | Immediate write plus 300ms `Timer.schedule`; release only cancels the timer | 4 writes, 300ms apart, with no release packet |
 | KSBT03CR | SomosBeds | 300ms `Timer.schedule` | 4 writes, 300ms apart |
 | Sleep Harmony (`KSBT04C` / `base-i5.`) | Sleep Harmony | 300ms handler loop | 4 writes, 300ms apart |
 | Ergomotion | Ergomotion / Ergomotion 4.0 / Tempur Zero G | 100ms handler loop | 10 writes, 100ms apart |
@@ -267,14 +275,14 @@ detected, even if a future factory path pairs the profile flag with a different
 base Keeson variant.
 
 Release behavior also varies. The current SFD direct-six-byte P2 apps stop their
-100 ms refresh and send `00 B0` queries at +300/+600/+900 ms. Member's Mark
-stops its 400 ms refresh without a dedicated release write, while its independent
-timer continues sending `00 B0`. None sends a zero-key frame. Base/Ergomotion/
-Serta families retain their family-specific zero frames. Purple uses the explicit
-seven-byte P2 zero frame. Sleep Harmony waits 200 ms and sends one zero frame
-after both movement and one-shot actions. KSBT03CR retains its independently
-derived release behavior. One-shot commands themselves are sent once before any
-profile-specific release.
+100 ms refresh and send `00 B0` queries at +300/+600/+900 ms. Ergomotion Sync
+and Member's Mark stop their movement refresh without a dedicated release write;
+their independent status timers continue sending `00 B0`. None sends a zero-key
+frame. Base/Ergomotion/Serta families retain their family-specific zero frames.
+Purple uses the explicit seven-byte P2 zero frame. Sleep Harmony waits 200 ms
+and sends one zero frame after both movement and one-shot actions. KSBT03CR
+retains its independently derived release behavior. One-shot commands themselves
+are sent once before any profile-specific release.
 
 ## Split-Bed Support (Member's Mark)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
@@ -25,6 +25,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_BEDTECH,
     BED_TYPE_DIAGNOSTIC,
     BED_TYPE_KAIDI,
+    BED_TYPE_KEESON,
     BED_TYPE_LEGGETT_GEN2,
     BED_TYPE_LINAK,
     BED_TYPE_MALOUF_LEGACY_OKIN,
@@ -52,6 +53,8 @@ from custom_components.adjustable_bed.const import (
     CONF_RICHMAT_REMOTE,
     DOMAIN,
     KAIDI_VARIANT_SEAT_1,
+    KEESON_KSBT_CHAR_UUID,
+    KEESON_VARIANT_KSBT,
     MALOUF_LAYOUT_HILO,
     OCTO_VARIANT_STANDARD,
     OKIN_HEAD_MAX_ANGLE,
@@ -1230,6 +1233,65 @@ class TestServices:
         )
 
         assert mock_bleak_client.write_gatt_char.call_count >= 1
+
+    async def test_timed_move_uses_controller_effective_pulse_delay(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        mock_async_ble_device_from_address: MagicMock,
+        mock_bleak_client: MagicMock,
+        enable_custom_integrations,
+    ):
+        """Timed moves should retain the detected KSBT03C 300 ms cadence."""
+        mock_async_ble_device_from_address.return_value.name = "KSBT03C300039050"
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="KSBT03C Timed Move Bed",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:11",
+                CONF_NAME: "KSBT03C Timed Move Bed",
+                CONF_BED_TYPE: BED_TYPE_KEESON,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+                CONF_PROTOCOL_VARIANT: KEESON_VARIANT_KSBT,
+            },
+            unique_id="AA:BB:CC:DD:EE:11",
+            entry_id="ksbt03c_timed_move_entry",
+        )
+        entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        from homeassistant.helpers import device_registry as dr
+
+        device_registry = dr.async_get(hass)
+        devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+        assert len(devices) == 1
+        device_id = devices[0].id
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TIMED_MOVE,
+            {
+                "device_id": [device_id],
+                "motor": "head",
+                "direction": "up",
+                "duration_ms": 900,
+            },
+            blocking=True,
+        )
+
+        assert mock_bleak_client.write_gatt_char.await_args_list == [
+            call(
+                KEESON_KSBT_CHAR_UUID,
+                bytes.fromhex("040200000001"),
+                response=True,
+            )
+        ] * 3
 
     async def test_timed_move_service_accepts_okin_rf_eco_bt_stair(
         self,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1291,7 +1291,7 @@ class TestServices:
                 bytes.fromhex("040200000001"),
                 response=True,
             )
-        ] * 3
+        ] * 4
 
     async def test_timed_move_service_accepts_okin_rf_eco_bt_stair(
         self,
@@ -1349,6 +1349,7 @@ class TestServices:
 
         payloads = [call.args[1] for call in mock_bleak_client.write_gatt_char.call_args_list]
         assert payloads == [
+            bytes.fromhex("040200000001"),
             bytes.fromhex("040200000001"),
             bytes.fromhex("040200000001"),
             bytes.fromhex("040200000000"),
@@ -1410,7 +1411,13 @@ class TestServices:
         move_packet = controller._build_packet([0x02, 0x70], [0x02])
         stop_packet = controller._build_packet([0x02, 0x73])
         payloads = [call.args[1] for call in mock_bleak_client.write_gatt_char.call_args_list]
-        assert payloads == [move_packet, move_packet, stop_packet, stop_packet]
+        assert payloads == [
+            move_packet,
+            move_packet,
+            move_packet,
+            stop_packet,
+            stop_packet,
+        ]
 
     async def test_timed_move_service_rejects_bed_height_for_standard_layout(
         self,

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -1648,7 +1648,7 @@ class TestKsbt03cMotorLayout:
         coordinator._motor_count = motor_count
         controller = KeesonController(coordinator, variant=variant)
 
-        assert controller._motor_pulse_settings() == expected
+        assert controller.motor_pulse_settings() == expected
 
     def test_ksbt03c_uses_ergomotion_sync_motor_cadence(
         self,
@@ -1663,7 +1663,7 @@ class TestKsbt03cMotorLayout:
             device_name="KSBT03C300039050",
         )
 
-        assert controller._motor_pulse_settings() == (4, 300)
+        assert controller.motor_pulse_settings() == (4, 300)
 
     @pytest.mark.parametrize(
         ("motor_count", "expected"),
@@ -1684,7 +1684,7 @@ class TestKsbt03cMotorLayout:
         coordinator._motor_count = motor_count
         controller = KeesonController(coordinator, variant="base", betterliving_presets=True)
 
-        assert controller._motor_pulse_settings() == expected
+        assert controller.motor_pulse_settings() == expected
 
     async def test_custom_motor_cadence_is_preserved(
         self,

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -241,6 +241,42 @@ class TestKeesonController:
             KEESON_JSON_WRITE_CHAR_UUID, command, response=True
         )
 
+    async def test_ksbt03c_write_command_uses_no_response_when_supported(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """KSBT03C should match Ergomotion Sync's Android-default write mode."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+
+        controller = KeesonController(
+            coordinator,
+            variant="ksbt",
+            device_name="KSBT03C300039050",
+        )
+        mock_bleak_client.services = [
+            SimpleNamespace(
+                characteristics=[
+                    SimpleNamespace(
+                        uuid=KEESON_KSBT_CHAR_UUID,
+                        properties=["write", "write-without-response"],
+                    )
+                ]
+            )
+        ]
+
+        command = controller._build_command(KeesonCommands.MOTOR_HEAD_UP)
+        await controller.write_command(command)
+
+        mock_bleak_client.write_gatt_char.assert_called_with(
+            KEESON_KSBT_CHAR_UUID,
+            command,
+            response=False,
+        )
+
     async def test_write_command_not_connected(
         self,
         hass: HomeAssistant,
@@ -1614,6 +1650,21 @@ class TestKsbt03cMotorLayout:
 
         assert controller._motor_pulse_settings() == expected
 
+    def test_ksbt03c_uses_ergomotion_sync_motor_cadence(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+    ):
+        """KSBT03C uses Ergomotion Sync's immediate plus 300 ms timer."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        controller = KeesonController(
+            coordinator,
+            variant="ksbt",
+            device_name="KSBT03C300039050",
+        )
+
+        assert controller._motor_pulse_settings() == (4, 300)
+
     @pytest.mark.parametrize(
         ("motor_count", "expected"),
         [
@@ -1682,17 +1733,17 @@ class TestKsbt03cMotorLayout:
         assert release_event is not coordinator.cancel_command
         assert not release_event.is_set()
 
-    async def test_ksbt_motion_uses_p2_hold_and_release_sequence(
+    async def test_generic_ksbt_motion_uses_sfd_hold_and_release_sequence(
         self,
         hass: HomeAssistant,
         mock_keeson_config_entry,
         mock_coordinator_connected,
         monkeypatch: pytest.MonkeyPatch,
     ):
-        """Test direct P2 motion refreshes at 100 ms and releases with queries."""
+        """Test non-KSBT03C P2 motion keeps the current SFD sequence."""
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         await coordinator.async_connect()
-        controller = KeesonController(coordinator, variant="ksbt", device_name="KSBT03C300039050")
+        controller = KeesonController(coordinator, variant="ksbt", device_name="KSBT300039050")
         controller.write_command = AsyncMock()
         sleep = AsyncMock()
         monkeypatch.setattr(
@@ -1723,6 +1774,37 @@ class TestKsbt03cMotorLayout:
             (0.3,),
             (0.3,),
         ]
+
+    async def test_ksbt03c_motion_matches_ergomotion_sync_hold_and_release(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test Rio 5 refreshes at 300 ms and release only ends refreshing."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        controller = KeesonController(
+            coordinator,
+            variant="ksbt",
+            device_name="KSBT03C300039050",
+        )
+        controller.write_command = AsyncMock()
+        sleep = AsyncMock()
+        monkeypatch.setattr(
+            "custom_components.adjustable_bed.beds.keeson.asyncio.sleep",
+            sleep,
+        )
+
+        await controller.move_head_up()
+
+        controller.write_command.assert_awaited_once_with(
+            bytes.fromhex("040200000001"),
+            repeat_count=4,
+            repeat_delay_ms=300,
+        )
+        sleep.assert_not_awaited()
 
     async def test_ksbt_stop_all_does_not_wait_for_status_queries(
         self,

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -1783,7 +1783,7 @@ class TestKsbt03cMotorLayout:
         mock_bleak_client: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ):
-        """Test Rio 5 repeats at 300 ms and emits no release packet."""
+        """Test the clean-room KSBT03C cadence and timer-cessation release."""
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         await coordinator.async_connect()
         controller = KeesonController(
@@ -1816,7 +1816,7 @@ class TestKsbt03cMotorLayout:
         mock_bleak_client: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ):
-        """Test cancelling the repeat timer stops Rio 5 without a release write."""
+        """Test coordinator cancellation ends refresh without a release frame."""
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         await coordinator.async_connect()
         controller = KeesonController(

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
@@ -1780,9 +1780,10 @@ class TestKsbt03cMotorLayout:
         hass: HomeAssistant,
         mock_keeson_config_entry,
         mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ):
-        """Test Rio 5 refreshes at 300 ms and release only ends refreshing."""
+        """Test Rio 5 repeats at 300 ms and emits no release packet."""
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         await coordinator.async_connect()
         controller = KeesonController(
@@ -1790,21 +1791,60 @@ class TestKsbt03cMotorLayout:
             variant="ksbt",
             device_name="KSBT03C300039050",
         )
-        controller.write_command = AsyncMock()
         sleep = AsyncMock()
         monkeypatch.setattr(
-            "custom_components.adjustable_bed.beds.keeson.asyncio.sleep",
+            "custom_components.adjustable_bed.beds.base.asyncio.sleep",
             sleep,
         )
 
         await controller.move_head_up()
 
-        controller.write_command.assert_awaited_once_with(
-            bytes.fromhex("040200000001"),
-            repeat_count=4,
-            repeat_delay_ms=300,
+        assert mock_bleak_client.write_gatt_char.await_args_list == [
+            call(
+                KEESON_KSBT_CHAR_UUID,
+                bytes.fromhex("040200000001"),
+                response=True,
+            )
+        ] * 4
+        assert sleep.await_args_list == [call(0.3)] * 3
+
+    async def test_ksbt03c_motion_honors_coordinator_cancellation(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test cancelling the repeat timer stops Rio 5 without a release write."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        controller = KeesonController(
+            coordinator,
+            variant="ksbt",
+            device_name="KSBT03C300039050",
         )
-        sleep.assert_not_awaited()
+        original_sleep = asyncio.sleep
+
+        async def cancel_during_refresh(delay: float) -> None:
+            if delay == 0.3:
+                coordinator.cancel_command.set()
+            else:
+                await original_sleep(delay)
+
+        monkeypatch.setattr(
+            "custom_components.adjustable_bed.beds.base.asyncio.sleep",
+            cancel_during_refresh,
+        )
+
+        await controller.move_head_up()
+
+        mock_bleak_client.write_gatt_char.assert_awaited_once_with(
+            KEESON_KSBT_CHAR_UUID,
+            bytes.fromhex("040200000001"),
+            response=True,
+        )
+        assert coordinator.cancel_command.is_set()
 
     async def test_ksbt_stop_all_does_not_wait_for_status_queries(
         self,


### PR DESCRIPTION
## Summary

- match detected KSBT03C / Rio 5 movement to the exact Ergomotion Sync profile
- use unacknowledged writes when the dual-mode Nordic UART characteristic supports them
- restore the app-proven 300 ms hold cadence and stop movement by ending refreshes, without a release/query burst
- preserve the independently verified 100 ms and `00 B0` behavior for other direct-P2 profiles

## Root cause

The v3.3.0 correction generalized behavior from current SFD direct-P2 apps to the Rio 5. A fresh clean-room analysis of Ergomotion Sync 1.0.5 proves its KSBT03C layout instead schedules an immediate write plus nominal 300 ms repeats and sends no BLE release frame. Its Android/FastBle path leaves the characteristic write type at the platform default.

The reporter's support bundle shows that `6e400002` advertises both write modes. Android therefore selects write-without-response, while the integration explicitly selected write-with-response. On an ESPHome proxy, that acknowledgement round trip stretched every refresh interval and could make motion stutter.

## Clean-room evidence

- package: `cn.com.mancini` 1.0.5 (5)
- complete four-APK Google Play split set
- artifact-set SHA-256: `3ab9ad019047f20a7a71f8563e5c0be9a855e3c20cae2f50957a3cbb90b63b47`
- report status: COMPLETE, schema `phase4-analysis-v1.1-2026-07-19`, checksum manifest verified
- hardware status: static verified, hardware unverified

## Validation

- `uv run --with ruff ruff check custom_components/adjustable_bed/beds/keeson.py tests/test_keeson.py`
- `uv run mypy custom_components/adjustable_bed/beds/keeson.py`
- `uv run pytest -q tests/test_keeson.py` (114 passed)
- `uv run pytest -q` (2406 passed)
- `git diff --check`

Ref #408
Related to #447


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KSBT03C “Ergomotion Sync” stopping and motion cadence by refining how held motion refresh is canceled and how status polling continues.
  * Prevented motion stutter by using unacknowledged BLE writes when supported for KSBT movement refresh.
  * Fixed timed-move pulse timing to use each controller’s detected effective cadence for KEESON KSBT devices.
* **Documentation**
  * Updated Keeson bed documentation with precise KSBT/direct P2 and KSBT03C Sync 1.0.5 timing and release behavior.
* **Tests**
  * Expanded KSBT/KSBT03C coverage for BLE write mode, pulse cadence, repeat/stop behavior, and refresh-loop cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->