### PR TITLE
Record OCTO commands in support bundles

### DIFF
--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -297,6 +297,10 @@ class BedController(ABC):
         This is the BLE characteristic that accepts motor/preset commands.
         """
 
+    def _format_command_trace_payload(self, command: bytes) -> dict[str, Any] | None:
+        """Return a safe diagnostic representation of a command."""
+        return format_payload(command)
+
     async def _write_gatt_with_retry(
         self,
         char_uuid: str,
@@ -339,12 +343,14 @@ class BedController(ABC):
             raise ConnectionError("Not connected to bed")
 
         effective_cancel = cancel_event or self._coordinator.cancel_command
+        payload = self._format_command_trace_payload(command)
+        logged_command = str(payload.get("hex", "**REDACTED**")) if payload else "**REDACTED**"
 
         _LOGGER.debug(
             "GATT write to %s (%s): %s (response=%s, repeat=%d, delay=%dms)",
             self._coordinator.address,
             char_uuid,
-            command.hex(),
+            logged_command,
             response,
             repeat_count,
             repeat_delay_ms,
@@ -365,7 +371,6 @@ class BedController(ABC):
         if caller_frame is not None and caller_frame.f_back is not None:
             command_origin = caller_frame.f_back.f_code.co_name
 
-        payload = format_payload(command)
         if payload is not None:
             self._coordinator.record_command_trace(
                 payload=payload,
@@ -396,13 +401,13 @@ class BedController(ABC):
                 if log_errors:
                     _LOGGER.exception(
                         "Failed to write command %s to %s",
-                        command.hex(),
+                        logged_command,
                         char_uuid,
                     )
                 else:
                     _LOGGER.debug(
                         "Suppressed write failure for %s to %s",
-                        command.hex(),
+                        logged_command,
                         char_uuid,
                         exc_info=True,
                     )

--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -68,6 +68,8 @@ class BedController(ABC):
     - massage_* methods
     """
 
+    _write_with_response: bool = True
+
     def __init__(self, coordinator: AdjustableBedCoordinator) -> None:
         """Initialize the controller.
 
@@ -419,9 +421,9 @@ class BedController(ABC):
         """Write a command to the bed.
 
         Default implementation delegates to _write_gatt_with_retry() using
-        the control_characteristic_uuid. Subclasses with custom write behavior
-        (init sequences, handle-based writes, custom error handling) should
-        override this method.
+        the control_characteristic_uuid and configured GATT response mode.
+        Subclasses with custom write behavior (init sequences, handle-based
+        writes, custom error handling) should override this method.
 
         Args:
             command: The command bytes to send (protocol-specific format)
@@ -442,6 +444,7 @@ class BedController(ABC):
             repeat_count=repeat_count,
             repeat_delay_ms=repeat_delay_ms,
             cancel_event=cancel_event,
+            response=self._write_with_response,
         )
 
     async def start_notify(self, callback: Callable[[str, float], None] | None = None) -> None:

--- a/custom_components/adjustable_bed/beds/octo.py
+++ b/custom_components/adjustable_bed/beds/octo.py
@@ -84,6 +84,8 @@ OCTO_UNESCAPE_MAP: dict[int, int] = {v: k for k, v in OCTO_ESCAPE_MAP.items()}
 class OctoController(BedController):
     """Controller for Octo beds."""
 
+    _write_with_response = False
+
     def __init__(self, coordinator: AdjustableBedCoordinator, pin: str = "") -> None:
         """Initialize the Octo controller.
 
@@ -434,43 +436,6 @@ class OctoController(BedController):
                             "Drivemode set acknowledged: %s",
                             "sync" if self._synchro_active else "single",
                         )
-
-    async def write_command(
-        self,
-        command: bytes,
-        repeat_count: int = 1,
-        repeat_delay_ms: int = 100,
-        cancel_event: asyncio.Event | None = None,
-    ) -> None:
-        """Write a command to the bed."""
-        if self.client is None or not self.client.is_connected:
-            _LOGGER.error("Cannot write command: BLE client not connected")
-            raise ConnectionError("Not connected to bed")
-
-        effective_cancel = cancel_event or self._coordinator.cancel_command
-
-        _LOGGER.debug(
-            "Writing command to Octo bed (%s): %s (repeat: %d, delay: %dms, response=False)",
-            OCTO_CHAR_UUID,
-            command.hex(),
-            repeat_count,
-            repeat_delay_ms,
-        )
-
-        for i in range(repeat_count):
-            if effective_cancel is not None and effective_cancel.is_set():
-                _LOGGER.info("Command cancelled after %d/%d writes", i, repeat_count)
-                return
-
-            try:
-                async with self._ble_lock:
-                    await self.client.write_gatt_char(OCTO_CHAR_UUID, command, response=False)
-            except BleakError:
-                _LOGGER.exception("Failed to write command")
-                raise
-
-            if i < repeat_count - 1:
-                await asyncio.sleep(repeat_delay_ms / 1000)
 
     async def _write_octo_command(
         self,
@@ -1208,6 +1173,8 @@ class OctoStar2Controller(BedController):
     - Packet format: starts with 0x68, ends with 0x16
     """
 
