### PR TITLE
Restore MotoSleep Panel Eight Home preset

### DIFF
--- a/custom_components/adjustable_bed/beds/motosleep_profiles.py
+++ b/custom_components/adjustable_bed/beds/motosleep_profiles.py
@@ -147,7 +147,7 @@ def _power_bob_profile(profile_id: str) -> MotoSleepProfile:
         motors["auxiliary"] = ("P", "Q")
 
     explicit_stop = profile_id in {"four", "wr1140", "one", "two", "three", "nine", "six_zg"}
-    return _profile(
+    profile = _profile(
         f"power_bob_{profile_id}",
         MotoSleepTransport.POWER_BOB_ASCII,
         motors=motors,
@@ -157,6 +157,11 @@ def _power_bob_profile(profile_id: str) -> MotoSleepProfile:
         # Night configuration independently of the root motor panel.
         rgb_light=True,
     )
+    if profile_id == "eight":
+        # MotoSleep's PanelEight sends $O for Home, and issue #468 confirms it
+        # on a short-name HHC bed that otherwise follows Power Bob routing.
+        profile = replace(profile, presets=_frozen({**profile.presets, "flat": "O"}))
+    return profile
 
 
 def _resolve_power_bob(name: str) -> MotoSleepProfile:

--- a/docs/beds/motosleep.md
+++ b/docs/beds/motosleep.md
@@ -52,6 +52,10 @@ index 8 and `5` at index 9, which selects the Power Bob A15 panel.
   WRS20ms, WRS16ms, WRC30Mms, WRS27ms, WRS20ms Swing, and WR219.
 - Advertised-name matching and model routing normalize letter case, including
   selector letters. Protocol command letters remain case-sensitive.
+- Short HHC names that select Power Bob Panel Eight retain Home as `$O`. A
+  user-confirmed device uses this shared command, matching the reachable
+  MotoSleep 5.1.5 PanelEight action even though Power Bob 2.0.3 does not render
+  that action on its separate Panel Eight.
 - Unmatched Power Bob selectors and malformed MOTO names receive no speculative
   controls. Legacy manual configurations without a usable advertised name keep
   a conservative two-axis fallback; current long HHC names retain the app's

--- a/tests/test_motosleep.py
+++ b/tests/test_motosleep.py
@@ -64,6 +64,20 @@ def test_issue_445_name_routes_pq_to_lumbar() -> None:
     assert "auxiliary" not in profile.motors
 
 
+async def test_issue_468_short_panel_eight_keeps_home_preset() -> None:
+    """The reported short HHC PanelEight bed retains its working Home action."""
+    controller, client = _controller("HHC0120182CDEH")
+
+    assert controller.profile.profile_id == "power_bob_eight"
+    assert controller.supports_preset_flat is True
+
+    await controller.preset_flat()
+
+    client.write_gatt_char.assert_awaited_once_with(
+        MOTOSLEEP_CHAR_UUID, b"$O", response=False
+    )
+
+
 def test_power_bob_accepts_exact_length_name_containing_hhc() -> None:
     """Power Bob filters for a case-sensitive HHC substring, not a prefix."""
     profile = resolve_motosleep_profile("XXHHC000150000")


### PR DESCRIPTION
## Summary

- restore the Home preset for short HHC names selecting the Panel Eight profile
- add a regression test for the reported device name and exact raw `$O` write
- document the cross-app compatibility evidence

## Root cause

The app-derived routing introduced in PR #446 maps 14-character HHC names to
Power Bob profiles. Power Bob 2.0.3 does not render Home on its separate Panel
Eight UI, so the profile inventory omitted `$O` and Home Assistant hid the
button.

The accepted MotoSleep 5.1.5 decomp renders Home on both reachable Panel Eight
variants and sends `$O`. The issue #468 device report confirms that command on
a short-name HHC bed. This change keeps the exact Power Bob inventory intact
and adds the verified compatibility command at the resolved profile boundary.

Ref #468

## Validation

- `uv run pytest -q -n 0 tests/test_motosleep.py` (97 passed)
- `uv run pytest -q` (2,427 passed)
- `uvx ruff@0.15.16 check custom_components tests`
- `uvx pyright@1.1.410 custom_components tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Home/Flat preset command for Power Bob Panel Eight devices.
  * Short HHC device names now correctly retain the `$O` Home action.

* **Tests**
  * Added coverage confirming the correct device profile, Flat preset support, and command sent to the device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->