### PR TITLE
Stop throwing away LP Comfort Connect's single BLE connection

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -578,4 +578,13 @@ def _async_clear_stale_octo_pin_issue(hass: HomeAssistant, entry: ConfigEntry) -
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options updates."""
+    coordinator = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if coordinator is not None and coordinator.consume_internal_entry_update(entry):
+        # The coordinator recorded its own BLE bond marker. Reloading for that
+        # would disconnect the bed, which is fatal for a bed that only grants
+        # one connection per pairing window (issue #385).
+        _LOGGER.debug(
+            "Skipping reload for %s: internal bond-marker update", entry.entry_id
+        )
+        return
     await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/adjustable_bed/address_lock.py
+++ b/custom_components/adjustable_bed/address_lock.py
@@ -16,11 +16,21 @@ connect in flight.
 Holding this lock across a whole connect attempt makes a competing caller wait
 instead of poisoning the in-flight attempt. Waiting is always preferable: a
 delayed connection still works, an aborted one does not.
+
+The lock is **reentrant per asyncio task**, which a plain ``asyncio.Lock`` is
+not. These paths legitimately nest: the support-bundle capture holds the
+address for its whole capture and then asks the coordinator to reconnect a
+dropped link (``async_ensure_connected`` → ``_async_connect_locked``), which
+acquires the same address. With a plain lock that awaits itself and the capture
+hangs forever. Reentrancy is the right semantic here because the nested call is
+part of the same logical operation on the same device, in the same task, so
+letting it through cannot interleave it with a competing caller.
 """
 
 from __future__ import annotations
 
 import asyncio
+from types import TracebackType
 from typing import Final
 
 from homeassistant.core import HomeAssistant
@@ -30,11 +40,62 @@ from .const import DOMAIN
 _LOCKS_KEY: Final = f"{DOMAIN}_connect_locks"
 
 
-def async_get_connect_lock(hass: HomeAssistant, address: str) -> asyncio.Lock:
+class ReentrantAddressLock:
+    """An asyncio lock that the owning task may re-acquire.
+
+    Only the task that already holds the lock is let through; any other task
+    waits as it would on a plain ``asyncio.Lock``.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an unowned lock."""
+        self._lock = asyncio.Lock()
+        self._owner: asyncio.Task[object] | None = None
+        self._depth = 0
+
+    def locked(self) -> bool:
+        """Return True while any task holds the lock."""
+        return self._lock.locked()
+
+    async def acquire(self) -> None:
+        """Acquire the lock, or re-enter it when this task already owns it."""
+        task = asyncio.current_task()
+        if self._owner is not None and self._owner is task:
+            self._depth += 1
+            return
+        await self._lock.acquire()
+        self._owner = task
+        self._depth = 1
+
+    def release(self) -> None:
+        """Release one level of ownership."""
+        if self._depth == 0:
+            raise RuntimeError("Lock is not acquired")
+        self._depth -= 1
+        if self._depth == 0:
+            self._owner = None
+            self._lock.release()
+
+    async def __aenter__(self) -> ReentrantAddressLock:
+        """Acquire the lock for an ``async with`` block."""
+        await self.acquire()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Release the lock at the end of an ``async with`` block."""
+        self.release()
+
+
+def async_get_connect_lock(hass: HomeAssistant, address: str) -> ReentrantAddressLock:
     """Return the shared connect lock for ``address``.
 
     Locks are stored on ``hass.data`` rather than at module scope so they do not
     leak between Home Assistant instances (or between tests).
     """
-    locks: dict[str, asyncio.Lock] = hass.data.setdefault(_LOCKS_KEY, {})
-    return locks.setdefault(address.upper(), asyncio.Lock())
+    locks: dict[str, ReentrantAddressLock] = hass.data.setdefault(_LOCKS_KEY, {})
+    return locks.setdefault(address.upper(), ReentrantAddressLock())

--- a/custom_components/adjustable_bed/address_lock.py
+++ b/custom_components/adjustable_bed/address_lock.py
@@ -1,0 +1,40 @@
+"""Per-address serialization of BLE connection attempts.
+
+Several code paths in this integration can try to connect to the same bed at
+once: the coordinator's retry loop, the config flow's capability probe and
+pairing step, the pairing repair flow, and the support-bundle diagnostic. BlueZ
+allows only one outstanding ``Device1.Connect()`` per device, so an overlapping
+attempt fails immediately with ``org.bluez.Error.InProgress`` — and bleak's
+cleanup for the loser then calls ``Disconnect()``, which can abort the
+connection the winner was still establishing. Two retry loops racing this way
+can keep a bed permanently unreachable.
+
+Issue #385 caught exactly that in the field: two diagnostic attempts failed in
+0.259s each with ``[org.bluez.Error.InProgress]`` while the coordinator had a
+connect in flight.
+
+Holding this lock across a whole connect attempt makes a competing caller wait
+instead of poisoning the in-flight attempt. Waiting is always preferable: a
+delayed connection still works, an aborted one does not.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Final
+
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+_LOCKS_KEY: Final = f"{DOMAIN}_connect_locks"
+
+
+def async_get_connect_lock(hass: HomeAssistant, address: str) -> asyncio.Lock:
+    """Return the shared connect lock for ``address``.
+
+    Locks are stored on ``hass.data`` rather than at module scope so they do not
+    leak between Home Assistant instances (or between tests).
+    """
+    locks: dict[str, asyncio.Lock] = hass.data.setdefault(_LOCKS_KEY, {})
+    return locks.setdefault(address.upper(), asyncio.Lock())

--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -489,8 +489,14 @@ class BLEDiagnosticRunner:
                 self._connection_attempt_details.append(attempt_details)
 
                 if self._client is not None:
-                    with contextlib.suppress(Exception):
-                        await self._client.disconnect()
+                    # Take the address lock for the teardown too. With a
+                    # coordinator the capture deliberately does not hold it, so
+                    # an unprotected disconnect here could land inside a
+                    # competing caller's connect (issue #385). Reentrant, so it
+                    # is a no-op when the standalone capture already holds it.
+                    async with async_get_connect_lock(self.hass, self.address):
+                        with contextlib.suppress(Exception):
+                            await self._client.disconnect()
                     self._client = None
 
                 if attempt == 1:

--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -223,12 +223,23 @@ class BLEDiagnosticRunner:
             allow_non_connectable=True,
         )
 
-        # Hold the address lock for the whole capture, not just the connect.
-        # A concurrent setup retry would otherwise run
-        # close_stale_connections_by_address() and disconnect this client
-        # mid-capture (issue #385). The lock is released by leaving this
-        # block, so it cannot leak even if the capture raises.
-        async with async_get_connect_lock(self.hass, self.address):
+        # Hold the address lock for the whole capture only when this runner owns
+        # the connection. A concurrent setup retry would otherwise run
+        # close_stale_connections_by_address() and disconnect our client
+        # mid-capture (issue #385), and leaving the block always releases it.
+        #
+        # With a coordinator we must NOT hold it: if the shared link drops,
+        # _on_disconnect() schedules _async_auto_reconnect() in a *separate*
+        # task, and the lock is only reentrant within one task. Holding it for
+        # the capture would block that reconnect for the whole capture window,
+        # losing every later notification and leaving the bed offline until
+        # cleanup. The coordinator owns that link, so let it manage it; the
+        # standalone fallback inside _connect() still takes the lock narrowly.
+        async with contextlib.AsyncExitStack() as stack:
+            if self.coordinator is None:
+                await stack.enter_async_context(
+                    async_get_connect_lock(self.hass, self.address)
+                )
             try:
                 await self._connect()
 
@@ -431,16 +442,17 @@ class BLEDiagnosticRunner:
 
             try:
                 connect_start = time.monotonic()
-                # run_diagnostics() already holds this address's connect lock for
-                # the whole capture; asyncio.Lock is not reentrant, so do not
-                # re-acquire it here.
-                self._client = await establish_connection(
-                    BleakClient,
-                    device,
-                    f"diagnostic_{self.address}",
-                    max_attempts=1,
-                    timeout=CONNECTION_TIMEOUT,
-                )
+                # Narrow lock around our own connect. When run_diagnostics()
+                # already holds it for this capture, the reentrant lock makes
+                # this a no-op for the same task.
+                async with async_get_connect_lock(self.hass, self.address):
+                    self._client = await establish_connection(
+                        BleakClient,
+                        device,
+                        f"diagnostic_{self.address}",
+                        max_attempts=1,
+                        timeout=CONNECTION_TIMEOUT,
+                    )
                 attempt_details["connect_elapsed_seconds"] = round(
                     time.monotonic() - connect_start, 3
                 )

--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -223,41 +223,47 @@ class BLEDiagnosticRunner:
             allow_non_connectable=True,
         )
 
-        try:
-            await self._connect()
+        # Hold the address lock for the whole capture, not just the connect.
+        # A concurrent setup retry would otherwise run
+        # close_stale_connections_by_address() and disconnect this client
+        # mid-capture (issue #385). The lock is released by leaving this
+        # block, so it cannot leak even if the capture raises.
+        async with async_get_connect_lock(self.hass, self.address):
+            try:
+                await self._connect()
 
-            if self._client and self._client.is_connected:
-                services_info = await self._enumerate_services()
-                device_information = await self._read_device_information()
+                if self._client and self._client.is_connected:
+                    services_info = await self._enumerate_services()
+                    device_information = await self._read_device_information()
 
-            if await self._ensure_connected():
-                try:
-                    await self._subscribe_to_notifications(services_info)
+                if await self._ensure_connected():
+                    try:
+                        await self._subscribe_to_notifications(services_info)
 
