### PR TITLE
Let controllers own their capabilities instead of the entity platforms

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -4,18 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable, Coroutine
-from typing import TYPE_CHECKING, Any, cast
 
-if TYPE_CHECKING:
-    from .beds.base import BedController
-
-import voluptuous as vol
 from homeassistant.components import bluetooth
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ADDRESS, CONF_DEVICE_ID, Platform
-from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
+from homeassistant.const import CONF_ADDRESS, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import ConfigType
@@ -23,14 +17,9 @@ from homeassistant.helpers.typing import ConfigType
 from .const import (
     BED_TYPE_BEDTECH,
     BED_TYPE_DIAGNOSTIC,
-    BED_TYPE_ERGOMOTION,
     BED_TYPE_KAIDI,
-    BED_TYPE_KEESON,
-    BED_TYPE_OKIN_CST,
     BED_TYPE_RICHMAT,
-    BED_TYPE_SLEEPYS_BOX25,
     BED_TYPE_VIBRADORM,
-    BEDS_WITH_POSITION_FEEDBACK,
     BEDTECH_MANUFACTURER_ID,
     BEDTECH_SERVICE_UUID,
     CONF_BED_TYPE,
@@ -47,58 +36,70 @@ from .const import (
     CONF_MOTOR_COUNT,
     CONF_PROTOCOL_VARIANT,
     CONF_RICHMAT_REMOTE,
-    DEFAULT_MOTOR_COUNT,
     DOMAIN,
-    KEESON_VARIANT_ERGOMOTION,
-    OKIN_CST_POSITION_AXES,
     VARIANT_AUTO,
     connection_gated_by_bond,
     requires_pairing,
 )
 from .coordinator import AdjustableBedCoordinator
 from .kaidi_metadata import add_kaidi_entry_metadata, resolve_kaidi_advertisement
+from .services import (
+    ATTR_CAPTURE_DURATION,
+    ATTR_DIRECTION,
+    ATTR_DURATION_MS,
+    ATTR_INCLUDE_LOGS,
+    ATTR_MOTOR,
+    ATTR_POSITION,
+    ATTR_PRESET,
+    ATTR_TARGET_ADDRESS,
+    DEFAULT_CAPTURE_DURATION,
+    MAX_CAPTURE_DURATION,
+    MAX_TIMED_MOVE_DURATION_MS,
+    MIN_CAPTURE_DURATION,
+    MIN_TIMED_MOVE_DURATION_MS,
+    SERVICE_GENERATE_SUPPORT_BUNDLE,
+    SERVICE_GOTO_PRESET,
+    SERVICE_SAVE_PRESET,
+    SERVICE_SET_POSITION,
+    SERVICE_STOP_ALL,
+    SERVICE_TIMED_MOVE,
+    TIMED_MOVE_MOTOR_OPTIONS,
+    async_register_services,
+)
 from .unsupported import (
     async_clear_unsupported_device_issues,
     create_pairing_required_issue,
 )
 
+# Re-exported for backwards compatibility: these moved to .services, but are
+# imported from the package root by tests and by downstream automations.
+__all__ = [
+    "ATTR_CAPTURE_DURATION",
+    "ATTR_DIRECTION",
+    "ATTR_DURATION_MS",
+    "ATTR_INCLUDE_LOGS",
+    "ATTR_MOTOR",
+    "ATTR_POSITION",
+    "ATTR_PRESET",
+    "ATTR_TARGET_ADDRESS",
+    "DEFAULT_CAPTURE_DURATION",
+    "MAX_CAPTURE_DURATION",
+    "MAX_TIMED_MOVE_DURATION_MS",
+    "MIN_CAPTURE_DURATION",
+    "MIN_TIMED_MOVE_DURATION_MS",
+    "SERVICE_GENERATE_SUPPORT_BUNDLE",
+    "SERVICE_GOTO_PRESET",
+    "SERVICE_SAVE_PRESET",
+    "SERVICE_SET_POSITION",
+    "SERVICE_STOP_ALL",
+    "SERVICE_TIMED_MOVE",
+    "TIMED_MOVE_MOTOR_OPTIONS",
+    "async_setup",
+    "async_setup_entry",
+    "async_unload_entry",
+]
+
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
-
-# Service constants
-SERVICE_GOTO_PRESET = "goto_preset"
-SERVICE_GENERATE_SUPPORT_BUNDLE = "generate_support_bundle"
-SERVICE_SAVE_PRESET = "save_preset"
-SERVICE_SET_POSITION = "set_position"
-SERVICE_STOP_ALL = "stop_all"
-SERVICE_TIMED_MOVE = "timed_move"
-ATTR_PRESET = "preset"
-ATTR_MOTOR = "motor"
-ATTR_POSITION = "position"
-ATTR_TARGET_ADDRESS = "target_address"
-ATTR_CAPTURE_DURATION = "capture_duration"
-ATTR_INCLUDE_LOGS = "include_logs"
-ATTR_DIRECTION = "direction"
-ATTR_DURATION_MS = "duration_ms"
-TIMED_MOVE_MOTOR_OPTIONS = (
-    "tv_lift",
-    "back",
-    "legs",
-    "head",
-    "feet",
-    "tilt",
-    "lumbar",
-    "bed_height",
-    "stair",
-)
-
-# Default capture duration for diagnostics (seconds)
-DEFAULT_CAPTURE_DURATION = 120
-MIN_CAPTURE_DURATION = 10
-MAX_CAPTURE_DURATION = 300
-
-# Timed move duration limits (milliseconds)
-MIN_TIMED_MOVE_DURATION_MS = 100
-MAX_TIMED_MOVE_DURATION_MS = 30000  # 30 seconds max
 
 # Timeout for initial connection at startup.
 # Must cover a full connection retry cycle: up to 3 attempts of ~30s each plus
@@ -138,7 +139,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     await async_register_frontend(hass)
 
-    await _async_register_services(hass)
+    await async_register_services(hass)
     return True
 
 
@@ -293,7 +294,7 @@ async def _async_setup_offline_diagnostic_entry(
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Adjustable Bed from a config entry."""
     hass.data.setdefault(DOMAIN, {})
-    await _async_register_services(hass)
+    await async_register_services(hass)
 
     await _async_maybe_reclassify_bedtech_qrrm_entry(hass, entry)
     _maybe_cache_kaidi_metadata(hass, entry)
@@ -529,760 +530,6 @@ async def _async_maybe_reclassify_bedtech_qrrm_entry(
         device_name,
         BEDTECH_MANUFACTURER_ID,
     )
-
-
-async def _async_register_services(hass: HomeAssistant) -> None:
-    """Register Adjustable Bed services."""
-    if hass.services.has_service(DOMAIN, SERVICE_GOTO_PRESET):
-        return  # Services already registered
-
-    async def _get_coordinator_from_device(
-        hass: HomeAssistant, device_id: str
-    ) -> AdjustableBedCoordinator | None:
-        """Get coordinator from device ID."""
-        device_registry = dr.async_get(hass)
-        device = device_registry.async_get(device_id)
-        if not device:
-            return None
-
-        for entry_id in device.config_entries:
-            if entry_id in hass.data.get(DOMAIN, {}):
-                return cast(AdjustableBedCoordinator, hass.data[DOMAIN][entry_id])
-        return None
-
-    def _get_support_bundle_target_from_device(
-        hass: HomeAssistant, device_id: str
-    ) -> tuple[str, AdjustableBedCoordinator | None, ConfigEntry] | None:
-        """Resolve support-bundle target details from a device registry ID."""
-        device_registry = dr.async_get(hass)
-        device = device_registry.async_get(device_id)
-        if not device:
-            return None
-
-        for entry_id in device.config_entries:
-            entry = hass.config_entries.async_get_entry(entry_id)
-            if entry is None or entry.domain != DOMAIN:
-                continue
-
-            address = entry.data.get(CONF_ADDRESS)
-            if not isinstance(address, str):
-                continue
-
-            coordinator = cast(AdjustableBedCoordinator | None, hass.data.get(DOMAIN, {}).get(entry_id))
-            return address, coordinator, entry
-
-        return None
-
-    async def _get_controller_for_service(
-        coordinator: AdjustableBedCoordinator,
-    ) -> BedController:
-        """Return an active controller for service validation/execution.
-
-        Service calls may arrive while the coordinator is idle-disconnected and
-        controller is None. Reconnect first so capability checks don't fail with
-        a false "not supported" error.
-        """
-        controller = coordinator.controller
-        if controller is not None:
-            return controller
-
-        _LOGGER.debug(
-            "No active controller for %s during service call; attempting reconnect",
-            coordinator.name,
-        )
-        connected = await coordinator.async_ensure_connected(reset_timer=False)
-        controller = coordinator.controller
-        if not connected or controller is None:
-            raise ServiceValidationError(
-                f"Device '{coordinator.name}' is currently unavailable (unable to connect)",
-            )
-        return controller
-
-    async def handle_goto_preset(call: ServiceCall) -> None:
-        """Handle goto_preset service call."""
-        preset = call.data[ATTR_PRESET]
-        device_ids = call.data.get(CONF_DEVICE_ID, [])
-
-        _LOGGER.info("Service goto_preset called: preset=%d", preset)
-
-        for device_id in device_ids:
-            coordinator = await _get_coordinator_from_device(hass, device_id)
-            if coordinator:
-                # Check if controller supports memory presets
-                controller = await _get_controller_for_service(coordinator)
-                if not getattr(controller, "supports_memory_presets", False):
-                    raise ServiceValidationError(
-                        f"Device '{coordinator.name}' does not support memory presets",
-                        translation_domain=DOMAIN,
-                        translation_key="memory_presets_not_supported",
-                        translation_placeholders={"device_name": coordinator.name},
-                    )
-                # Validate preset against controller's memory slot count
-                slot_count = getattr(controller, "memory_slot_count", 4)
-                if preset > slot_count:
-                    raise ServiceValidationError(
-                        f"Device '{coordinator.name}' only supports memory presets 1-{slot_count}. "
-                        f"Preset {preset} is not available for this bed type.",
-                        translation_domain=DOMAIN,
-                        translation_key="invalid_preset_number",
-                        translation_placeholders={
-                            "device_name": coordinator.name,
-                            "max_preset": str(slot_count),
-                            "requested_preset": str(preset),
-                        },
-                    )
-                await coordinator.async_execute_controller_command(
-                    lambda ctrl, p=preset: ctrl.preset_memory(p)  # type: ignore[misc]
-                )
-            else:
-                raise ServiceValidationError(
-                    f"Could not find Adjustable Bed device with ID {device_id}",
-                    translation_domain=DOMAIN,
-                    translation_key="device_not_found",
-                    translation_placeholders={"device_id": device_id},
-                )
-
-    async def handle_save_preset(call: ServiceCall) -> None:
-        """Handle save_preset service call."""
-        preset = call.data[ATTR_PRESET]
-        device_ids = call.data.get(CONF_DEVICE_ID, [])
-
-        _LOGGER.info("Service save_preset called: preset=%d", preset)
-
-        for device_id in device_ids:
-            coordinator = await _get_coordinator_from_device(hass, device_id)
-            if coordinator:
-                # Check if controller supports programming memory presets
-                controller = await _get_controller_for_service(coordinator)
-                if not getattr(controller, "supports_memory_programming", False):
-                    raise ServiceValidationError(
-                        f"Device '{coordinator.name}' does not support programming memory presets",
-                        translation_domain=DOMAIN,
-                        translation_key="memory_programming_not_supported",
-                        translation_placeholders={"device_name": coordinator.name},
-                    )
-                # Validate preset against controller's memory slot count
-                slot_count = getattr(controller, "memory_slot_count", 4)
-                if preset > slot_count:
-                    raise ServiceValidationError(
-                        f"Device '{coordinator.name}' only supports memory presets 1-{slot_count}. "
-                        f"Preset {preset} is not available for this bed type.",
-                        translation_domain=DOMAIN,
-                        translation_key="invalid_preset_number",
-                        translation_placeholders={
-                            "device_name": coordinator.name,
-                            "max_preset": str(slot_count),
-                            "requested_preset": str(preset),
-                        },
-                    )
-                await coordinator.async_execute_controller_command(
-                    lambda ctrl, p=preset: ctrl.program_memory(p),  # type: ignore[misc]
-                    cancel_running=False,
-                )
-            else:
-                raise ServiceValidationError(
-                    f"Could not find Adjustable Bed device with ID {device_id}",
-                    translation_domain=DOMAIN,
-                    translation_key="device_not_found",
-                    translation_placeholders={"device_id": device_id},
-                )
-
-    async def handle_stop_all(call: ServiceCall) -> None:
-        """Handle stop_all service call."""
-        device_ids = call.data.get(CONF_DEVICE_ID, [])
-
-        _LOGGER.info("Service stop_all called")
-
-        missing_device_ids: list[str] = []
-
-        for device_id in device_ids:
-            coordinator = await _get_coordinator_from_device(hass, device_id)
-            if coordinator:
-                await coordinator.async_stop_command()
-            else:
-                missing_device_ids.append(device_id)
-
-        if missing_device_ids:
-            raise ServiceValidationError(
-                f"Could not find Adjustable Bed device(s) with ID(s): {', '.join(missing_device_ids)}",
-                translation_domain=DOMAIN,
-                translation_key="devices_not_found",
-                translation_placeholders={"device_ids": ", ".join(missing_device_ids)},
-            )
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_GOTO_PRESET,
-        handle_goto_preset,
-        schema=vol.Schema(
-            {
-                vol.Required(CONF_DEVICE_ID): cv.ensure_list,
-                vol.Required(ATTR_PRESET): vol.All(vol.Coerce(int), vol.Range(min=1)),
-            }
-        ),
-    )
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_SAVE_PRESET,
-        handle_save_preset,
-        schema=vol.Schema(
-            {
-                vol.Required(CONF_DEVICE_ID): cv.ensure_list,
-                vol.Required(ATTR_PRESET): vol.All(vol.Coerce(int), vol.Range(min=1)),
-            }
-        ),
-    )
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_STOP_ALL,
-        handle_stop_all,
-        schema=vol.Schema(
-            {
-                vol.Required(CONF_DEVICE_ID): cv.ensure_list,
-            }
-        ),
-    )
-
-    async def handle_set_position(call: ServiceCall) -> None:
-        """Handle set_position service call."""
-        device_ids = call.data.get(CONF_DEVICE_ID, [])
-        motor = call.data[ATTR_MOTOR]
-        position = call.data[ATTR_POSITION]
-
-        _LOGGER.info(
-            "Service set_position called: motor=%s, position=%.1f%%",
-            motor,
-            position,
-        )
-
-        for device_id in device_ids:
-            coordinator = await _get_coordinator_from_device(hass, device_id)
-            if not coordinator:
-                raise ServiceValidationError(
-                    f"Could not find Adjustable Bed device with ID {device_id}",
-                    translation_domain=DOMAIN,
-                    translation_key="device_not_found",
-                    translation_placeholders={"device_id": device_id},
-                )
-            controller = await _get_controller_for_service(coordinator)
-
-            # Get config entry for bed type and motor count
-            entry: ConfigEntry | None = None
-            for entry_id, coord in hass.data[DOMAIN].items():
-                if coord is coordinator:
-                    entry = hass.config_entries.async_get_entry(entry_id)
-                    break
-
-            if not entry:
-                raise ServiceValidationError(
-                    f"Could not find config entry for device {device_id}",
-                    translation_domain=DOMAIN,
-                    translation_key="device_not_found",
-                    translation_placeholders={"device_id": device_id},
-                )
-
-            bed_type = entry.data.get(CONF_BED_TYPE)
-            motor_count = entry.data.get(CONF_MOTOR_COUNT, DEFAULT_MOTOR_COUNT)
-            protocol_variant = entry.data.get(CONF_PROTOCOL_VARIANT)
-            supports_direct_position_control = bool(
-                getattr(controller, "supports_direct_position_control", False)
-            )
-
-            # Validate bed supports position feedback
-            # Special case: BED_TYPE_KEESON only supports position feedback with ergomotion variant
-            has_position_feedback = bed_type in BEDS_WITH_POSITION_FEEDBACK or (
-                bed_type == BED_TYPE_KEESON
-                and protocol_variant == KEESON_VARIANT_ERGOMOTION
-            )
-            if not has_position_feedback and not supports_direct_position_control:
-                raise ServiceValidationError(
-                    f"Device '{coordinator.name}' (type: {bed_type}) does not support position feedback",
-                    translation_domain=DOMAIN,
-                    translation_key="position_feedback_not_supported",
-                    translation_placeholders={
-                        "device_name": coordinator.name,
-                        "bed_type": bed_type or "unknown",
-                    },
-                )
-
-            # Validate angle sensing is enabled
-            if coordinator.disable_angle_sensing:
-                raise ServiceValidationError(
-                    f"Angle sensing is disabled for device '{coordinator.name}'",
-                    translation_domain=DOMAIN,
-                    translation_key="angle_sensing_disabled",
-                    translation_placeholders={"device_name": coordinator.name},
-                )
-
-            # Define motor configurations.
-            # For Keeson/Ergomotion: only head and feet are valid, they map to back/legs keys.
-            # For BOX25: only head and feet are valid, using direct percentage positions.
-            # For CST: only back and legs publish position feedback.
-            # For Kaidi: direct position writes expose back/legs percentage targets.
-            # For standard beds: based on motor_count (2=back/legs, 3=+head, 4=+feet).
-            uses_percentage_positions = bed_type in (
-                BED_TYPE_KEESON,
-                BED_TYPE_ERGOMOTION,
-                BED_TYPE_SLEEPYS_BOX25,
-            ) or (bed_type == BED_TYPE_KAIDI and supports_direct_position_control)
-
-            if bed_type == BED_TYPE_KAIDI and supports_direct_position_control:
-                valid_motors = {"back", "legs"}
-                motor_configs = {
-                    "back": {
-                        "position_key": "back",
-                        "move_up_fn": lambda ctrl: ctrl.move_back_up(),
-                        "move_down_fn": lambda ctrl: ctrl.move_back_down(),
-                        "move_stop_fn": lambda ctrl: ctrl.move_back_stop(),
-                        "max_value": 100.0,
-                    },
-                    "legs": {
-                        "position_key": "legs",
-                        "move_up_fn": lambda ctrl: ctrl.move_legs_up(),
-                        "move_down_fn": lambda ctrl: ctrl.move_legs_down(),
-                        "move_stop_fn": lambda ctrl: ctrl.move_legs_stop(),
-                        "max_value": 100.0,
-                    },
-                }
-            elif bed_type in (BED_TYPE_KEESON, BED_TYPE_ERGOMOTION):
-                # Keeson/Ergomotion only have head and feet motors
-                valid_motors = {"head", "feet"}
-                motor_configs = {
-                    "head": {
-                        "position_key": "back",  # Maps to "back" in position_data
-                        "move_up_fn": lambda ctrl: ctrl.move_head_up(),
-                        "move_down_fn": lambda ctrl: ctrl.move_head_down(),
-                        "move_stop_fn": lambda ctrl: ctrl.move_head_stop(),
-                        "max_value": 100.0,  # Percentage
-                    },
-                    "feet": {
-                        "position_key": "legs",  # Maps to "legs" in position_data
-                        "move_up_fn": lambda ctrl: ctrl.move_feet_up(),
-                        "move_down_fn": lambda ctrl: ctrl.move_feet_down(),
-                        "move_stop_fn": lambda ctrl: ctrl.move_feet_stop(),
-                        "max_value": 100.0,  # Percentage
-                    },
-                }
-            elif bed_type == BED_TYPE_SLEEPYS_BOX25:
-                valid_motors = {"head", "feet"}
-                motor_configs = {
-                    "head": {
-                        "position_key": "head",
-                        "move_up_fn": lambda ctrl: ctrl.move_head_up(),
-                        "move_down_fn": lambda ctrl: ctrl.move_head_down(),
-                        "move_stop_fn": lambda ctrl: ctrl.move_head_stop(),
-                        "max_value": 100.0,
-                    },
-                    "feet": {
-                        "position_key": "feet",
-                        "move_up_fn": lambda ctrl: ctrl.move_feet_up(),
-                        "move_down_fn": lambda ctrl: ctrl.move_feet_down(),
-                        "move_stop_fn": lambda ctrl: ctrl.move_feet_stop(),
-                        "max_value": 100.0,
-                    },
-                }
-            elif bed_type == BED_TYPE_OKIN_CST:
-                valid_motors = set(OKIN_CST_POSITION_AXES)
-                motor_configs = {
-                    "back": {
-                        "position_key": "back",
-                        "move_up_fn": lambda ctrl: ctrl.move_back_up(),
-                        "move_down_fn": lambda ctrl: ctrl.move_back_down(),
-                        "move_stop_fn": lambda ctrl: ctrl.move_back_stop(),
-                        "max_value": coordinator.get_max_angle("back"),  # Degrees
-                    },
-                    "legs": {
-                        "position_key": "legs",
-                        "move_up_fn": lambda ctrl: ctrl.move_legs_up(),
-                        "move_down_fn": lambda ctrl: ctrl.move_legs_down(),
-                        "move_stop_fn": lambda ctrl: ctrl.move_legs_stop(),
-                        "max_value": coordinator.get_max_angle("legs"),  # Degrees
-                    },
-                }
-            else:
-                # Standard beds: motor availability depends on motor_count
-                motor_configs = {
-                    "back": {
-                        "position_key": "back",
-                        "move_up_fn": lambda ctrl: ctrl.move_back_up(),
-                        "move_down_fn": lambda ctrl: ctrl.move_back_down(),
-                        "move_stop_fn": lambda ctrl: ctrl.move_back_stop(),
-                        "max_value": coordinator.get_max_angle("back"),  # Degrees
-                        "min_motors": 2,
-                    },
-                    "legs": {
-                        "position_key": "legs",
-                        "move_up_fn": lambda ctrl: ctrl.move_legs_up(),
-                        "move_down_fn": lambda ctrl: ctrl.move_legs_down(),
-                        "move_stop_fn": lambda ctrl: ctrl.move_legs_stop(),
-                        "max_value": coordinator.get_max_angle("legs"),  # Degrees
-                        "min_motors": 2,
-                    },
-                    "head": {
-                        "position_key": "head",
-                        "move_up_fn": lambda ctrl: ctrl.move_head_up(),
-                        "move_down_fn": lambda ctrl: ctrl.move_head_down(),
-                        "move_stop_fn": lambda ctrl: ctrl.move_head_stop(),
-                        "max_value": coordinator.get_max_angle("head"),  # Degrees
-                        "min_motors": 3,
-                    },
-                    "feet": {
-                        "position_key": "feet",
-                        "move_up_fn": lambda ctrl: ctrl.move_feet_up(),
-                        "move_down_fn": lambda ctrl: ctrl.move_feet_down(),
-                        "move_stop_fn": lambda ctrl: ctrl.move_feet_stop(),
-                        "max_value": coordinator.get_max_angle("feet"),  # Degrees
-                        "min_motors": 4,
-                    },
-                }
-                # Filter to valid motors based on motor_count
-                valid_motors = {
-                    m for m, cfg in motor_configs.items() if motor_count >= cfg.get("min_motors", 2)
-                }
-
-            # Validate motor is valid for this bed
-            if motor not in valid_motors:
-                raise ServiceValidationError(
-                    f"Motor '{motor}' is not valid for device '{coordinator.name}'. "
-                    f"Valid motors: {', '.join(sorted(valid_motors))}",
-                    translation_domain=DOMAIN,
-                    translation_key="invalid_motor_for_bed_type",
-                    translation_placeholders={
-                        "motor": motor,
-                        "device_name": coordinator.name,
-                        "valid_motors": ", ".join(sorted(valid_motors)),
-                    },
-                )
-
-            config = motor_configs[motor]
-            max_value = config["max_value"]
-
-            # Validate position is in range
-            if position < 0 or position > max_value:
-                unit = "%" if uses_percentage_positions else "°"
-                raise ServiceValidationError(
-                    f"Position {position} is out of range for motor '{motor}'. "
-                    f"Valid range: 0-{max_value}{unit}",
-                    translation_domain=DOMAIN,
-                    translation_key="invalid_position_range",
-                    translation_placeholders={
-                        "position": str(position),
-                        "motor": motor,
-                        "max_value": str(max_value),
-                        "unit": unit,
-                    },
-                )
-
-            # Call async_seek_position
-            await coordinator.async_seek_position(
-                position_key=cast(str, config["position_key"]),
-                target_angle=position,
-                move_up_fn=config["move_up_fn"],  # type: ignore[arg-type]
-                move_down_fn=config["move_down_fn"],  # type: ignore[arg-type]
-                move_stop_fn=config["move_stop_fn"],  # type: ignore[arg-type]
-            )
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_SET_POSITION,
-        handle_set_position,
-        schema=vol.Schema(
-            {
-                vol.Required(CONF_DEVICE_ID): cv.ensure_list,
-                vol.Required(ATTR_MOTOR): vol.In(["back", "legs", "head", "feet"]),
-                # No max cap here - per-motor validation handles bed-specific limits
-                vol.Required(ATTR_POSITION): vol.All(vol.Coerce(float), vol.Range(min=0)),
-            }
-        ),
-    )
-
-    async def handle_timed_move(call: ServiceCall) -> None:
-        """Handle timed_move service call."""
-        device_ids = call.data.get(CONF_DEVICE_ID, [])
-        motor = call.data[ATTR_MOTOR]
-        direction = call.data[ATTR_DIRECTION]
-        duration_ms = call.data[ATTR_DURATION_MS]
-
-        _LOGGER.info(
-            "Service timed_move called: motor=%s, direction=%s, duration_ms=%d",
-            motor,
-            direction,
-            duration_ms,
-        )
-
-        for device_id in device_ids:
-            coordinator = await _get_coordinator_from_device(hass, device_id)
-            if not coordinator:
-                raise ServiceValidationError(
-                    f"Could not find Adjustable Bed device with ID {device_id}",
-                    translation_domain=DOMAIN,
-                    translation_key="device_not_found",
-                    translation_placeholders={"device_id": device_id},
-                )
-            # Create a narrowed reference for use in closures (mypy doesn't narrow across closures)
-            coordinator_: AdjustableBedCoordinator = coordinator
-            controller = await _get_controller_for_service(coordinator)
-            motor_configs = {
-                spec.key: {
-                    "move_up_fn": spec.open_fn,
-                    "move_down_fn": spec.close_fn,
-                    "move_stop_fn": spec.stop_fn,
-                }
-                for spec in controller.motor_control_specs
-                if spec.key in TIMED_MOVE_MOTOR_OPTIONS
-            }
-            valid_motors = set(motor_configs)
-
-            # Validate motor is valid for this bed
-            if motor not in valid_motors:
-                raise ServiceValidationError(
-                    f"Motor '{motor}' is not valid for device '{coordinator.name}'. "
-                    f"Valid motors: {', '.join(sorted(valid_motors))}",
-                    translation_domain=DOMAIN,
-                    translation_key="invalid_motor_for_bed_type",
-                    translation_placeholders={
-                        "motor": motor,
-                        "device_name": coordinator.name,
-                        "valid_motors": ", ".join(sorted(valid_motors)),
-                    },
-                )
-
-            config = motor_configs[motor]
-
-            # Get the appropriate move function based on direction
-            move_fn = config["move_up_fn"] if direction == "up" else config["move_down_fn"]
-            stop_fn = config["move_stop_fn"]
-
-            # Execute timed movement
-            # Calculate repeat count: duration_ms / pulse_delay_ms
-            # Example: 3500ms on Octo (350ms delay) = 10 repeats
-            _, pulse_delay_ms = controller.motor_pulse_settings()
-            if pulse_delay_ms <= 0:
-                _LOGGER.warning(
-                    "Invalid motor_pulse_delay_ms (%d) for device %s, using default 100ms",
-                    pulse_delay_ms,
-                    coordinator.name,
-                )
-                pulse_delay_ms = 100  # DEFAULT_MOTOR_PULSE_DELAY_MS
-            # The first write is immediate, so one additional repeat is needed
-            # after the requested number of delay intervals.
-            calculated_repeat_count = max(
-                2,
-                (duration_ms + pulse_delay_ms - 1) // pulse_delay_ms + 1,
-            )
-
-            _LOGGER.debug(
-                "Timed move: duration=%dms, pulse_delay=%dms, repeat_count=%d",
-                duration_ms,
-                pulse_delay_ms,
-                calculated_repeat_count,
-            )
-
-            # Store original pulse settings to restore after
-            original_pulse_count = coordinator.motor_pulse_count
-            original_pulse_delay_ms = coordinator.motor_pulse_delay_ms
-
-            # Bind closure variables as defaults to avoid late-binding bugs
-            async def timed_movement(
-                ctrl: BedController,
-                *,
-                _coordinator: AdjustableBedCoordinator = coordinator_,
-                _move_fn: Callable[..., Coroutine[Any, Any, None]] = move_fn,
-                _stop_fn: Callable[..., Coroutine[Any, Any, None]] = stop_fn,
-                _calculated_repeat_count: int = calculated_repeat_count,
-                _pulse_delay_ms: int = pulse_delay_ms,
-                _original_pulse_count: int = original_pulse_count,
-                _original_pulse_delay_ms: int = original_pulse_delay_ms,
-            ) -> None:
-                """Execute movement for specified duration, always sending stop."""
-                try:
-                    # Temporarily set the effective pulse settings
-                    # This is safe because we're inside the command lock
-                    _coordinator._motor_pulse_count = _calculated_repeat_count
-                    _coordinator._motor_pulse_delay_ms = _pulse_delay_ms
-
-                    # Call the movement function (uses coordinator's pulse settings)
-                    await _move_fn(ctrl)
-                finally:
-                    # Restore original pulse settings
-                    _coordinator._motor_pulse_count = _original_pulse_count
-                    _coordinator._motor_pulse_delay_ms = _original_pulse_delay_ms
-
-                    # Always send stop command
-                    await asyncio.shield(_stop_fn(ctrl))
-
-            await coordinator.async_execute_controller_command(timed_movement)
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_TIMED_MOVE,
-        handle_timed_move,
-        schema=vol.Schema(
-            {
-                vol.Required(CONF_DEVICE_ID): cv.ensure_list,
-                vol.Required(ATTR_MOTOR): vol.In(TIMED_MOVE_MOTOR_OPTIONS),
-                vol.Required(ATTR_DIRECTION): vol.In(["up", "down"]),
-                vol.Required(ATTR_DURATION_MS): vol.All(
-                    vol.Coerce(int),
-                    vol.Range(min=MIN_TIMED_MOVE_DURATION_MS, max=MAX_TIMED_MOVE_DURATION_MS),
-                ),
-            }
-        ),
-    )
-
-    async def handle_generate_support_bundle(call: ServiceCall) -> None:
-        """Handle generate_support_bundle service call."""
-        from homeassistant.components.persistent_notification import async_create
-
-        from .download import register_download
-        from .support_bundle import generate_support_bundle, save_support_bundle
-
-        device_ids = call.data.get(CONF_DEVICE_ID, [])
-        target_address = call.data.get(ATTR_TARGET_ADDRESS)
-        capture_duration = call.data.get(ATTR_CAPTURE_DURATION, DEFAULT_CAPTURE_DURATION)
-        include_logs = call.data.get(ATTR_INCLUDE_LOGS, True)
-
-        address: str | None = None
-        coordinator: AdjustableBedCoordinator | None = None
-        entry: ConfigEntry | None = None
-        selected_device_id: str | None = None
-
-        if target_address:
-            from .config_flow import is_valid_mac_address
-
-            address = str(target_address).upper().replace("-", ":")
-            if not is_valid_mac_address(address):
-                raise ServiceValidationError(
-                    f"Invalid MAC address format: {target_address}. "
-                    "Please provide a valid MAC address in the format "
-                    "XX:XX:XX:XX:XX:XX or XX-XX-XX-XX-XX-XX.",
-                    translation_domain=DOMAIN,
-                    translation_key="invalid_mac_address",
-                )
-            _LOGGER.info(
-                "Generating support bundle for unconfigured device at %s",
-                address,
-            )
-        elif device_ids:
-            if len(device_ids) > 1:
-                raise ServiceValidationError(
-                    "Support bundle generation only supports one configured device at a time. "
-                    "Select a single device or use target_address for an unconfigured bed.",
-                    translation_domain=DOMAIN,
-                    translation_key="multiple_device_targets_not_supported",
-                )
-            # str() narrows the untyped service-call value for the str-typed parameter
-            selected_device_id = str(device_ids[0])
-            target = _get_support_bundle_target_from_device(hass, selected_device_id)
-            if target is not None:
-                address, coordinator, entry = target
-                device_name = coordinator.name if coordinator is not None else entry.title
-                _LOGGER.info(
-                    "Generating support bundle for configured device %s at %s",
-                    device_name,
-                    address,
-                )
-            else:
-                raise ServiceValidationError(
-                    f"Could not find Adjustable Bed device with ID: {selected_device_id}. "
-                    "Please verify the device is configured and try again.",
-                    translation_domain=DOMAIN,
-                    translation_key="device_not_found",
-                )
-        else:
-            raise ServiceValidationError(
-                "No device_id or target_address was provided. "
-                "Please specify either a configured device or a target MAC address.",
-                translation_domain=DOMAIN,
-                translation_key="missing_target",
-            )
-
-        assert address is not None
-        try:
-            report = await asyncio.wait_for(
-                generate_support_bundle(
-                    hass,
-                    address=address,
-                    capture_duration=capture_duration,
-                    include_logs=include_logs,
-                    coordinator=coordinator,
-                    entry=entry,
-                    device_id=selected_device_id,
-                ),
-                timeout=capture_duration + 120,
-            )
-            filepath = await hass.async_add_executor_job(
-                save_support_bundle,
-                hass,
-                report,
-                address,
-            )
-
-            download_url = register_download(hass, filepath)
-            notification_count = len(report.get("notifications", []))
-            evidence_warnings = report.get("evidence", {}).get("warnings", [])
-            warning_summary = ""
-            if evidence_warnings:
-                warning_summary = "\n\n**Capture warnings:**\n" + "\n".join(
-                    f"- {warning}" for warning in evidence_warnings
-                )
-            async_create(
-                hass,
-                f"[**Download support bundle**]({download_url})\n\n"
-                f"Captured {notification_count} notifications over "
-                f"{capture_duration} seconds."
-                f"{warning_summary}\n\n"
-                "Attach this JSON file when reporting unsupported or broken beds.\n\n"
-                f"File path: `{filepath}`",
-                title="Adjustable Bed Support Bundle Ready",
-                notification_id=f"adjustable_bed_support_bundle_{address.replace(':', '_').lower()}",
-            )
-            _LOGGER.info("Support bundle saved to %s", filepath)
-        except TimeoutError:
-            _LOGGER.exception(
-                "Support bundle generation timed out after %d seconds for %s",
-                capture_duration + 120,
-                address,
-            )
-            async_create(
-                hass,
-                f"Support bundle generation timed out after {capture_duration + 120} seconds "
-                f"for {address}.\n\n"
-                "The BLE diagnostics may be hanging. Check Bluetooth connectivity and try again.",
-                title="Adjustable Bed Support Bundle Timeout",
-                notification_id=f"adjustable_bed_support_bundle_error_{address.replace(':', '_').lower()}",
-            )
-            raise
-        except Exception as err:
-            _LOGGER.exception("Failed to generate support bundle for %s", address)
-            async_create(
-                hass,
-                f"Failed to generate support bundle for {address}:\n\n{err}",
-                title="Adjustable Bed Support Bundle Error",
-                notification_id=f"adjustable_bed_support_bundle_error_{address.replace(':', '_').lower()}",
-            )
-            raise
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_GENERATE_SUPPORT_BUNDLE,
-        handle_generate_support_bundle,
-        schema=vol.Schema(
-            {
-                vol.Exclusive(CONF_DEVICE_ID, "target"): cv.ensure_list,
-                vol.Exclusive(ATTR_TARGET_ADDRESS, "target"): cv.string,
-                vol.Optional(ATTR_CAPTURE_DURATION, default=DEFAULT_CAPTURE_DURATION): vol.All(
-                    vol.Coerce(int),
-                    vol.Range(min=MIN_CAPTURE_DURATION, max=MAX_CAPTURE_DURATION),
-                ),
-                vol.Optional(ATTR_INCLUDE_LOGS, default=True): cv.boolean,
-            }
-        ),
-    )
-
-    _LOGGER.debug("Registered Adjustable Bed services")
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -13,7 +13,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 from bleak import BleakClient
 from bleak.exc import BleakError
@@ -45,6 +45,111 @@ class MotorControlSpec:
     stop_fn: MotorCommandCallable
     position_key: str | None = None
     max_angle: float = 68
+
+
+# Units a position slider can be scaled in.
+POSITION_UNIT_PERCENT: Final = "%"
+POSITION_UNIT_DEGREES: Final = "°"
+
+
+@dataclass(frozen=True, slots=True)
+class PositionNumberSpec:
+    """Describes a position slider the controller exposes.
+
+    Distinct from MotorControlSpec, which is about *movement* (and drives the
+    cover entities): this describes a numeric position the bed can be told to
+    seek. Values are fully resolved by the controller -- ``native_max_value``
+    already accounts for the user's angle calibration where that applies -- so
+    the number platform renders these without knowing any bed types.
+
+    ``key`` names the entity while ``position_key`` names the axis to read from
+    ``coordinator.position_data``; they differ on beds whose remote labels a
+    motor differently from the axis its firmware reports (e.g. Keeson exposes
+    "head" but reports it as "back").
+    """
+
+    key: str
+    translation_key: str
+    position_key: str
+    icon: str
+    native_max_value: float
+    native_unit_of_measurement: str
+    open_fn: MotorCommandCallable
+    close_fn: MotorCommandCallable
+    stop_fn: MotorCommandCallable
+
+
+# Movement commands for the four standard position axes, so controllers can
+# build sliders without restating the lambdas.
+POSITION_AXIS_COMMANDS: Final[
+    dict[str, tuple[MotorCommandCallable, MotorCommandCallable, MotorCommandCallable]]
+] = {
+    "back": (
+        lambda ctrl: ctrl.move_back_up(),
+        lambda ctrl: ctrl.move_back_down(),
+        lambda ctrl: ctrl.move_back_stop(),
+    ),
+    "legs": (
+        lambda ctrl: ctrl.move_legs_up(),
+        lambda ctrl: ctrl.move_legs_down(),
+        lambda ctrl: ctrl.move_legs_stop(),
+    ),
+    "head": (
+        lambda ctrl: ctrl.move_head_up(),
+        lambda ctrl: ctrl.move_head_down(),
+        lambda ctrl: ctrl.move_head_stop(),
+    ),
+    "feet": (
+        lambda ctrl: ctrl.move_feet_up(),
+        lambda ctrl: ctrl.move_feet_down(),
+        lambda ctrl: ctrl.move_feet_stop(),
+    ),
+}
+
+POSITION_AXIS_ICONS: Final[dict[str, str]] = {
+    "back": "mdi:human-handsup",
+    "legs": "mdi:human-handsdown",
+    "head": "mdi:head",
+    "feet": "mdi:foot-print",
+    "lumbar": "mdi:human-handsup",
+}
+
+# The standard motor layout: axis -> motor_count needed before it is exposed.
+_STANDARD_POSITION_AXES: Final[tuple[tuple[str, int], ...]] = (
+    ("back", 2),
+    ("legs", 2),
+    ("head", 3),
+    ("feet", 4),
+)
+
+
+def build_position_number_spec(
+    axis: str,
+    *,
+    max_value: float,
+    unit: str,
+    position_key: str | None = None,
+    key: str | None = None,
+    icon: str | None = None,
+) -> PositionNumberSpec:
+    """Build a slider for ``axis`` using that axis's standard commands and icon.
+
+    ``position_key`` defaults to ``axis``; override it when the firmware reports
+    the axis under a different name. ``key`` defaults to ``f"{axis}_position"``.
+    """
+    open_fn, close_fn, stop_fn = POSITION_AXIS_COMMANDS[axis]
+    entity_key = key or f"{axis}_position"
+    return PositionNumberSpec(
+        key=entity_key,
+        translation_key=entity_key,
+        position_key=position_key or axis,
+        icon=icon or POSITION_AXIS_ICONS.get(axis, "mdi:bed-outline"),
+        native_max_value=max_value,
+        native_unit_of_measurement=unit,
+        open_fn=open_fn,
+        close_fn=close_fn,
+        stop_fn=stop_fn,
+    )
 
 
 class BedController(ABC):
@@ -802,6 +907,31 @@ class BedController(ABC):
         return False
 
     @property
+    def bed_presence_sides(self) -> tuple[str, ...]:
+        """Return the bed sides that report occupancy, e.g. ``("left", "right")``.
+
+        Empty for single-sleeper beds and for controllers without presence
+        reporting. Only meaningful when ``supports_bed_presence`` is True.
+        """
+        return ()
+
+    @property
+    def thermal_climate_sides(self) -> tuple[str, ...]:
+        """Return the bed sides exposing heating/cooling climate control.
+
+        Empty when the bed has no thermal climate zones.
+        """
+        return ()
+
+    @property
+    def footwarming_climate_sides(self) -> tuple[str, ...]:
+        """Return the bed sides exposing foot-warming climate control.
+
+        Empty when the bed has no foot warmer.
+        """
+        return ()
+
+    @property
     def supports_light_cycle(self) -> bool:
         """Return True if bed supports light cycle control."""
         return False
@@ -907,6 +1037,17 @@ class BedController(ABC):
     @property
     def supports_massage(self) -> bool:
         """Return True if bed supports massage commands."""
+        return False
+
+    @property
+    def auto_enable_massage(self) -> bool:
+        """Return True if massage entities should be created without user opt-in.
+
+        The ``has_massage`` config option exists because most protocols cannot
+        tell whether the frame actually has massage motors. Controllers that do
+        know (because the protocol or profile declares it) override this to
+        skip asking the user.
+        """
         return False
 
     @property
@@ -1018,6 +1159,50 @@ class BedController(ABC):
         return False
 
     @property
+    def foundation_preset_sides(self) -> tuple[str, ...]:
+        """Return the bed sides exposing named foundation presets.
+
+        Distinct from numbered memory slots: these beds recall presets by name
+        (``foundation_preset_options``) rather than by slot index. Empty when
+        the bed has no named presets.
+        """
+        return ()
+
+    @property
+    def foundation_preset_options(self) -> list[str]:
+        """Return the selectable named foundation presets, e.g. ``["flat", "zero_g"]``."""
+        return []
+
+    @property
+    def supports_sleep_number_setting(self) -> bool:
+        """Return True if the bed exposes an air-chamber firmness setting."""
+        return False
+
+    @property
+    def sleep_number_setting_sides(self) -> tuple[str, ...]:
+        """Return the bed sides with independently adjustable firmness.
+
+        Empty for single-chamber beds, which expose one setting via
+        ``supports_sleep_number_setting`` instead.
+        """
+        return ()
+
+    @property
+    def sleep_number_setting_min(self) -> int:
+        """Return the minimum firmness value."""
+        return 5
+
+    @property
+    def sleep_number_setting_max(self) -> int:
+        """Return the maximum firmness value."""
+        return 100
+
+    @property
+    def sleep_number_setting_step(self) -> int:
+        """Return the firmness adjustment step."""
+        return 5
+
+    @property
     def motor_translation_keys(self) -> dict[str, str] | None:
         """Return custom translation keys for motor cover entities, or None for defaults.
 
@@ -1028,9 +1213,46 @@ class BedController(ABC):
         return None
 
     @property
+    def position_number_specs(self) -> tuple[PositionNumberSpec, ...]:
+        """Return the position sliders to expose for this controller.
+
+        The default is the standard back/legs/head/feet layout in degrees, scaled
+        to the user's configured angle limits and gated on motor_count.
+        Controllers override when the hardware reports percentages instead of
+        angles, drives a different set of axes, or labels a motor differently
+        from the axis its firmware reports.
+
+        Only consulted for beds that report position feedback -- see
+        ``bed_type_has_position_feedback()``. Deliberately not derived from
+        ``motor_control_specs``: that describes every axis the remote can drive,
+        which is a broader set than the axes the bed reports a position for.
+        """
+        motor_count = self._coordinator.motor_count
+        return tuple(
+            build_position_number_spec(
+                axis,
+                max_value=self._coordinator.get_max_angle(axis),
+                unit=POSITION_UNIT_DEGREES,
+            )
+            for axis, required_motors in _STANDARD_POSITION_AXES
+            if motor_count >= required_motors
+        )
+
+    @property
+    def motor_max_angles(self) -> dict[str, float]:
+        """Return per-axis travel limits that differ from the standard defaults.
+
+        The standard limits are 68 degrees for back/head and 45 for legs/feet.
+        Frames whose hardware travels a different range map axis key -> degrees
+        here rather than restating the whole motor layout.
+        """
+        return {}
+
+    @property
     def motor_control_specs(self) -> tuple[MotorControlSpec, ...]:
         """Return motor controls that should be exposed for this controller."""
         translation_overrides = self.motor_translation_keys or {}
+        max_angle_overrides = self.motor_max_angles
         motor_count = self._coordinator.motor_count
 
         def _spec(
@@ -1049,7 +1271,7 @@ class BedController(ABC):
                 close_fn=close_fn,
                 stop_fn=stop_fn,
                 position_key=position_key,
-                max_angle=max_angle,
+                max_angle=max_angle_overrides.get(key, max_angle),
             )
 
         specs = [

--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -104,6 +104,11 @@ POSITION_AXIS_COMMANDS: Final[
         lambda ctrl: ctrl.move_feet_down(),
         lambda ctrl: ctrl.move_feet_stop(),
     ),
+    "lumbar": (
+        lambda ctrl: ctrl.move_lumbar_up(),
+        lambda ctrl: ctrl.move_lumbar_down(),
+        lambda ctrl: ctrl.move_lumbar_stop(),
+    ),
 }
 
 POSITION_AXIS_ICONS: Final[dict[str, str]] = {

--- a/custom_components/adjustable_bed/beds/kaidi.py
+++ b/custom_components/adjustable_bed/beds/kaidi.py
@@ -42,7 +42,12 @@ from ..const import (
     KAIDI_WRITE_CHAR_UUID,
 )
 from ..kaidi_protocol import extract_kaidi_advertisement, format_kaidi_node_address
-from .base import BedController
+from .base import (
+    POSITION_UNIT_PERCENT,
+    BedController,
+    PositionNumberSpec,
+    build_position_number_spec,
+)
 
 if TYPE_CHECKING:
     from ..coordinator import AdjustableBedCoordinator
@@ -560,6 +565,20 @@ class KaidiController(BedController):
         return (
             self._command_profile.head_setting is not None
             and self._command_profile.leg_setting is not None
+        )
+
+    @property
+    def position_number_specs(self) -> tuple[PositionNumberSpec, ...]:
+        """Expose back/legs percentage sliders when the profile can set positions.
+
+        Kaidi writes target positions directly rather than seeking with feedback,
+        and its targets are percentages, so angle calibration does not apply.
+        """
+        if not self.supports_direct_position_control:
+            return ()
+        return (
+            build_position_number_spec("back", max_value=100.0, unit=POSITION_UNIT_PERCENT),
+            build_position_number_spec("legs", max_value=100.0, unit=POSITION_UNIT_PERCENT),
         )
 
     @property

--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -49,7 +49,13 @@ from ..const import (
     KEESON_VARIANT_SINO,
     KEESON_VARIANT_SLEEP_HARMONY,
 )
-from .base import BedController, MotorControlSpec
+from .base import (
+    POSITION_UNIT_PERCENT,
+    BedController,
+    MotorControlSpec,
+    PositionNumberSpec,
+    build_position_number_spec,
+)
 from .okin_protocol import int_to_bytes
 
 if TYPE_CHECKING:
@@ -645,6 +651,29 @@ class KeesonController(BedController):
             "tilt": "keeson_head",
             "feet": "keeson_legs",
         }
+
+    @property
+    def position_number_specs(self) -> tuple[PositionNumberSpec, ...]:
+        """Return Keeson's percentage sliders.
+
+        Keeson remotes are labelled head/feet, but the firmware reports those
+        axes as "back"/"legs" in its position frames, so the entity keys and the
+        position keys deliberately differ. Positions are percentages, not angles,
+        so the user's angle calibration does not apply.
+
+        Only the Ergomotion variant reports positions at all; the shared Keeson
+        protocol is also used by Serta and OKIN FFE frames, which report none.
+        """
+        if self._variant != KEESON_VARIANT_ERGOMOTION:
+            return ()
+        return (
+            build_position_number_spec(
+                "head", max_value=100.0, unit=POSITION_UNIT_PERCENT, position_key="back"
+            ),
+            build_position_number_spec(
+                "feet", max_value=100.0, unit=POSITION_UNIT_PERCENT, position_key="legs"
+            ),
+        )
 
     @property
     def motor_control_specs(self) -> tuple[MotorControlSpec, ...]:

--- a/custom_components/adjustable_bed/beds/okin_cst.py
+++ b/custom_components/adjustable_bed/beds/okin_cst.py
@@ -160,8 +160,9 @@ class OkinCstController(BedController):
                 max_value=self._coordinator.get_max_angle(axis),
                 unit=POSITION_UNIT_DEGREES,
             )
-            for axis in ("back", "legs")
-            if axis in OKIN_CST_POSITION_AXES
+            # sorted() because OKIN_CST_POSITION_AXES is a frozenset and entity
+            # creation order must not vary between runs.
+            for axis in sorted(OKIN_CST_POSITION_AXES)
         )
 
     @property