+    _write_with_response = False
+
     # Star2 fixed command bytes
     # Protocol reverse-engineered by goedh452
     # (https://community.home-assistant.io/t/how-to-setup-esphome-to-control-my-bluetooth-controlled-octocontrol-bed/540790/10)
@@ -1265,43 +1232,6 @@ class OctoStar2Controller(BedController):
     def control_characteristic_uuid(self) -> str:
         """Return the UUID of the control characteristic."""
         return OCTO_STAR2_CHAR_UUID
-
-    async def write_command(
-        self,
-        command: bytes,
-        repeat_count: int = 1,
-        repeat_delay_ms: int = 100,
-        cancel_event: asyncio.Event | None = None,
-    ) -> None:
-        """Write a command to the bed."""
-        if self.client is None or not self.client.is_connected:
-            _LOGGER.error("Cannot write command: BLE client not connected")
-            raise ConnectionError("Not connected to bed")
-
-        effective_cancel = cancel_event or self._coordinator.cancel_command
-
-        _LOGGER.debug(
-            "Writing command to Octo Star2 bed (%s): %s (repeat: %d, delay: %dms, response=False)",
-            OCTO_STAR2_CHAR_UUID,
-            command.hex(),
-            repeat_count,
-            repeat_delay_ms,
-        )
-
-        for i in range(repeat_count):
-            if effective_cancel is not None and effective_cancel.is_set():
-                _LOGGER.info("Command cancelled after %d/%d writes", i, repeat_count)
-                return
-
-            try:
-                async with self._ble_lock:
-                    await self.client.write_gatt_char(OCTO_STAR2_CHAR_UUID, command, response=False)
-            except BleakError:
-                _LOGGER.exception("Failed to write command")
-                raise
-
-            if i < repeat_count - 1:
-                await asyncio.sleep(repeat_delay_ms / 1000)
 
     async def start_notify(self, callback: Callable[[str, float], None] | None = None) -> None:
         """Start listening for notifications.

--- a/custom_components/adjustable_bed/beds/octo.py
+++ b/custom_components/adjustable_bed/beds/octo.py
@@ -199,6 +199,16 @@ class OctoController(BedController):
         # Build final packet with unescaped delimiters
         return bytes([OCTO_PACKET_CHAR, *escaped_payload, OCTO_PACKET_CHAR])
 
+    def _format_command_trace_payload(self, command: bytes) -> dict[str, object] | None:
+        """Redact PIN authentication packets from logs and support bundles."""
+        if command[:3] == bytes((OCTO_PACKET_CHAR, 0x20, 0x43)):
+            return {
+                "hex": "**REDACTED**",
+                "length": len(command),
+                "ascii_preview": None,
+            }
+        return super()._format_command_trace_payload(command)
+
     def _parse_response_packet(self, message: bytes) -> dict[str, list[int]] | None:
         """Parse a response packet from the bed.
 

--- a/tests/test_octo.py
+++ b/tests/test_octo.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -353,6 +354,45 @@ class TestOctoPinAuth:
         await controller.send_pin()
 
         mock_bleak_client.write_gatt_char.assert_not_called()