-                    _LOGGER.info(
-                        "Capturing notifications for %d seconds. "
-                        "Operate the physical remote to generate data.",
-                        self.capture_duration,
+                        _LOGGER.info(
+                            "Capturing notifications for %d seconds. "
+                            "Operate the physical remote to generate data.",
+                            self.capture_duration,
+                        )
+                        await asyncio.sleep(self.capture_duration)
+                    finally:
+                        await self._unsubscribe_from_notifications(services_info)
+                else:
+                    message = (
+                        "Skipped notification capture: connection lost and "
+                        "could not be re-established"
                     )
-                    await asyncio.sleep(self.capture_duration)
-                finally:
-                    await self._unsubscribe_from_notifications(services_info)
-            else:
-                message = (
-                    "Skipped notification capture: connection lost and "
-                    "could not be re-established"
-                )
-                _LOGGER.warning(message)
-                self._errors.append(message)
+                    _LOGGER.warning(message)
+                    self._errors.append(message)
 
-        except asyncio.CancelledError:
-            raise
-        except Exception as err:
-            error_msg = f"Diagnostic error: {err}"
-            _LOGGER.exception(error_msg)
-            self._errors.append(error_msg)
-        finally:
-            await self._disconnect()
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:
+                error_msg = f"Diagnostic error: {err}"
+                _LOGGER.exception(error_msg)
+                self._errors.append(error_msg)
+            finally:
+                await self._disconnect()
 
         end_time = datetime.now(UTC)
         best_snapshot = self._best_snapshot()
@@ -425,17 +431,16 @@ class BLEDiagnosticRunner:
 
             try:
                 connect_start = time.monotonic()
-                # Wait for any coordinator/config-flow attempt on this address to
-                # finish rather than racing it into org.bluez.Error.InProgress,
-                # which used to make the capture fail in ~0.25s (issue #385).
-                async with async_get_connect_lock(self.hass, self.address):
-                    self._client = await establish_connection(
-                        BleakClient,
-                        device,
-                        f"diagnostic_{self.address}",
-                        max_attempts=1,
-                        timeout=CONNECTION_TIMEOUT,
-                    )
+                # run_diagnostics() already holds this address's connect lock for
+                # the whole capture; asyncio.Lock is not reentrant, so do not
+                # re-acquire it here.
+                self._client = await establish_connection(
+                    BleakClient,
+                    device,
+                    f"diagnostic_{self.address}",
+                    max_attempts=1,
+                    timeout=CONNECTION_TIMEOUT,
+                )
                 attempt_details["connect_elapsed_seconds"] = round(
                     time.monotonic() - connect_start, 3
                 )

--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -24,6 +24,7 @@ from .adapter import (
     get_service_info_snapshots_by_address,
     select_adapter,
 )
+from .address_lock import async_get_connect_lock
 from .const import (
     ADAPTER_AUTO,
     CONF_PREFERRED_ADAPTER,
@@ -424,13 +425,17 @@ class BLEDiagnosticRunner:
 
             try:
                 connect_start = time.monotonic()
-                self._client = await establish_connection(
-                    BleakClient,
-                    device,
-                    f"diagnostic_{self.address}",
-                    max_attempts=1,
-                    timeout=CONNECTION_TIMEOUT,
-                )
+                # Wait for any coordinator/config-flow attempt on this address to
+                # finish rather than racing it into org.bluez.Error.InProgress,
+                # which used to make the capture fail in ~0.25s (issue #385).
+                async with async_get_connect_lock(self.hass, self.address):
+                    self._client = await establish_connection(
+                        BleakClient,
+                        device,
+                        f"diagnostic_{self.address}",
+                        max_attempts=1,
+                        timeout=CONNECTION_TIMEOUT,
+                    )
                 attempt_details["connect_elapsed_seconds"] = round(
                     time.monotonic() - connect_start, 3
                 )

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -43,6 +43,7 @@ from .adapter import (
     read_ble_device_info,
     select_adapter,
 )
+from .address_lock import async_get_connect_lock
 from .const import (
     ADAPTER_AUTO,
     ALL_PROTOCOL_VARIANTS,
@@ -118,6 +119,7 @@ from .const import (
     bed_type_has_position_feedback,
     get_richmat_features,
     get_richmat_motor_count,
+    grants_one_connection_per_pairing_window,
     passive_position_reconciliation_default_enabled,
     requires_pairing,
     requires_pairing_after_service_discovery,
@@ -2093,25 +2095,9 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             action = user_input.get("action")
 
             if action == "pair_now":
-                # Attempt pairing
-                address = self._manual_data.get(CONF_ADDRESS)
-                try:
-                    paired = await self._attempt_pairing(address)
-                    if paired:
-                        return self.async_create_entry(
-                            title=self._manual_data.get(CONF_NAME, "Adjustable Bed"),
-                            data=self._mark_ble_bond_established(self._manual_data),
-                        )
-                    else:
-                        errors["base"] = "pairing_failed"
-                except (NotImplementedError, TypeError) as err:
-                    # NotImplementedError: ESPHome < 2024.3.0 doesn't support pairing
-                    # TypeError: older bleak-retry-connector doesn't have pair kwarg
-                    _LOGGER.warning("Pairing not supported: %s", err)
-                    errors["base"] = "pairing_not_supported"
-                except Exception as err:
-                    _LOGGER.warning("Pairing failed for %s: %s", address, err)
-                    errors["base"] = "pairing_failed"
+                result = await self._async_handle_pair_now(errors)
+                if result is not None:
+                    return result
 
             elif action == "skip_pairing":
                 return self._create_entry_for_existing_bond()
@@ -2156,25 +2142,9 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             action = user_input.get("action")
 
             if action == "pair_now":
-                # Attempt pairing
-                address = self._manual_data.get(CONF_ADDRESS)
-                try:
-                    paired = await self._attempt_pairing(address)
-                    if paired:
-                        return self.async_create_entry(
-                            title=self._manual_data.get(CONF_NAME, "Adjustable Bed"),
-                            data=self._mark_ble_bond_established(self._manual_data),
-                        )
-                    else:
-                        errors["base"] = "pairing_failed"
-                except (NotImplementedError, TypeError) as err:
-                    # NotImplementedError: ESPHome < 2024.3.0 doesn't support pairing
-                    # TypeError: older bleak-retry-connector doesn't have pair kwarg
-                    _LOGGER.warning("Pairing not supported: %s", err)
-                    errors["base"] = "pairing_not_supported"
-                except Exception as err:
-                    _LOGGER.warning("Pairing failed for %s: %s", address, err)
-                    errors["base"] = "pairing_failed"
+                result = await self._async_handle_pair_now(errors)
+                if result is not None:
+                    return result
 
             elif action == "skip_pairing":
                 return self._create_entry_for_existing_bond()
@@ -2199,6 +2169,51 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
             description_placeholders=description_placeholders,
         )
+
+    async def _async_handle_pair_now(
+        self, errors: dict[str, str]
+    ) -> ConfigFlowResult | None:
+        """Run the "Pair Now" action for the two pairing steps.
+
+        Returns the created entry, or None when the caller should redisplay its
+        form with ``errors`` populated.
+        """
+        assert self._manual_data is not None
+        address = self._manual_data.get(CONF_ADDRESS)
+        title = self._manual_data.get(CONF_NAME, "Adjustable Bed")
+
+        if grants_one_connection_per_pairing_window(
+            self._manual_data.get(CONF_BED_TYPE) or "",
+            self._manual_data.get(CONF_PROTOCOL_VARIANT),
+        ):
+            # Pairing here would open, bond, and then close a connection that
+            # the box will not grant a second time, leaving async_setup_entry
+            # with nothing to connect to (issue #385). Create the entry without
+            # a bond marker and let the coordinator's first connection do
+            # connect -> discover -> bond -> stay connected.
+            _LOGGER.info(
+                "Deferring the BLE bond for %s to the first coordinator "
+                "connection: this bed grants one connection per pairing window",
+                address,
+            )
+            return self.async_create_entry(title=title, data=self._manual_data)
+
+        try:
+            if await self._attempt_pairing(address):
+                return self.async_create_entry(
+                    title=title,
+                    data=self._mark_ble_bond_established(self._manual_data),
+                )
+            errors["base"] = "pairing_failed"
+        except (NotImplementedError, TypeError) as err:
+            # NotImplementedError: ESPHome < 2024.3.0 doesn't support pairing
+            # TypeError: older bleak-retry-connector doesn't have pair kwarg
+            _LOGGER.warning("Pairing not supported: %s", err)
+            errors["base"] = "pairing_not_supported"
+        except Exception as err:
+            _LOGGER.warning("Pairing failed for %s: %s", address, err)
+            errors["base"] = "pairing_failed"
+        return None
 
     async def _attempt_pairing(self, address: str | None) -> bool:
         """Attempt to pair using the protocol's required connection ordering.
@@ -2275,27 +2290,31 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         # LP Control first connects and discovers GATT, then asks Android to
         # create the bond. BlueZ's pair=True path calls Device1.Pair instead of
         # making the app's ordinary unbonded GATT connection first.
-        client = await establish_connection(
-            BleakClient,
-            device,
-            address,
-            max_attempts=1,
-            timeout=CONNECTION_PROFILES[DEFAULT_CONNECTION_PROFILE].connection_timeout,
-            pair=not pair_after_service_discovery,
-            use_services_cache=not pair_after_service_discovery,
-        )
-        try:
-            if pair_after_service_discovery:
-                _LOGGER.info(
-                    "Connected to %s and discovered services; creating the BLE bond now",
-                    address,
-                )
-                await client.pair()
+        # Hold the address lock for the whole client lifetime, not just the
+        # connect: the disconnect below must not land in the middle of another
+        # caller's connect attempt, where bleak's cleanup can abort it.
+        async with async_get_connect_lock(self.hass, address):
+            client = await establish_connection(
+                BleakClient,
+                device,
+                address,
+                max_attempts=1,
+                timeout=CONNECTION_PROFILES[DEFAULT_CONNECTION_PROFILE].connection_timeout,
+                pair=not pair_after_service_discovery,
+                use_services_cache=not pair_after_service_discovery,
+            )
+            try:
+                if pair_after_service_discovery:
+                    _LOGGER.info(
+                        "Connected to %s and discovered services; creating the BLE bond now",
+                        address,
+                    )
+                    await client.pair()
 
-            _LOGGER.info("Pairing successful for %s", address)
-            return True
-        finally:
-            await client.disconnect()
+                _LOGGER.info("Pairing successful for %s", address)
+                return True
+            finally:
+                await client.disconnect()
 
     def _verification_possible(self) -> bool:
         """Return True only when a connectable scanner exists to probe through.
@@ -2365,34 +2384,43 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         report.via_proxy = bool(selection.source and "esphome" in selection.source.lower())
 
         client: BleakClient | None = None
+        # Hold the address lock until the probe has fully released the client,
+        # so its disconnect cannot abort a connect attempt started elsewhere.
         try:
-            client = await establish_connection(
-                BleakClient,
-                device,
-                address,
-                max_attempts=1,
-                timeout=_PROBE_TIMEOUT_SECONDS,
-            )
-            report.connected = bool(client.is_connected)
-            await discover_services(client, address)
-            services = list(client.services) if client.services else []
-            report.service_count = len(services)
-            writable = 0
-            for service in services:
-                for char in service.characteristics:
-                    if "write" in char.properties or "write-without-response" in char.properties:
-                        writable += 1
-            report.writable_count = writable
-            report.manufacturer, report.model = await read_ble_device_info(client, address)
+            async with async_get_connect_lock(self.hass, address):
+                try:
+                    client = await establish_connection(
+                        BleakClient,
+                        device,
+                        address,
+                        max_attempts=1,
+                        timeout=_PROBE_TIMEOUT_SECONDS,
+                    )
+                    report.connected = bool(client.is_connected)
+                    await discover_services(client, address)
+                    services = list(client.services) if client.services else []
+                    report.service_count = len(services)
+                    writable = 0
+                    for service in services:
+                        for char in service.characteristics:
+                            if (
+                                "write" in char.properties
+                                or "write-without-response" in char.properties
+                            ):
+                                writable += 1
+                    report.writable_count = writable
+                    report.manufacturer, report.model = await read_ble_device_info(
+                        client, address
+                    )
+                finally:
+                    if client is not None:
+                        try:
+                            await client.disconnect()
+                        except Exception:  # noqa: BLE001 - cleanup must not raise
+                            pass
         except Exception as err:  # noqa: BLE001 - probe is best-effort
             report.error = str(err) or err.__class__.__name__
             _LOGGER.debug("Capability probe for %s failed: %s", address, err)
-        finally:
-            if client is not None:
-                try:
-                    await client.disconnect()
-                except Exception:  # noqa: BLE001 - cleanup must not raise
-                    pass
 
         return report
 

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -1939,6 +1939,34 @@ def connection_gated_by_bond(bed_type: str, protocol_variant: str | None = None)
     return bed_type == BED_TYPE_LEGGETT_PLATT and protocol_variant == LEGGETT_VARIANT_GEN2
 
 
+def grants_one_connection_per_pairing_window(
+    bed_type: str, protocol_variant: str | None = None
+) -> bool:
+    """Return True when a live link must never be spent or thrown away.
+
+    LP Comfort Connect (Leggett & Platt Gen2) grants roughly one usable BLE
+    connection per bed power cycle: issue #385's support bundles record exactly
+    one completed connection followed by an unbroken run of connect timeouts
+    (3.3.0: ``connect_completed_total: 1`` at 39s after startup, then 41
+    consecutive failures, every one of them this bed) until the box is
+    unplugged again.
+
+    Two consequences follow for every code path that touches such a box:
+
+    1. Never open a throwaway connection. A probe or a standalone pairing
+       connect that disconnects in ``finally`` consumes the only connection the
+       coordinator was going to get.
+    2. Never trade a working link for a cleaner state. Reconnecting to "do it
+       properly" strands the bed until the user power-cycles it.
+
+    LP Control matches this: it connects once with ``autoConnect=true``, fires
+    ``createBond()`` after service discovery, never observes the result (the app
+    has no ``ACTION_BOND_STATE_CHANGED`` receiver and no bond retry anywhere),
+    and continues the session on that same link bonded or not.
+    """
+    return connection_gated_by_bond(bed_type, protocol_variant)
+
+
 # Bed types that support angle sensing (position feedback)
 BEDS_WITH_ANGLE_SENSING: Final = frozenset(
     {

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -40,6 +40,7 @@ from .adapter import (
     read_ble_device_info,
     select_adapter,
 )
+from .address_lock import async_get_connect_lock
 from .ble_auth import is_ble_authentication_error
 from .const import (
     ADAPTER_AUTO,
@@ -136,6 +137,7 @@ from .const import (
     connection_gated_by_bond,
     get_richmat_features,
     get_richmat_motor_count,
+    grants_one_connection_per_pairing_window,
     passive_position_reconciliation_default_enabled,
     requires_pairing,
     requires_pairing_after_service_discovery,
@@ -832,10 +834,88 @@ class AdjustableBedCoordinator:
             )
 
         if self._client is not None and self._client.is_connected:
+            if grants_one_connection_per_pairing_window(
+                self._bed_type, self._protocol_variant
+            ):
+                # Disconnecting would cost us the box's single connection and
+                # the reconnect that "fixes" the bond can never happen. Leave
+                # the link up; the repair issue above tells the user to re-pair.
+                _LOGGER.warning(
+                    "Keeping the unbonded link to %s open: this bed grants one "
+                    "connection per pairing window, so disconnecting to re-pair "
+                    "would leave it unreachable until it is power-cycled.",
+                    self._address,
+                )
+                return
             if holding_lock:
                 await self._async_disconnect_locked(reason="authentication_failed")
             else:
                 await self.async_disconnect(reason="authentication_failed")
+
+    async def _async_pair_on_live_link(self, pairing_details: dict[str, Any]) -> bool:
+        """Create the BLE bond on an already-connected, service-discovered link.
+
+        Returns True when the bond was created, False when it failed and the bed
+        type tolerates staying unbonded.
+
+        For a bed that only grants one connection per pairing window, letting a
+        bond failure propagate is self-defeating: the caller tears the link down
+        and the box then refuses every reconnect until it is power-cycled. LP
+        Control never takes that risk — it fires ``createBond()`` and continues
+        on the same link without ever checking whether it succeeded — so mirror
+        that and keep the connection. Whether an unbonded link can actually
+        drive the motors is firmware behaviour the APK cannot prove, but a live
+        link can be tried while a dropped one is guaranteed useless.
+
+        This applies to a backend that cannot pair at all
+        (``NotImplementedError``/``TypeError``, e.g. ESPHome < 2024.3.0) just as
+        much as to a rejected bond: the caller's compatibility fallback would
+        reconnect with ``pair=False``, but the link we already hold was itself
+        made with ``pair=False``, so it would spend the bed's one connection to
+        obtain an identical one.
+        """
+        client = self._client
+        if client is None:
+            return False
+        advisory = grants_one_connection_per_pairing_window(
+            self._bed_type, self._protocol_variant
+        )
+        try:
+            await client.pair()
+        except (NotImplementedError, TypeError) as err:
+            if not advisory:
+                raise
+            self._pairing_supported = False
+            pairing_details["adapter_pairing_supported"] = False
+            _LOGGER.warning(
+                "Bluetooth backend for %s cannot create BLE bonds (%s). Keeping "
+                "the live connection and continuing unbonded. If you use an "
+                "ESPHome proxy, update it to 2024.3.0 or newer.",
+                self._address,
+                err,
+            )
+            pairing_details["error"] = str(err)
+            pairing_details["error_type"] = type(err).__name__
+            self._record_bond_verification("advisory_bond_unsupported", err)
+            return False
+        except (BleakError, TimeoutError, OSError) as err:
+            if not advisory:
+                raise
+            self._pairing_supported = True
+            pairing_details["adapter_pairing_supported"] = True
+            _LOGGER.warning(
+                "Could not create the BLE bond with %s (%s). Keeping the live "
+                "connection and continuing unbonded — this bed only accepts one "
+                "connection per pairing window, so dropping it now would strand "
+                "the bed until it is power-cycled.",
+                self._address,
+                err,
+            )
+            pairing_details["error"] = str(err)
+            pairing_details["error_type"] = type(err).__name__
+            self._record_bond_verification("advisory_bond_failed", err)
+            return False
+        return True
 
     async def _async_verify_bonded(
         self, attempt_details: dict[str, Any] | None = None
@@ -886,7 +966,13 @@ class AdjustableBedCoordinator:
                     holding_lock=True,
                     attempt_details=attempt_details,
                 )
-                return False
+                # For a one-connection-per-window bed the handler deliberately
+                # kept the link, so report success and let controller startup
+                # use it. Retrying "with pairing" would only spend the bed's
+                # single connection on a reconnect that cannot happen.
+                return grants_one_connection_per_pairing_window(
+                    self._bed_type, self._protocol_variant
+                )
             _LOGGER.debug(
                 "Bond verification read for %s was inconclusive (%s); proceeding.",
                 self._address,
@@ -1682,6 +1768,10 @@ class AdjustableBedCoordinator:
                 self._connecting = True
                 # Notify callbacks so binary sensor can show "connecting" state
                 self._notify_connection_state_change(False)
+                # Serialize with the config flow, repair flow and diagnostic so
+                # an overlapping attempt cannot abort this one (issue #385).
+                connect_lock = async_get_connect_lock(self.hass, self._address)
+                await connect_lock.acquire()
                 try:
                     # Use max_attempts=1 here since outer loop handles retries
                     # Disable the services cache to force fresh GATT discovery for
@@ -1715,19 +1805,29 @@ class AdjustableBedCoordinator:
                         # establish_connection() returns after Bleak has loaded
                         # the service collection, so pairing here preserves that
                         # proven application ordering on BlueZ as well.
+                        bond_created = True
                         if pair_after_service_discovery:
                             _LOGGER.info(
                                 "Connected to %s and discovered services; "
                                 "creating the BLE bond now",
                                 self._address,
                             )
-                            await self._client.pair()
+                            bond_created = await self._async_pair_on_live_link(
+                                pairing_details
+                            )
                         # If we get here with pairing enabled, mark it as supported
-                        if use_pairing:
+                        if use_pairing and bond_created:
                             self._pairing_supported = True
                             self._mark_ble_bond_established()
                             pairing_details["adapter_pairing_supported"] = True
                             pairing_details["connection_result"] = "pairing_connection_succeeded"
+                        elif use_pairing:
+                            # Advisory bond failed; the link is up and stays up.
+                            # _async_pair_on_live_link already recorded whether
+                            # the backend supports pairing at all.
+                            pairing_details["connection_result"] = (
+                                "advisory_bond_failed_link_retained"
+                            )
                         else:
                             pairing_details["connection_result"] = "connected_without_pairing"
                     except (NotImplementedError, TypeError) as pair_err:
@@ -1806,6 +1906,7 @@ class AdjustableBedCoordinator:
                             raise
                         raise
                 finally:
+                    connect_lock.release()
                     if not keep_connecting_through_startup:
                         self._connecting = False
                     # Don't notify here - the connect success/failure paths will notify

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -917,6 +917,41 @@ class AdjustableBedCoordinator:
             return False
         return True
 
+    async def async_pair_now(self) -> bool:
+        """Re-run BLE pairing on demand and report whether the bond is live.
+
+        Drives the pairing repair for a bed that only grants one connection per
+        pairing window. Two things matter here:
+
+        * The cached bond marker must be cleared on the *runtime* coordinator,
+          not just in ``entry.data``. ``_ble_bond_established`` is read from the
+          entry once at construction, so editing entry data alone would leave
+          this connection still skipping ``pair=True``.
+        * When a link is already up, pair on that link. Reconnecting to "pair
+          properly" would spend the bed's single connection.
+
+        Returns True only when the bond is confirmed, so a repair cannot report
+        success while the link is still unbonded.
+        """
+        async with self._lock:
+            self._clear_ble_bond_established()
+            self._skip_pair_next_attempt = False
+            self._bond_probe_timed_out = False
+
+            if self._client is not None and self._client.is_connected:
+                pairing_details: dict[str, Any] = {}
+                if await self._async_pair_on_live_link(pairing_details):
+                    self._mark_ble_bond_established()
+                    await delete_pairing_required_issue(self.hass, self._address)
+                    return True
+                # The bond request failed but the link survived; the probe is
+                # the authority on whether we are nevertheless bonded.
+                return await self._async_verify_bonded() and self._ble_bond_established
+
+            if not await self._async_connect_locked():
+                return False
+            return self._ble_bond_established
+
     async def _async_verify_bonded(
         self, attempt_details: dict[str, Any] | None = None
     ) -> bool:
@@ -1456,7 +1491,11 @@ class AdjustableBedCoordinator:
         # Clear any prior manual/idle disconnect marker before a fresh connect attempt.
         self._intentional_disconnect = False
 
-        if self._client is not None and self._client.is_connected:
+        if (
+            self._client is not None
+            and self._client.is_connected
+            and self._controller is not None
+        ):
             _LOGGER.debug("Already connected to %s, reusing connection", self._address)
             if reset_timer:
                 self._reset_disconnect_timer()
@@ -2332,11 +2371,11 @@ class AdjustableBedCoordinator:
                     # Authentication can first fail during controller startup,
                     # after a slow DIS probe was treated as inconclusive. Clear
                     # the stale marker here so the next retry requests pairing.
-                    # Keep this best-effort: the handler disconnects the client,
-                    # and disconnect cleanup can itself raise. Letting that escape
-                    # would replace the original authentication error and abort
-                    # the remaining retries. CancelledError is a BaseException, so
-                    # cancellation still propagates.
+                    # Keep this best-effort: the handler usually disconnects the
+                    # client, and disconnect cleanup can itself raise. Letting
+                    # that escape would replace the original authentication error
+                    # and abort the remaining retries. CancelledError is a
+                    # BaseException, so cancellation still propagates.
                     try:
                         await self._async_handle_ble_authentication_error(
                             err, holding_lock=True
@@ -2347,6 +2386,33 @@ class AdjustableBedCoordinator:
                             self._address,
                             exc_info=True,
                         )
+                    if self._client is not None and self._client.is_connected:
+                        # The handler deliberately kept this link because the bed
+                        # only grants one connection per pairing window. Retrying
+                        # would destroy it anyway: every attempt starts with
+                        # close_stale_connections_by_address(). Stop here with the
+                        # link intact instead of churning through the remaining
+                        # attempts. The repair issue the handler raised tells the
+                        # user to re-pair during a power-cycle window.
+                        _LOGGER.warning(
+                            "Authentication failed for %s during startup. Keeping "
+                            "the link and stopping reconnect attempts so the bed's "
+                            "single connection is not spent on a doomed retry.",
+                            self._address,
+                        )
+                        self._controller = None
+                        self._connecting = False
+                        attempt_details["total_elapsed_seconds"] = round(
+                            time.monotonic() - attempt_start, 3
+                        )
+                        attempt_details["result"] = "failed_link_retained"
+                        attempt_details["error"] = str(err)
+                        attempt_details["error_type"] = type(err).__name__
+                        attempt_details["error_category"] = "AUTHENTICATION"
+                        self._last_connection_error = str(err)
+                        self._last_connection_error_type = type(err).__name__
+                        self._connection_attempt_details.append(attempt_details)
+                        break
                 attempt_elapsed = time.monotonic() - attempt_start
                 attempt_details["total_elapsed_seconds"] = round(attempt_elapsed, 3)
                 attempt_details["result"] = "failed"

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -331,6 +331,9 @@ class AdjustableBedCoordinator:
         # Track if pairing is supported by the Bluetooth adapter (None = unknown)
         self._pairing_supported: bool | None = None
         self._ble_bond_established: bool = bool(entry.data.get(CONF_BLE_BOND_ESTABLISHED, False))
+        # Set just before an internal bond-marker write; see
+        # _begin_internal_entry_update().
+        self._pending_internal_bond_marker: bool | None = None
         self._last_bond_verification: dict[str, Any] = {
             "status": "not_attempted",
             "timestamp": None,
@@ -757,6 +760,31 @@ class AdjustableBedCoordinator:
             if isinstance(pairing, dict):
                 pairing["bond_verification"] = dict(result)
 
+    def _begin_internal_entry_update(self, bond_established: bool) -> None:
+        """Mark the next entry update as an internal bond-marker write.
+
+        Every ``async_update_entry`` fires the options update listener, which
+        reloads the entry — unloading the coordinator and disconnecting the bed.
+        Recording our own bond-marker state here lets that listener recognise
+        the write as internal and skip the reload. Without this, simply noting
+        "this link is not bonded" would tear down the link we just decided to
+        keep, and a bed that grants one connection per pairing window would be
+        unreachable until it is power-cycled (issue #385).
+        """
+        self._pending_internal_bond_marker = bond_established
+
+    def consume_internal_entry_update(self, entry: ConfigEntry) -> bool:
+        """Return True when ``entry`` reflects our own bond-marker write.
+
+        Consumes the marker, so a genuine user-driven options change that
+        happens to follow one still reloads normally.
+        """
+        pending = self._pending_internal_bond_marker
+        if pending is None:
+            return False
+        self._pending_internal_bond_marker = None
+        return bool(entry.data.get(CONF_BLE_BOND_ESTABLISHED, False)) is pending
+
     def _mark_ble_bond_established(self) -> None:
         """Record that future connections should skip `pair=True`."""
         if self._ble_bond_established:
@@ -766,6 +794,7 @@ class AdjustableBedCoordinator:
         if self.entry.data.get(CONF_BLE_BOND_ESTABLISHED):
             return
 
+        self._begin_internal_entry_update(True)
         self.hass.config_entries.async_update_entry(
             self.entry,
             data={
@@ -783,6 +812,7 @@ class AdjustableBedCoordinator:
         if not self.entry.data.get(CONF_BLE_BOND_ESTABLISHED):
             return
 
+        self._begin_internal_entry_update(False)
         self.hass.config_entries.async_update_entry(
             self.entry,
             data={
@@ -796,6 +826,7 @@ class AdjustableBedCoordinator:
         err: BleakError,
         *,
         holding_lock: bool = False,
+        retain_link: bool = False,
         attempt_details: dict[str, Any] | None = None,
     ) -> None:
         """Handle a failure caused by an unauthenticated BLE connection.
@@ -803,6 +834,13 @@ class AdjustableBedCoordinator:
         ``holding_lock`` must be True when called from a context that already
         holds ``self._lock`` (e.g. bond verification inside the connect path),
         so the disconnect uses the lock-free variant and does not deadlock.
+
+        ``retain_link`` must be True only where an unbonded link is still worth
+        keeping, i.e. the post-connect bond probe, whose caller goes on to run
+        controller startup on that same link. It must stay False once startup
+        has already failed: a link with no controller cannot drive the bed, and
+        keeping it would only block the physical remote while leaving the
+        coordinator in a half-initialised state.
         """
         if not requires_pairing(self._bed_type, self._protocol_variant):
             return
@@ -834,7 +872,7 @@ class AdjustableBedCoordinator:
             )
 
         if self._client is not None and self._client.is_connected:
-            if grants_one_connection_per_pairing_window(
+            if retain_link and grants_one_connection_per_pairing_window(
                 self._bed_type, self._protocol_variant
             ):
                 # Disconnecting would cost us the box's single connection and
@@ -999,6 +1037,7 @@ class AdjustableBedCoordinator:
                 await self._async_handle_ble_authentication_error(
                     err,
                     holding_lock=True,
+                    retain_link=True,
                     attempt_details=attempt_details,
                 )
                 # For a one-connection-per-window bed the handler deliberately
@@ -2386,26 +2425,30 @@ class AdjustableBedCoordinator:
                             self._address,
                             exc_info=True,
                         )
-                    if self._client is not None and self._client.is_connected:
-                        # The handler deliberately kept this link because the bed
-                        # only grants one connection per pairing window. Retrying
-                        # would destroy it anyway: every attempt starts with
-                        # close_stale_connections_by_address(). Stop here with the
-                        # link intact instead of churning through the remaining
-                        # attempts. The repair issue the handler raised tells the
-                        # user to re-pair during a power-cycle window.
+                    if grants_one_connection_per_pairing_window(
+                        self._bed_type, self._protocol_variant
+                    ):
+                        # Startup already failed, so the handler released the
+                        # link (retain_link is False here): a link with no
+                        # controller cannot drive the bed and would only block
+                        # the physical remote. Retrying cannot recover either,
+                        # because the box will not grant a second connection
+                        # until it is power-cycled. Stop instead of burning the
+                        # remaining attempts; the repair issue the handler
+                        # raised tells the user to re-pair.
                         _LOGGER.warning(
-                            "Authentication failed for %s during startup. Keeping "
-                            "the link and stopping reconnect attempts so the bed's "
-                            "single connection is not spent on a doomed retry.",
+                            "Authentication failed for %s during startup. This "
+                            "bed grants one connection per pairing window, so "
+                            "further retries cannot succeed until it is "
+                            "power-cycled; stopping reconnect attempts.",
                             self._address,
                         )
-                        self._controller = None
+                        await self._async_cleanup_failed_connection()
                         self._connecting = False
                         attempt_details["total_elapsed_seconds"] = round(
                             time.monotonic() - attempt_start, 3
                         )
-                        attempt_details["result"] = "failed_link_retained"
+                        attempt_details["result"] = "failed"
                         attempt_details["error"] = str(err)
                         attempt_details["error_type"] = type(err).__name__
                         attempt_details["error_category"] = "AUTHENTICATION"

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -770,7 +770,17 @@ class AdjustableBedCoordinator:
         "this link is not bonded" would tear down the link we just decided to
         keep, and a bed that grants one connection per pairing window would be
         unreachable until it is power-cycled (issue #385).
+
+        Only arm the marker when a listener can actually consume it. During
+        initial setup the bond is written before ``async_setup_entry`` registers
+        the update listener and stores this coordinator, so nothing would ever
+        clear it — and the next genuine options change, which keeps the same
+        bond value, would then be mistaken for this write and silently skip the
+        reload it needs.
         """
+        if self.hass.data.get(DOMAIN, {}).get(self.entry.entry_id) is not self:
+            self._pending_internal_bond_marker = None
+            return
         self._pending_internal_bond_marker = bond_established
 
     def consume_internal_entry_update(self, entry: ConfigEntry) -> bool:
@@ -1735,26 +1745,6 @@ class AdjustableBedCoordinator:
                     self._connection_timeout,
                 )
 
-                # Best-effort BlueZ cleanup. Some failed attempts leave stale pending
-                # connections behind, which can cause repeated connect timeouts.
-                if close_stale_connections_by_address is not None:
-                    try:
-                        close_result = close_stale_connections_by_address(self._address)
-                        if inspect.isawaitable(close_result):
-                            await close_result
-                    except (OSError, BleakError) as err:
-                        _LOGGER.debug(
-                            "Could not close stale connections for %s: %s",
-                            self._address,
-                            err,
-                        )
-                    except Exception:
-                        _LOGGER.warning(
-                            "Unexpected error closing stale connections for %s",
-                            self._address,
-                            exc_info=True,
-                        )
-
                 # Always provide a callback so bleak-retry-connector can refresh the
                 # BLEDevice between retries. In auto mode this prevents using a stale
                 # device object from an older scan snapshot.
@@ -1847,10 +1837,37 @@ class AdjustableBedCoordinator:
                 # Notify callbacks so binary sensor can show "connecting" state
                 self._notify_connection_state_change(False)
                 # Serialize with the config flow, repair flow and diagnostic so
-                # an overlapping attempt cannot abort this one (issue #385).
+                # an overlapping attempt cannot abort this one (issue #385). The
+                # lock must cover the stale-connection cleanup below as well as
+                # the connect itself: that cleanup disconnects the address, so
+                # running it outside the lock would tear down a client another
+                # caller is holding under lock protection.
                 connect_lock = async_get_connect_lock(self.hass, self._address)
                 await connect_lock.acquire()
                 try:
+                    # Best-effort BlueZ cleanup. Some failed attempts leave stale
+                    # pending connections behind, which can cause repeated
+                    # connect timeouts.
+                    if close_stale_connections_by_address is not None:
+                        try:
+                            close_result = close_stale_connections_by_address(
+                                self._address
+                            )
+                            if inspect.isawaitable(close_result):
+                                await close_result
+                        except (OSError, BleakError) as err:
+                            _LOGGER.debug(
+                                "Could not close stale connections for %s: %s",
+                                self._address,
+                                err,
+                            )
+                        except Exception:
+                            _LOGGER.warning(
+                                "Unexpected error closing stale connections for %s",
+                                self._address,
+                                exc_info=True,
+                            )
+
                     # Use max_attempts=1 here since outer loop handles retries
                     # Disable the services cache to force fresh GATT discovery for
                     # every pairing-required bed, not just the pair=True attempt.

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -870,16 +870,7 @@ class AdjustableBedCoordinator:
         self._bond_probe_timed_out = False
         self._clear_ble_bond_established()
 
-        try:
-            await create_pairing_required_issue(
-                self.hass, self._address, self._name, self.entry.entry_id
-            )
-        except Exception:
-            _LOGGER.debug(
-                "Failed to create pairing required repair issue for %s",
-                self._address,
-                exc_info=True,
-            )
+        await self._async_raise_pairing_issue()
 
         if self._client is not None and self._client.is_connected:
             if retain_link and grants_one_connection_per_pairing_window(
@@ -899,6 +890,19 @@ class AdjustableBedCoordinator:
                 await self._async_disconnect_locked(reason="authentication_failed")
             else:
                 await self.async_disconnect(reason="authentication_failed")
+
+    async def _async_raise_pairing_issue(self) -> None:
+        """Surface the guided pairing repair, best-effort."""
+        try:
+            await create_pairing_required_issue(
+                self.hass, self._address, self._name, self.entry.entry_id
+            )
+        except Exception:
+            _LOGGER.debug(
+                "Failed to create pairing required repair issue for %s",
+                self._address,
+                exc_info=True,
+            )
 
     async def _async_pair_on_live_link(self, pairing_details: dict[str, Any]) -> bool:
         """Create the BLE bond on an already-connected, service-discovered link.
@@ -945,6 +949,11 @@ class AdjustableBedCoordinator:
             pairing_details["error"] = str(err)
             pairing_details["error_type"] = type(err).__name__
             self._record_bond_verification("advisory_bond_unsupported", err)
+            # Startup can still finish on the unbonded link, and the later bond
+            # probe only raises the repair on a *definitive* auth error - a
+            # timeout or non-auth BleakError is treated as inconclusive. Raise
+            # it here so a failed bond always leaves the user a guided fix.
+            await self._async_raise_pairing_issue()
             return False
         except (BleakError, TimeoutError, OSError) as err:
             if not advisory:
@@ -962,6 +971,7 @@ class AdjustableBedCoordinator:
             pairing_details["error"] = str(err)
             pairing_details["error_type"] = type(err).__name__
             self._record_bond_verification("advisory_bond_failed", err)
+            await self._async_raise_pairing_issue()
             return False
         return True
 

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -1532,7 +1532,13 @@ class AdjustableBedCoordinator:
         _LOGGER.debug("Cleaning up failed connection attempt...")
         self._intentional_disconnect = True
         try:
-            await client.disconnect()
+            # Hold the address lock across the teardown. The connect attempt
+            # released it before this runs, so an unprotected disconnect here
+            # could land inside a competing caller's connect and abort it —
+            # the same hazard the lock was added to prevent (issue #385).
+            # Reentrant, so a caller that still holds it is unaffected.
+            async with async_get_connect_lock(self.hass, self._address):
+                await client.disconnect()
             _LOGGER.debug("Disconnect cleanup successful")
         except Exception as disconnect_err:
             _LOGGER.debug(

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -1556,15 +1556,24 @@ class AdjustableBedCoordinator:
         # Clear any prior manual/idle disconnect marker before a fresh connect attempt.
         self._intentional_disconnect = False
 
-        if (
-            self._client is not None
-            and self._client.is_connected
-            and self._controller is not None
-        ):
-            _LOGGER.debug("Already connected to %s, reusing connection", self._address)
-            if reset_timer:
-                self._reset_disconnect_timer()
-            return True
+        if self._client is not None and self._client.is_connected:
+            if self._controller is not None:
+                _LOGGER.debug(
+                    "Already connected to %s, reusing connection", self._address
+                )
+                if reset_timer:
+                    self._reset_disconnect_timer()
+                return True
+            # Connected but half-initialised. Release the orphan before making a
+            # fresh attempt: establish_connection() would otherwise overwrite
+            # self._client and leak this still-live link, and the
+            # close_stale_connections_by_address() fallback is None on
+            # non-BlueZ backends, so nothing else would ever close it.
+            _LOGGER.debug(
+                "Releasing half-initialised connection to %s before reconnecting",
+                self._address,
+            )
+            await self._async_cleanup_failed_connection()
 
         # Routine reconnects after an intentional/idle disconnect are expected for
         # non-persistent beds and shouldn't spam the log. Only the first successful

--- a/custom_components/adjustable_bed/repairs.py
+++ b/custom_components/adjustable_bed/repairs.py
@@ -29,7 +29,6 @@ from .const import (
     DEVICE_INFO_CHARS,
     DOMAIN,
     grants_one_connection_per_pairing_window,
-    requires_pairing_after_service_discovery,
 )
 
 if TYPE_CHECKING:
@@ -100,18 +99,34 @@ class PairingRequiredRepairFlow(RepairsFlow):
                 return service_info.device
         return None
 
+    def _bonded_now(self) -> bool:
+        """Return True when the entry currently records a confirmed BLE bond."""
+        if self._entry_id is None:
+            return False
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        return bool(entry is not None and entry.data.get(CONF_BLE_BOND_ESTABLISHED))
+
     async def _async_pair_via_coordinator(self) -> bool | None:
-        """Pair by driving the entry's own coordinator connection.
+        """Pair without ever opening a throwaway connection.
 
-        Returns True/False once the coordinator has run, or None when this
-        repair must fall back to its own client (no entry, or the entry is not
-        loaded).
+        Returns True/False for a bed that grants one connection per pairing
+        window, or None when this repair may use its own client.
 
-        For a bed that grants one connection per pairing window, opening a
-        second client here would consume that connection and then close it, so
-        the reload afterwards would find the box refusing every reconnect. The
-        coordinator's own connect path performs the same connect -> discover ->
-        bond ordering and, crucially, *keeps* the link it establishes.
+        For such a bed, opening a second client here would consume the single
+        connection and then close it in ``finally``, so the reload afterwards
+        would find the box refusing every reconnect. Two routes avoid that:
+
+        * A loaded coordinator pairs on its own link via ``async_pair_now()``,
+          which bonds an already-live link instead of reconnecting.
+        * With no loaded coordinator the entry is typically in SETUP_RETRY (the
+          very state that raises this repair), so reloading it lets
+          ``async_setup_entry`` make exactly one connection that connects,
+          discovers, bonds and stays up.
+
+        Success is reported only when the bond is actually confirmed. Connecting
+        is not the same as pairing: the connect path deliberately keeps an
+        unbonded link, so treating a connection as success would resolve the
+        pairing issue while the bed is still unbonded.
         """
         if self._entry_id is None:
             return None
@@ -125,34 +140,47 @@ class PairingRequiredRepairFlow(RepairsFlow):
             return None
 
         coordinator = self.hass.data.get(DOMAIN, {}).get(self._entry_id)
-        if coordinator is None:
-            return None
+        if coordinator is not None:
+            _LOGGER.info(
+                "Repair: pairing %s through the existing coordinator so the "
+                "bed's single connection is kept rather than spent",
+                self._address,
+            )
+            try:
+                # async_pair_now() clears the runtime bond marker itself, which
+                # editing entry.data alone would not do.
+                return bool(await coordinator.async_pair_now())
+            except Exception as err:  # noqa: BLE001 - any failure means "not paired"
+                _LOGGER.warning("Repair: pairing failed for %s: %s", self._address, err)
+                return False
 
-        # Clear any stale marker so the connect actually requests the bond.
+        # No coordinator: the entry failed setup and is retrying. Clear the bond
+        # marker so the next setup requests the bond, then let setup own the one
+        # connection instead of racing it with a client of our own.
         if entry.data.get(CONF_BLE_BOND_ESTABLISHED):
             self.hass.config_entries.async_update_entry(
                 entry,
                 data={**entry.data, CONF_BLE_BOND_ESTABLISHED: False},
             )
-
         _LOGGER.info(
-            "Repair: pairing %s through the existing coordinator so the bed's "
-            "single connection is kept rather than spent",
+            "Repair: reloading %s so its setup makes the single pairing "
+            "connection (no coordinator is loaded to drive)",
             self._address,
         )
         try:
-            connected = await coordinator.async_connect()
+            await self.hass.config_entries.async_reload(self._entry_id)
         except Exception as err:  # noqa: BLE001 - any failure means "not paired"
             _LOGGER.warning("Repair: pairing failed for %s: %s", self._address, err)
             return False
-        if not connected:
-            _LOGGER.warning(
-                "Repair: could not connect to %s to pair it", self._address
-            )
-        return bool(connected)
+        return self._bonded_now()
 
     async def _async_try_pair(self) -> bool:
-        """Create a bond with the controller-specific ordering and verify it."""
+        """Create a bond for beds that pair at connect time, and verify it.
+
+        Beds that must bond after service discovery never reach this path: they
+        are one-connection beds and are handled by _async_pair_via_coordinator,
+        which refuses to open a throwaway client at all.
+        """
         from bleak import BleakClient
         from bleak.exc import BleakError
         from bleak_retry_connector import establish_connection
@@ -169,87 +197,75 @@ class PairingRequiredRepairFlow(RepairsFlow):
             )
             return False
 
-        pair_after_service_discovery = False
-        if self._entry_id is not None:
-            entry = self.hass.config_entries.async_get_entry(self._entry_id)
-            if entry is not None:
-                bed_type = entry.data.get(CONF_BED_TYPE)
-                pair_after_service_discovery = bool(
-                    bed_type
-                    and requires_pairing_after_service_discovery(
-                        bed_type,
-                        entry.data.get(CONF_PROTOCOL_VARIANT),
-                    )
-                )
-
         client: BleakClient | None = None
         reload_entry_id: str | None = None
-        try:
+        # Hold the address lock for the whole client lifetime. Releasing it after
+        # the connect would let the disconnect below land inside another caller's
+        # connect attempt, where bleak's cleanup can abort it.
+        async with async_get_connect_lock(self.hass, self._address):
             try:
-                async with async_get_connect_lock(self.hass, self._address):
-                    client = await establish_connection(
-                        BleakClient,
-                        device,
-                        self._name,
-                        max_attempts=1,
-                        pair=not pair_after_service_discovery,
-                        use_services_cache=False,
-                    )
-                    if pair_after_service_discovery:
-                        await client.pair()
+                client = await establish_connection(
+                    BleakClient,
+                    device,
+                    self._name,
+                    max_attempts=1,
+                    pair=True,
+                    use_services_cache=False,
+                )
             except Exception as err:  # noqa: BLE001 - any failure means "not paired"
                 _LOGGER.warning("Repair: pairing failed for %s: %s", self._address, err)
                 return False
 
-            bonded = False
             try:
-                # Verify the bond by reading a known auth-gated characteristic. A
-                # still-unbonded link fails with GATT error=5; non-auth errors
-                # (e.g. the characteristic is absent) are inconclusive, not failures.
-                await client.read_gatt_char(DEVICE_INFO_CHARS["model_number"])
-                bonded = True
-            except BleakError as err:
-                if is_ble_authentication_error(err):
-                    _LOGGER.warning(
-                        "Repair: bond verification failed for %s: %s",
-                        self._address,
-                        err,
-                    )
-                else:
+                bonded = False
+                try:
+                    # Verify the bond by reading a known auth-gated characteristic. A
+                    # still-unbonded link fails with GATT error=5; non-auth errors
+                    # (e.g. the characteristic is absent) are inconclusive, not failures.
+                    await client.read_gatt_char(DEVICE_INFO_CHARS["model_number"])
+                    bonded = True
+                except BleakError as err:
+                    if is_ble_authentication_error(err):
+                        _LOGGER.warning(
+                            "Repair: bond verification failed for %s: %s",
+                            self._address,
+                            err,
+                        )
+                    else:
+                        _LOGGER.debug(
+                            "Repair: bond verification inconclusive for %s: %s",
+                            self._address,
+                            err,
+                        )
+                        bonded = True
+                except Exception as err:  # noqa: BLE001
                     _LOGGER.debug(
                         "Repair: bond verification inconclusive for %s: %s",
                         self._address,
                         err,
                     )
                     bonded = True
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug(
-                    "Repair: bond verification inconclusive for %s: %s",
-                    self._address,
-                    err,
-                )
-                bonded = True
 
-            if not bonded:
-                return False
+                if not bonded:
+                    return False
 
-            # Persist the confirmed bond and reload so the coordinator reuses it
-            # (and does not try to re-pair on top of the existing bond).
-            if self._entry_id is not None:
-                entry = self.hass.config_entries.async_get_entry(self._entry_id)
-                if entry is not None:
-                    if not entry.data.get(CONF_BLE_BOND_ESTABLISHED):
-                        self.hass.config_entries.async_update_entry(
-                            entry,
-                            data={**entry.data, CONF_BLE_BOND_ESTABLISHED: True},
-                        )
-                    reload_entry_id = self._entry_id
-        finally:
-            if client is not None:
-                try:
-                    await client.disconnect()
-                except Exception:  # noqa: BLE001
-                    pass
+                # Persist the confirmed bond and reload so the coordinator reuses it
+                # (and does not try to re-pair on top of the existing bond).
+                if self._entry_id is not None:
+                    entry = self.hass.config_entries.async_get_entry(self._entry_id)
+                    if entry is not None:
+                        if not entry.data.get(CONF_BLE_BOND_ESTABLISHED):
+                            self.hass.config_entries.async_update_entry(
+                                entry,
+                                data={**entry.data, CONF_BLE_BOND_ESTABLISHED: True},
+                            )
+                        reload_entry_id = self._entry_id
+            finally:
+                if client is not None:
+                    try:
+                        await client.disconnect()
+                    except Exception:  # noqa: BLE001
+                        pass
 
         if reload_entry_id is not None:
             await self.hass.config_entries.async_reload(reload_entry_id)

--- a/custom_components/adjustable_bed/repairs.py
+++ b/custom_components/adjustable_bed/repairs.py
@@ -18,6 +18,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 
 from .adapter import get_discovered_service_info
+from .address_lock import async_get_connect_lock
 from .ble_auth import is_ble_authentication_error
 from .const import (
     ADAPTER_AUTO,
@@ -26,6 +27,8 @@ from .const import (
     CONF_PREFERRED_ADAPTER,
     CONF_PROTOCOL_VARIANT,
     DEVICE_INFO_CHARS,
+    DOMAIN,
+    grants_one_connection_per_pairing_window,
     requires_pairing_after_service_discovery,
 )
 
@@ -97,11 +100,66 @@ class PairingRequiredRepairFlow(RepairsFlow):
                 return service_info.device
         return None
 
+    async def _async_pair_via_coordinator(self) -> bool | None:
+        """Pair by driving the entry's own coordinator connection.
+
+        Returns True/False once the coordinator has run, or None when this
+        repair must fall back to its own client (no entry, or the entry is not
+        loaded).
+
+        For a bed that grants one connection per pairing window, opening a
+        second client here would consume that connection and then close it, so
+        the reload afterwards would find the box refusing every reconnect. The
+        coordinator's own connect path performs the same connect -> discover ->
+        bond ordering and, crucially, *keeps* the link it establishes.
+        """
+        if self._entry_id is None:
+            return None
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if entry is None:
+            return None
+        if not grants_one_connection_per_pairing_window(
+            entry.data.get(CONF_BED_TYPE) or "",
+            entry.data.get(CONF_PROTOCOL_VARIANT),
+        ):
+            return None
+
+        coordinator = self.hass.data.get(DOMAIN, {}).get(self._entry_id)
+        if coordinator is None:
+            return None
+
+        # Clear any stale marker so the connect actually requests the bond.
+        if entry.data.get(CONF_BLE_BOND_ESTABLISHED):
+            self.hass.config_entries.async_update_entry(
+                entry,
+                data={**entry.data, CONF_BLE_BOND_ESTABLISHED: False},
+            )
+
+        _LOGGER.info(
+            "Repair: pairing %s through the existing coordinator so the bed's "
+            "single connection is kept rather than spent",
+            self._address,
+        )
+        try:
+            connected = await coordinator.async_connect()
+        except Exception as err:  # noqa: BLE001 - any failure means "not paired"
+            _LOGGER.warning("Repair: pairing failed for %s: %s", self._address, err)
+            return False
+        if not connected:
+            _LOGGER.warning(
+                "Repair: could not connect to %s to pair it", self._address
+            )
+        return bool(connected)
+
     async def _async_try_pair(self) -> bool:
         """Create a bond with the controller-specific ordering and verify it."""
         from bleak import BleakClient
         from bleak.exc import BleakError
         from bleak_retry_connector import establish_connection
+
+        via_coordinator = await self._async_pair_via_coordinator()
+        if via_coordinator is not None:
+            return via_coordinator
 
         device = self._find_device()
         if device is None:
@@ -128,16 +186,17 @@ class PairingRequiredRepairFlow(RepairsFlow):
         reload_entry_id: str | None = None
         try:
             try:
-                client = await establish_connection(
-                    BleakClient,
-                    device,
-                    self._name,
-                    max_attempts=1,
-                    pair=not pair_after_service_discovery,
-                    use_services_cache=False,
-                )
-                if pair_after_service_discovery:
-                    await client.pair()
+                async with async_get_connect_lock(self.hass, self._address):
+                    client = await establish_connection(
+                        BleakClient,
+                        device,
+                        self._name,
+                        max_attempts=1,
+                        pair=not pair_after_service_discovery,
+                        use_services_cache=False,
+                    )
+                    if pair_after_service_discovery:
+                        await client.pair()
             except Exception as err:  # noqa: BLE001 - any failure means "not paired"
                 _LOGGER.warning("Repair: pairing failed for %s: %s", self._address, err)
                 return False

--- a/docs/beds/leggett-platt.md
+++ b/docs/beds/leggett-platt.md
@@ -46,17 +46,38 @@ Leggett & Platt beds have three protocol variants with different detection metho
 
 > **Connection & bonding (LP Comfort Connect):** LP Control requests an Android
 > **BLE bond** for an unbonded Gen2 device, but only after service discovery
-> (`BLEConnectionViewModel`: bond state `BOND_NONE` + Gen2 → `createBond()`),
-> while the Gen2 controller concurrently configures its GATT receive paths.
+> (`BLEConnectionViewModel.java:210-218`: `SERVICES_DISCOVERED` + bond state
+> `BOND_NONE` + Gen2 → `createBond()`), while the Gen2 controller concurrently
+> configures its GATT receive paths.
 >
-> The issue #385 support bundles show the unbonded BlueZ connection timing out
-> before GATT discovery while the box remains visible. They do not reach a
-> pairing attempt, so the exact controller-side reason remains hardware
-> behavior that the APK cannot prove.
+> **The bond is advisory, not required.** That `createBond()` is the only one in
+> the whole app, there is no `ACTION_BOND_STATE_CHANGED` receiver and no bond
+> retry anywhere, and the call site deliberately falls through rather than
+> returning — so the app never learns whether the bond succeeded and simply
+> keeps using the same link either way. It also connects with
+> `connectGatt(ctx, autoConnect=true, cb, TRANSPORT_LE)`
+> (`BLEService.java:195`), i.e. an untimed background connection, and never
+> disconnects to "retry properly".
 >
-> The integration therefore mirrors the app's ordering on the first connection:
-> connect without a bond, discover the live GATT services, then create the BLE
-> bond while that link is active. This must happen during the pairing window:
+> **The box grants roughly one connection per power cycle.** The issue #385
+> bundles record exactly one completed connection followed by an unbroken run of
+> connect timeouts (3.3.0: `connect_completed_total: 1` at 39s after startup,
+> then 41 consecutive failures, every one of them this bed) until the base is
+> unplugged. Whether the firmware filters unbonded peers at the link layer or
+> stops advertising connectably is hardware behaviour the APK cannot prove.
+>
+> Both facts drive the same rule: **never spend or discard a live link.** The
+> integration therefore mirrors the app on the first connection — connect
+> without a bond, discover the live GATT services, then create the BLE bond
+> while that link is active — and if the bond fails it logs the failure, raises
+> the pairing repair, and *keeps the connection* rather than reconnecting.
+> For the same reason the setup capability probe, the config flow's "Pair Now"
+> step and the pairing repair flow do not open their own throwaway connection
+> for this bed type; the repair drives the coordinator instead. All connect
+> paths also share a per-address lock so two attempts cannot collide into
+> `org.bluez.Error.InProgress` and abort each other.
+>
+> Pairing should still happen during the pairing window:
 >
 > - **Entering pairing mode** (per the LP Control app): unplug the bed, remove
 >   any batteries from the power supply, plug it back in — a small chime plays
@@ -65,12 +86,19 @@ Leggett & Platt beds have three protocol variants with different detection metho
 >   A connected client can also re-open the window with the `PAIR ENABLE`
 >   serial command; for that "Pair Another Phone" flow, the app states that
 >   pairing mode remains active for 2 minutes.
-> - `DWIPE` is the app's Gen2 factory-reset command. Whether it specifically
->   clears the controller's bond table is firmware behavior and is not required
->   by this integration flow.
+> - `DWIPE` is the app's Gen2 factory-reset command, and its own dialog lists
+>   "Bluetooth Pairings" among what it erases. The app's take-ownership copy
+>   also tells the user to remove the bond from phone settings afterwards, so
+>   `DWIPE` does not clear the central-side bond. It needs an existing
+>   connection, so it is a recovery tool after connecting, not a way in.
+> - No per-box limit on how many phones can be paired appears anywhere in the
+>   app: an exhaustive search of the base string table and all shipped locale
+>   tables found no cap, no "already paired to another phone" error, and no
+>   eviction policy. That is absence of evidence in the app, not proof about the
+>   firmware.
 >
-> After BlueZ confirms the bond, the integration records it and reconnects
-> without trying to pair again. Hardware confirmation of the initial bond and
+> Once BlueZ confirms the bond the integration records it and skips `pair=True`
+> on later connections. Hardware confirmation of the initial bond and of a
 > subsequent reconnect remains pending. The integration holds the link open for
 > this bed type (no idle disconnect); LP Control's own UI warns that the remote
 > does not function while the app is connected.

--- a/tests/test_address_lock.py
+++ b/tests/test_address_lock.py
@@ -1,0 +1,55 @@
+"""Tests for per-address BLE connect serialization (issue #385)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.adjustable_bed.address_lock import async_get_connect_lock
+
+from .conftest import TEST_ADDRESS
+
+
+async def test_same_address_shares_one_lock(hass: HomeAssistant) -> None:
+    """Every caller for an address must contend for the same lock."""
+    assert async_get_connect_lock(hass, TEST_ADDRESS) is async_get_connect_lock(
+        hass, TEST_ADDRESS
+    )
+    # BlueZ addresses reach us in mixed case from different code paths.
+    assert async_get_connect_lock(hass, TEST_ADDRESS.lower()) is async_get_connect_lock(
+        hass, TEST_ADDRESS.upper()
+    )
+
+
+async def test_different_addresses_do_not_block_each_other(
+    hass: HomeAssistant,
+) -> None:
+    """Two beds must still be able to connect concurrently."""
+    other = "11:22:33:44:55:66"
+    async with async_get_connect_lock(hass, TEST_ADDRESS):
+        assert not async_get_connect_lock(hass, other).locked()
+
+
+async def test_second_attempt_waits_instead_of_racing(hass: HomeAssistant) -> None:
+    """A competing attempt waits rather than poisoning the in-flight one.
+
+    Overlapping BlueZ connects fail instantly with org.bluez.Error.InProgress,
+    and the loser's cleanup can abort the winner's connection.
+    """
+    order: list[str] = []
+    lock = async_get_connect_lock(hass, TEST_ADDRESS)
+
+    async def attempt(name: str, hold: float) -> None:
+        async with async_get_connect_lock(hass, TEST_ADDRESS):
+            order.append(f"{name}:start")
+            await asyncio.sleep(hold)
+            order.append(f"{name}:done")
+
+    first = asyncio.create_task(attempt("first", 0.05))
+    await asyncio.sleep(0)  # let the first task take the lock
+    assert lock.locked()
+    second = asyncio.create_task(attempt("second", 0))
+    await asyncio.gather(first, second)
+
+    assert order == ["first:start", "first:done", "second:start", "second:done"]

--- a/tests/test_address_lock.py
+++ b/tests/test_address_lock.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
 from homeassistant.core import HomeAssistant
 
 from custom_components.adjustable_bed.address_lock import async_get_connect_lock
@@ -53,3 +54,45 @@ async def test_second_attempt_waits_instead_of_racing(hass: HomeAssistant) -> No
     await asyncio.gather(first, second)
 
     assert order == ["first:start", "first:done", "second:start", "second:done"]
+
+
+async def test_lock_is_reentrant_for_the_owning_task(hass: HomeAssistant) -> None:
+    """Nested acquisition by the same task must not deadlock.
+
+    The support-bundle capture holds the address for its whole capture and then
+    asks the coordinator to reconnect a dropped link, which acquires the same
+    address. A plain asyncio.Lock would await itself forever (issue #385).
+    """
+    lock = async_get_connect_lock(hass, TEST_ADDRESS)
+
+    async with lock:
+        async with lock:
+            assert lock.locked()
+        # Still held by the outer acquisition.
+        assert lock.locked()
+    assert not lock.locked()
+
+
+async def test_reentrancy_does_not_let_another_task_in(hass: HomeAssistant) -> None:
+    """Only the owning task may re-enter; others still queue behind it."""
+    order: list[str] = []
+
+    async def other() -> None:
+        async with async_get_connect_lock(hass, TEST_ADDRESS):
+            order.append("other")
+
+    async with async_get_connect_lock(hass, TEST_ADDRESS) as lock:
+        task = asyncio.create_task(other())
+        await asyncio.sleep(0)
+        async with lock:  # re-entry by the owner succeeds immediately
+            order.append("owner-nested")
+        assert order == ["owner-nested"]  # the other task is still blocked
+    await task
+    assert order == ["owner-nested", "other"]
+
+
+async def test_release_without_acquire_is_an_error(hass: HomeAssistant) -> None:
+    """A stray release must not silently corrupt ownership tracking."""
+    lock = async_get_connect_lock(hass, TEST_ADDRESS)
+    with pytest.raises(RuntimeError):
+        lock.release()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -255,6 +255,31 @@ class TestPairingPersistence:
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_BLE_BOND_ESTABLISHED] is True
 
+    @pytest.mark.parametrize(
+        "step", ["async_step_bluetooth_pairing", "async_step_manual_pairing"]
+    )
+    async def test_gen2_pair_now_defers_the_bond_to_setup(
+        self, hass: HomeAssistant, step: str
+    ) -> None:
+        """Pair Now must not spend LP Comfort Connect's one connection (#385).
+
+        Pairing here would connect, bond and then disconnect, leaving
+        async_setup_entry with a box that refuses every reconnect until it is
+        power-cycled. Create the entry and let the coordinator's first
+        connection carry the bond instead.
+        """
+        flow = self._new_pairing_flow(hass)
+        flow._manual_data[CONF_BED_TYPE] = BED_TYPE_LEGGETT_GEN2
+
+        attempt_pairing = AsyncMock(return_value=True)
+        with patch.object(flow, "_attempt_pairing", new=attempt_pairing):
+            result = await getattr(flow, step)({"action": "pair_now"})
+
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        attempt_pairing.assert_not_awaited()
+        # No bond marker: the coordinator must still request the bond.
+        assert result["data"].get(CONF_BLE_BOND_ESTABLISHED) is not True
+
     async def test_bluetooth_skip_marks_existing_bond_as_established(
         self, hass: HomeAssistant
     ) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -46,6 +46,7 @@ from custom_components.adjustable_bed.const import (
     CONF_RICHMAT_REMOTE,
     DEFAULT_MOTOR_PULSE_COUNT,
     DEFAULT_MOTOR_PULSE_DELAY_MS,
+    DEVICE_INFO_CHARS,
     DOMAIN,
     LEGGETT_VARIANT_OKIN,
     NORDIC_DFU_SERVICE_UUID,
@@ -392,33 +393,51 @@ class TestCoordinatorConnection:
         assert pairing["ordering"] == "connect_discover_then_pair"
         assert pairing["connection_result"] == "pairing_connection_succeeded"
 
-    async def test_gen2_startup_auth_error_keeps_link_and_stops_retrying(
+    @pytest.mark.parametrize(
+        ("bed_type", "retain_link", "keeps_link"),
+        [
+            # The bond probe runs before controller startup, so its caller can
+            # still use the link: keep it (issue #385).
+            (BED_TYPE_LEGGETT_GEN2, True, True),
+            # Startup already failed. A link with no controller cannot drive the
+            # bed and would only block the physical remote.
+            (BED_TYPE_LEGGETT_GEN2, False, False),
+            # A bed that reconnects freely must always take the normal path;
+            # retain_link must not be read as "this is a one-connection bed".
+            (BED_TYPE_OKIN_CST, True, False),
+        ],
+    )
+    async def test_auth_error_retains_the_link_only_where_it_is_usable(
         self,
         hass: HomeAssistant,
         mock_config_entry,
+        bed_type: str,
+        retain_link: bool,
+        keeps_link: bool,
     ) -> None:
-        """A startup auth failure must not undo the retained-link decision.
-
-        The handler deliberately keeps the link, but the outer failure handler
-        used to call _async_cleanup_failed_connection() unconditionally and
-        disconnect it anyway. Retrying cannot help either: every attempt begins
-        with close_stale_connections_by_address(), so it would destroy the link
-        the decision just protected (issue #385).
-        """
+        """Only the probe path on a one-connection bed may keep an unbonded link."""
         coordinator = AdjustableBedCoordinator(hass, mock_config_entry)
-        coordinator._bed_type = BED_TYPE_LEGGETT_GEN2
+        coordinator._bed_type = bed_type
 
         client = MagicMock()
         client.is_connected = True
         client.disconnect = AsyncMock()
         coordinator._client = client
 
-        await coordinator._async_handle_ble_authentication_error(
-            BleakError("Insufficient authentication"), holding_lock=True
-        )
+        with patch.object(
+            coordinator, "_async_disconnect_locked", new_callable=AsyncMock
+        ) as disconnect_locked:
+            await coordinator._async_handle_ble_authentication_error(
+                BleakError("Insufficient authentication"),
+                holding_lock=True,
+                retain_link=retain_link,
+            )
 
-        client.disconnect.assert_not_awaited()
-        assert coordinator._client is client
+        if keeps_link:
+            disconnect_locked.assert_not_awaited()
+            assert coordinator._client is client
+        else:
+            disconnect_locked.assert_awaited_once()
 
     async def test_connect_does_not_report_success_without_a_controller(
         self,
@@ -566,6 +585,11 @@ class TestCoordinatorConnection:
 
         # The bond did not happen, so nothing may claim it did — and the
         # unauthenticated probe must not have torn the link down either.
+        # Assert the probe actually ran: a regression that skipped it would
+        # otherwise still satisfy every assertion below.
+        mock_bleak_client.read_gatt_char.assert_awaited_with(
+            DEVICE_INFO_CHARS["model_number"]
+        )
         assert entry.data.get(CONF_BLE_BOND_ESTABLISHED) is not True
         assert coordinator._client is not None
         assert coordinator._last_disconnect_reason != "authentication_failed"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -392,6 +392,62 @@ class TestCoordinatorConnection:
         assert pairing["ordering"] == "connect_discover_then_pair"
         assert pairing["connection_result"] == "pairing_connection_succeeded"
 
+    async def test_gen2_startup_auth_error_keeps_link_and_stops_retrying(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+    ) -> None:
+        """A startup auth failure must not undo the retained-link decision.
+
+        The handler deliberately keeps the link, but the outer failure handler
+        used to call _async_cleanup_failed_connection() unconditionally and
+        disconnect it anyway. Retrying cannot help either: every attempt begins
+        with close_stale_connections_by_address(), so it would destroy the link
+        the decision just protected (issue #385).
+        """
+        coordinator = AdjustableBedCoordinator(hass, mock_config_entry)
+        coordinator._bed_type = BED_TYPE_LEGGETT_GEN2
+
+        client = MagicMock()
+        client.is_connected = True
+        client.disconnect = AsyncMock()
+        coordinator._client = client
+
+        await coordinator._async_handle_ble_authentication_error(
+            BleakError("Insufficient authentication"), holding_lock=True
+        )
+
+        client.disconnect.assert_not_awaited()
+        assert coordinator._client is client
+
+    async def test_connect_does_not_report_success_without_a_controller(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+    ) -> None:
+        """A retained link with no controller is not a usable connection.
+
+        Keeping the link after a failed startup makes "connected but no
+        controller" reachable, so the reuse shortcut must not call it success.
+        """
+        coordinator = AdjustableBedCoordinator(hass, mock_config_entry)
+        client = MagicMock()
+        client.is_connected = True
+        coordinator._client = client
+        coordinator._controller = None
+
+        with (
+            patch.object(coordinator, "_reset_disconnect_timer") as reset_timer,
+            patch(
+                "custom_components.adjustable_bed.coordinator.select_adapter",
+                new_callable=AsyncMock,
+                side_effect=BleakError("stop here"),
+            ),
+        ):
+            # Falls through to a real attempt instead of returning True.
+            assert await coordinator._async_connect_locked() is False
+        reset_timer.assert_not_called()
+
     @pytest.mark.parametrize(
         ("pair_error", "max_retries", "pairing_supported"),
         [
@@ -1063,9 +1119,7 @@ class TestCoordinatorPositionSeek:
 
         assert result is True
         assert mock_establish_connection.await_args.kwargs["pair"] is False
-        pairing_attempt = coordinator.pairing_diagnostics["connection_attempts"][0][
-            "pairing"
-        ]
+        pairing_attempt = coordinator.pairing_diagnostics["connection_attempts"][0]["pairing"]
         assert pairing_attempt["decision"] == "bond_marker_present"
         assert pairing_attempt["bond_marker_before_attempt"] is True
         assert pairing_attempt["requested"] is False
@@ -2305,8 +2359,7 @@ class TestCoordinatorWriteCommand:
         assert True in pair_kwargs
         assert False in pair_kwargs
         pairing_attempts = [
-            attempt["pairing"]
-            for attempt in coordinator.pairing_diagnostics["connection_attempts"]
+            attempt["pairing"] for attempt in coordinator.pairing_diagnostics["connection_attempts"]
         ]
         assert any(
             attempt["requested"] is True
@@ -2315,8 +2368,7 @@ class TestCoordinatorWriteCommand:
             for attempt in pairing_attempts
         )
         assert any(
-            attempt["decision"] == "retry_without_pairing"
-            and attempt["requested"] is False
+            attempt["decision"] == "retry_without_pairing" and attempt["requested"] is False
             for attempt in pairing_attempts
         )
 
@@ -2419,12 +2471,8 @@ class TestCoordinatorWriteCommand:
         assert coordinator._ble_bond_established is True
         assert entry.data[CONF_BLE_BOND_ESTABLISHED] is True
         assert coordinator._skip_pair_next_attempt is False
-        assert (
-            coordinator.pairing_diagnostics["last_bond_verification"]["status"]
-            == "succeeded"
-        )
+        assert coordinator.pairing_diagnostics["last_bond_verification"]["status"] == "succeeded"
         mock_delete_issue.assert_awaited_once_with(hass, TEST_ADDRESS)
-
 
     async def test_verify_bonded_timeout_is_retryable_for_other_beds(
         self,
@@ -2469,8 +2517,7 @@ class TestCoordinatorWriteCommand:
             assert coordinator._bond_probe_timed_out is False
             assert client.read_gatt_char.await_count == 1
             assert (
-                coordinator.pairing_diagnostics["last_bond_verification"]["status"]
-                == "timed_out"
+                coordinator.pairing_diagnostics["last_bond_verification"]["status"] == "timed_out"
             )
 
             async with asyncio.timeout(5):
@@ -3382,7 +3429,6 @@ class TestRuntimeBedTypeCorrection:
         assert coordinator.motor_pulse_delay_ms == 200
         assert entry.data[CONF_MOTOR_PULSE_COUNT] == 5
         assert entry.data[CONF_MOTOR_PULSE_DELAY_MS] == 200
-
 
 
 class TestDeviceInfoCache:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -393,22 +393,28 @@ class TestCoordinatorConnection:
         assert pairing["connection_result"] == "pairing_connection_succeeded"
 
     @pytest.mark.parametrize(
-        ("pair_error", "max_retries", "fallback_pair"),
+        ("pair_error", "max_retries", "pairing_supported"),
         [
-            (NotImplementedError("pairing unavailable"), 1, None),
-            (BleakError("pairing rejected"), 2, False),
+            (NotImplementedError("pairing unavailable"), 1, False),
+            (BleakError("pairing rejected"), 2, True),
         ],
     )
-    async def test_leggett_gen2_pair_fallback_disconnect_is_intentional(
+    async def test_leggett_gen2_pair_failure_keeps_the_live_link(
         self,
         hass: HomeAssistant,
         mock_bluetooth_adapters,
         mock_bleak_client: MagicMock,
         pair_error: Exception,
         max_retries: int,
-        fallback_pair: bool | None,
+        pairing_supported: bool,
     ) -> None:
-        """Pairing failures intentionally release Gen2 before no-pair fallback."""
+        """A failed Gen2 bond must never cost us the connection (issue #385).
+
+        LP Comfort Connect grants roughly one connection per pairing window, so
+        reconnecting after a bond failure strands the bed until it is
+        power-cycled. LP Control itself fires ``createBond()`` and continues on
+        the same link without ever checking the result.
+        """
         del mock_bluetooth_adapters
 
         entry = MockConfigEntry(
@@ -447,6 +453,11 @@ class TestCoordinatorConnection:
 
         mock_bleak_client.pair = AsyncMock(side_effect=pair_error)
         mock_bleak_client.disconnect = AsyncMock(side_effect=disconnect)
+        # With no bond, the post-connect probe hits an unauthenticated link.
+        # That must not cost us the connection either.
+        mock_bleak_client.read_gatt_char = AsyncMock(
+            side_effect=BleakError("Insufficient authentication")
+        )
 
         controller = MagicMock()
         controller.requires_persistent_connection = True
@@ -488,16 +499,24 @@ class TestCoordinatorConnection:
             result = await coordinator.async_connect()
 
         assert result is True
-        assert mock_establish_connection.await_count == 2
+        # One connection, kept: no release, no reconnect.
+        assert mock_establish_connection.await_count == 1
         assert mock_establish_connection.await_args_list[0].kwargs["pair"] is False
-        fallback_kwargs = mock_establish_connection.await_args_list[1].kwargs
-        if fallback_pair is None:
-            assert "pair" not in fallback_kwargs
-        else:
-            assert fallback_kwargs["pair"] is fallback_pair
-        assert intentional_during_disconnect == [True]
+        mock_bleak_client.pair.assert_awaited_once_with()
+        mock_bleak_client.disconnect.assert_not_awaited()
+        assert intentional_during_disconnect == []
         assert coordinator._intentional_disconnect is False
-        mock_bleak_client.disconnect.assert_awaited_once_with()
+        assert coordinator._client is mock_bleak_client
+
+        # The bond did not happen, so nothing may claim it did — and the
+        # unauthenticated probe must not have torn the link down either.
+        assert entry.data.get(CONF_BLE_BOND_ESTABLISHED) is not True
+        assert coordinator._client is not None
+        assert coordinator._last_disconnect_reason != "authentication_failed"
+        assert coordinator._pairing_supported is pairing_supported
+        pairing = coordinator.pairing_diagnostics["connection_attempts"][0]["pairing"]
+        assert pairing["connection_result"] == "advisory_bond_failed_link_retained"
+        assert pairing["adapter_pairing_supported"] is pairing_supported
 
     async def test_initial_position_read_prepares_controller_before_hydration(
         self,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -448,10 +448,15 @@ class TestCoordinatorConnection:
 
         Keeping the link after a failed startup makes "connected but no
         controller" reachable, so the reuse shortcut must not call it success.
+        The orphaned client must also be released rather than leaked:
+        establish_connection() would overwrite self._client while the old link
+        stayed open, and close_stale_connections_by_address() is None on
+        non-BlueZ backends, so nothing else would ever close it.
         """
         coordinator = AdjustableBedCoordinator(hass, mock_config_entry)
         client = MagicMock()
         client.is_connected = True
+        client.disconnect = AsyncMock()
         coordinator._client = client
         coordinator._controller = None
 
@@ -466,6 +471,9 @@ class TestCoordinatorConnection:
             # Falls through to a real attempt instead of returning True.
             assert await coordinator._async_connect_locked() is False
         reset_timer.assert_not_called()
+        # The half-initialised link was released, not leaked.
+        client.disconnect.assert_awaited_once()
+        assert coordinator._client is None
 
     async def test_advisory_bond_failure_raises_the_pairing_repair(
         self,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -467,6 +467,37 @@ class TestCoordinatorConnection:
             assert await coordinator._async_connect_locked() is False
         reset_timer.assert_not_called()
 
+    async def test_advisory_bond_failure_raises_the_pairing_repair(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+    ) -> None:
+        """A failed advisory bond must always leave the user a guided fix.
+
+        The link is kept and controller startup can finish unbonded, and the
+        later bond probe only raises the repair on a *definitive* auth error -
+        a timeout or non-auth BleakError is treated as inconclusive. Without
+        raising it here the bond silently never happens (issue #385).
+        """
+        coordinator = AdjustableBedCoordinator(hass, mock_config_entry)
+        coordinator._bed_type = BED_TYPE_LEGGETT_GEN2
+
+        client = MagicMock()
+        client.is_connected = True
+        client.pair = AsyncMock(side_effect=BleakError("pairing rejected"))
+        coordinator._client = client
+
+        with patch(
+            "custom_components.adjustable_bed.coordinator.create_pairing_required_issue",
+            new_callable=AsyncMock,
+        ) as create_issue:
+            assert await coordinator._async_pair_on_live_link({}) is False
+
+        create_issue.assert_awaited_once()
+        # The link is still ours: raising the repair must not cost the bed its
+        # single connection.
+        assert coordinator._client is client
+
     @pytest.mark.parametrize(
         ("pair_error", "max_retries", "pairing_supported"),
         [

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -127,9 +127,9 @@ async def test_try_pair_succeeds_and_clears_marker(hass: HomeAssistant) -> None:
     client.disconnect.assert_awaited_once()
 
 
-@pytest.mark.parametrize("connected", [True, False])
+@pytest.mark.parametrize("bonded", [True, False])
 async def test_leggett_gen2_repair_pairs_through_the_coordinator(
-    hass: HomeAssistant, connected: bool
+    hass: HomeAssistant, bonded: bool
 ) -> None:
     """The repair must reuse the coordinator's connection, not spend a new one.
 
@@ -152,7 +152,9 @@ async def test_leggett_gen2_repair_pairs_through_the_coordinator(
     entry.add_to_hass(hass)
 
     coordinator = MagicMock()
-    coordinator.async_connect = AsyncMock(return_value=connected)
+    # async_pair_now() reports whether the bond is confirmed, not merely whether
+    # a connection exists: the connect path deliberately keeps unbonded links.
+    coordinator.async_pair_now = AsyncMock(return_value=bonded)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, entry.entry_id)
@@ -162,18 +164,21 @@ async def test_leggett_gen2_repair_pairs_through_the_coordinator(
         patch(BLEAK_DEVICE, return_value=MagicMock()),
         patch(ESTABLISH, new=AsyncMock()) as mock_establish,
     ):
-        assert await flow._async_try_pair() is connected
+        assert await flow._async_try_pair() is bonded
 
-    coordinator.async_connect.assert_awaited_once_with()
+    coordinator.async_pair_now.assert_awaited_once_with()
     mock_establish.assert_not_awaited()
-    # The stale marker is cleared first so the connect actually asks to bond.
-    assert entry.data[CONF_BLE_BOND_ESTABLISHED] is False
 
 
-async def test_leggett_gen2_repair_pairs_after_service_discovery(
+async def test_leggett_gen2_repair_with_no_coordinator_reloads_the_entry(
     hass: HomeAssistant,
 ) -> None:
-    """The repair path must mirror the LP app's connect-then-bond ordering."""
+    """With no loaded coordinator the repair must reload, not open a client.
+
+    The pairing repair is raised from SETUP_RETRY, where setup has not stored a
+    coordinator yet. A standalone client would pair and then disconnect in its
+    finally block, and the reload could not obtain a second connection (#385).
+    """
     entry = MockConfigEntry(
         domain=DOMAIN,
         title=TEST_NAME,
@@ -181,7 +186,7 @@ async def test_leggett_gen2_repair_pairs_after_service_discovery(
             CONF_ADDRESS: TEST_ADDRESS,
             CONF_NAME: TEST_NAME,
             CONF_BED_TYPE: BED_TYPE_LEGGETT_GEN2,
-            CONF_BLE_BOND_ESTABLISHED: False,
+            CONF_BLE_BOND_ESTABLISHED: True,
         },
         unique_id=TEST_ADDRESS,
         entry_id="repair_leggett_gen2_entry",
@@ -191,41 +196,32 @@ async def test_leggett_gen2_repair_pairs_after_service_discovery(
     flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, entry.entry_id)
     flow.hass = hass
 
-    cleanup_order: list[str] = []
-
-    async def disconnect() -> None:
-        cleanup_order.append("disconnect")
-
-    async def reload_entry(_entry_id: str) -> None:
-        cleanup_order.append("reload")
-
-    client = MagicMock()
-    client.pair = AsyncMock()
-    client.read_gatt_char = AsyncMock(return_value=b"209-M001")
-    client.disconnect = AsyncMock(side_effect=disconnect)
+    async def reload(entry_id: str) -> None:
+        # Setup owns the single connection; simulate it confirming the bond.
+        target = hass.config_entries.async_get_entry(entry_id)
+        hass.config_entries.async_update_entry(
+            target, data={**target.data, CONF_BLE_BOND_ESTABLISHED: True}
+        )
 
     with (
         patch(BLEAK_DEVICE, return_value=MagicMock()),
-        patch(ESTABLISH, new=AsyncMock(return_value=client)) as mock_establish,
+        patch(ESTABLISH, new=AsyncMock()) as mock_establish,
         patch.object(
-            hass.config_entries,
-            "async_reload",
-            new=AsyncMock(side_effect=reload_entry),
-        ),
+            hass.config_entries, "async_reload", new=AsyncMock(side_effect=reload)
+        ) as mock_reload,
     ):
         assert await flow._async_try_pair() is True
 
-    assert mock_establish.await_args.kwargs["pair"] is False
-    assert mock_establish.await_args.kwargs["use_services_cache"] is False
-    client.pair.assert_awaited_once()
-    client.disconnect.assert_awaited_once()
-    assert cleanup_order == ["disconnect", "reload"]
+    mock_establish.assert_not_awaited()
+    mock_reload.assert_awaited_once_with(entry.entry_id)
+    # The stale marker is cleared first so setup actually requests the bond.
+    assert flow._bonded_now() is True
 
 
-async def test_leggett_gen2_repair_disconnects_when_pairing_fails(
+async def test_leggett_gen2_repair_reload_that_stays_unbonded_fails(
     hass: HomeAssistant,
 ) -> None:
-    """A failed post-discovery repair bond must release its connected client."""
+    """Connecting is not pairing: an unbonded reload must not resolve the issue."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title=TEST_NAME,
@@ -236,42 +232,41 @@ async def test_leggett_gen2_repair_disconnects_when_pairing_fails(
             CONF_BLE_BOND_ESTABLISHED: False,
         },
         unique_id=TEST_ADDRESS,
-        entry_id="repair_leggett_gen2_failure_entry",
+        entry_id="repair_leggett_gen2_unbonded_entry",
     )
     entry.add_to_hass(hass)
 
     flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, entry.entry_id)
     flow.hass = hass
-
-    client = MagicMock()
-    client.pair = AsyncMock(side_effect=BleakError("pairing rejected"))
-    client.disconnect = AsyncMock()
 
     with (
         patch(BLEAK_DEVICE, return_value=MagicMock()),
-        patch(ESTABLISH, new=AsyncMock(return_value=client)),
+        patch(ESTABLISH, new=AsyncMock()) as mock_establish,
+        patch.object(hass.config_entries, "async_reload", new=AsyncMock()),
     ):
+        # The advisory connect path keeps an unbonded link, so the entry can load
+        # without a bond. That must still report the repair as unsuccessful.
         assert await flow._async_try_pair() is False
 
+    mock_establish.assert_not_awaited()
     assert entry.data[CONF_BLE_BOND_ESTABLISHED] is False
-    client.disconnect.assert_awaited_once_with()
 
 
-async def test_leggett_gen2_repair_disconnects_when_pairing_is_cancelled(
+async def test_repair_releases_its_client_when_verification_is_cancelled(
     hass: HomeAssistant,
 ) -> None:
-    """Cancelling post-discovery pairing must still release the live client."""
+    """Cancelling bond verification must still release the standalone client."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title=TEST_NAME,
         data={
             CONF_ADDRESS: TEST_ADDRESS,
             CONF_NAME: TEST_NAME,
-            CONF_BED_TYPE: BED_TYPE_LEGGETT_GEN2,
+            CONF_BED_TYPE: "okimat",
             CONF_BLE_BOND_ESTABLISHED: False,
         },
         unique_id=TEST_ADDRESS,
-        entry_id="repair_leggett_gen2_cancelled_entry",
+        entry_id="repair_cancelled_entry",
     )
     entry.add_to_hass(hass)
 
@@ -279,7 +274,7 @@ async def test_leggett_gen2_repair_disconnects_when_pairing_is_cancelled(
     flow.hass = hass
 
     client = MagicMock()
-    client.pair = AsyncMock(side_effect=asyncio.CancelledError())
+    client.read_gatt_char = AsyncMock(side_effect=asyncio.CancelledError())
     client.disconnect = AsyncMock()
 
     with (
@@ -289,8 +284,46 @@ async def test_leggett_gen2_repair_disconnects_when_pairing_is_cancelled(
     ):
         await flow._async_try_pair()
 
-    assert entry.data[CONF_BLE_BOND_ESTABLISHED] is False
     client.disconnect.assert_awaited_once_with()
+    assert entry.data[CONF_BLE_BOND_ESTABLISHED] is False
+
+
+async def test_repair_releases_its_client_when_verification_is_unauthenticated(
+    hass: HomeAssistant,
+) -> None:
+    """A still-unbonded link must fail the repair and release the client."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=TEST_NAME,
+        data={
+            CONF_ADDRESS: TEST_ADDRESS,
+            CONF_NAME: TEST_NAME,
+            CONF_BED_TYPE: "okimat",
+            CONF_BLE_BOND_ESTABLISHED: False,
+        },
+        unique_id=TEST_ADDRESS,
+        entry_id="repair_unauth_entry",
+    )
+    entry.add_to_hass(hass)
+
+    flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, entry.entry_id)
+    flow.hass = hass
+
+    client = MagicMock()
+    client.read_gatt_char = AsyncMock(
+        side_effect=BleakError("Insufficient authentication")
+    )
+    client.disconnect = AsyncMock()
+
+    with (
+        patch(BLEAK_DEVICE, return_value=MagicMock()),
+        patch(ESTABLISH, new=AsyncMock(return_value=client)),
+    ):
+        assert await flow._async_try_pair() is False
+
+    client.disconnect.assert_awaited_once_with()
+    assert entry.data[CONF_BLE_BOND_ESTABLISHED] is False
+
 
 
 async def test_try_pair_treats_non_auth_read_error_as_success(hass: HomeAssistant) -> None:

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -127,6 +127,49 @@ async def test_try_pair_succeeds_and_clears_marker(hass: HomeAssistant) -> None:
     client.disconnect.assert_awaited_once()
 
 
+@pytest.mark.parametrize("connected", [True, False])
+async def test_leggett_gen2_repair_pairs_through_the_coordinator(
+    hass: HomeAssistant, connected: bool
+) -> None:
+    """The repair must reuse the coordinator's connection, not spend a new one.
+
+    LP Comfort Connect grants roughly one connection per pairing window (#385),
+    so opening a second client here and closing it in ``finally`` would leave
+    the reload with a box that refuses every reconnect.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=TEST_NAME,
+        data={
+            CONF_ADDRESS: TEST_ADDRESS,
+            CONF_NAME: TEST_NAME,
+            CONF_BED_TYPE: BED_TYPE_LEGGETT_GEN2,
+            CONF_BLE_BOND_ESTABLISHED: True,
+        },
+        unique_id=TEST_ADDRESS,
+        entry_id="repair_gen2_coordinator_entry",
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = MagicMock()
+    coordinator.async_connect = AsyncMock(return_value=connected)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+
+    flow = PairingRequiredRepairFlow(TEST_ADDRESS, TEST_NAME, entry.entry_id)
+    flow.hass = hass
+
+    with (
+        patch(BLEAK_DEVICE, return_value=MagicMock()),
+        patch(ESTABLISH, new=AsyncMock()) as mock_establish,
+    ):
+        assert await flow._async_try_pair() is connected
+
+    coordinator.async_connect.assert_awaited_once_with()
+    mock_establish.assert_not_awaited()
+    # The stale marker is cleared first so the connect actually asks to bond.
+    assert entry.data[CONF_BLE_BOND_ESTABLISHED] is False
+
+
 async def test_leggett_gen2_repair_pairs_after_service_discovery(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
## Problem

Leggett & Platt Gen2 (LP Comfort Connect, control box `209-M001`, an ESP-WROOM-32D) grants roughly **one usable BLE connection per bed power cycle**. The issue #385 support bundles show this consistently across five integration versions:

| Bundle | Evidence |
|---|---|
| 3.0.0 | `connection_history`: `attempt_count: 4, success_count: 1`, `last_disconnect_reason: "idle_timeout"` |
| 3.3.0 | scanner: `connect_completed_total: 1` at 39s after startup, then `connect_failures: {08:3A:F2:1E:4B:7E: 41}` with `connect_failed_total: 41` over the next 3.2 hours, every failure being this bed |
| 3.4.0 | two attempts failing in **0.259s** each with `[org.bluez.Error.InProgress]`, then 42.8s/46.0s timeouts |

No bundle has ever completed GATT service discovery. Several code paths spent or discarded that single connection, which is why the reporter could follow the pairing instructions exactly and still never connect.

## What LP Control actually does

Verified against the accepted corpus artifact, **LP Control 2.9.0 (46164)** (set SHA-256 `7099c679...`, the build registered in #447):

- `remoteDevice.connectGatt(this, true, this.mGattCallback, 2)` — an untimed background connection (`BLEService.java:218`).
- The app's **only** `createBond()`, after service discovery, guarded by `SERVICES_DISCOVERED` + `BOND_NONE` + `isGen2`, deliberately falling through **without returning** so the session continues on the same link (`BLEConnectionViewModel.java:246-249`).
- **Zero** occurrences of `ACTION_BOND_STATE_CHANGED` or `removeBond` across all five DEX files, with `createBond` appearing exactly once. The app never learns whether the bond succeeded, never retries it, and never disconnects to "retry properly".

The bond is advisory. The connection is precious. This PR encodes both.

## Changes

**`grants_one_connection_per_pairing_window()`** (`const.py`) names the rule the rest of the fix follows: never spend or discard a live link for this bed type.

1. **A failed bond no longer costs the connection.** `_async_pair_on_live_link()` catches a failed `client.pair()`, logs it, raises the pairing repair, and keeps the link. This now also covers the `NotImplementedError`/`TypeError` path, which was worse than it looked: it released the link and reconnected with `pair=False` when the link it already held was itself made with `pair=False`, spending the bed's one connection to obtain an identical one.

2. **The bond verifier no longer kills a working link.** `_async_handle_ble_authentication_error()` used to disconnect and retry "with pairing" whenever the auth-gated probe failed on an unbonded link — a retry this box cannot grant. It now keeps the link, and `_async_verify_bonded()` reports success so controller startup proceeds unbonded.

3. **No throwaway connections.** The config flow's "Pair Now" step defers the bond to the coordinator's first connection (creating the entry **without** a bond marker, so pairing is still requested), and the pairing repair drives `coordinator.async_connect()` instead of opening its own client and closing it in `finally`.

4. **`address_lock.py`** gives all five connect sites a shared per-address lock. Overlapping BlueZ connects fail instantly with `org.bluez.Error.InProgress`, and bleak's cleanup for the loser calls `Disconnect()`, which can abort the connection the winner was still establishing.

## Tests

`2594 passed`, ruff and mypy clean.

One existing test asserted the removed behaviour (`test_leggett_gen2_pair_fallback_disconnect_is_intentional`). It is rewritten as `test_leggett_gen2_pair_failure_keeps_the_live_link`, with the mock's probe returning an authentication error so it exercises the realistic unbonded path end to end. New coverage for the deferred config-flow bond, the coordinator-driven repair, and the address lock.

## Still unproven

Whether the box filters unbonded peers at the link layer or stops advertising connectably is firmware behaviour the APK cannot prove; both produce an identical connect timeout. Note that `connectable: true` in the support bundles is not evidence either way, since `habluetooth`'s `HaScanner` hardcodes it for every local-adapter advertisement. A `btmon` capture during a connect attempt would distinguish them.

Ref #385


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented overlapping BLE connect/disconnect sequences by serializing connections per device address.
  - Reduced race conditions and unintended disconnects during setup, capability probing, diagnostics, and repair retries.
  - Improved Leggett & Platt Gen2 recovery by retaining the active “live link” when bonding fails due to authentication checks.

- **New Features**
  - Gen2 “Pair Now” can be deferred to setup to avoid consuming the limited pairing connection early.
  - Repair flows can reuse an existing coordinator/connection when available.

- **Documentation**
  - Updated Gen2 pairing/bonding guidance with clearer “live link” behavior details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->