### PR TITLE
Show MAC addresses in bed discovery UI

### DIFF
--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -390,6 +390,13 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         self._pending_title: str | None = None
         _LOGGER.debug("AdjustableBedConfigFlow initialized")
 
+    def _set_device_title_placeholders(self, name: str | None, address: str) -> None:
+        """Identify the selected device in the flow title."""
+        self.context["title_placeholders"] = {
+            "name": name or "Unknown",
+            "address": address.upper(),
+        }
+
     def _prepare_disambiguation(self, detection_result: DetectionResult) -> bool:
         """Prepare the focused bed-type chooser for an ambiguous detection."""
         self._disambiguation_types = None
@@ -699,7 +706,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
         self._discovery_info = discovery_info
-        self.context["title_placeholders"] = {"name": discovery_info.name or discovery_info.address}
+        self._set_device_title_placeholders(discovery_info.name, discovery_info.address)
 
         # Check if disambiguation is needed (low confidence with alternatives)
         if self._prepare_disambiguation(detection_result):
@@ -765,7 +772,8 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 }
             ),
             description_placeholders={
-                "name": self._discovery_info.name or self._discovery_info.address,
+                "name": self._discovery_info.name or "Unknown",
+                "address": self._discovery_info.address.upper(),
             },
         )
 
@@ -1101,7 +1109,8 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # Build description placeholders with optional ambiguity warning
         description_placeholders = {
-            "name": self._discovery_info.name or self._discovery_info.address,
+            "name": self._discovery_info.name or "Unknown",
+            "address": self._discovery_info.address.upper(),
         }
 
         # Add detection confidence info for ambiguous cases
@@ -1198,6 +1207,9 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured()
 
             self._discovery_info = self._discovered_devices[address]
+            self._set_device_title_placeholders(
+                self._discovery_info.name, self._discovery_info.address
+            )
             return await self.async_step_bluetooth_confirm()
 
         # Discover devices
@@ -1423,6 +1435,9 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured()
 
             self._discovery_info = self._all_ble_devices[address]
+            self._set_device_title_placeholders(
+                self._discovery_info.name, self._discovery_info.address
+            )
             return await self.async_step_manual_config()
 
         # Get ALL BLE devices (not just beds)
@@ -1791,6 +1806,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
 
                     await self.async_set_unique_id(address)
                     self._abort_if_unique_id_configured()
+                    self._set_device_title_placeholders(user_input.get(CONF_NAME), address)
 
                     _LOGGER.info(
                         "Manual bed configuration: address=%s, type=%s, variant=%s, name=%s, motors=%s, massage=%s, disable_angle_sensing=%s, adapter=%s, pulse_count=%s, pulse_delay=%s",

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "{name} ({address})",
     "step": {
       "user": {
         "title": "Select Adjustable Bed",
@@ -30,7 +31,7 @@
       },
       "bluetooth_disambiguate": {
         "title": "Select Bed Type",
-        "description": "Multiple bed types use the same Bluetooth identifier as **{name}**.\n\nSelect which type matches your bed:",
+        "description": "Multiple bed types use the same Bluetooth identifier as **{name} ({address})**.\n\nSelect which type matches your bed:",
         "data": {
           "bed_type_choice": "Bed type",
           "show_all_option": "Show all bed types..."
@@ -41,7 +42,7 @@
       },
       "bluetooth_confirm": {
         "title": "Confirm Adjustable Bed",
-        "description": "Do you want to set up {name}?\n{detection_note}\n\n{report_note}",
+        "description": "Do you want to set up {name} ({address})?\n{detection_note}\n\n{report_note}",
         "data": {
           "bed_type": "Bed type",
           "name": "Name",

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "flow_title": "{name} ({address})",
     "step": {
       "user": {
         "title": "Select Adjustable Bed",
@@ -30,7 +31,7 @@
       },
       "bluetooth_disambiguate": {
         "title": "Select Bed Type",
-        "description": "Multiple bed types use the same Bluetooth identifier as **{name}**.\n\nSelect which type matches your bed:",
+        "description": "Multiple bed types use the same Bluetooth identifier as **{name} ({address})**.\n\nSelect which type matches your bed:",
         "data": {
           "bed_type_choice": "Bed type",
           "show_all_option": "Show all bed types..."
@@ -41,7 +42,7 @@
       },
       "bluetooth_confirm": {
         "title": "Confirm Adjustable Bed",
-        "description": "Do you want to set up {name}?\n{detection_note}\n\n{report_note}",
+        "description": "Do you want to set up {name} ({address})?\n{detection_note}\n\n{report_note}",
         "data": {
           "bed_type": "Bed type",
           "name": "Name",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from copy import copy
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -781,6 +782,40 @@ class TestPinValidation:
 class TestBluetoothDiscoveryFlow:
     """Test Bluetooth discovery flow."""
 
+    async def test_bluetooth_discovery_identical_names_include_address(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info: BluetoothServiceInfoBleak,
+        enable_custom_integrations,
+    ):
+        """Discovery cards and confirmation distinguish beds with identical names."""
+        raw_addresses = ("aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02")
+        discovered_titles: list[dict[str, str]] = []
+
+        for raw_address in raw_addresses:
+            service_info = copy(mock_bluetooth_service_info)
+            service_info.name = "LP BED CONTROL"
+            service_info.address = raw_address
+
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_BLUETOOTH},
+                data=service_info,
+            )
+
+            address = raw_address.upper()
+            progress = hass.config_entries.flow.async_get(result["flow_id"])
+            title_placeholders = progress["context"]["title_placeholders"]
+            discovered_titles.append(title_placeholders)
+            assert title_placeholders == {
+                "name": "LP BED CONTROL",
+                "address": address,
+            }
+            assert result["description_placeholders"]["name"] == "LP BED CONTROL"
+            assert result["description_placeholders"]["address"] == address
+
+        assert discovered_titles[0] != discovered_titles[1]
+
     async def test_bluetooth_discovery_creates_entry(
         self,
         hass: HomeAssistant,
@@ -1235,6 +1270,8 @@ class TestBluetoothDiscoveryFlow:
         enable_custom_integrations,
     ):
         """Test that ambiguous BLE detection shows disambiguation step."""
+        raw_address = mock_bluetooth_service_info_ambiguous_okin.address.lower()
+        mock_bluetooth_service_info_ambiguous_okin.address = raw_address
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_BLUETOOTH},
@@ -1244,6 +1281,7 @@ class TestBluetoothDiscoveryFlow:
         # Should show disambiguation form instead of confirm
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "bluetooth_disambiguate"
+        assert result["description_placeholders"]["address"] == raw_address.upper()
 
     async def test_bluetooth_discovery_name_only_okin_receiver_shows_disambiguation(
         self,


### PR DESCRIPTION
## Summary

- label Bluetooth discovery cards with the advertised name and normalized MAC address
- keep the MAC address visible in confirmation, disambiguation, and selected-device setup flows
- add focused config-flow coverage for two identically named LP BED CONTROL devices

Ref #368

## Validation

- uv run pytest tests/test_config_flow.py -q (118 passed)
- uvx ruff check custom_components/adjustable_bed/config_flow.py tests/test_config_flow.py
- uvx pyright custom_components/adjustable_bed/config_flow.py tests/test_config_flow.py
- crq preflight --type uncommitted (clean)

<!-- crq:skip-autoreview -->