+
+    async def test_send_pin_redacts_command_diagnostics(
+        self,
+        hass: HomeAssistant,
+        mock_octo_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """PIN packets should be written but redacted from traces and logs."""
+        coordinator = AdjustableBedCoordinator(hass, mock_octo_config_entry)
+        await coordinator.async_connect()
+
+        controller = cast(OctoController, coordinator.controller)
+        controller._has_pin = True
+        controller._pin_locked = True
+        coordinator._command_trace.clear()
+        mock_bleak_client.write_gatt_char.reset_mock()
+        caplog.set_level(logging.DEBUG, logger="custom_components.adjustable_bed.beds.base")
+        caplog.clear()
+
+        await coordinator.async_execute_controller_command(
+            lambda active: cast(OctoController, active).send_pin()
+        )
+
+        expected_packet = controller._build_packet([0x20, 0x43], [1, 2, 3, 4])
+        mock_bleak_client.write_gatt_char.assert_called_once_with(
+            OCTO_CHAR_UUID,
+            expected_packet,
+            response=False,
+        )
+        assert len(coordinator.command_trace) == 1
+        assert coordinator.command_trace[0]["payload"] == {
+            "hex": "**REDACTED**",
+            "length": len(expected_packet),
+            "ascii_preview": None,
+        }
+        assert expected_packet.hex() not in caplog.text
+        assert "**REDACTED**" in caplog.text
 
 
 class TestOctoCommands:

--- a/tests/test_octo.py
+++ b/tests/test_octo.py
@@ -35,6 +35,7 @@ from custom_components.adjustable_bed.const import (
     CONF_PROTOCOL_VARIANT,
     DOMAIN,
     OCTO_CHAR_UUID,
+    OCTO_STAR2_CHAR_UUID,
     OCTO_VARIANT_STANDARD,
     OCTO_VARIANT_STAR2,
 )
@@ -454,6 +455,53 @@ class TestOctoCommands:
 
         assert calls[0][0][1] == move_packet
         assert calls[-1][0][1] == stop_packet
+
+    async def test_standard_commands_are_recorded_for_support_bundles(
+        self,
+        hass: HomeAssistant,
+        mock_octo_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Standard OCTO movement writes should appear in command traces."""
+        coordinator = AdjustableBedCoordinator(hass, mock_octo_config_entry)
+        await coordinator.async_connect()
+        coordinator._command_trace.clear()
+
+        controller = cast(OctoController, coordinator.controller)
+        await coordinator.async_execute_controller_command(lambda active: active.move_head_up())
+
+        move_packet = controller._build_packet([0x02, 0x70], [OCTO_MOTOR_HEAD])
+        stop_packet = controller._build_packet([0x02, 0x73])
+        trace = coordinator.command_trace
+
+        assert [entry["payload"]["hex"] for entry in trace] == [
+            move_packet.hex(),
+            stop_packet.hex(),
+        ]
+        assert all(entry["characteristic_uuid"] == OCTO_CHAR_UUID for entry in trace)
+        assert all(entry["write_mode"] == "without_response" for entry in trace)
+        assert all(entry["operation_name"] == "command" for entry in trace)
+
+    async def test_star2_commands_are_recorded_for_support_bundles(
+        self,
+        hass: HomeAssistant,
+        mock_octo_star2_config_entry,
+        mock_coordinator_connected,
+    ):
+        """Star2 movement writes should appear in command traces."""
+        coordinator = AdjustableBedCoordinator(hass, mock_octo_star2_config_entry)
+        await coordinator.async_connect()
+        coordinator._command_trace.clear()
+
+        controller = cast(OctoStar2Controller, coordinator.controller)
+        await coordinator.async_execute_controller_command(lambda active: active.move_head_up())
+
+        assert len(coordinator.command_trace) == 1
+        trace = coordinator.command_trace[0]
+        assert trace["payload"]["hex"] == controller.CMD_HEAD_UP.hex()
+        assert trace["characteristic_uuid"] == OCTO_STAR2_CHAR_UUID
+        assert trace["write_mode"] == "without_response"
+        assert trace["operation_name"] == "command"
 
     async def test_move_with_stop_sends_stop_on_error(
         self,


### PR DESCRIPTION
## Summary

- route default controller writes through a configurable GATT response mode
- remove the duplicate Standard OCTO and Star2 BLE write loops
- record OCTO movement and STOP packets in support-bundle command traces
- add regression coverage for both OCTO protocol variants

## Root cause

The OCTO controllers implemented their own BLE write loops instead of using the shared `BedController` writer. Those loops preserved write-without-response behavior, but bypassed the command-trace recorder used by support bundles.

## Validation

- `uvx ruff@0.15.16 check custom_components tests`
- `uvx pyright@1.1.410 custom_components tests`
- `uv run mypy --explicit-package-bases custom_components/adjustable_bed/beds/base.py custom_components/adjustable_bed/beds/octo.py`
- `uv run pytest -n 8` (2,441 passed)
- `crq preflight --type uncommitted` (clean, zero findings)

Ref #440

<!-- crq:skip-autoreview -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command delivery for OCTO and OCTO Star2 adjustable beds by using the appropriate Bluetooth write mode.
  * Centralized command handling to provide more consistent behavior and reliability.

* **Improvements**
  * Added command trace recording for support bundles, including head movement and stop commands.
  * Improved diagnostic details for Star2 bed commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->