### PR TITLE
Restore MotoSleep Panel Eight light toggle

### DIFF
--- a/custom_components/adjustable_bed/beds/motosleep_profiles.py
+++ b/custom_components/adjustable_bed/beds/motosleep_profiles.py
@@ -154,13 +154,20 @@ def _power_bob_profile(profile_id: str) -> MotoSleepProfile:
         commands=_POWER_BOB_COMMANDS[profile_id],
         explicit_stop=explicit_stop,
         # Settings always routes to PanelRGB. Character 10 selects its Mood or
-        # Night configuration independently of the root motor panel.
+        # Night configuration independently of the root motor panel. This proves
+        # app reachability; user-confirmed hardware exceptions are narrowed below.
         rgb_light=True,
     )
     if profile_id == "eight":
         # MotoSleep's PanelEight sends $O for Home, and issue #468 confirms it
         # on a short-name HHC bed that otherwise follows Power Bob routing.
-        profile = replace(profile, presets=_frozen({**profile.presets, "flat": "O"}))
+        # The same hardware uses PanelEight's $A light toggle; issue #470
+        # confirms that the separate generic PanelRGB controls do not apply.
+        profile = replace(
+            profile,
+            presets=_frozen({**profile.presets, "flat": "O"}),
+            rgb_light=False,
+        )
     return profile
 
 

--- a/docs/beds/motosleep.md
+++ b/docs/beds/motosleep.md
@@ -56,6 +56,9 @@ index 8 and `5` at index 9, which selects the Power Bob A15 panel.
   user-confirmed device uses this shared command, matching the reachable
   MotoSleep 5.1.5 PanelEight action even though Power Bob 2.0.3 does not render
   that action on its separate Panel Eight.
+- The same user-confirmed Panel Eight hardware exposes its under-bed light as
+  the root `$A` toggle. It does not support the generic Power Bob RGB settings,
+  so Home Assistant keeps the toggle button and does not expose RGB controls.
 - Unmatched Power Bob selectors and malformed MOTO names receive no speculative
   controls. Legacy manual configurations without a usable advertised name keep
   a conservative two-axis fallback; current long HHC names retain the app's
@@ -138,10 +141,12 @@ Power Bob places selector before value; MotoSleep places value before selector.
 Both XOR the decimal digits and append a five-digit decimal checksum plus
 `R\r`.
 
-Power Bob RGB settings are independent of the selected root motor panel.
-Advertised-name character 10 selects the Mood configuration when it is `D` and
-the Night configuration otherwise, so even minimal one-motor panels retain RGB
-settings when their root controls do not include the raw `$A` light toggle.
+The Power Bob app's RGB settings route is independent of the selected root
+motor panel. Advertised-name character 10 selects the Mood configuration when
+it is `D` and the Night configuration otherwise. Reachability in the generic
+settings UI does not by itself prove the connected hardware implements those
+numeric commands: the user-confirmed Panel Eight compatibility profile supports
+only its root `$A` light toggle.
 
 ## MOTO binary protocol
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -20,6 +20,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_LEGGETT_GEN2,
     BED_TYPE_MALOUF_LEGACY_OKIN,
     BED_TYPE_MALOUF_NEW_OKIN,
+    BED_TYPE_MOTOSLEEP,
     BED_TYPE_OCTO,
     BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_RF_ECO_BT,
@@ -1677,6 +1678,60 @@ class TestSwitchEntities:
 
 class TestLightEntities:
     """Test light entities."""
+
+    async def test_motosleep_panel_eight_restores_toggle_button(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        mock_async_ble_device_from_address,
+        enable_custom_integrations,
+    ):
+        """PanelEight should remove its stale RGB light and restore the toggle button."""
+        address = "AA:BB:CC:DD:EE:70"
+        device_name = "HHC0120182CDEH"
+        mock_async_ble_device_from_address.return_value.name = device_name
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="MotoSleep Panel Eight",
+            data={
+                CONF_ADDRESS: address,
+                CONF_NAME: device_name,
+                CONF_BED_TYPE: BED_TYPE_MOTOSLEEP,
+                CONF_PROTOCOL_VARIANT: "auto",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=address,
+            entry_id="motosleep_panel_eight_toggle_light_entry",
+        )
+        entry.add_to_hass(hass)
+
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        registry.async_get_or_create(
+            "light",
+            DOMAIN,
+            f"{address}_under_bed_lights",
+            config_entry=entry,
+            suggested_object_id="motosleep_panel_eight_under_bed_lights",
+        )
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        assert coordinator.controller.profile.profile_id == "power_bob_eight"
+        assert (
+            registry.async_get_entity_id("light", DOMAIN, f"{address}_under_bed_lights")
+            is None
+        )
+        assert (
+            registry.async_get_entity_id("button", DOMAIN, f"{address}_toggle_light")
+            is not None
+        )
 
     async def test_richmat_qrrm_light_entity_created_and_toggle_button_removed(
         self,

--- a/tests/test_motosleep.py
+++ b/tests/test_motosleep.py
@@ -78,6 +78,25 @@ async def test_issue_468_short_panel_eight_keeps_home_preset() -> None:
     )
 
 
+async def test_issue_470_short_panel_eight_keeps_toggle_only_light() -> None:
+    """The reported PanelEight bed uses its root light toggle, not generic RGB."""
+    controller, client = _controller("HHC0120182CDEH")
+
+    assert controller.profile.profile_id == "power_bob_eight"
+    assert controller.profile.light_toggle == "A"
+    assert controller.profile.rgb_light is False
+    assert controller.supports_lights is True
+    assert controller.supports_light_toggle_control is True
+    assert controller.supports_light_color_control is False
+    assert controller.supports_discrete_light_control is False
+
+    await controller.lights_toggle()
+
+    client.write_gatt_char.assert_awaited_once_with(
+        MOTOSLEEP_CHAR_UUID, b"$A", response=False
+    )
+
+
 def test_power_bob_accepts_exact_length_name_containing_hhc() -> None:
     """Power Bob filters for a case-sensitive HHC substring, not a prefix."""
     profile = resolve_motosleep_profile("XXHHC000150000")


### PR DESCRIPTION
## Summary

- restore the `$A` toggle-only under-bed light for the user-confirmed MotoSleep Panel Eight profile
- remove the stale RGB light entity during setup and allow the light toggle button to return
- document the hardware-specific exception and cover both command routing and entity migration

## Root cause and APK evidence

Commit `28a3c2c8` enabled `rgb_light=True` for every Power Bob profile after finding that Power Bob 2.0.3 always exposes a generic PanelRGB settings route. That made Home Assistant replace the existing toggle button with an RGB light entity.

A comparison decompilation of the accepted frozen Power Bob 2.0.3 artifact (`134568e8bbdc3a6794eb12e3452abec74957924824d8c24c0b1479af4f90ab31`) confirms that Panel Eight sends the root `$A` light command, while the numeric RGB selectors live in a separate generic settings screen. Issues #51 and #470 provide hardware evidence from the same `HHC0120182CDEH` device that `$A` works and the RGB path does not.

## Adjacent audit

I reviewed the complete MotoSleep and Power Bob profile capability matrix, the APK-derived routes, and related hardware reports. RGB is the only Power Bob capability inherited from a generic settings route rather than the selected root panel. No other profile has contradictory real-hardware evidence, so this keeps the exception scoped to Panel Eight instead of guessing about unreported models.

## Validation

- `uv run pytest -q`: 2442 passed
- focused MotoSleep and entity migration tests: 99 passed
- Ruff: passed
- Pyright: 0 errors

Ref #470