--- a/custom_components/adjustable_bed/beds/okin_cst.py
+++ b/custom_components/adjustable_bed/beds/okin_cst.py
@@ -29,13 +29,19 @@ from bleak.exc import BleakError
 
 from ..const import (
     OKIMAT_WRITE_CHAR_UUID,
+    OKIN_CST_POSITION_AXES,
     OKIN_FOOT_MAX_ANGLE,
     OKIN_FOOT_MAX_RAW,
     OKIN_HEAD_MAX_ANGLE,
     OKIN_HEAD_MAX_RAW,
     OKIN_POSITION_NOTIFY_CHAR_UUID,
 )
-from .base import BedController
+from .base import (
+    POSITION_UNIT_DEGREES,
+    BedController,
+    PositionNumberSpec,
+    build_position_number_spec,
+)
 from .okin_protocol import build_cst_command
 
 if TYPE_CHECKING:
@@ -140,6 +146,23 @@ class OkinCstController(BedController):
     @property
     def supports_preset_incline(self) -> bool:
         return True
+
+    @property
+    def position_number_specs(self) -> tuple[PositionNumberSpec, ...]:
+        """Expose only the axes CST publishes feedback for.
+
+        CST reports angles for back and legs only, whatever motor count the user
+        configured, so this does not fall back to the standard motor_count gate.
+        """
+        return tuple(
+            build_position_number_spec(
+                axis,
+                max_value=self._coordinator.get_max_angle(axis),
+                unit=POSITION_UNIT_DEGREES,
+            )
+            for axis in ("back", "legs")
+            if axis in OKIN_CST_POSITION_AXES
+        )
 
     @property
     def supports_memory_presets(self) -> bool:

--- a/custom_components/adjustable_bed/beds/reverie.py
+++ b/custom_components/adjustable_bed/beds/reverie.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from bleak.exc import BleakError
 
-from ..const import REVERIE_CHAR_UUID
+from ..const import REVERIE_BACK_MAX_ANGLE, REVERIE_CHAR_UUID
 from .base import BedController
 
 if TYPE_CHECKING:
@@ -114,6 +114,11 @@ class ReverieController(BedController):
     def control_characteristic_uuid(self) -> str:
         """Return the UUID of the control characteristic."""
         return REVERIE_CHAR_UUID
+
+    @property
+    def motor_max_angles(self) -> dict[str, float]:
+        """Reverie frames stop the head/back axis short of the standard 68 degrees."""
+        return {"back": REVERIE_BACK_MAX_ANGLE, "head": REVERIE_BACK_MAX_ANGLE}
 
     # Capability properties
     @property

--- a/custom_components/adjustable_bed/beds/reverie_nightstand.py
+++ b/custom_components/adjustable_bed/beds/reverie_nightstand.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 from bleak.exc import BleakError
 
 from ..const import (
+    REVERIE_BACK_MAX_ANGLE,
     REVERIE_NIGHTSTAND_FOOT_POSITION_UUID,
     REVERIE_NIGHTSTAND_FOOT_WAVE_UUID,
     REVERIE_NIGHTSTAND_HEAD_POSITION_UUID,
@@ -99,6 +100,11 @@ class ReverieNightstandController(BedController):
         returns the linear head UUID as the primary one.
         """
         return REVERIE_NIGHTSTAND_LINEAR_HEAD_UUID
+
+    @property
+    def motor_max_angles(self) -> dict[str, float]:
+        """Reverie frames stop the head/back axis short of the standard 68 degrees."""
+        return {"back": REVERIE_BACK_MAX_ANGLE, "head": REVERIE_BACK_MAX_ANGLE}
 
     # Capability properties
     @property

--- a/custom_components/adjustable_bed/beds/sleep_number.py
+++ b/custom_components/adjustable_bed/beds/sleep_number.py
@@ -30,7 +30,13 @@ from ..const import (
     SLEEP_NUMBER_VARIANT_RIGHT,
     VARIANT_AUTO,
 )
-from .base import BedController, MotorControlSpec
+from .base import (
+    POSITION_UNIT_PERCENT,
+    BedController,
+    MotorControlSpec,
+    PositionNumberSpec,
+    build_position_number_spec,
+)
 
 if TYPE_CHECKING:
     from ..coordinator import AdjustableBedCoordinator
@@ -458,6 +464,14 @@ class SleepNumberController(BedController):
     @property
     def supports_preset_tv(self) -> bool:
         return True
+
+    @property
+    def position_number_specs(self) -> tuple[PositionNumberSpec, ...]:
+        """Expose back/legs as percentage sliders; the foundation reports percent."""
+        return (
+            build_position_number_spec("back", max_value=100.0, unit=POSITION_UNIT_PERCENT),
+            build_position_number_spec("legs", max_value=100.0, unit=POSITION_UNIT_PERCENT),
+        )
 
     @property
     def motor_control_specs(self) -> tuple[MotorControlSpec, ...]:

--- a/custom_components/adjustable_bed/beds/sleepstar.py
+++ b/custom_components/adjustable_bed/beds/sleepstar.py
@@ -29,7 +29,13 @@ from ..const import (
     SLEEPSTAR_MANUFACTURER_ID,
     SLEEPSTAR_SINGLE_SUBTYPE,
 )
-from .base import BedController, MotorControlSpec
+from .base import (
+    POSITION_AXIS_ICONS,
+    POSITION_UNIT_PERCENT,
+    BedController,
+    MotorControlSpec,
+    PositionNumberSpec,
+)
 
 if TYPE_CHECKING:
     from bleak.backends.characteristic import BleakGATTCharacteristic
@@ -422,6 +428,30 @@ class SleepStarController(BedController):
     def massage_timer_options(self) -> list[int]:
         """Return the app's timer durations in minutes."""
         return [10, 20, 30]
+
+    @property
+    def position_number_specs(self) -> tuple[PositionNumberSpec, ...]:
+        """Expose a percentage slider per motor that reports a position.
+
+        Unlike other controllers this tracks motor_control_specs directly: the
+        app-addressable motor list is the same set SLEEPSTAR reports positions
+        for, including the unproven Part4/Part5 axes.
+        """
+        return tuple(
+            PositionNumberSpec(
+                key=f"{spec.key}_position",
+                translation_key=f"{spec.translation_key}_position",
+                position_key=spec.position_key,
+                icon=POSITION_AXIS_ICONS.get(spec.key, "mdi:bed-outline"),
+                native_max_value=float(spec.max_angle),
+                native_unit_of_measurement=POSITION_UNIT_PERCENT,
+                open_fn=spec.open_fn,
+                close_fn=spec.close_fn,
+                stop_fn=spec.stop_fn,
+            )
+            for spec in self.motor_control_specs
+            if spec.position_key is not None
+        )
 
     @property
     def motor_control_specs(self) -> tuple[MotorControlSpec, ...]:

--- a/custom_components/adjustable_bed/beds/sleepys_box25.py
+++ b/custom_components/adjustable_bed/beds/sleepys_box25.py
@@ -30,7 +30,13 @@ from typing import TYPE_CHECKING
 from bleak.exc import BleakError
 
 from ..const import NORDIC_UART_WRITE_CHAR_UUID
-from .base import BedController, MotorControlSpec
+from .base import (
+    POSITION_UNIT_PERCENT,
+    BedController,
+    MotorControlSpec,
+    PositionNumberSpec,
+    build_position_number_spec,
+)
 
 if TYPE_CHECKING:
     from bleak.backends.characteristic import BleakGATTCharacteristic
@@ -246,6 +252,14 @@ class SleepysBox25Controller(BedController):
     @property
     def supports_direct_position_control(self) -> bool:
         return True
+
+    @property
+    def position_number_specs(self) -> tuple[PositionNumberSpec, ...]:
+        """Expose head/feet as percentage sliders; BOX25 reports percent, not angles."""
+        return (
+            build_position_number_spec("head", max_value=100.0, unit=POSITION_UNIT_PERCENT),
+            build_position_number_spec("feet", max_value=100.0, unit=POSITION_UNIT_PERCENT),
+        )
 
     @property
     def motor_control_specs(self) -> tuple[MotorControlSpec, ...]:

--- a/custom_components/adjustable_bed/binary_sensor.py
+++ b/custom_components/adjustable_bed/binary_sensor.py
@@ -66,10 +66,10 @@ async def async_setup_entry(
     entities: list[BinarySensorEntity] = []
     for description in BINARY_SENSOR_DESCRIPTIONS:
         if description.key == "bed_presence":
-            if controller is None or not getattr(controller, "supports_bed_presence", False):
+            if controller is None or not controller.supports_bed_presence:
                 continue
 
-            bed_presence_sides = tuple(getattr(controller, "bed_presence_sides", ()))
+            bed_presence_sides = controller.bed_presence_sides
             if bed_presence_sides:
                 _async_remove_stale_presence_entity(hass, coordinator)
             else:

--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -725,10 +725,8 @@ class BLEDiagnosticRunner:
                 _LOGGER.debug("Registering raw notification callback with coordinator")
                 self.coordinator.set_raw_notify_callback(self._raw_notify_callback)
                 controller = self.coordinator.controller
-                requires_notify_channel = bool(
-                    controller is not None
-                    and getattr(controller, "requires_notification_channel", False)
-                    is True
+                requires_notify_channel = (
+                    controller is not None and controller.requires_notification_channel
                 )
                 if (
                     self.coordinator.disable_angle_sensing

--- a/custom_components/adjustable_bed/button.py
+++ b/custom_components/adjustable_bed/button.py
@@ -520,7 +520,7 @@ async def async_setup_entry(
     coordinator: AdjustableBedCoordinator = hass.data[DOMAIN][entry.entry_id]
     has_massage = entry.data.get(CONF_HAS_MASSAGE, False)
     controller = coordinator.controller
-    if controller is not None and getattr(controller, "auto_enable_massage", False):
+    if controller is not None and controller.auto_enable_massage:
         has_massage = True
 
     if controller is not None:
@@ -547,14 +547,17 @@ def _should_add_button(
     # Hide the manual Disconnect for beds that can't recover from it — e.g. LP
     # Comfort Connect only accepts a connection while in pairing mode. Beds that
     # stay connected but CAN reconnect on demand (e.g. Sleep Number MCR) keep it.
-    if description.key == "disconnect" and getattr(
-        controller, "manual_disconnect_strands_connection", False
+    if (
+        description.key == "disconnect"
+        and controller is not None
+        and controller.manual_disconnect_strands_connection
     ):
         return False
 
     if description.key == "toggle_light" and controller is not None:
-        if getattr(controller, "supports_discrete_light_control", False) or getattr(
-            controller, "supports_light_color_control", False
+        if (
+            controller.supports_discrete_light_control
+            or controller.supports_light_color_control
         ):
             return False
 
@@ -565,12 +568,11 @@ def _should_add_button(
             return False
 
     if description.memory_slot is not None and controller is not None:
-        slot_count = getattr(controller, "memory_slot_count", 4)
-        if description.memory_slot > slot_count:
+        if description.memory_slot > controller.memory_slot_count:
             return False
 
     if description.is_program_button and controller is not None:
-        if not getattr(controller, "supports_memory_programming", False):
+        if not controller.supports_memory_programming:
             return False
 
     return True

--- a/custom_components/adjustable_bed/climate.py
+++ b/custom_components/adjustable_bed/climate.py
@@ -159,7 +159,7 @@ async def async_setup_entry(
 
     entities: list[AdjustableBedClimate] = []
 
-    thermal_sides: tuple[str, ...] = tuple(getattr(controller, "thermal_climate_sides", ()))
+    thermal_sides = controller.thermal_climate_sides
     if thermal_sides:
         _async_remove_stale_split_climate_entity(
             hass,
@@ -176,7 +176,7 @@ async def async_setup_entry(
     elif getattr(controller, SLEEP_NUMBER_THERMAL_CLIMATE_DESCRIPTION.required_capability, False):
         entities.append(AdjustableBedClimate(coordinator, SLEEP_NUMBER_THERMAL_CLIMATE_DESCRIPTION))
 
-    footwarming_sides: tuple[str, ...] = tuple(getattr(controller, "footwarming_climate_sides", ()))
+    footwarming_sides = controller.footwarming_climate_sides
     if footwarming_sides:
         _async_remove_stale_split_climate_entity(
             hass,

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -50,7 +50,6 @@ from .const import (
     BED_TYPE_DIAGNOSTIC,
     BED_TYPE_JENSEN,
     BED_TYPE_KAIDI,
-    BED_TYPE_KEESON,
     BED_TYPE_LEGGETT_GEN2,
     BED_TYPE_LEGGETT_OKIN,
     BED_TYPE_LEGGETT_PLATT,
@@ -104,7 +103,6 @@ from .const import (
     DEFAULT_POSITION_MODE,
     DEFAULT_PROTOCOL_VARIANT,
     DOMAIN,
-    KEESON_VARIANT_ERGOMOTION,
     LEGGETT_VARIANT_GEN2,
     MALOUF_LAYOUT_AUTO,
     MALOUF_LAYOUTS,
@@ -117,6 +115,7 @@ from .const import (
     RICHMAT_REMOTES,
     VARIANT_AUTO,
     DetectionResult,
+    bed_type_has_position_feedback,
     get_richmat_features,
     get_richmat_motor_count,
     passive_position_reconciliation_default_enabled,
@@ -199,13 +198,6 @@ def _is_valid_motor_count(
 ) -> bool:
     """Return whether a motor count is valid for the selected protocol."""
     return motor_count in _motor_count_options(bed_type, protocol_variant)
-
-
-def _has_position_feedback(bed_type: str | None, protocol_variant: str) -> bool:
-    """Return whether the selected protocol exposes motor position feedback."""
-    return bed_type in BEDS_WITH_POSITION_FEEDBACK or (
-        bed_type == BED_TYPE_KEESON and protocol_variant == KEESON_VARIANT_ERGOMOTION
-    )
 
 
 def _default_motor_count(
@@ -1692,9 +1684,8 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         defaults_bed_type = preselected_bed_type or confident_bed_type
         if defaults_bed_type:
             # Keeson with Ergomotion variant supports position feedback
-            has_position_feedback = defaults_bed_type in BEDS_WITH_POSITION_FEEDBACK or (
-                defaults_bed_type == BED_TYPE_KEESON
-                and preselected_protocol_variant == KEESON_VARIANT_ERGOMOTION
+            has_position_feedback = bed_type_has_position_feedback(
+                defaults_bed_type, preselected_protocol_variant
             )
             default_disable_angle = not has_position_feedback
             # Use bed-specific motor pulse defaults if available
@@ -1906,9 +1897,8 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         # Determine smart defaults based on preselected bed type and variant
         if preselected_bed_type:
             # Keeson with Ergomotion variant supports position feedback
-            has_position_feedback = preselected_bed_type in BEDS_WITH_POSITION_FEEDBACK or (
-                preselected_bed_type == BED_TYPE_KEESON
-                and preselected_protocol_variant == KEESON_VARIANT_ERGOMOTION
+            has_position_feedback = bed_type_has_position_feedback(
+                preselected_bed_type, preselected_protocol_variant
             )
             default_disable_angle = not has_position_feedback
             # Use bed-specific motor pulse defaults if available
@@ -2351,12 +2341,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         from bleak import BleakClient
         from bleak_retry_connector import establish_connection
 
-        # Keeson exposes position feedback only on its Ergomotion variant, so
-        # mirror the same special-case the confirm step uses for angle sensing.
-        has_position_feedback = bool(bed_type) and (
-            bed_type in BEDS_WITH_POSITION_FEEDBACK
-            or (bed_type == BED_TYPE_KEESON and protocol_variant == KEESON_VARIANT_ERGOMOTION)
-        )
+        has_position_feedback = bed_type_has_position_feedback(bed_type, protocol_variant)
         report = CapabilityReport(position_feedback=has_position_feedback)
 
         try:
@@ -2921,7 +2906,7 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
                 )
                 self._pending_data[CONF_MOTOR_PULSE_COUNT] = pulse_count
                 self._pending_data[CONF_MOTOR_PULSE_DELAY_MS] = pulse_delay
-                self._pending_data[CONF_DISABLE_ANGLE_SENSING] = not _has_position_feedback(
+                self._pending_data[CONF_DISABLE_ANGLE_SENSING] = not bed_type_has_position_feedback(
                     requested_bed_type,
                     requested_variant,
                 )
@@ -2945,14 +2930,14 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
                 user_input.pop(CONF_PROTOCOL_VARIANT, None)
             if (
                 self.config_entry.data.get(CONF_BED_TYPE) != bed_type
-                and _has_position_feedback(bed_type, form_variant)
-                != _has_position_feedback(bed_type, requested_variant)
+                and bed_type_has_position_feedback(bed_type, form_variant)
+                != bed_type_has_position_feedback(bed_type, requested_variant)
             ):
                 # Rebuild once more when the chosen variant changes position
                 # capability, so the user sees the new sensing default and can
                 # still explicitly override it on the following submission.
                 self._pending_data = {**self._pending_data, **user_input}
-                self._pending_data[CONF_DISABLE_ANGLE_SENSING] = not _has_position_feedback(
+                self._pending_data[CONF_DISABLE_ANGLE_SENSING] = not bed_type_has_position_feedback(
                     bed_type,
                     requested_variant,
                 )

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -1961,6 +1961,24 @@ BEDS_WITH_POSITION_FEEDBACK: Final = frozenset(
     }
 )
 
+
+def bed_type_has_position_feedback(
+    bed_type: str | None, protocol_variant: str | None
+) -> bool:
+    """Return True if this bed type/variant combination reports motor positions.
+
+    Membership in BEDS_WITH_POSITION_FEEDBACK is not sufficient on its own:
+    Keeson hardware only reports positions on the ergomotion variant, so the
+    variant has to be consulted too. Callers that decide whether to create
+    position entities, accept set_position calls, or probe for position
+    feedback must all agree, so they share this single predicate.
+    """
+    if not bed_type:
+        return False
+    if bed_type in BEDS_WITH_POSITION_FEEDBACK:
+        return True
+    return bed_type == BED_TYPE_KEESON and protocol_variant == KEESON_VARIANT_ERGOMOTION
+
 # Bed types that may have angle sensing enabled but report NO degree-angle data.
 # Sleep Number MCR/BAM beds only report sleep-number values and bed presence over BLE
 # (no motor angle feedback at all), so degree angle sensors would sit at "unknown"

--- a/custom_components/adjustable_bed/controller_factory.py
+++ b/custom_components/adjustable_bed/controller_factory.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from collections.abc import Mapping
+from dataclasses import dataclass
+from importlib import import_module
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Final
 
 from .adapter import discover_services
 from .const import (
@@ -234,6 +238,96 @@ def _is_dewertokin_rf_gateway(client: BleakClient | None, ble_model: str | None)
     )
 
 
+@dataclass(frozen=True, slots=True)
+class _ControllerSpec:
+    """Lazy pointer to a controller class, plus any fixed constructor kwargs.
+
+    Controller modules are imported on demand: eagerly importing all ~50 of them
+    at integration load would cost startup time for protocols the user does not
+    have. ``module`` is resolved relative to ``.beds``.
+    """
+
+    module: str
+    class_name: str
+    kwargs: Mapping[str, Any] = MappingProxyType({})
+
+
+# Bed types whose construction is fully described by "import this class and pass
+# the coordinator (plus fixed kwargs)". Bed types needing runtime detection,
+# variant resolution, or constructor arguments derived from the advertisement
+# stay as explicit branches in create_controller().
+#
+# tests/test_controller_contract.py resolves every entry, so a bad module or
+# class name fails the suite rather than a user's bed setup.
+_SIMPLE_CONTROLLERS: Final[dict[str, _ControllerSpec]] = {
+    BED_TYPE_OKIN_RF_ECO_BT: _ControllerSpec("okin_rf_eco_bt", "OkinRfEcoBtController"),
+    BED_TYPE_OKIN_7BYTE: _ControllerSpec("okin_7byte", "Okin7ByteController"),
+    BED_TYPE_OKIN_NORDIC: _ControllerSpec("okin_nordic", "OkinNordicController"),
+    BED_TYPE_OKIN_CB35: _ControllerSpec("okin_cb35", "OkinCB35Controller"),
+    BED_TYPE_OKIN_ORE: _ControllerSpec("okin_ore", "OkinOreController"),
+    BED_TYPE_OKIN_CST: _ControllerSpec("okin_cst", "OkinCstController"),
+    BED_TYPE_MALOUF_NEW_OKIN: _ControllerSpec("malouf", "MaloufNewOkinController"),
+    BED_TYPE_MALOUF_LEGACY_OKIN: _ControllerSpec("malouf", "MaloufLegacyOkinController"),
+    BED_TYPE_LEGGETT_OKIN: _ControllerSpec("leggett_okin", "LeggettOkinController"),
+    BED_TYPE_LEGGETT_WILINKE: _ControllerSpec("leggett_wilinke", "LeggettWilinkeController"),
+    BED_TYPE_LINAK: _ControllerSpec("linak", "LinakController"),
+    # OKIN FFE uses the Keeson protocol with an 0xE6 prefix.
+    BED_TYPE_OKIN_FFE: _ControllerSpec(
+        "keeson", "KeesonController", MappingProxyType({"variant": KEESON_VARIANT_OKIN})
+    ),
+    BED_TYPE_SOLACE: _ControllerSpec("solace", "SolaceController"),
+    BED_TYPE_SUTA: _ControllerSpec("suta", "SutaController"),
+    BED_TYPE_TIMOTION_AHF: _ControllerSpec("timotion_ahf", "TiMOTIONAhfController"),
+    BED_TYPE_REVERIE: _ControllerSpec("reverie", "ReverieController"),
+    BED_TYPE_REVERIE_NIGHTSTAND: _ControllerSpec(
+        "reverie_nightstand", "ReverieNightstandController"
+    ),
+    BED_TYPE_COMFORT_MOTION: _ControllerSpec("jiecang", "JiecangController"),
+    # Ergomotion is the Keeson protocol with position feedback; Serta Motion
+    # Perfect is the same protocol with its own variant.
+    BED_TYPE_ERGOMOTION: _ControllerSpec(
+        "keeson", "KeesonController", MappingProxyType({"variant": KEESON_VARIANT_ERGOMOTION})
+    ),
+    BED_TYPE_SERTA: _ControllerSpec(
+        "keeson", "KeesonController", MappingProxyType({"variant": KEESON_VARIANT_SERTA})
+    ),
+    BED_TYPE_JIECANG: _ControllerSpec("jiecang", "JiecangController"),
+    BED_TYPE_LIMOSS: _ControllerSpec("limoss", "LimossController"),
+    BED_TYPE_LOGICDATA: _ControllerSpec("logicdata", "LogicdataController"),
+    BED_TYPE_MATTRESSFIRM: _ControllerSpec("okin_nordic", "OkinNordicController"),
+    BED_TYPE_NECTAR: _ControllerSpec("okin_7byte", "Okin7ByteController"),
+    BED_TYPE_DIAGNOSTIC: _ControllerSpec("diagnostic", "DiagnosticBedController"),
+    BED_TYPE_BEDTECH: _ControllerSpec("bedtech", "BedTechController"),
+    BED_TYPE_SLEEP_NUMBER_MCR: _ControllerSpec("sleep_number_mcr", "SleepNumberMcrController"),
+    BED_TYPE_SLEEPYS_BOX15: _ControllerSpec("sleepys", "SleepysBox15Controller"),
+    BED_TYPE_SLEEPYS_BOX24: _ControllerSpec("sleepys", "SleepysBox24Controller"),
+    BED_TYPE_STAR_ELEVATE: _ControllerSpec("star_elevate", "StarElevateController"),
+    BED_TYPE_SVANE: _ControllerSpec("svane", "SvaneController"),
+    BED_TYPE_VIBRADORM: _ControllerSpec("vibradorm", "VibradormController"),
+    BED_TYPE_REMACRO: _ControllerSpec("remacro", "RemacroController"),
+    BED_TYPE_SCOTT_LIVING: _ControllerSpec("scott_living", "ScottLivingController"),
+}
+
+
+def _create_from_registry(
+    coordinator: AdjustableBedCoordinator, bed_type: str
+) -> BedController | None:
+    """Instantiate ``bed_type`` from the registry, or None if it needs a custom branch."""
+    spec = _SIMPLE_CONTROLLERS.get(bed_type)
+    if spec is None:
+        return None
+
+    module = import_module(f".beds.{spec.module}", __package__)
+    controller_cls: type[BedController] = getattr(module, spec.class_name)
+    _LOGGER.debug(
+        "Using %s for bed type %s%s",
+        spec.class_name,
+        bed_type,
+        f" ({spec.kwargs})" if spec.kwargs else "",
+    )
+    return controller_cls(coordinator, **spec.kwargs)
+
+
 async def create_controller(
     coordinator: AdjustableBedCoordinator,
     bed_type: str,
@@ -326,26 +420,6 @@ async def create_controller(
         _LOGGER.debug("Using Okin UUID variant: %s", variant)
         return OkinUuidController(coordinator, variant=variant)
 
-    if bed_type == BED_TYPE_OKIN_RF_ECO_BT:
-        from .beds.okin_rf_eco_bt import OkinRfEcoBtController
-
-        return OkinRfEcoBtController(coordinator)
-
-    if bed_type == BED_TYPE_OKIN_7BYTE:
-        from .beds.okin_7byte import Okin7ByteController
-
-        return Okin7ByteController(coordinator)
-
-    if bed_type == BED_TYPE_OKIN_NORDIC:
-        from .beds.okin_nordic import OkinNordicController
-
-        return OkinNordicController(coordinator)
-
-    if bed_type == BED_TYPE_OKIN_CB35:
-        from .beds.okin_cb35 import OkinCB35Controller
-
-        return OkinCB35Controller(coordinator)
-
     if bed_type == BED_TYPE_KAIDI:
         from .beds.kaidi import KaidiController
 
@@ -409,48 +483,12 @@ async def create_controller(
             protocol_variant=profile_variant,
         )
 
-    if bed_type == BED_TYPE_OKIN_ORE:
-        from .beds.okin_ore import OkinOreController
-
-        return OkinOreController(coordinator)
-
-    if bed_type == BED_TYPE_OKIN_CST:
-        from .beds.okin_cst import OkinCstController
-
-        _LOGGER.debug("Using OKIN CST controller (14-byte CSTProtocol)")
-        return OkinCstController(coordinator)
-
-    if bed_type == BED_TYPE_MALOUF_NEW_OKIN:
-        from .beds.malouf import MaloufNewOkinController
-
-        return MaloufNewOkinController(coordinator)
-
-    if bed_type == BED_TYPE_MALOUF_LEGACY_OKIN:
-        from .beds.malouf import MaloufLegacyOkinController
-
-        return MaloufLegacyOkinController(coordinator)
-
     if bed_type == BED_TYPE_LEGGETT_GEN2:
         from .beds.leggett_gen2 import LeggettGen2Controller
 
         return LeggettGen2Controller(coordinator, manufacturer_data=manufacturer_data)
 
-    if bed_type == BED_TYPE_LEGGETT_OKIN:
-        from .beds.leggett_okin import LeggettOkinController
-
-        return LeggettOkinController(coordinator)
-
-    if bed_type == BED_TYPE_LEGGETT_WILINKE:
-        from .beds.leggett_wilinke import LeggettWilinkeController
-
-        return LeggettWilinkeController(coordinator)
-
     # Brand-specific bed types
-    if bed_type == BED_TYPE_LINAK:
-        from .beds.linak import LinakController
-
-        return LinakController(coordinator)
-
     if bed_type == BED_TYPE_RICHMAT:
         from .beds.richmat import RichmatController, detect_richmat_variant
 
@@ -656,32 +694,10 @@ async def create_controller(
             _LOGGER.debug("Using Base Keeson variant")
             return KeesonController(coordinator, variant="base", device_name=device_name)
 
-    if bed_type == BED_TYPE_OKIN_FFE:
-        from .beds.keeson import KeesonController
-
-        # OKIN FFE uses Keeson protocol with 0xE6 prefix
-        _LOGGER.debug("Using OKIN FFE controller (Keeson protocol with 0xE6 prefix)")
-        return KeesonController(coordinator, variant="okin")
-
-    if bed_type == BED_TYPE_SOLACE:
-        from .beds.solace import SolaceController
-
-        return SolaceController(coordinator)
-
     if bed_type == BED_TYPE_MOTOSLEEP:
         from .beds.motosleep import MotoSleepController
 
         return MotoSleepController(coordinator, device_name=device_name)
-
-    if bed_type == BED_TYPE_SUTA:
-        from .beds.suta import SutaController
-
-        return SutaController(coordinator)
-
-    if bed_type == BED_TYPE_TIMOTION_AHF:
-        from .beds.timotion_ahf import TiMOTIONAhfController
-
-        return TiMOTIONAhfController(coordinator)
 
     if bed_type == BED_TYPE_LEGGETT_PLATT:
         # Use configured variant or auto-detect
@@ -735,49 +751,6 @@ async def create_controller(
             _LOGGER.debug("Using Gen2 Leggett & Platt variant (configured)")
             return LeggettGen2Controller(coordinator, manufacturer_data=manufacturer_data)
 
-    if bed_type == BED_TYPE_REVERIE:
-        from .beds.reverie import ReverieController
-
-        return ReverieController(coordinator)
-
-    if bed_type == BED_TYPE_REVERIE_NIGHTSTAND:
-        from .beds.reverie_nightstand import ReverieNightstandController
-
-        return ReverieNightstandController(coordinator)
-
-    if bed_type == BED_TYPE_COMFORT_MOTION:
-        # Comfort Motion uses the enhanced Jiecang controller
-        from .beds.jiecang import JiecangController
-
-        return JiecangController(coordinator)
-
-    if bed_type == BED_TYPE_ERGOMOTION:
-        # Ergomotion uses the same protocol as Keeson with position feedback
-        from .beds.keeson import KeesonController
-
-        return KeesonController(coordinator, variant="ergomotion")
-
-    if bed_type == BED_TYPE_SERTA:
-        # Serta Motion Perfect uses the Keeson protocol with serta variant
-        from .beds.keeson import KeesonController
-
-        return KeesonController(coordinator, variant="serta")
-
-    if bed_type == BED_TYPE_JIECANG:
-        from .beds.jiecang import JiecangController
-
-        return JiecangController(coordinator)
-
-    if bed_type == BED_TYPE_LIMOSS:
-        from .beds.limoss import LimossController
-
-        return LimossController(coordinator)
-
-    if bed_type == BED_TYPE_LOGICDATA:
-        from .beds.logicdata import LogicdataController
-
-        return LogicdataController(coordinator)
-
     if bed_type == BED_TYPE_DEWERTOKIN:
         if _is_dewertokin_rf_gateway(client, ble_model):
             from .beds.dewertokin_rf_gateway import DewertOkinRfGatewayController
@@ -806,26 +779,6 @@ async def create_controller(
             _LOGGER.debug("Using standard Octo variant")
             return OctoController(coordinator, pin=octo_pin)
 
-    if bed_type == BED_TYPE_MATTRESSFIRM:
-        from .beds.okin_nordic import OkinNordicController
-
-        return OkinNordicController(coordinator)
-
-    if bed_type == BED_TYPE_NECTAR:
-        from .beds.okin_7byte import Okin7ByteController
-
-        return Okin7ByteController(coordinator)
-
-    if bed_type == BED_TYPE_DIAGNOSTIC:
-        from .beds.diagnostic import DiagnosticBedController
-
-        return DiagnosticBedController(coordinator)
-
-    if bed_type == BED_TYPE_BEDTECH:
-        from .beds.bedtech import BedTechController
-
-        return BedTechController(coordinator)
-
     if bed_type == BED_TYPE_JENSEN:
         from .beds.jensen import JensenController
 
@@ -839,11 +792,6 @@ async def create_controller(
             _LOGGER.debug("Unknown Sleep Number side variant %s, defaulting to auto", side)
             side = VARIANT_AUTO
         return SleepNumberController(coordinator, side=side)
-
-    if bed_type == BED_TYPE_SLEEP_NUMBER_MCR:
-        from .beds.sleep_number_mcr import SleepNumberMcrController
-
-        return SleepNumberMcrController(coordinator)
 
     if bed_type == BED_TYPE_SLEEPSTAR:
         from .beds.sleepstar import SleepStarController
@@ -861,18 +809,6 @@ async def create_controller(
         variant = protocol_variant if protocol_variant and protocol_variant != "auto" else "nordic"
         _LOGGER.debug("Using OKIN 64-bit variant: %s", variant)
         return Okin64BitController(coordinator, variant=variant)
-
-    if bed_type == BED_TYPE_SLEEPYS_BOX15:
-        from .beds.sleepys import SleepysBox15Controller
-
-        _LOGGER.debug("Using Sleepy's BOX15 controller")
-        return SleepysBox15Controller(coordinator)
-
-    if bed_type == BED_TYPE_SLEEPYS_BOX24:
-        from .beds.sleepys import SleepysBox24Controller
-
-        _LOGGER.debug("Using Sleepy's BOX24 controller")
-        return SleepysBox24Controller(coordinator)
 
     if bed_type == BED_TYPE_SLEEPYS_BOX25:
         from .beds.sleepys_box25 import (
@@ -913,22 +849,6 @@ async def create_controller(
         _LOGGER.info("Using BOX25 StarCode dialect (%s)", selection_reason)
         return SleepysBox25Controller(coordinator)
 
-    if bed_type == BED_TYPE_STAR_ELEVATE:
-        from .beds.star_elevate import StarElevateController
-
-        _LOGGER.debug("Using ELEVATE two-actuator StarCode controller")
-        return StarElevateController(coordinator)
-
-    if bed_type == BED_TYPE_SVANE:
-        from .beds.svane import SvaneController
-
-        return SvaneController(coordinator)
-
-    if bed_type == BED_TYPE_VIBRADORM:
-        from .beds.vibradorm import VibradormController
-
-        return VibradormController(coordinator)
-
     if bed_type == BED_TYPE_RONDURE:
         from .beds.rondure import RondureController
         from .const import RONDURE_VARIANTS
@@ -948,11 +868,6 @@ async def create_controller(
         _LOGGER.debug("Using Rondure controller with variant: %s", variant)
         return RondureController(coordinator, variant=variant)
 
-    if bed_type == BED_TYPE_REMACRO:
-        from .beds.remacro import RemacroController
-
-        return RemacroController(coordinator)
-
     if bed_type == BED_TYPE_COOLBASE:
         from .beds.coolbase import CoolBaseController
 
@@ -966,12 +881,6 @@ async def create_controller(
         )
         return CoolBaseController(coordinator, dewert_okin_profile=dewert_okin_profile)
 
-    if bed_type == BED_TYPE_SCOTT_LIVING:
-        from .beds.scott_living import ScottLivingController
-
-        _LOGGER.debug("Using Scott Living controller")
-        return ScottLivingController(coordinator)
-
     if bed_type == BED_TYPE_SBI:
         from .beds.sbi import SBIController
 
@@ -983,5 +892,9 @@ async def create_controller(
         )
         _LOGGER.debug("Using SBI controller with variant: %s", variant)
         return SBIController(coordinator, variant=variant)
+
+    controller = _create_from_registry(coordinator, bed_type)
+    if controller is not None:
+        return controller
 
     raise ValueError(f"Unknown bed type: {bed_type}")

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -589,6 +589,10 @@ class AdjustableBedCoordinator:
         Returns:
             Maximum angle in degrees for the specified motor.
         """
+        # Deliberately keyed on bed type rather than the controller's
+        # motor_max_angles: this limit must hold while disconnected, so that
+        # set_position validation still rejects a target the frame cannot reach
+        # when the controller is momentarily absent.
         if position_key in ("back", "head"):
             if self._bed_type == BED_TYPE_OKIN_CST:
                 return OKIN_HEAD_MAX_ANGLE

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -127,13 +127,9 @@ from .const import (
     OKIN_CST_POSITION_AXES,
     OKIN_FOOT_MAX_ANGLE,
     OKIN_HEAD_MAX_ANGLE,
-    POSITION_CHECK_INTERVAL,
     POSITION_MODE_ACCURACY,
     POSITION_OVERSHOOT_TOLERANCE,
     POSITION_SEEK_TIMEOUT,
-    POSITION_STALL_COUNT,
-    POSITION_STALL_THRESHOLD,
-    POSITION_TOLERANCE,
     REVERIE_BACK_MAX_ANGLE,
     RICHMAT_REMOTE_AUTO,
     VARIANT_AUTO,
@@ -3191,9 +3187,7 @@ class AdjustableBedCoordinator:
             _LOGGER.warning("Cannot start notifications: no controller available")
             return
 
-        requires_notify_channel = getattr(self._controller, "requires_notification_channel", False)
-        if not isinstance(requires_notify_channel, bool):
-            requires_notify_channel = False
+        requires_notify_channel = self._controller.requires_notification_channel
 
         # Some controllers depend on notifications for command responses or
         # authentication even when angle sensing is disabled.
@@ -3694,9 +3688,15 @@ class AdjustableBedCoordinator:
                     _LOGGER.error("Cannot seek position: no controller available")
                     raise NoControllerError("No controller available")
 
+                # Pin the controller for the whole seek. A disconnect callback can
+                # clear self._controller while we await below, and every step of the
+                # seek -- including the STOP in the finally block -- must keep acting
+                # on the controller we validated rather than dereferencing None.
+                controller = self._controller
+
                 await self._async_refresh_controller_auth()
 
-                supports_direct_position_control = self._controller.supports_direct_position_control
+                supports_direct_position_control = controller.supports_direct_position_control
 
                 # Get current position, attempting a read if not available.
                 # Direct-position controllers can operate without a current reading.
@@ -3713,47 +3713,14 @@ class AdjustableBedCoordinator:
                             f"Cannot seek {position_key}: no position data available"
                         )
 
-                position_tolerance = getattr(
-                    self._controller, "position_seek_tolerance", POSITION_TOLERANCE
+                position_tolerance = controller.position_seek_tolerance
+                position_check_interval = controller.position_seek_check_interval
+                position_stall_count = controller.position_seek_stall_count
+                position_stall_threshold = controller.position_seek_stall_threshold
+                chain_seek_steps = controller.chains_position_seek_steps_while_moving
+                position_seek_chain_min_remaining_distance = (
+                    controller.position_seek_chain_min_remaining_distance
                 )
-                if not isinstance(position_tolerance, (int, float)):
-                    position_tolerance = POSITION_TOLERANCE
-                position_check_interval = getattr(
-                    self._controller,
-                    "position_seek_check_interval",
-                    POSITION_CHECK_INTERVAL,
-                )
-                if not isinstance(position_check_interval, (int, float)):
-                    position_check_interval = POSITION_CHECK_INTERVAL
-                position_stall_count = getattr(
-                    self._controller, "position_seek_stall_count", POSITION_STALL_COUNT
-                )
-                if not isinstance(position_stall_count, int):
-                    position_stall_count = POSITION_STALL_COUNT
-                position_stall_threshold = getattr(
-                    self._controller,
-                    "position_seek_stall_threshold",
-                    POSITION_STALL_THRESHOLD,
-                )
-                if not isinstance(position_stall_threshold, (int, float)):
-                    position_stall_threshold = POSITION_STALL_THRESHOLD
-                chain_seek_steps = getattr(
-                    self._controller,
-                    "chains_position_seek_steps_while_moving",
-                    False,
-                )
-                if not isinstance(chain_seek_steps, bool):
-                    chain_seek_steps = False
-                position_seek_chain_min_remaining_distance = getattr(
-                    self._controller,
-                    "position_seek_chain_min_remaining_distance",
-                    position_tolerance,
-                )
-                if not isinstance(
-                    position_seek_chain_min_remaining_distance,
-                    (int, float),
-                ):
-                    position_seek_chain_min_remaining_distance = position_tolerance
 
                 # Check if already at target (within tolerance)
                 if (
@@ -3785,7 +3752,7 @@ class AdjustableBedCoordinator:
                 # Check if controller supports direct position control (e.g., Reverie)
                 # This bypasses the incremental seek loop for beds that can set positions directly
                 if supports_direct_position_control:
-                    native_position = self._controller.angle_to_native_position(
+                    native_position = controller.angle_to_native_position(
                         position_key, target_angle
                     )
                     _LOGGER.debug(
@@ -3793,7 +3760,7 @@ class AdjustableBedCoordinator:
                         position_key,
                         native_position,
                     )
-                    await self._controller.set_motor_position(position_key, native_position)
+                    await controller.set_motor_position(position_key, native_position)
                     self._handle_position_update(position_key, target_angle)
                     return  # finally block handles disconnect timer
 
@@ -3806,7 +3773,6 @@ class AdjustableBedCoordinator:
 
                 # Determine initial direction
                 moving_up = target_angle > current_angle
-                controller = self._controller
                 reverse_on_overshoot = controller.reverses_position_seek_on_overshoot
                 use_custom_seek_steps = controller.uses_custom_position_seek_steps
 
@@ -3916,8 +3882,8 @@ class AdjustableBedCoordinator:
                             )
                             # Only send explicit stop for controllers that don't auto-stop
                             # (Linak auto-stops and explicit STOP can cause reverse blips)
-                            if not getattr(self._controller, "auto_stops_on_idle", False):
-                                await move_stop_fn(self._controller)
+                            if not controller.auto_stops_on_idle:
+                                await move_stop_fn(controller)
                                 await asyncio.sleep(0.3)  # Ensure stop completes before reversal
                             # Check if a new stop was requested while we were stopping
                             if self._cancel_counter > entry_cancel_count:
@@ -3937,8 +3903,8 @@ class AdjustableBedCoordinator:
                             )
                             # Only send explicit stop for controllers that don't auto-stop
                             # (Linak auto-stops and explicit STOP can cause reverse blips)
-                            if not getattr(self._controller, "auto_stops_on_idle", False):
-                                await move_stop_fn(self._controller)
+                            if not controller.auto_stops_on_idle:
+                                await move_stop_fn(controller)
                                 await asyncio.sleep(0.3)  # Ensure stop completes before reversal
                             # Check if a new stop was requested while we were stopping
                             if self._cancel_counter > entry_cancel_count:
@@ -3994,10 +3960,10 @@ class AdjustableBedCoordinator:
                 finally:
                     # Stop the motor unless it auto-stops on idle
                     # Some controllers (e.g., Linak) auto-stop and sending explicit
-                    # STOP can cause brief reverse movement
-                    if not getattr(self._controller, "auto_stops_on_idle", False):
+                    # STOP can cause brief reverse movement.
+                    if not controller.auto_stops_on_idle:
                         try:
-                            await move_stop_fn(self._controller)
+                            await move_stop_fn(controller)
                         except Exception:
                             _LOGGER.exception(
                                 "CRITICAL: Failed to stop motor %s - manual intervention may be required",

--- a/custom_components/adjustable_bed/cover.py
+++ b/custom_components/adjustable_bed/cover.py
@@ -19,11 +19,8 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
-    BED_TYPE_REVERIE,
-    BED_TYPE_REVERIE_NIGHTSTAND,
     BEDS_WITH_PERCENTAGE_POSITIONS,
     DOMAIN,
-    REVERIE_BACK_MAX_ANGLE,
 )
 from .coordinator import AdjustableBedCoordinator
 from .entity import AdjustableBedEntity
@@ -218,7 +215,7 @@ async def async_setup_entry(
     _async_remove_stale_cover_entities(hass, coordinator, controller)
 
     entities = [
-        AdjustableBedCover(coordinator, _build_cover_description(coordinator, spec))
+        AdjustableBedCover(coordinator, _build_cover_description(spec))
         for spec in controller.motor_control_specs
     ]
 
@@ -226,19 +223,15 @@ async def async_setup_entry(
 
 
 def _build_cover_description(
-    coordinator: AdjustableBedCoordinator,
     spec: MotorControlSpec,
 ) -> AdjustableBedCoverEntityDescription:
-    """Build a cover description from the controller-provided motor spec."""
+    """Build a cover description from the controller-provided motor spec.
+
+    Travel limits come from the spec, so per-frame limits belong on the
+    controller's motor_max_angles rather than as a bed-type check here.
+    """
     templates_by_key = {description.key: description for description in COVER_DESCRIPTIONS}
     template = templates_by_key.get(spec.key)
-    max_angle = spec.max_angle
-
-    if coordinator.bed_type in (BED_TYPE_REVERIE, BED_TYPE_REVERIE_NIGHTSTAND) and spec.key in (
-        "back",
-        "head",
-    ):
-        max_angle = REVERIE_BACK_MAX_ANGLE
 
     return AdjustableBedCoverEntityDescription(
         key=spec.key,
@@ -249,7 +242,7 @@ def _build_cover_description(
         close_fn=spec.close_fn,
         stop_fn=spec.stop_fn,
         position_key=spec.position_key,
-        max_angle=max_angle,
+        max_angle=spec.max_angle,
     )
 
 

--- a/custom_components/adjustable_bed/light.py
+++ b/custom_components/adjustable_bed/light.py
@@ -80,14 +80,14 @@ async def async_setup_entry(
         _async_remove_stale_light_entity(hass, coordinator)
         return
 
-    if getattr(controller, "supports_light_color_control", False):
+    if controller.supports_light_color_control:
         _async_remove_stale_switch_entity(hass, coordinator)
         async_add_entities([AdjustableBedLight(coordinator, LIGHT_DESCRIPTION)])
         return
 
     if (
         coordinator.bed_type == BED_TYPE_SLEEP_NUMBER_MCR
-        and getattr(controller, "supports_discrete_light_control", False)
+        and controller.supports_discrete_light_control
     ):
         _async_remove_stale_switch_entity(hass, coordinator)
         async_add_entities([AdjustableBedOnOffLight(coordinator, LIGHT_DESCRIPTION)])
@@ -142,9 +142,7 @@ class AdjustableBedLight(AdjustableBedEntity, RestoreEntity, LightEntity):
         self._attr_unique_id = f"{coordinator.address}_{description.key}"
 
         controller = coordinator.controller
-        color_mode_str = (
-            getattr(controller, "supported_color_mode", None) if controller is not None else None
-        )
+        color_mode_str = controller.supported_color_mode if controller is not None else None
         if color_mode_str == "rgbw":
             self._attr_color_mode = ColorMode.RGBW
             self._attr_supported_color_modes = {ColorMode.RGBW}
@@ -152,13 +150,9 @@ class AdjustableBedLight(AdjustableBedEntity, RestoreEntity, LightEntity):
             self._attr_color_mode = ColorMode.RGB
             self._attr_supported_color_modes = {ColorMode.RGB}
 
-        default_rgb = (
-            getattr(controller, "default_light_rgb_color", None) if controller is not None else None
-        )
-        self._supports_discrete_light_control = bool(
-            getattr(controller, "supports_discrete_light_control", False)
-            if controller is not None
-            else False
+        default_rgb = controller.default_light_rgb_color if controller is not None else None
+        self._supports_discrete_light_control = (
+            controller is not None and controller.supports_discrete_light_control
         )
         self._default_rgb_color = _normalize_rgb_color(default_rgb)
         self._attr_is_on = False

--- a/custom_components/adjustable_bed/number.py
+++ b/custom_components/adjustable_bed/number.py
@@ -17,24 +17,15 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .beds.base import PositionNumberSpec
 from .const import (
-    BED_TYPE_ERGOMOTION,
-    BED_TYPE_KAIDI,
-    BED_TYPE_KEESON,
-    BED_TYPE_OKIN_CST,
-    BED_TYPE_SLEEP_NUMBER,
     BED_TYPE_SLEEPSTAR,
-    BED_TYPE_SLEEPYS_BOX25,
-    BEDS_WITH_POSITION_FEEDBACK,
     BEDS_WITHOUT_ANGLE_FEEDBACK,
     CONF_BED_TYPE,
     CONF_HAS_MASSAGE,
-    CONF_MOTOR_COUNT,
     CONF_PROTOCOL_VARIANT,
-    DEFAULT_MOTOR_COUNT,
     DOMAIN,
-    KEESON_VARIANT_ERGOMOTION,
-    OKIN_CST_POSITION_AXES,
+    bed_type_has_position_feedback,
 )
 from .coordinator import AdjustableBedCoordinator
 from .entity import AdjustableBedEntity
@@ -240,6 +231,32 @@ SLEEP_NUMBER_SETTING_RIGHT_DESCRIPTION = AdjustableBedSideStateNumberEntityDescr
 )
 
 
+def _build_position_description(
+    spec: PositionNumberSpec,
+) -> AdjustableBedNumberEntityDescription:
+    """Render a controller-declared position slider as an entity description.
+
+    Everything bed-specific (axis set, scale, unit, calibration) is already
+    resolved in the spec, so this only adapts it to Home Assistant's shape.
+    """
+    return AdjustableBedNumberEntityDescription(
+        key=spec.key,
+        translation_key=spec.translation_key,
+        icon=spec.icon,
+        native_min_value=0,
+        native_max_value=spec.native_max_value,
+        native_step=1,
+        native_unit_of_measurement=spec.native_unit_of_measurement,
+        mode=NumberMode.SLIDER,
+        position_key=spec.position_key,
+        move_up_fn=spec.open_fn,
+        move_down_fn=spec.close_fn,
+        move_stop_fn=spec.stop_fn,
+        max_angle=spec.native_max_value,
+        min_motors=1,
+    )
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -247,11 +264,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up Adjustable Bed number entities."""
     coordinator: AdjustableBedCoordinator = hass.data[DOMAIN][entry.entry_id]
-    motor_count = entry.data.get(CONF_MOTOR_COUNT, DEFAULT_MOTOR_COUNT)
     bed_type = entry.data.get(CONF_BED_TYPE)
     has_massage = entry.data.get(CONF_HAS_MASSAGE, False)
     controller = coordinator.controller
-    if controller is not None and getattr(controller, "auto_enable_massage", False):
+    if controller is not None and controller.auto_enable_massage:
         has_massage = True
 
     entities: list[NumberEntity] = []
@@ -270,256 +286,19 @@ async def async_setup_entry(
 
     # Set up position number entities (only for beds with position feedback)
     if not coordinator.disable_angle_sensing:
-        # Check if bed supports position feedback
-        # Special case: BED_TYPE_KEESON only supports position feedback with ergomotion variant
         protocol_variant = entry.data.get(CONF_PROTOCOL_VARIANT)
-        has_position_feedback = bed_type in BEDS_WITH_POSITION_FEEDBACK or (
-            bed_type == BED_TYPE_KEESON and protocol_variant == KEESON_VARIANT_ERGOMOTION
-        )
+        has_position_feedback = bed_type_has_position_feedback(bed_type, protocol_variant)
 
-        if has_position_feedback or (
-            bed_type == BED_TYPE_KAIDI
-            and controller is not None
-            and getattr(controller, "supports_direct_position_control", False)
+        if controller is not None and (
+            has_position_feedback or controller.supports_direct_position_control
         ):
-            descriptions_by_key = {d.key: d for d in NUMBER_DESCRIPTIONS}
-
-            # Keeson and Ergomotion beds use different motor naming:
-            # Head/Feet instead of Back/Legs, but position data still uses "back"/"legs" keys
-            if bed_type in (BED_TYPE_KEESON, BED_TYPE_ERGOMOTION):
-                _LOGGER.debug(
-                    "Setting up Keeson/Ergomotion position numbers for %s (motor_count=%d)",
-                    coordinator.name,
-                    motor_count,
-                )
-
-                # Create head position (maps to "back" position data)
-                # Keeson/Ergomotion report percentage positions (0-100), not angles
-                head_desc = descriptions_by_key["head_position"]
-                keeson_head_desc = AdjustableBedNumberEntityDescription(
-                    key=head_desc.key,
-                    translation_key=head_desc.translation_key,
-                    icon=head_desc.icon,
-                    native_min_value=0,
-                    native_max_value=100,
-                    native_step=1,
-                    native_unit_of_measurement="%",
-                    mode=head_desc.mode,
-                    position_key="back",  # Map to "back" in position_data
-                    move_up_fn=head_desc.move_up_fn,
-                    move_down_fn=head_desc.move_down_fn,
-                    move_stop_fn=head_desc.move_stop_fn,
-                    max_angle=100.0,  # Use 100 as max for percentage-based beds
-                    min_motors=2,
-                )
-                entities.append(AdjustableBedPositionNumber(coordinator, keeson_head_desc))
-
-                # Create feet position (maps to "legs" position data)
-                # Keeson/Ergomotion report percentage positions (0-100), not angles
-                feet_desc = descriptions_by_key["feet_position"]
-                keeson_feet_desc = AdjustableBedNumberEntityDescription(
-                    key=feet_desc.key,
-                    translation_key=feet_desc.translation_key,
-                    icon=feet_desc.icon,
-                    native_min_value=0,
-                    native_max_value=100,
-                    native_step=1,
-                    native_unit_of_measurement="%",
-                    mode=feet_desc.mode,
-                    position_key="legs",  # Map to "legs" in position_data
-                    move_up_fn=feet_desc.move_up_fn,
-                    move_down_fn=feet_desc.move_down_fn,
-                    move_stop_fn=feet_desc.move_stop_fn,
-                    max_angle=100.0,  # Use 100 as max for percentage-based beds
-                    min_motors=2,
-                )
-                entities.append(AdjustableBedPositionNumber(coordinator, keeson_feet_desc))
-            elif bed_type == BED_TYPE_SLEEPYS_BOX25:
-                _LOGGER.debug(
-                    "Setting up BOX25 position numbers for %s",
-                    coordinator.name,
-                )
-
-                for key, position_key in (
-                    ("head_position", "head"),
-                    ("feet_position", "feet"),
-                ):
-                    description = descriptions_by_key[key]
-                    box25_desc = AdjustableBedNumberEntityDescription(
-                        key=description.key,
-                        translation_key=description.translation_key,
-                        icon=description.icon,
-                        native_min_value=0,
-                        native_max_value=100,
-                        native_step=1,
-                        native_unit_of_measurement="%",
-                        mode=description.mode,
-                        position_key=position_key,
-                        move_up_fn=description.move_up_fn,
-                        move_down_fn=description.move_down_fn,
-                        move_stop_fn=description.move_stop_fn,
-                        max_angle=100.0,
-                        min_motors=2,
-                    )
-                    entities.append(AdjustableBedPositionNumber(coordinator, box25_desc))
-            elif bed_type == BED_TYPE_SLEEPSTAR and controller is not None:
-                _LOGGER.debug(
-                    "Setting up SLEEPSTAR position numbers for %s",
-                    coordinator.name,
-                )
-
-                icons = {
-                    "head": "mdi:head",
-                    "feet": "mdi:foot-print",
-                    "lumbar": "mdi:human-handsup",
-                    "sleepstar_part4": "mdi:bed-outline",
-                    "sleepstar_part5": "mdi:bed-outline",
-                }
-                for spec in controller.motor_control_specs:
-                    if spec.position_key is None:
-                        continue
-                    max_value = float(spec.max_angle)
-                    sleepstar_desc = AdjustableBedNumberEntityDescription(
-                        key=f"{spec.key}_position",
-                        translation_key=f"{spec.translation_key}_position",
-                        icon=icons.get(spec.key, "mdi:bed-outline"),
-                        native_min_value=0,
-                        native_max_value=max_value,
-                        native_step=1,
-                        native_unit_of_measurement="%",
-                        mode=NumberMode.SLIDER,
-                        position_key=spec.position_key,
-                        move_up_fn=spec.open_fn,
-                        move_down_fn=spec.close_fn,
-                        move_stop_fn=spec.stop_fn,
-                        max_angle=max_value,
-                        min_motors=1,
-                    )
-                    entities.append(AdjustableBedPositionNumber(coordinator, sleepstar_desc))
-            elif bed_type == BED_TYPE_OKIN_CST:
-                _LOGGER.debug(
-                    "Setting up CST position numbers for %s",
-                    coordinator.name,
-                )
-
-                for key in ("back_position", "legs_position"):
-                    description = descriptions_by_key[key]
-                    if description.position_key not in OKIN_CST_POSITION_AXES:
-                        continue
-                    max_angle = coordinator.get_max_angle(description.position_key)
-                    cst_desc = AdjustableBedNumberEntityDescription(
-                        key=description.key,
-                        translation_key=description.translation_key,
-                        icon=description.icon,
-                        native_min_value=description.native_min_value,
-                        native_max_value=max_angle,
-                        native_step=description.native_step,
-                        native_unit_of_measurement=description.native_unit_of_measurement,
-                        mode=description.mode,
-                        position_key=description.position_key,
-                        move_up_fn=description.move_up_fn,
-                        move_down_fn=description.move_down_fn,
-                        move_stop_fn=description.move_stop_fn,
-                        max_angle=max_angle,
-                        min_motors=description.min_motors,
-                    )
-                    entities.append(AdjustableBedPositionNumber(coordinator, cst_desc))
-            elif bed_type == BED_TYPE_KAIDI and controller is not None:
-                _LOGGER.debug(
-                    "Setting up Kaidi direct-position numbers for %s",
-                    coordinator.name,
-                )
-
-                for key, position_key, max_value, icon in (
-                    ("back_position", "back", 100.0, "mdi:human-handsup"),
-                    ("legs_position", "legs", 100.0, "mdi:human-handsdown"),
-                ):
-                    entities.append(
-                        AdjustableBedPositionNumber(
-                            coordinator,
-                            AdjustableBedNumberEntityDescription(
-                                key=key,
-                                translation_key=key,
-                                icon=icon,
-                                native_min_value=0,
-                                native_max_value=max_value,
-                                native_step=1,
-                                native_unit_of_measurement="%",
-                                mode=NumberMode.SLIDER,
-                                position_key=position_key,
-                                move_up_fn=(
-                                    (lambda ctrl: ctrl.move_back_up())
-                                    if position_key == "back"
-                                    else (lambda ctrl: ctrl.move_legs_up())
-                                ),
-                                move_down_fn=(
-                                    (lambda ctrl: ctrl.move_back_down())
-                                    if position_key == "back"
-                                    else (lambda ctrl: ctrl.move_legs_down())
-                                ),
-                                move_stop_fn=(
-                                    (lambda ctrl: ctrl.move_back_stop())
-                                    if position_key == "back"
-                                    else (lambda ctrl: ctrl.move_legs_stop())
-                                ),
-                                max_angle=max_value,
-                                min_motors=2,
-                            ),
-                        )
-                    )
-            elif bed_type == BED_TYPE_SLEEP_NUMBER:
-                _LOGGER.debug(
-                    "Setting up Sleep Number direct-position numbers for %s",
-                    coordinator.name,
-                )
-
-                for description in NUMBER_DESCRIPTIONS[:2]:
-                    entities.append(
-                        AdjustableBedPositionNumber(
-                            coordinator,
-                            AdjustableBedNumberEntityDescription(
-                                key=description.key,
-                                translation_key=description.translation_key,
-                                icon=description.icon,
-                                native_min_value=0,
-                                native_max_value=100,
-                                native_step=1,
-                                native_unit_of_measurement="%",
-                                mode=description.mode,
-                                position_key=description.position_key,
-                                move_up_fn=description.move_up_fn,
-                                move_down_fn=description.move_down_fn,
-                                move_stop_fn=description.move_stop_fn,
-                                max_angle=100.0,
-                                min_motors=2,
-                            ),
-                        )
-                    )
-            else:
-                # Standard bed motor layout (Back/Legs/Head/Feet)
-                # Use configurable angle limits for beds that support angle-based positions
-                for description in NUMBER_DESCRIPTIONS:
-                    if motor_count >= description.min_motors:
-                        # Get dynamic max angle from coordinator (preserves decimal precision)
-                        max_angle = coordinator.get_max_angle(description.position_key)
-                        # Create a new description with the dynamic max angle
-                        dynamic_desc = AdjustableBedNumberEntityDescription(
-                            key=description.key,
-                            translation_key=description.translation_key,
-                            icon=description.icon,
-                            native_min_value=description.native_min_value,
-                            native_max_value=max_angle,
-                            native_step=description.native_step,
-                            native_unit_of_measurement=description.native_unit_of_measurement,
-                            mode=description.mode,
-                            position_key=description.position_key,
-                            move_up_fn=description.move_up_fn,
-                            move_down_fn=description.move_down_fn,
-                            move_stop_fn=description.move_stop_fn,
-                            max_angle=max_angle,
-                            min_motors=description.min_motors,
-                        )
-                        entities.append(AdjustableBedPositionNumber(coordinator, dynamic_desc))
+            # The controller owns the layout: which axes exist, whether they are
+            # scaled in degrees or percent, and which position_data key each one
+            # reads. See BedController.position_number_specs.
+            entities.extend(
+                AdjustableBedPositionNumber(coordinator, _build_position_description(spec))
+                for spec in controller.position_number_specs
+            )
         else:
             _LOGGER.debug(
                 "Bed type %s (variant=%s) does not support position feedback, skipping position number entities",
@@ -529,9 +308,9 @@ async def async_setup_entry(
 
     # Set up massage intensity number entities (only for beds with massage and direct intensity control)
     if has_massage and controller is not None:
-        if getattr(controller, "supports_massage_intensity_control", False):
-            supported_zones = getattr(controller, "massage_intensity_zones", [])
-            max_intensity = getattr(controller, "massage_intensity_max", 10)
+        if controller.supports_massage_intensity_control:
+            supported_zones = controller.massage_intensity_zones
+            max_intensity = controller.massage_intensity_max
             _LOGGER.debug(
                 "Setting up massage intensity numbers for %s (zones: %s, max: %d)",
                 coordinator.name,
@@ -555,8 +334,8 @@ async def async_setup_entry(
                     entities.append(AdjustableBedMassageNumber(coordinator, massage_adjusted))
 
     # Set up light level number entity (only for beds that support it)
-    if controller is not None and getattr(controller, "supports_light_level_control", False):
-        max_level = getattr(controller, "light_level_max", 10)
+    if controller is not None and controller.supports_light_level_control:
+        max_level = controller.light_level_max
         _LOGGER.debug(
             "Setting up light level number for %s (max: %d)",
             coordinator.name,
@@ -574,8 +353,8 @@ async def async_setup_entry(
         )
         entities.append(AdjustableBedLightLevelNumber(coordinator, light_adjusted))
 
-    sleep_number_sides = tuple(getattr(controller, "sleep_number_setting_sides", ()))
-    if sleep_number_sides:
+    sleep_number_sides = controller.sleep_number_setting_sides if controller else ()
+    if controller is not None and sleep_number_sides:
         _LOGGER.debug(
             "Setting up side-specific Sleep Number controls for %s (sides: %s)",
             coordinator.name,
@@ -595,9 +374,9 @@ async def async_setup_entry(
                         key=side_description.key,
                         translation_key=side_description.translation_key,
                         icon=side_description.icon,
-                        native_min_value=getattr(controller, "sleep_number_setting_min", 5),
-                        native_max_value=getattr(controller, "sleep_number_setting_max", 100),
-                        native_step=getattr(controller, "sleep_number_setting_step", 5),
+                        native_min_value=controller.sleep_number_setting_min,
+                        native_max_value=controller.sleep_number_setting_max,
+                        native_step=controller.sleep_number_setting_step,
                         mode=side_description.mode,
                         state_key=side_description.state_key,
                         setter_name=side_description.setter_name,
@@ -605,7 +384,7 @@ async def async_setup_entry(
                     ),
                 )
             )
-    elif controller is not None and getattr(controller, "supports_sleep_number_setting", False):
+    elif controller is not None and controller.supports_sleep_number_setting:
         _LOGGER.debug("Setting up Sleep Number setting control for %s", coordinator.name)
         entities.append(
             AdjustableBedSleepNumberSettingNumber(
@@ -614,9 +393,9 @@ async def async_setup_entry(
                     key=SLEEP_NUMBER_SETTING_DESCRIPTION.key,
                     translation_key=SLEEP_NUMBER_SETTING_DESCRIPTION.translation_key,
                     icon=SLEEP_NUMBER_SETTING_DESCRIPTION.icon,
-                    native_min_value=getattr(controller, "sleep_number_setting_min", 5),
-                    native_max_value=getattr(controller, "sleep_number_setting_max", 100),
-                    native_step=getattr(controller, "sleep_number_setting_step", 5),
+                    native_min_value=controller.sleep_number_setting_min,
+                    native_max_value=controller.sleep_number_setting_max,
+                    native_step=controller.sleep_number_setting_step,
                     mode=SLEEP_NUMBER_SETTING_DESCRIPTION.mode,
                 ),
             )

--- a/custom_components/adjustable_bed/number.py
+++ b/custom_components/adjustable_bed/number.py
@@ -299,11 +299,20 @@ async def async_setup_entry(
                 AdjustableBedPositionNumber(coordinator, _build_position_description(spec))
                 for spec in controller.position_number_specs
             )
+        elif controller is None:
+            # The layout comes from the controller, so a bed that is disconnected
+            # at setup gets no sliders until the entry reloads. Say so plainly
+            # rather than blaming the bed type.
+            _LOGGER.warning(
+                "No controller available for %s, skipping position number entities; "
+                "reload the entry once the bed reconnects",
+                coordinator.name,
+            )
         else:
             _LOGGER.debug(
                 "Bed type %s (variant=%s) does not support position feedback, skipping position number entities",
                 bed_type,
-                entry.data.get(CONF_PROTOCOL_VARIANT),
+                protocol_variant,
             )
 
     # Set up massage intensity number entities (only for beds with massage and direct intensity control)

--- a/custom_components/adjustable_bed/select.py
+++ b/custom_components/adjustable_bed/select.py
@@ -145,15 +145,15 @@ async def async_setup_entry(
     coordinator: AdjustableBedCoordinator = hass.data[DOMAIN][entry.entry_id]
     has_massage = entry.data.get(CONF_HAS_MASSAGE, False)
     controller = coordinator.controller
-    if controller is not None and getattr(controller, "auto_enable_massage", False):
+    if controller is not None and controller.auto_enable_massage:
         has_massage = True
 
     entities: list[SelectEntity] = []
 
     # Set up massage timer select (only for beds with massage and timer support)
     if has_massage and controller is not None:
-        if getattr(controller, "supports_massage_timer", False):
-            timer_options = getattr(controller, "massage_timer_options", [])
+        if controller.supports_massage_timer:
+            timer_options = controller.massage_timer_options
             if timer_options:
                 _LOGGER.debug(
                     "Setting up massage timer select for %s (options: %s)",
@@ -190,7 +190,7 @@ async def async_setup_entry(
             _async_remove_stale_select_entity(hass, coordinator, LIGHT_TIMER_DESCRIPTION.key)
 
         thermal_timer_options = list(getattr(controller, THERMAL_TIMER_DESCRIPTION.options_attr, []))
-        thermal_sides = tuple(getattr(controller, "thermal_climate_sides", ()))
+        thermal_sides = controller.thermal_climate_sides
         if thermal_sides and thermal_timer_options:
             _LOGGER.debug(
                 "Setting up side-specific thermal timer selects for %s (sides: %s, options: %s)",
@@ -231,7 +231,7 @@ async def async_setup_entry(
         footwarming_timer_options = list(
             getattr(controller, FOOTWARMING_TIMER_DESCRIPTION.options_attr, [])
         )
-        footwarming_sides = tuple(getattr(controller, "footwarming_climate_sides", ()))
+        footwarming_sides = controller.footwarming_climate_sides
         if footwarming_sides and footwarming_timer_options:
             _LOGGER.debug(
                 "Setting up side-specific footwarming timer selects for %s (sides: %s, options: %s)",
@@ -273,12 +273,8 @@ async def async_setup_entry(
                     )
                 )
 
-    foundation_preset_sides: tuple[str, ...] = tuple(
-        getattr(controller, "foundation_preset_sides", ())
-    )
-    foundation_preset_options: list[str] = list(
-        getattr(controller, "foundation_preset_options", ())
-    )
+    foundation_preset_sides = controller.foundation_preset_sides if controller else ()
+    foundation_preset_options = controller.foundation_preset_options if controller else []
     if foundation_preset_sides and foundation_preset_options:
         _LOGGER.debug(
             "Setting up side-specific foundation preset selects for %s (sides: %s, options: %s)",

--- a/custom_components/adjustable_bed/services.py
+++ b/custom_components/adjustable_bed/services.py
@@ -1,0 +1,827 @@
+"""Service registration for the Adjustable Bed integration.
+
+Handlers live here as module-level functions rather than closures so they can be
+read, tested, and type-checked independently of integration setup. Each one
+recovers Home Assistant from ``call.hass``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable, Coroutine
+from typing import TYPE_CHECKING, Any, cast
+
+import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ADDRESS, CONF_DEVICE_ID
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
+
+from .const import (
+    BED_TYPE_ERGOMOTION,
+    BED_TYPE_KAIDI,
+    BED_TYPE_KEESON,
+    BED_TYPE_OKIN_CST,
+    BED_TYPE_SLEEPYS_BOX25,
+    CONF_BED_TYPE,
+    CONF_MOTOR_COUNT,
+    CONF_PROTOCOL_VARIANT,
+    DEFAULT_MOTOR_COUNT,
+    DOMAIN,
+    OKIN_CST_POSITION_AXES,
+    bed_type_has_position_feedback,
+)
+from .coordinator import AdjustableBedCoordinator
+
+if TYPE_CHECKING:
+    from .beds.base import BedController
+
+_LOGGER = logging.getLogger(__name__)
+
+# Service names
+SERVICE_GOTO_PRESET = "goto_preset"
+SERVICE_GENERATE_SUPPORT_BUNDLE = "generate_support_bundle"
+SERVICE_SAVE_PRESET = "save_preset"
+SERVICE_SET_POSITION = "set_position"
+SERVICE_STOP_ALL = "stop_all"
+SERVICE_TIMED_MOVE = "timed_move"
+
+# Service call attributes
+ATTR_PRESET = "preset"
+ATTR_MOTOR = "motor"
+ATTR_POSITION = "position"
+ATTR_TARGET_ADDRESS = "target_address"
+ATTR_CAPTURE_DURATION = "capture_duration"
+ATTR_INCLUDE_LOGS = "include_logs"
+ATTR_DIRECTION = "direction"
+ATTR_DURATION_MS = "duration_ms"
+
+TIMED_MOVE_MOTOR_OPTIONS = (
+    "tv_lift",
+    "back",
+    "legs",
+    "head",
+    "feet",
+    "tilt",
+    "lumbar",
+    "bed_height",
+    "stair",
+)
+
+# Default capture duration for diagnostics (seconds)
+DEFAULT_CAPTURE_DURATION = 120
+MIN_CAPTURE_DURATION = 10
+MAX_CAPTURE_DURATION = 300
+
+# Timed move duration limits (milliseconds)
+MIN_TIMED_MOVE_DURATION_MS = 100
+MAX_TIMED_MOVE_DURATION_MS = 30000  # 30 seconds max
+
+
+async def _get_coordinator_from_device(
+    hass: HomeAssistant, device_id: str
+) -> AdjustableBedCoordinator | None:
+    """Get coordinator from device ID."""
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get(device_id)
+    if not device:
+        return None
+
+    for entry_id in device.config_entries:
+        if entry_id in hass.data.get(DOMAIN, {}):
+            return cast(AdjustableBedCoordinator, hass.data[DOMAIN][entry_id])
+    return None
+
+
+def _get_support_bundle_target_from_device(
+    hass: HomeAssistant, device_id: str
+) -> tuple[str, AdjustableBedCoordinator | None, ConfigEntry] | None:
+    """Resolve support-bundle target details from a device registry ID."""
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get(device_id)
+    if not device:
+        return None
+
+    for entry_id in device.config_entries:
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if entry is None or entry.domain != DOMAIN:
+            continue
+
+        address = entry.data.get(CONF_ADDRESS)
+        if not isinstance(address, str):
+            continue
+
+        coordinator = cast(AdjustableBedCoordinator | None, hass.data.get(DOMAIN, {}).get(entry_id))
+        return address, coordinator, entry
+
+    return None
+
+
+async def _get_controller_for_service(
+    coordinator: AdjustableBedCoordinator,
+) -> BedController:
+    """Return an active controller for service validation/execution.
+
+    Service calls may arrive while the coordinator is idle-disconnected and
+    controller is None. Reconnect first so capability checks don't fail with
+    a false "not supported" error.
+    """
+    controller = coordinator.controller
+    if controller is not None:
+        return controller
+
+    _LOGGER.debug(
+        "No active controller for %s during service call; attempting reconnect",
+        coordinator.name,
+    )
+    connected = await coordinator.async_ensure_connected(reset_timer=False)
+    controller = coordinator.controller
+    if not connected or controller is None:
+        raise ServiceValidationError(
+            f"Device '{coordinator.name}' is currently unavailable (unable to connect)",
+        )
+    return controller
+
+
+async def handle_goto_preset(call: ServiceCall) -> None:
+    """Handle goto_preset service call."""
+    hass = call.hass
+    preset = call.data[ATTR_PRESET]
+    device_ids = call.data.get(CONF_DEVICE_ID, [])
+
+    _LOGGER.info("Service goto_preset called: preset=%d", preset)
+
+    for device_id in device_ids:
+        coordinator = await _get_coordinator_from_device(hass, device_id)
+        if coordinator:
+            # Check if controller supports memory presets
+            controller = await _get_controller_for_service(coordinator)
+            if not controller.supports_memory_presets:
+                raise ServiceValidationError(
+                    f"Device '{coordinator.name}' does not support memory presets",
+                    translation_domain=DOMAIN,
+                    translation_key="memory_presets_not_supported",
+                    translation_placeholders={"device_name": coordinator.name},
+                )
+            # Validate preset against controller's memory slot count
+            slot_count = controller.memory_slot_count
+            if preset > slot_count:
+                raise ServiceValidationError(
+                    f"Device '{coordinator.name}' only supports memory presets 1-{slot_count}. "
+                    f"Preset {preset} is not available for this bed type.",
+                    translation_domain=DOMAIN,
+                    translation_key="invalid_preset_number",
+                    translation_placeholders={
+                        "device_name": coordinator.name,
+                        "max_preset": str(slot_count),
+                        "requested_preset": str(preset),
+                    },
+                )
+            await coordinator.async_execute_controller_command(
+                lambda ctrl, p=preset: ctrl.preset_memory(p)  # type: ignore[misc]
+            )
+        else:
+            raise ServiceValidationError(
+                f"Could not find Adjustable Bed device with ID {device_id}",
+                translation_domain=DOMAIN,
+                translation_key="device_not_found",
+                translation_placeholders={"device_id": device_id},
+            )
+
+
+async def handle_save_preset(call: ServiceCall) -> None:
+    """Handle save_preset service call."""
+    hass = call.hass
+    preset = call.data[ATTR_PRESET]
+    device_ids = call.data.get(CONF_DEVICE_ID, [])
+
+    _LOGGER.info("Service save_preset called: preset=%d", preset)
+
+    for device_id in device_ids:
+        coordinator = await _get_coordinator_from_device(hass, device_id)
+        if coordinator:
+            # Check if controller supports programming memory presets
+            controller = await _get_controller_for_service(coordinator)
+            if not controller.supports_memory_programming:
+                raise ServiceValidationError(
+                    f"Device '{coordinator.name}' does not support programming memory presets",
+                    translation_domain=DOMAIN,
+                    translation_key="memory_programming_not_supported",
+                    translation_placeholders={"device_name": coordinator.name},
+                )
+            # Validate preset against controller's memory slot count
+            slot_count = controller.memory_slot_count
+            if preset > slot_count:
+                raise ServiceValidationError(
+                    f"Device '{coordinator.name}' only supports memory presets 1-{slot_count}. "
+                    f"Preset {preset} is not available for this bed type.",
+                    translation_domain=DOMAIN,
+                    translation_key="invalid_preset_number",
+                    translation_placeholders={
+                        "device_name": coordinator.name,
+                        "max_preset": str(slot_count),
+                        "requested_preset": str(preset),
+                    },
+                )
+            await coordinator.async_execute_controller_command(
+                lambda ctrl, p=preset: ctrl.program_memory(p),  # type: ignore[misc]
+                cancel_running=False,
+            )
+        else:
+            raise ServiceValidationError(
+                f"Could not find Adjustable Bed device with ID {device_id}",
+                translation_domain=DOMAIN,
+                translation_key="device_not_found",
+                translation_placeholders={"device_id": device_id},
+            )
+
+
+async def handle_stop_all(call: ServiceCall) -> None:
+    """Handle stop_all service call."""
+    hass = call.hass
+    device_ids = call.data.get(CONF_DEVICE_ID, [])
+
+    _LOGGER.info("Service stop_all called")
+
+    missing_device_ids: list[str] = []
+
+    for device_id in device_ids:
+        coordinator = await _get_coordinator_from_device(hass, device_id)
+        if coordinator:
+            await coordinator.async_stop_command()
+        else:
+            missing_device_ids.append(device_id)
+
+    if missing_device_ids:
+        raise ServiceValidationError(
+            f"Could not find Adjustable Bed device(s) with ID(s): {', '.join(missing_device_ids)}",
+            translation_domain=DOMAIN,
+            translation_key="devices_not_found",
+            translation_placeholders={"device_ids": ", ".join(missing_device_ids)},
+        )
+
+
+async def handle_set_position(call: ServiceCall) -> None:
+    """Handle set_position service call."""
+    hass = call.hass
+    device_ids = call.data.get(CONF_DEVICE_ID, [])
+    motor = call.data[ATTR_MOTOR]
+    position = call.data[ATTR_POSITION]
+
+    _LOGGER.info(
+        "Service set_position called: motor=%s, position=%.1f%%",
+        motor,
+        position,
+    )
+
+    for device_id in device_ids:
+        coordinator = await _get_coordinator_from_device(hass, device_id)
+        if not coordinator:
+            raise ServiceValidationError(
+                f"Could not find Adjustable Bed device with ID {device_id}",
+                translation_domain=DOMAIN,
+                translation_key="device_not_found",
+                translation_placeholders={"device_id": device_id},
+            )
+        controller = await _get_controller_for_service(coordinator)
+
+        # Get config entry for bed type and motor count
+        entry = coordinator.entry
+        bed_type = entry.data.get(CONF_BED_TYPE)
+        motor_count = entry.data.get(CONF_MOTOR_COUNT, DEFAULT_MOTOR_COUNT)
+        protocol_variant = entry.data.get(CONF_PROTOCOL_VARIANT)
+        supports_direct_position_control = controller.supports_direct_position_control
+
+        # Validate bed supports position feedback
+        if (
+            not bed_type_has_position_feedback(bed_type, protocol_variant)
+            and not supports_direct_position_control
+        ):
+            raise ServiceValidationError(
+                f"Device '{coordinator.name}' (type: {bed_type}) does not support position feedback",
+                translation_domain=DOMAIN,
+                translation_key="position_feedback_not_supported",
+                translation_placeholders={
+                    "device_name": coordinator.name,
+                    "bed_type": bed_type or "unknown",
+                },
+            )
+
+        # Validate angle sensing is enabled
+        if coordinator.disable_angle_sensing:
+            raise ServiceValidationError(
+                f"Angle sensing is disabled for device '{coordinator.name}'",
+                translation_domain=DOMAIN,
+                translation_key="angle_sensing_disabled",
+                translation_placeholders={"device_name": coordinator.name},
+            )
+
+        # Define motor configurations.
+        # For Keeson/Ergomotion: only head and feet are valid, they map to back/legs keys.
+        # For BOX25: only head and feet are valid, using direct percentage positions.
+        # For CST: only back and legs publish position feedback.
+        # For Kaidi: direct position writes expose back/legs percentage targets.
+        # For standard beds: based on motor_count (2=back/legs, 3=+head, 4=+feet).
+        uses_percentage_positions = bed_type in (
+            BED_TYPE_KEESON,
+            BED_TYPE_ERGOMOTION,
+            BED_TYPE_SLEEPYS_BOX25,
+        ) or (bed_type == BED_TYPE_KAIDI and supports_direct_position_control)
+
+        if bed_type == BED_TYPE_KAIDI and supports_direct_position_control:
+            valid_motors = {"back", "legs"}
+            motor_configs = {
+                "back": {
+                    "position_key": "back",
+                    "move_up_fn": lambda ctrl: ctrl.move_back_up(),
+                    "move_down_fn": lambda ctrl: ctrl.move_back_down(),
+                    "move_stop_fn": lambda ctrl: ctrl.move_back_stop(),
+                    "max_value": 100.0,
+                },
+                "legs": {
+                    "position_key": "legs",
+                    "move_up_fn": lambda ctrl: ctrl.move_legs_up(),
+                    "move_down_fn": lambda ctrl: ctrl.move_legs_down(),
+                    "move_stop_fn": lambda ctrl: ctrl.move_legs_stop(),
+                    "max_value": 100.0,
+                },
+            }
+        elif bed_type in (BED_TYPE_KEESON, BED_TYPE_ERGOMOTION):
+            # Keeson/Ergomotion only have head and feet motors
+            valid_motors = {"head", "feet"}
+            motor_configs = {
+                "head": {
+                    "position_key": "back",  # Maps to "back" in position_data
+                    "move_up_fn": lambda ctrl: ctrl.move_head_up(),
+                    "move_down_fn": lambda ctrl: ctrl.move_head_down(),
+                    "move_stop_fn": lambda ctrl: ctrl.move_head_stop(),
+                    "max_value": 100.0,  # Percentage
+                },
+                "feet": {
+                    "position_key": "legs",  # Maps to "legs" in position_data
+                    "move_up_fn": lambda ctrl: ctrl.move_feet_up(),
+                    "move_down_fn": lambda ctrl: ctrl.move_feet_down(),
+                    "move_stop_fn": lambda ctrl: ctrl.move_feet_stop(),
+                    "max_value": 100.0,  # Percentage
+                },
+            }
+        elif bed_type == BED_TYPE_SLEEPYS_BOX25:
+            valid_motors = {"head", "feet"}
+            motor_configs = {
+                "head": {
+                    "position_key": "head",
+                    "move_up_fn": lambda ctrl: ctrl.move_head_up(),
+                    "move_down_fn": lambda ctrl: ctrl.move_head_down(),
+                    "move_stop_fn": lambda ctrl: ctrl.move_head_stop(),
+                    "max_value": 100.0,
+                },
+                "feet": {
+                    "position_key": "feet",
+                    "move_up_fn": lambda ctrl: ctrl.move_feet_up(),
+                    "move_down_fn": lambda ctrl: ctrl.move_feet_down(),
+                    "move_stop_fn": lambda ctrl: ctrl.move_feet_stop(),
+                    "max_value": 100.0,
+                },
+            }
+        elif bed_type == BED_TYPE_OKIN_CST:
+            valid_motors = set(OKIN_CST_POSITION_AXES)
+            motor_configs = {
+                "back": {
+                    "position_key": "back",
+                    "move_up_fn": lambda ctrl: ctrl.move_back_up(),
+                    "move_down_fn": lambda ctrl: ctrl.move_back_down(),
+                    "move_stop_fn": lambda ctrl: ctrl.move_back_stop(),
+                    "max_value": coordinator.get_max_angle("back"),  # Degrees
+                },
+                "legs": {
+                    "position_key": "legs",
+                    "move_up_fn": lambda ctrl: ctrl.move_legs_up(),
+                    "move_down_fn": lambda ctrl: ctrl.move_legs_down(),
+                    "move_stop_fn": lambda ctrl: ctrl.move_legs_stop(),
+                    "max_value": coordinator.get_max_angle("legs"),  # Degrees
+                },
+            }
+        else:
+            # Standard beds: motor availability depends on motor_count
+            motor_configs = {
+                "back": {
+                    "position_key": "back",
+                    "move_up_fn": lambda ctrl: ctrl.move_back_up(),
+                    "move_down_fn": lambda ctrl: ctrl.move_back_down(),
+                    "move_stop_fn": lambda ctrl: ctrl.move_back_stop(),
+                    "max_value": coordinator.get_max_angle("back"),  # Degrees
+                    "min_motors": 2,
+                },
+                "legs": {
+                    "position_key": "legs",
+                    "move_up_fn": lambda ctrl: ctrl.move_legs_up(),
+                    "move_down_fn": lambda ctrl: ctrl.move_legs_down(),
+                    "move_stop_fn": lambda ctrl: ctrl.move_legs_stop(),
+                    "max_value": coordinator.get_max_angle("legs"),  # Degrees
+                    "min_motors": 2,
+                },
+                "head": {
+                    "position_key": "head",
+                    "move_up_fn": lambda ctrl: ctrl.move_head_up(),
+                    "move_down_fn": lambda ctrl: ctrl.move_head_down(),
+                    "move_stop_fn": lambda ctrl: ctrl.move_head_stop(),
+                    "max_value": coordinator.get_max_angle("head"),  # Degrees
+                    "min_motors": 3,
+                },
+                "feet": {
+                    "position_key": "feet",
+                    "move_up_fn": lambda ctrl: ctrl.move_feet_up(),
+                    "move_down_fn": lambda ctrl: ctrl.move_feet_down(),
+                    "move_stop_fn": lambda ctrl: ctrl.move_feet_stop(),
+                    "max_value": coordinator.get_max_angle("feet"),  # Degrees
+                    "min_motors": 4,
+                },
+            }
+            # Filter to valid motors based on motor_count
+            valid_motors = {
+                m for m, cfg in motor_configs.items() if motor_count >= cfg.get("min_motors", 2)
+            }
+
+        # Validate motor is valid for this bed
+        if motor not in valid_motors:
+            raise ServiceValidationError(
+                f"Motor '{motor}' is not valid for device '{coordinator.name}'. "
+                f"Valid motors: {', '.join(sorted(valid_motors))}",
+                translation_domain=DOMAIN,
+                translation_key="invalid_motor_for_bed_type",
+                translation_placeholders={
+                    "motor": motor,
+                    "device_name": coordinator.name,
+                    "valid_motors": ", ".join(sorted(valid_motors)),
+                },
+            )
+
+        config = motor_configs[motor]
+        max_value = config["max_value"]
+
+        # Validate position is in range
+        if position < 0 or position > max_value:
+            unit = "%" if uses_percentage_positions else "°"
+            raise ServiceValidationError(
+                f"Position {position} is out of range for motor '{motor}'. "
+                f"Valid range: 0-{max_value}{unit}",
+                translation_domain=DOMAIN,
+                translation_key="invalid_position_range",
+                translation_placeholders={
+                    "position": str(position),
+                    "motor": motor,
+                    "max_value": str(max_value),
+                    "unit": unit,
+                },
+            )
+
+        # Call async_seek_position
+        await coordinator.async_seek_position(
+            position_key=cast(str, config["position_key"]),
+            target_angle=position,
+            move_up_fn=config["move_up_fn"],  # type: ignore[arg-type]
+            move_down_fn=config["move_down_fn"],  # type: ignore[arg-type]
+            move_stop_fn=config["move_stop_fn"],  # type: ignore[arg-type]
+        )
+
+
+async def handle_timed_move(call: ServiceCall) -> None:
+    """Handle timed_move service call."""
+    hass = call.hass
+    device_ids = call.data.get(CONF_DEVICE_ID, [])
+    motor = call.data[ATTR_MOTOR]
+    direction = call.data[ATTR_DIRECTION]
+    duration_ms = call.data[ATTR_DURATION_MS]
+
+    _LOGGER.info(
+        "Service timed_move called: motor=%s, direction=%s, duration_ms=%d",
+        motor,
+        direction,
+        duration_ms,
+    )
+
+    for device_id in device_ids:
+        coordinator = await _get_coordinator_from_device(hass, device_id)
+        if not coordinator:
+            raise ServiceValidationError(
+                f"Could not find Adjustable Bed device with ID {device_id}",
+                translation_domain=DOMAIN,
+                translation_key="device_not_found",
+                translation_placeholders={"device_id": device_id},
+            )
+        # Create a narrowed reference for use in closures (mypy doesn't narrow across closures)
+        coordinator_: AdjustableBedCoordinator = coordinator
+        controller = await _get_controller_for_service(coordinator)
+        motor_configs = {
+            spec.key: {
+                "move_up_fn": spec.open_fn,
+                "move_down_fn": spec.close_fn,
+                "move_stop_fn": spec.stop_fn,
+            }
+            for spec in controller.motor_control_specs
+            if spec.key in TIMED_MOVE_MOTOR_OPTIONS
+        }
+        valid_motors = set(motor_configs)
+
+        # Validate motor is valid for this bed
+        if motor not in valid_motors:
+            raise ServiceValidationError(
+                f"Motor '{motor}' is not valid for device '{coordinator.name}'. "
+                f"Valid motors: {', '.join(sorted(valid_motors))}",
+                translation_domain=DOMAIN,
+                translation_key="invalid_motor_for_bed_type",
+                translation_placeholders={
+                    "motor": motor,
+                    "device_name": coordinator.name,
+                    "valid_motors": ", ".join(sorted(valid_motors)),
+                },
+            )
+
+        config = motor_configs[motor]
+
+        # Get the appropriate move function based on direction
+        move_fn = config["move_up_fn"] if direction == "up" else config["move_down_fn"]
+        stop_fn = config["move_stop_fn"]
+
+        # Execute timed movement
+        # Calculate repeat count: duration_ms / pulse_delay_ms
+        # Example: 3500ms on Octo (350ms delay) = 10 repeats
+        _, pulse_delay_ms = controller.motor_pulse_settings()
+        if pulse_delay_ms <= 0:
+            _LOGGER.warning(
+                "Invalid motor_pulse_delay_ms (%d) for device %s, using default 100ms",
+                pulse_delay_ms,
+                coordinator.name,
+            )
+            pulse_delay_ms = 100  # DEFAULT_MOTOR_PULSE_DELAY_MS
+        # The first write is immediate, so one additional repeat is needed
+        # after the requested number of delay intervals.
+        calculated_repeat_count = max(
+            2,
+            (duration_ms + pulse_delay_ms - 1) // pulse_delay_ms + 1,
+        )
+
+        _LOGGER.debug(
+            "Timed move: duration=%dms, pulse_delay=%dms, repeat_count=%d",
+            duration_ms,
+            pulse_delay_ms,
+            calculated_repeat_count,
+        )
+
+        # Store original pulse settings to restore after
+        original_pulse_count = coordinator.motor_pulse_count
+        original_pulse_delay_ms = coordinator.motor_pulse_delay_ms
+
+        # Bind closure variables as defaults to avoid late-binding bugs
+        async def timed_movement(
+            ctrl: BedController,
+            *,
+            _coordinator: AdjustableBedCoordinator = coordinator_,
+            _move_fn: Callable[..., Coroutine[Any, Any, None]] = move_fn,
+            _stop_fn: Callable[..., Coroutine[Any, Any, None]] = stop_fn,
+            _calculated_repeat_count: int = calculated_repeat_count,
+            _pulse_delay_ms: int = pulse_delay_ms,
+            _original_pulse_count: int = original_pulse_count,
+            _original_pulse_delay_ms: int = original_pulse_delay_ms,
+        ) -> None:
+            """Execute movement for specified duration, always sending stop."""
+            try:
+                # Temporarily set the effective pulse settings
+                # This is safe because we're inside the command lock
+                _coordinator._motor_pulse_count = _calculated_repeat_count
+                _coordinator._motor_pulse_delay_ms = _pulse_delay_ms
+
+                # Call the movement function (uses coordinator's pulse settings)
+                await _move_fn(ctrl)
+            finally:
+                # Restore original pulse settings
+                _coordinator._motor_pulse_count = _original_pulse_count
+                _coordinator._motor_pulse_delay_ms = _original_pulse_delay_ms
+
+                # Always send stop command
+                await asyncio.shield(_stop_fn(ctrl))
+
+        await coordinator.async_execute_controller_command(timed_movement)
+
+
+async def handle_generate_support_bundle(call: ServiceCall) -> None:
+    """Handle generate_support_bundle service call."""
+    hass = call.hass
+    from homeassistant.components.persistent_notification import async_create
+
+    from .download import register_download
+    from .support_bundle import generate_support_bundle, save_support_bundle
+
+    device_ids = call.data.get(CONF_DEVICE_ID, [])
+    target_address = call.data.get(ATTR_TARGET_ADDRESS)
+    capture_duration = call.data.get(ATTR_CAPTURE_DURATION, DEFAULT_CAPTURE_DURATION)
+    include_logs = call.data.get(ATTR_INCLUDE_LOGS, True)
+
+    address: str | None = None
+    coordinator: AdjustableBedCoordinator | None = None
+    entry: ConfigEntry | None = None
+    selected_device_id: str | None = None
+
+    if target_address:
+        from .config_flow import is_valid_mac_address
+
+        address = str(target_address).upper().replace("-", ":")
+        if not is_valid_mac_address(address):
+            raise ServiceValidationError(
+                f"Invalid MAC address format: {target_address}. "
+                "Please provide a valid MAC address in the format "
+                "XX:XX:XX:XX:XX:XX or XX-XX-XX-XX-XX-XX.",
+                translation_domain=DOMAIN,
+                translation_key="invalid_mac_address",
+            )
+        _LOGGER.info(
+            "Generating support bundle for unconfigured device at %s",
+            address,
+        )
+    elif device_ids:
+        if len(device_ids) > 1:
+            raise ServiceValidationError(
+                "Support bundle generation only supports one configured device at a time. "
+                "Select a single device or use target_address for an unconfigured bed.",
+                translation_domain=DOMAIN,
+                translation_key="multiple_device_targets_not_supported",
+            )
+        # str() narrows the untyped service-call value for the str-typed parameter
+        selected_device_id = str(device_ids[0])
+        target = _get_support_bundle_target_from_device(hass, selected_device_id)
+        if target is not None:
+            address, coordinator, entry = target
+            device_name = coordinator.name if coordinator is not None else entry.title
+            _LOGGER.info(
+                "Generating support bundle for configured device %s at %s",
+                device_name,
+                address,
+            )
+        else:
+            raise ServiceValidationError(
+                f"Could not find Adjustable Bed device with ID: {selected_device_id}. "
+                "Please verify the device is configured and try again.",
+                translation_domain=DOMAIN,
+                translation_key="device_not_found",
+            )
+    else:
+        raise ServiceValidationError(
+            "No device_id or target_address was provided. "
+            "Please specify either a configured device or a target MAC address.",
+            translation_domain=DOMAIN,
+            translation_key="missing_target",
+        )
+
+    assert address is not None
+    try:
+        report = await asyncio.wait_for(
+            generate_support_bundle(
+                hass,
+                address=address,
+                capture_duration=capture_duration,
+                include_logs=include_logs,
+                coordinator=coordinator,
+                entry=entry,
+                device_id=selected_device_id,
+            ),
+            timeout=capture_duration + 120,
+        )
+        filepath = await hass.async_add_executor_job(
+            save_support_bundle,
+            hass,
+            report,
+            address,
+        )
+
+        download_url = register_download(hass, filepath)
+        notification_count = len(report.get("notifications", []))
+        evidence_warnings = report.get("evidence", {}).get("warnings", [])
+        warning_summary = ""
+        if evidence_warnings:
+            warning_summary = "\n\n**Capture warnings:**\n" + "\n".join(
+                f"- {warning}" for warning in evidence_warnings
+            )
+        async_create(
+            hass,
+            f"[**Download support bundle**]({download_url})\n\n"
+            f"Captured {notification_count} notifications over "
+            f"{capture_duration} seconds."
+            f"{warning_summary}\n\n"
+            "Attach this JSON file when reporting unsupported or broken beds.\n\n"
+            f"File path: `{filepath}`",
+            title="Adjustable Bed Support Bundle Ready",
+            notification_id=f"adjustable_bed_support_bundle_{address.replace(':', '_').lower()}",
+        )
+        _LOGGER.info("Support bundle saved to %s", filepath)
+    except TimeoutError:
+        _LOGGER.exception(
+            "Support bundle generation timed out after %d seconds for %s",
+            capture_duration + 120,
+            address,
+        )
+        async_create(
+            hass,
+            f"Support bundle generation timed out after {capture_duration + 120} seconds "
+            f"for {address}.\n\n"
+            "The BLE diagnostics may be hanging. Check Bluetooth connectivity and try again.",
+            title="Adjustable Bed Support Bundle Timeout",
+            notification_id=f"adjustable_bed_support_bundle_error_{address.replace(':', '_').lower()}",
+        )
+        raise
+    except Exception as err:
+        _LOGGER.exception("Failed to generate support bundle for %s", address)
+        async_create(
+            hass,
+            f"Failed to generate support bundle for {address}:\n\n{err}",
+            title="Adjustable Bed Support Bundle Error",
+            notification_id=f"adjustable_bed_support_bundle_error_{address.replace(':', '_').lower()}",
+        )
+        raise
+
+async def async_register_services(hass: HomeAssistant) -> None:
+    """Register the Adjustable Bed services (idempotent)."""
+    if hass.services.has_service(DOMAIN, SERVICE_GOTO_PRESET):
+        return  # Services already registered
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GOTO_PRESET,
+        handle_goto_preset,
+        schema=vol.Schema(
+            {
+                vol.Required(CONF_DEVICE_ID): cv.ensure_list,
+                vol.Required(ATTR_PRESET): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            }
+        ),
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SAVE_PRESET,
+        handle_save_preset,
+        schema=vol.Schema(
+            {
+                vol.Required(CONF_DEVICE_ID): cv.ensure_list,
+                vol.Required(ATTR_PRESET): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            }
+        ),
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_STOP_ALL,
+        handle_stop_all,
+        schema=vol.Schema(
+            {
+                vol.Required(CONF_DEVICE_ID): cv.ensure_list,
+            }
+        ),
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_POSITION,
+        handle_set_position,
+        schema=vol.Schema(
+            {
+                vol.Required(CONF_DEVICE_ID): cv.ensure_list,
+                vol.Required(ATTR_MOTOR): vol.In(["back", "legs", "head", "feet"]),
+                # No max cap here - per-motor validation handles bed-specific limits
+                vol.Required(ATTR_POSITION): vol.All(vol.Coerce(float), vol.Range(min=0)),
+            }
+        ),
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_TIMED_MOVE,
+        handle_timed_move,
+        schema=vol.Schema(
+            {
+                vol.Required(CONF_DEVICE_ID): cv.ensure_list,
+                vol.Required(ATTR_MOTOR): vol.In(TIMED_MOVE_MOTOR_OPTIONS),
+                vol.Required(ATTR_DIRECTION): vol.In(["up", "down"]),
+                vol.Required(ATTR_DURATION_MS): vol.All(
+                    vol.Coerce(int),
+                    vol.Range(min=MIN_TIMED_MOVE_DURATION_MS, max=MAX_TIMED_MOVE_DURATION_MS),
+                ),
+            }
+        ),
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GENERATE_SUPPORT_BUNDLE,
+        handle_generate_support_bundle,
+        schema=vol.Schema(
+            {
+                vol.Exclusive(CONF_DEVICE_ID, "target"): cv.ensure_list,
+                vol.Exclusive(ATTR_TARGET_ADDRESS, "target"): cv.string,
+                vol.Optional(ATTR_CAPTURE_DURATION, default=DEFAULT_CAPTURE_DURATION): vol.All(
+                    vol.Coerce(int),
+                    vol.Range(min=MIN_CAPTURE_DURATION, max=MAX_CAPTURE_DURATION),
+                ),
+                vol.Optional(ATTR_INCLUDE_LOGS, default=True): cv.boolean,
+            }
+        ),
+    )
+
+    _LOGGER.debug("Registered Adjustable Bed services")

--- a/custom_components/adjustable_bed/switch.py
+++ b/custom_components/adjustable_bed/switch.py
@@ -77,10 +77,10 @@ async def async_setup_entry(
             description.key == "under_bed_lights"
             and controller is not None
             and (
-                getattr(controller, "supports_light_color_control", False)
+                controller.supports_light_color_control
                 or (
                     coordinator.bed_type == BED_TYPE_SLEEP_NUMBER_MCR
-                    and getattr(controller, "supports_discrete_light_control", False)
+                    and controller.supports_discrete_light_control
                 )
             )
         ):
@@ -138,9 +138,7 @@ class AdjustableBedSwitch(AdjustableBedEntity, SwitchEntity):
         # Default to False for toggle-only beds when controller disconnects
         controller = coordinator.controller
         self._supports_discrete_light_control = (
-            getattr(controller, "supports_discrete_light_control", False)
-            if controller is not None
-            else False
+            controller is not None and controller.supports_discrete_light_control
         )
         # Timer handle for auto-off state updates (e.g., Octo lights turn off after 5 min)
         self._auto_off_timer: asyncio.TimerHandle | None = None
@@ -189,7 +187,7 @@ class AdjustableBedSwitch(AdjustableBedEntity, SwitchEntity):
         if controller is None:
             return
 
-        auto_off_seconds = getattr(controller, "light_auto_off_seconds", None)
+        auto_off_seconds = controller.light_auto_off_seconds
         if auto_off_seconds is None:
             return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,44 @@ TEST_ADDRESS = "AA:BB:CC:DD:EE:FF"
 TEST_NAME = "Test Bed"
 
 
+def make_controller_mock(**overrides: object) -> MagicMock:
+    """Return a controller mock that honors BedController's declared defaults.
+
+    A bare ``MagicMock()`` answers every capability probe with a truthy Mock, so
+    a test that doesn't set a capability silently exercises the capability-enabled
+    path, and Mock objects leak into numeric comparisons (seek tolerances, stall
+    thresholds). Seeding the abstract base's real defaults keeps the mock faithful
+    to the contract that production code type-checks against.
+
+    Defaults are read from ``BedController`` itself rather than duplicated here, so
+    adding a capability to the base automatically covers every mock. Properties
+    that need real coordinator or client state are left as plain Mocks.
+
+    Pass keyword overrides for the capabilities a given test actually cares about.
+    """
+    from custom_components.adjustable_bed.beds.base import BedController
+
+    controller = MagicMock()
+    for name, member in vars(BedController).items():
+        if not isinstance(member, property) or member.fget is None:
+            continue
+        try:
+            default = member.fget(controller)
+        except Exception:  # noqa: BLE001 - property needs real state; leave it a Mock
+            continue
+        if isinstance(default, bool | int | float | str | tuple | list | dict | None):
+            setattr(controller, name, default)
+    for name, value in overrides.items():
+        setattr(controller, name, value)
+    return controller
+
+
+@pytest.fixture
+def controller_mock() -> Callable[..., MagicMock]:
+    """Return the :func:`make_controller_mock` factory."""
+    return make_controller_mock
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_xdist_auto_num_workers(config: pytest.Config) -> int | None:
     """Keep automatic local test parallelism laptop-friendly."""

--- a/tests/test_controller_contract.py
+++ b/tests/test_controller_contract.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import inspect
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
+from custom_components.adjustable_bed import const, controller_factory
 from custom_components.adjustable_bed.beds.base import BedController
 from custom_components.adjustable_bed.const import (
     BED_TYPE_COOLBASE,
@@ -31,7 +34,11 @@ from custom_components.adjustable_bed.const import (
     SUPPORTED_BED_TYPES,
     VARIANT_AUTO,
 )
-from custom_components.adjustable_bed.controller_factory import create_controller
+from custom_components.adjustable_bed.controller_factory import (
+    _SIMPLE_CONTROLLERS,
+    _create_from_registry,
+    create_controller,
+)
 
 SHARED_CAPABILITY_FLAGS: tuple[str, ...] = (
     "supports_memory_presets",
@@ -210,6 +217,51 @@ async def test_factory_resolves_every_supported_bed_type(bed_type: str) -> None:
     """Every supported bed type should resolve through create_controller."""
     controller = await _create_controller_for_bed_type(bed_type)
     assert isinstance(controller, BedController)
+
+
+@pytest.mark.parametrize("bed_type", sorted(_SIMPLE_CONTROLLERS))
+async def test_registry_entries_resolve_to_controller_classes(bed_type: str) -> None:
+    """Every _SIMPLE_CONTROLLERS entry must name a real module and class.
+
+    The registry addresses controller classes by string, so this is what turns a
+    typo into a failing test instead of a ValueError on a user's bed. Covers
+    entries like BED_TYPE_DIAGNOSTIC that are absent from SUPPORTED_BED_TYPES.
+    """
+    controller = _create_from_registry(_FactoryCoordinator(), bed_type)
+    assert isinstance(controller, BedController)
+
+
+def test_registry_and_explicit_branches_are_disjoint() -> None:
+    """A bed type handled by an explicit branch must not also sit in the registry.
+
+    create_controller() consults the registry only after every explicit branch, so
+    a duplicate would be silently unreachable rather than an error.
+    """
+    factory_source = Path(controller_factory.__file__).read_text()
+    create_fn = next(
+        node
+        for node in ast.walk(ast.parse(factory_source))
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "create_controller"
+    )
+    # Walk every If in the function, not just top-level ones: elif chains live in
+    # `orelse` and a dispatch branch could be nested inside another conditional.
+    explicit: set[str] = {
+        node.id
+        for branch in ast.walk(create_fn)
+        if isinstance(branch, ast.If)
+        for node in ast.walk(branch.test)
+        if isinstance(node, ast.Name) and node.id.startswith("BED_TYPE_")
+    }
+    registry = {
+        name
+        for name, value in vars(const).items()
+        if name.startswith("BED_TYPE_")
+        and isinstance(value, str)
+        and value in _SIMPLE_CONTROLLERS
+    }
+    assert not (explicit & registry), (
+        f"Bed types are both branched on and registered: {sorted(explicit & registry)}"
+    )
 
 
 async def test_factory_auto_detects_keeson_sino_variant_for_okin_ble_signature() -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -59,7 +59,7 @@ from custom_components.adjustable_bed.const import (
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
 
-from .conftest import TEST_ADDRESS, TEST_NAME
+from .conftest import TEST_ADDRESS, TEST_NAME, make_controller_mock
 
 
 class TestCoordinatorInit:
@@ -270,7 +270,7 @@ class TestCoordinatorConnection:
             patch(
                 "custom_components.adjustable_bed.coordinator.create_controller",
                 new_callable=AsyncMock,
-                return_value=MagicMock(),
+                return_value=make_controller_mock(),
             ),
         ):
             coordinator = AdjustableBedCoordinator(hass, entry)
@@ -731,7 +731,7 @@ class TestCoordinatorPositionSeek:
         coordinator._client.is_connected = True
         coordinator._position_data["legs"] = 0.0
 
-        controller = MagicMock()
+        controller = make_controller_mock()
         controller.supports_direct_position_control = False
         controller.reverses_position_seek_on_overshoot = False
         controller.uses_custom_position_seek_steps = True
@@ -781,7 +781,7 @@ class TestCoordinatorPositionSeek:
         coordinator._client.is_connected = True
         coordinator._position_data["legs"] = 0.0
 
-        controller = MagicMock()
+        controller = make_controller_mock()
         controller.supports_direct_position_control = False
         controller.reverses_position_seek_on_overshoot = True
         controller.uses_custom_position_seek_steps = False
@@ -830,7 +830,7 @@ class TestCoordinatorPositionSeek:
         coordinator._client.is_connected = True
         coordinator._position_data["legs"] = 0.0
 
-        controller = MagicMock()
+        controller = make_controller_mock()
         controller.supports_direct_position_control = False
         controller.reverses_position_seek_on_overshoot = False
         controller.uses_custom_position_seek_steps = True
@@ -883,7 +883,7 @@ class TestCoordinatorPositionSeek:
         coordinator._client.is_connected = True
         coordinator._position_data["legs"] = 0.0
 
-        controller = MagicMock()
+        controller = make_controller_mock()
         controller.supports_direct_position_control = False
         controller.reverses_position_seek_on_overshoot = False
         controller.uses_custom_position_seek_steps = True
@@ -938,7 +938,7 @@ class TestCoordinatorPositionSeek:
         coordinator._client.is_connected = True
         coordinator._position_data["legs"] = 0.0
 
-        controller = MagicMock()
+        controller = make_controller_mock()
         controller.supports_direct_position_control = False
         controller.reverses_position_seek_on_overshoot = False
         controller.uses_custom_position_seek_steps = True
@@ -1036,7 +1036,7 @@ class TestCoordinatorPositionSeek:
             patch(
                 "custom_components.adjustable_bed.coordinator.create_controller",
                 new_callable=AsyncMock,
-                return_value=MagicMock(),
+                return_value=make_controller_mock(),
             ),
         ):
             coordinator = AdjustableBedCoordinator(hass, entry)
@@ -1092,7 +1092,7 @@ class TestCoordinatorPositionSeek:
             patch(
                 "custom_components.adjustable_bed.coordinator.create_controller",
                 new_callable=AsyncMock,
-                return_value=MagicMock(),
+                return_value=make_controller_mock(),
             ) as mock_create_controller,
         ):
             coordinator = AdjustableBedCoordinator(hass, entry)
@@ -1144,7 +1144,7 @@ class TestCoordinatorPositionSeek:
             patch(
                 "custom_components.adjustable_bed.coordinator.create_controller",
                 new_callable=AsyncMock,
-                return_value=MagicMock(),
+                return_value=make_controller_mock(),
             ),
             patch(
                 "custom_components.adjustable_bed.coordinator.bluetooth.async_discovered_service_info",
@@ -1202,7 +1202,7 @@ class TestCoordinatorPositionSeek:
             patch(
                 "custom_components.adjustable_bed.coordinator.create_controller",
                 new_callable=AsyncMock,
-                return_value=MagicMock(),
+                return_value=make_controller_mock(),
             ),
             patch(
                 "custom_components.adjustable_bed.coordinator.bluetooth.async_discovered_service_info",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1821,7 +1821,7 @@ class TestServices:
         """Standard set_position validation should honor configured back/head calibration."""
         from homeassistant.helpers import device_registry as dr
 
-        from custom_components.adjustable_bed import _async_register_services
+        from custom_components.adjustable_bed import async_register_services
 
         entry = MockConfigEntry(
             domain=DOMAIN,
@@ -1849,6 +1849,7 @@ class TestServices:
         )
 
         coordinator = MagicMock()
+        coordinator.entry = entry
         coordinator.controller = MagicMock()
         coordinator.name = entry.title
         coordinator.disable_angle_sensing = False
@@ -1861,7 +1862,7 @@ class TestServices:
         coordinator.async_seek_position = AsyncMock()
         hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
-        await _async_register_services(hass)
+        await async_register_services(hass)
 
         await hass.services.async_call(
             DOMAIN,
@@ -1917,7 +1918,7 @@ class TestServices:
         from homeassistant.exceptions import ServiceValidationError
         from homeassistant.helpers import device_registry as dr
 
-        from custom_components.adjustable_bed import _async_register_services
+        from custom_components.adjustable_bed import async_register_services
 
         entry = MockConfigEntry(
             domain=DOMAIN,
@@ -1945,6 +1946,7 @@ class TestServices:
         )
 
         coordinator = MagicMock()
+        coordinator.entry = entry
         coordinator.controller = MagicMock()
         coordinator.name = entry.title
         coordinator.disable_angle_sensing = False
@@ -1956,7 +1958,7 @@ class TestServices:
         }[motor]
         hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
-        await _async_register_services(hass)
+        await async_register_services(hass)
 
         with pytest.raises(ServiceValidationError, match=r"Valid range: 0-50.0°"):
             await hass.services.async_call(

--- a/tests/test_jensen.py
+++ b/tests/test_jensen.py
@@ -32,6 +32,8 @@ from custom_components.adjustable_bed.const import (
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
 
+from .conftest import make_controller_mock
+
 
 @pytest.fixture
 def _shorten_mocked_config_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -382,7 +384,7 @@ class TestJensenCoordinatorAuthRefresh:
         coordinator = AdjustableBedCoordinator(hass, mock_jensen_config_entry)
         coordinator._client = MagicMock()
         coordinator._client.is_connected = True
-        coordinator._controller = MagicMock()
+        coordinator._controller = make_controller_mock()
         coordinator._controller.send_pin = AsyncMock()
         coordinator._controller.command_called = AsyncMock()
 
@@ -407,7 +409,7 @@ class TestJensenCoordinatorAuthRefresh:
         coordinator = AdjustableBedCoordinator(hass, mock_jensen_config_entry)
         coordinator._client = MagicMock()
         coordinator._client.is_connected = True
-        coordinator._controller = MagicMock()
+        coordinator._controller = make_controller_mock()
         coordinator._controller.send_pin = AsyncMock()
         coordinator._controller.write_command = AsyncMock()
 
@@ -435,7 +437,7 @@ class TestJensenCoordinatorAuthRefresh:
         coordinator = AdjustableBedCoordinator(hass, mock_jensen_config_entry)
         coordinator._client = MagicMock()
         coordinator._client.is_connected = True
-        coordinator._controller = MagicMock()
+        coordinator._controller = make_controller_mock()
         coordinator._controller.send_pin = AsyncMock()
         coordinator._controller.stop_all = AsyncMock()
 
@@ -477,7 +479,7 @@ class TestJensenCoordinatorAuthRefresh:
         coordinator = AdjustableBedCoordinator(hass, mock_jensen_config_entry)
         coordinator._client = MagicMock()
         coordinator._client.is_connected = True
-        coordinator._controller = MagicMock()
+        coordinator._controller = make_controller_mock()
         coordinator._controller.send_pin = AsyncMock()
         coordinator._controller.supports_direct_position_control = True
         coordinator._controller.angle_to_native_position = MagicMock(return_value=123)
@@ -516,7 +518,7 @@ class TestJensenCoordinatorAuthRefresh:
         coordinator = AdjustableBedCoordinator(hass, mock_jensen_config_entry)
         coordinator._client = MagicMock()
         coordinator._client.is_connected = True
-        coordinator._controller = MagicMock()
+        coordinator._controller = make_controller_mock()
         coordinator._controller.send_pin = AsyncMock()
         coordinator._controller.supports_direct_position_control = True
         coordinator._controller.angle_to_native_position = MagicMock(return_value=55)

--- a/tests/test_motosleep.py
+++ b/tests/test_motosleep.py
@@ -143,10 +143,8 @@ def test_neutral_axis_builds_a_generic_cover_description() -> None:
     """An APK-proven axis with tentative semantics must still create an entity."""
     controller, _client = _controller("HHC0000040CDEF")
     auxiliary = next(spec for spec in controller.motor_control_specs if spec.key == "auxiliary_1")
-    coordinator = MagicMock()
-    coordinator.bed_type = "motosleep"
 
-    description = _build_cover_description(coordinator, auxiliary)
+    description = _build_cover_description(auxiliary)
 
     assert description.key == "auxiliary_1"
     assert description.translation_key == "auxiliary_1"


### PR DESCRIPTION
Four related refactors that push bed-specific knowledge out of the entity platforms and the factory, and into the controllers that own it. Behavior-preserving except for one documented case, called out below.

## What changed

**Capability contracts.** Declares 11 previously-undeclared capabilities on `BedController` and removes 57 of 68 `getattr(controller, "...", default)` probes. 26 of those named properties the base already declared, so the default was dead code that also blinded pyright; the other 18 were implicit contracts nothing verified, where a typo would return the default forever. The 11 remaining `getattr` calls (in `diagnostics.py` / `support_report.py`) are deliberate optional introspection over per-controller privates and stay.

**Registry dispatch.** `create_controller()` was 750 lines, 35 branches of which amounted to "import this class and pass the coordinator". Those become a `_SIMPLE_CONTROLLERS` table; the 20 branches doing real work stay explicit. Now 566 lines.

**Position sliders.** `number.py`'s six-way `bed_type` chain (243 lines building near-identical entity descriptions) becomes one loop over `controller.position_number_specs`, extending the pattern `motor_control_specs` already established for covers. Reverie's 60 degree head limit moves onto the controller via a new `motor_max_angles` hook, so `cover.py` stops checking bed types too.

**Service handlers.** `_async_register_services` and its closures move out of `__init__.py` into `services.py` as module-level functions. `__init__.py`: 1294 to 546 lines.

Plus `bed_type_has_position_feedback()`, replacing six copies of the same predicate, one of which was already a private helper in `config_flow.py` that three inline copies in that same file did not use.

## Verification

- Full suite green: 2508 passed (2472 before, plus 36 new registry tests).
- pyright: 0 errors across 154 files. ruff: clean.
- Equivalence checked by replaying the old branching against the new specs: 14 bed types x 3 motor counts for position sliders, and all 55 bed types x 3 motor counts (565 motor specs) for cover travel limits. Both identical.
- Confirmed no `__getattr__`/`__getattribute__` anywhere and no raising property override, so every removed `getattr` default was provably unreachable.

## Behavior change

`number.py` now requires a live controller to create position sliders. Previously most beds built them from `bed_type` alone, so a bed disconnecting between a successful setup connect and platform forwarding loses its sliders until a reload. The old defensiveness was already inconsistent (Kaidi and SleepStar required a controller) and `cover.py` has always required one; this makes the platforms uniform. Happy to restore the old behavior by caching the controller on the coordinator if preferred.

## Notes for review

- Registry entries address controller classes by name, which is needed to keep imports lazy. Two tests back it: one resolves every entry, one parses the factory AST to prove no bed type is both branched on and registered (which the registry-last ordering would make silently unreachable).
- `coordinator.py`'s `isinstance` re-validation of seek tuning values existed only to sanitize bare `MagicMock`s in tests. Rather than keep it, `conftest` gains `make_controller_mock()`, which seeds mocks from the base class's own defaults so they stay faithful as the contract grows.
- `sensor.py` was left alone deliberately. Its remaining bed-type references are central registry lookups that work without a live controller (angle sensors are gated only on `disable_angle_sensing`), so converting them would force the behavior change above onto a much wider path.

## Found but not changed

`BED_TYPE_OKIN_FFE` runs the Keeson protocol, which reports percentages, but is absent from `BEDS_WITH_PERCENTAGE_POSITIONS`. With angle sensing enabled it would get degree sensors fed percentage values. Only visible if a user turns angle sensing on (it defaults off). Left alone since it needs a protocol judgement rather than a refactor.

`config_flow.py:957` computes `default_disable_angle` without the Keeson/ergomotion case that a sibling path in the same step applies. Possibly intentional, since the variant is not chosen yet at that point.

`CLAUDE.md`'s 9-step "Adding a New Bed Type" is now out of date: step 5 is usually a one-line registry entry, and there is a new optional step for `position_number_specs`. Left for a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Home Assistant services for presets, position control, timed movement, stopping all motors, and generating support bundles.
  * Added/expanded position slider entities using capability-driven specs (percentage vs angle) for supported bed models.
  * Enhanced bed-controller capabilities (foundation presets/options, Sleep Number settings, bed presence, climate side controls, optional auto-massage).
* **Bug Fixes**
  * Improved position feedback detection and entity capability gating.
  * Refined max-angle handling for affected models (including Reverie head/back constraints) and more robust movement/disconnect behavior.
* **Refactor**
  * Centralized service registration and simplified controller creation via a registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->