### PR TITLE
Warn before a support bundle captures without logs

### DIFF
--- a/custom_components/adjustable_bed/services.py
+++ b/custom_components/adjustable_bed/services.py
@@ -78,7 +78,7 @@ DEFAULT_CAPTURE_DURATION = 120
 # short enough that a stalled mount cannot delay the capture noticeably.
 _LOG_PROBE_TIMEOUT = 5.0
 
-# hass.data key: notification id -> token of the invocation that raised it.
+# hass.data key: notification id -> tokens of the invocations that raised it.
 _LOG_NOTICE_OWNERS = f"{DOMAIN}_log_notice_owners"
 MIN_CAPTURE_DURATION = 10
 MAX_CAPTURE_DURATION = 300
@@ -760,9 +760,9 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
                     title="Adjustable Bed: this bundle will have no logs",
                     notification_id=log_notification_id,
                 )
-                hass.data.setdefault(_LOG_NOTICE_OWNERS, {})[log_notification_id] = (
-                    log_notice_token
-                )
+                hass.data.setdefault(_LOG_NOTICE_OWNERS, {}).setdefault(
+                    log_notification_id, set()
+                ).add(log_notice_token)
                 owns_log_notice = True
 
     try:
@@ -778,6 +778,19 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
             ),
             timeout=capture_duration + 120,
         )
+        if not read_logs and probe_reason is not None:
+            # The read was skipped, so the report would otherwise say
+            # "not_requested" even though logs *were* requested and the probe
+            # failed. The bundle is what gets shared with a maintainer, so the
+            # reason has to survive in it, not only in a transient notification.
+            report_evidence = report.setdefault("evidence", {})
+            report_evidence["log_capture_status"] = "unavailable"
+            report_evidence["log_capture_reason"] = probe_reason
+            report_evidence["log_capture_error"] = probe_error
+            report_evidence.setdefault("warnings", []).append(
+                f"Log collection was skipped: {probe_error}"
+            )
+
         filepath = await hass.async_add_executor_job(
             save_support_bundle,
             hass,
@@ -798,13 +811,20 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
         # A bundle without logs usually cannot explain why a command failed, and
         # the user only learns that after a maintainer asks for a second one. Say
         # it up front, at the moment they still have the bed in front of them.
-        # The probe's verdict counts too. An empty log file makes the capture
-        # report "empty" rather than "unavailable", and a timed-out probe skips
-        # the read entirely, so relying on the capture's status alone would drop
-        # the guidance and then dismiss the only notice that carried it.
-        logs_missing = include_logs and (
-            evidence.get("log_capture_status") == "unavailable" or probe_reason is not None
-        )
+        log_status = evidence.get("log_capture_status")
+        if not read_logs:
+            # Nothing read it, so the report has no verdict of its own.
+            logs_missing = include_logs and probe_reason is not None
+        else:
+            # The capture is the authority once it has actually read: a log that
+            # appeared or filled up during the window really is usable, whatever
+            # the probe saw beforehand. The one carry-over is a file the probe
+            # measured as empty, which the capture reports as "empty" rather
+            # than "unavailable" but which is still unusable.
+            logs_missing = include_logs and (
+                log_status == "unavailable"
+                or (log_status == "empty" and probe_reason == "empty_file")
+            )
         logging_notice = ""
         if logs_missing:
             log_error = evidence.get("log_capture_error") or probe_error
@@ -860,10 +880,15 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
         # covers cancellation: CancelledError inherits from BaseException, so an
         # automation stopped mid-capture would skip an except Exception handler
         # and strand the notice forever.
-        owners = hass.data.get(_LOG_NOTICE_OWNERS, {})
-        if owns_log_notice and owners.get(log_notification_id) is log_notice_token:
-            owners.pop(log_notification_id, None)
-            async_dismiss(hass, log_notification_id)
+        owners = hass.data.get(_LOG_NOTICE_OWNERS, {}).get(log_notification_id)
+        if owns_log_notice and owners is not None:
+            owners.discard(log_notice_token)
+            # Retract only once the last overlapping logless capture is done,
+            # so a short one finishing first cannot pull the notice out from
+            # under a longer one that is still running without logs.
+            if not owners:
+                hass.data[_LOG_NOTICE_OWNERS].pop(log_notification_id, None)
+                async_dismiss(hass, log_notification_id)
 
 async def async_register_services(hass: HomeAssistant) -> None:
     """Register the Adjustable Bed services (idempotent)."""

--- a/custom_components/adjustable_bed/services.py
+++ b/custom_components/adjustable_bed/services.py
@@ -708,7 +708,6 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
     # comes back as "empty", not "unavailable") or never read the log at all.
     probe_reason: str | None = None
     probe_error: str | None = None
-    read_logs = include_logs
     if include_logs:
         try:
             # O_NONBLOCK does not make regular-file I/O asynchronous, so a
@@ -720,27 +719,25 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
                 async_check_log_file(hass), _LOG_PROBE_TIMEOUT
             )
         except TimeoutError:
-            log_path = hass.config.path("home-assistant.log")
+            # Inconclusive, not proof of a wedged path: Home Assistant's shared
+            # executor can be saturated enough that the job never started. Say
+            # nothing and change nothing - the capture performs its own read and
+            # reports what it actually found. Disabling logs here would drop them
+            # from a minutes-long capture over a five-second queue delay.
             _LOGGER.warning(
-                "Timed out checking whether %s is readable; capturing without logs",
-                log_path,
+                "Timed out checking whether %s is readable; capturing anyway",
+                hass.config.path("home-assistant.log"),
             )
-            # The path is wedged. Reading it again during the capture would
-            # strand a second shared worker on the same mount for no benefit,
-            # so skip the log read and say why.
-            read_logs = False
-            log_check = {
-                "available": False,
-                "reason": "unreadable",
-                "path": log_path,
-                "error": f"timed out after {_LOG_PROBE_TIMEOUT:g}s",
-            }
+            log_check = None
         if log_check is not None:
             if log_check["available"]:
-                # A previous run may have warned about missing logs. That warning is
-                # device-stable and would otherwise sit there contradicting a bundle
-                # that does contain logs.
-                async_dismiss(hass, log_notification_id)
+                # A previous run may have warned about missing logs, and that
+                # warning is address-stable, so it would otherwise sit there
+                # contradicting a bundle that does contain logs. Only clear it
+                # when no capture still owns it: another logless capture may be
+                # running right now and its warning is not stale.
+                if not hass.data.get(_LOG_NOTICE_OWNERS, {}).get(log_notification_id):
+                    async_dismiss(hass, log_notification_id)
             else:
                 probe_reason = log_check["reason"]
                 probe_error = log_check["error"]
@@ -771,26 +768,13 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
                 hass,
                 address=address,
                 capture_duration=capture_duration,
-                include_logs=read_logs,
+                include_logs=include_logs,
                 coordinator=coordinator,
                 entry=entry,
                 device_id=selected_device_id,
             ),
             timeout=capture_duration + 120,
         )
-        if not read_logs and probe_reason is not None:
-            # The read was skipped, so the report would otherwise say
-            # "not_requested" even though logs *were* requested and the probe
-            # failed. The bundle is what gets shared with a maintainer, so the
-            # reason has to survive in it, not only in a transient notification.
-            report_evidence = report.setdefault("evidence", {})
-            report_evidence["log_capture_status"] = "unavailable"
-            report_evidence["log_capture_reason"] = probe_reason
-            report_evidence["log_capture_error"] = probe_error
-            report_evidence.setdefault("warnings", []).append(
-                f"Log collection was skipped: {probe_error}"
-            )
-
         filepath = await hass.async_add_executor_job(
             save_support_bundle,
             hass,
@@ -811,20 +795,16 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
         # A bundle without logs usually cannot explain why a command failed, and
         # the user only learns that after a maintainer asks for a second one. Say
         # it up front, at the moment they still have the bed in front of them.
+        # The capture is the authority: it actually read the file, so a log that
+        # appeared or filled up during the window really is usable whatever the
+        # probe saw beforehand. The one carry-over is a file the probe measured
+        # as empty, which the capture reports as "empty" rather than
+        # "unavailable" but which is still unusable.
         log_status = evidence.get("log_capture_status")
-        if not read_logs:
-            # Nothing read it, so the report has no verdict of its own.
-            logs_missing = include_logs and probe_reason is not None
-        else:
-            # The capture is the authority once it has actually read: a log that
-            # appeared or filled up during the window really is usable, whatever
-            # the probe saw beforehand. The one carry-over is a file the probe
-            # measured as empty, which the capture reports as "empty" rather
-            # than "unavailable" but which is still unusable.
-            logs_missing = include_logs and (
-                log_status == "unavailable"
-                or (log_status == "empty" and probe_reason == "empty_file")
-            )
+        logs_missing = include_logs and (
+            log_status == "unavailable"
+            or (log_status == "empty" and probe_reason == "empty_file")
+        )
         logging_notice = ""
         if logs_missing:
             log_error = evidence.get("log_capture_error") or probe_error

--- a/custom_components/adjustable_bed/services.py
+++ b/custom_components/adjustable_bed/services.py
@@ -614,6 +614,7 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
 
     from .download import register_download
     from .support_bundle import generate_support_bundle, save_support_bundle
+    from .support_report import async_check_log_file, build_missing_log_notice
 
     device_ids = call.data.get(CONF_DEVICE_ID, [])
     target_address = call.data.get(ATTR_TARGET_ADDRESS)
@@ -676,6 +677,34 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
         )
 
     assert address is not None
+
+    # Probe the log file before capturing. The capture runs for minutes, and a
+    # bundle without logs is missing the evidence that matters most for
+    # connection problems, so warn while the user can still fix it and re-run
+    # rather than only telling them afterwards (issue #385).
+    if include_logs:
+        log_check = await async_check_log_file(hass)
+        if not log_check["available"]:
+            _LOGGER.warning(
+                "Support bundle for %s will not include logs: %s (%s)",
+                address,
+                log_check["path"],
+                log_check["reason"],
+            )
+            async_create(
+                hass,
+                build_missing_log_notice(
+                    log_check["reason"], log_check["error"], future=True
+                )
+                + "\n\nThe capture is running anyway, so you will still get a "
+                "bundle with Bluetooth diagnostics.",
+                title="Adjustable Bed: this bundle will have no logs",
+                notification_id=(
+                    "adjustable_bed_support_bundle_logs_"
+                    f"{address.replace(':', '_').lower()}"
+                ),
+            )
+
     try:
         report = await asyncio.wait_for(
             generate_support_bundle(
@@ -718,32 +747,9 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
                 address,
                 log_error or "the Home Assistant log file could not be read",
             )
-            if evidence.get("log_capture_reason") == "unreadable":
-                # `logger:` only changes levels; it cannot fix a permission
-                # problem or a log path Home Assistant is not writing to.
-                logging_notice = (
-                    "\n\n⚠️ **This bundle contains no logs.** The Home Assistant log "
-                    f"file could not be read (`{log_error}`), so the reason a command "
-                    "failed is usually not recoverable from it. Check the file's "
-                    "permissions and the configured log path, then run this service "
-                    "again."
-                )
-            else:
-                # `logger:` only sets levels - it does not create a file handler,
-                # so it cannot help an install that logs to stdout instead of
-                # home-assistant.log. Point at the flow that always yields a
-                # downloadable log.
-                logging_notice = (
-                    "\n\n⚠️ **This bundle contains no logs.** Home Assistant is not "
-                    "writing a `home-assistant.log` file (common on container "
-                    "installs that log to stdout), so the reason a command failed is "
-                    "usually not recoverable from it.\n\n"
-                    "Use **Settings → Devices & services → Adjustable Bed → ⋮ → "
-                    "Enable debug logging** instead, reproduce the problem, then "
-                    "**Disable debug logging** to download the captured log and "
-                    "attach it alongside this bundle. The full log is also available "
-                    "under **Settings → System → Logs → Load full logs**."
-                )
+            logging_notice = "\n\n" + build_missing_log_notice(
+                evidence.get("log_capture_reason"), log_error
+            )
 
         async_create(
             hass,

--- a/custom_components/adjustable_bed/services.py
+++ b/custom_components/adjustable_bed/services.py
@@ -781,6 +781,9 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
             capture_duration + 120,
             address,
         )
+        # No bundle will exist, so the pre-capture notice ("the capture is
+        # running anyway") would sit there permanently claiming otherwise.
+        async_dismiss(hass, log_notification_id)
         async_create(
             hass,
             f"Support bundle generation timed out after {capture_duration + 120} seconds "
@@ -792,6 +795,7 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
         raise
     except Exception as err:
         _LOGGER.exception("Failed to generate support bundle for %s", address)
+        async_dismiss(hass, log_notification_id)
         async_create(
             hass,
             f"Failed to generate support bundle for {address}:\n\n{err}",

--- a/custom_components/adjustable_bed/services.py
+++ b/custom_components/adjustable_bed/services.py
@@ -766,12 +766,6 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
         # the user only learns that after a maintainer asks for a second one. Say
         # it up front, at the moment they still have the bed in front of them.
         logs_missing = include_logs and evidence.get("log_capture_status") == "unavailable"
-        # The capture has finished either way, so the pre-capture notice ("the
-        # capture is running anyway") has served its purpose. The Ready
-        # notification below carries the same guidance for a log-less bundle,
-        # so leaving the old one up would only duplicate it and misdescribe the
-        # state.
-        async_dismiss(hass, log_notification_id)
         logging_notice = ""
         if logs_missing:
             log_error = evidence.get("log_capture_error")
@@ -803,9 +797,6 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
             capture_duration + 120,
             address,
         )
-        # No bundle will exist, so the pre-capture notice ("the capture is
-        # running anyway") would sit there permanently claiming otherwise.
-        async_dismiss(hass, log_notification_id)
         async_create(
             hass,
             f"Support bundle generation timed out after {capture_duration + 120} seconds "
@@ -817,7 +808,6 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
         raise
     except Exception as err:
         _LOGGER.exception("Failed to generate support bundle for %s", address)
-        async_dismiss(hass, log_notification_id)
         async_create(
             hass,
             f"Failed to generate support bundle for {address}:\n\n{err}",
@@ -825,6 +815,14 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
             notification_id=f"adjustable_bed_support_bundle_error_{address.replace(':', '_').lower()}",
         )
         raise
+    finally:
+        # Whatever happened, the capture is no longer running, so the
+        # pre-capture notice must not keep claiming that it is. A finally also
+        # covers cancellation: CancelledError inherits from BaseException, so an
+        # automation stopped mid-capture would skip an except Exception handler
+        # and strand the notice forever. Dismissing an id that was never created
+        # is a no-op.
+        async_dismiss(hass, log_notification_id)
 
 async def async_register_services(hass: HomeAssistant) -> None:
     """Register the Adjustable Bed services (idempotent)."""

--- a/custom_components/adjustable_bed/services.py
+++ b/custom_components/adjustable_bed/services.py
@@ -73,6 +73,10 @@ TIMED_MOVE_MOTOR_OPTIONS = (
 
 # Default capture duration for diagnostics (seconds)
 DEFAULT_CAPTURE_DURATION = 120
+
+# Bound for the best-effort pre-capture log probe. Generous for a local stat,
+# short enough that a stalled mount cannot delay the capture noticeably.
+_LOG_PROBE_TIMEOUT = 5.0
 MIN_CAPTURE_DURATION = 10
 MAX_CAPTURE_DURATION = 300
 
@@ -689,29 +693,44 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
         f"adjustable_bed_support_bundle_logs_{address.replace(':', '_').lower()}"
     )
     if include_logs:
-        log_check = await async_check_log_file(hass)
-        if log_check["available"]:
-            # A previous run may have warned about missing logs. That warning is
-            # device-stable and would otherwise sit there contradicting a bundle
-            # that does contain logs.
-            async_dismiss(hass, log_notification_id)
-        else:
+        try:
+            # O_NONBLOCK does not make regular-file I/O asynchronous, so a
+            # stalled network or FUSE mount can still block the open. This probe
+            # runs before the capture's own timeout, so bound it here or the
+            # service could hang without ever starting or reporting. The
+            # executor thread stays blocked either way, but the service does not.
+            log_check = await asyncio.wait_for(
+                async_check_log_file(hass), _LOG_PROBE_TIMEOUT
+            )
+        except TimeoutError:
             _LOGGER.warning(
-                "Support bundle for %s will not include logs: %s (%s)",
-                address,
-                log_check["path"],
-                log_check["reason"],
+                "Timed out checking whether %s is readable; capturing anyway",
+                hass.config.path("home-assistant.log"),
             )
-            async_create(
-                hass,
-                build_missing_log_notice(
-                    log_check["reason"], log_check["error"], future=True
+            log_check = None
+        if log_check is not None:
+            if log_check["available"]:
+                # A previous run may have warned about missing logs. That warning is
+                # device-stable and would otherwise sit there contradicting a bundle
+                # that does contain logs.
+                async_dismiss(hass, log_notification_id)
+            else:
+                _LOGGER.warning(
+                    "Support bundle for %s will not include logs: %s (%s)",
+                    address,
+                    log_check["path"],
+                    log_check["reason"],
                 )
-                + "\n\nThe capture is running anyway, so you will still get a "
-                "bundle with Bluetooth diagnostics.",
-                title="Adjustable Bed: this bundle will have no logs",
-                notification_id=log_notification_id,
-            )
+                async_create(
+                    hass,
+                    build_missing_log_notice(
+                        log_check["reason"], log_check["error"], future=True
+                    )
+                    + "\n\nThe capture is running anyway, so you will still get a "
+                    "bundle with Bluetooth diagnostics.",
+                    title="Adjustable Bed: this bundle will have no logs",
+                    notification_id=log_notification_id,
+                )
 
     try:
         report = await asyncio.wait_for(
@@ -747,9 +766,12 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
         # the user only learns that after a maintainer asks for a second one. Say
         # it up front, at the moment they still have the bed in front of them.
         logs_missing = include_logs and evidence.get("log_capture_status") == "unavailable"
-        if not logs_missing:
-            # Logs became available during the capture, so retract any warning.
-            async_dismiss(hass, log_notification_id)
+        # The capture has finished either way, so the pre-capture notice ("the
+        # capture is running anyway") has served its purpose. The Ready
+        # notification below carries the same guidance for a log-less bundle,
+        # so leaving the old one up would only duplicate it and misdescribe the
+        # state.
+        async_dismiss(hass, log_notification_id)
         logging_notice = ""
         if logs_missing:
             log_error = evidence.get("log_capture_error")

--- a/custom_components/adjustable_bed/services.py
+++ b/custom_components/adjustable_bed/services.py
@@ -77,6 +77,9 @@ DEFAULT_CAPTURE_DURATION = 120
 # Bound for the best-effort pre-capture log probe. Generous for a local stat,
 # short enough that a stalled mount cannot delay the capture noticeably.
 _LOG_PROBE_TIMEOUT = 5.0
+
+# hass.data key: notification id -> token of the invocation that raised it.
+_LOG_NOTICE_OWNERS = f"{DOMAIN}_log_notice_owners"
 MIN_CAPTURE_DURATION = 10
 MAX_CAPTURE_DURATION = 300
 
@@ -692,10 +695,13 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
     log_notification_id = (
         f"adjustable_bed_support_bundle_logs_{address.replace(':', '_').lower()}"
     )
-    # Only retract a notice this invocation actually raised. The id is
-    # address-stable on purpose, so a later run can clear a stale warning, but
-    # that also means an unrelated overlapping call (an include_logs: false one,
-    # say) must not dismiss somebody else's live warning.
+    # Only retract a notice this invocation still owns. The id is
+    # address-stable on purpose, so a later run can clear a stale warning left
+    # by an earlier one; per-invocation ids would lose that. The cost is that
+    # overlapping captures share the id, so record who raised it last and let
+    # only that invocation retract it. A later capture that re-raises the notice
+    # takes ownership, and the earlier one then leaves it alone.
+    log_notice_token = object()
     owns_log_notice = False
     if include_logs:
         try:
@@ -735,6 +741,9 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
                     "bundle with Bluetooth diagnostics.",
                     title="Adjustable Bed: this bundle will have no logs",
                     notification_id=log_notification_id,
+                )
+                hass.data.setdefault(_LOG_NOTICE_OWNERS, {})[log_notification_id] = (
+                    log_notice_token
                 )
                 owns_log_notice = True
 
@@ -827,7 +836,9 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
         # covers cancellation: CancelledError inherits from BaseException, so an
         # automation stopped mid-capture would skip an except Exception handler
         # and strand the notice forever.
-        if owns_log_notice:
+        owners = hass.data.get(_LOG_NOTICE_OWNERS, {})
+        if owns_log_notice and owners.get(log_notification_id) is log_notice_token:
+            owners.pop(log_notification_id, None)
             async_dismiss(hass, log_notification_id)
 
 async def async_register_services(hass: HomeAssistant) -> None:

--- a/custom_components/adjustable_bed/services.py
+++ b/custom_components/adjustable_bed/services.py
@@ -703,6 +703,12 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
     # takes ownership, and the earlier one then leaves it alone.
     log_notice_token = object()
     owns_log_notice = False
+    # What the probe concluded, kept so the finished-bundle notice can repeat the
+    # guidance even when the capture itself reports something else (an empty file
+    # comes back as "empty", not "unavailable") or never read the log at all.
+    probe_reason: str | None = None
+    probe_error: str | None = None
+    read_logs = include_logs
     if include_logs:
         try:
             # O_NONBLOCK does not make regular-file I/O asynchronous, so a
@@ -714,11 +720,21 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
                 async_check_log_file(hass), _LOG_PROBE_TIMEOUT
             )
         except TimeoutError:
+            log_path = hass.config.path("home-assistant.log")
             _LOGGER.warning(
-                "Timed out checking whether %s is readable; capturing anyway",
-                hass.config.path("home-assistant.log"),
+                "Timed out checking whether %s is readable; capturing without logs",
+                log_path,
             )
-            log_check = None
+            # The path is wedged. Reading it again during the capture would
+            # strand a second shared worker on the same mount for no benefit,
+            # so skip the log read and say why.
+            read_logs = False
+            log_check = {
+                "available": False,
+                "reason": "unreadable",
+                "path": log_path,
+                "error": f"timed out after {_LOG_PROBE_TIMEOUT:g}s",
+            }
         if log_check is not None:
             if log_check["available"]:
                 # A previous run may have warned about missing logs. That warning is
@@ -726,11 +742,13 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
                 # that does contain logs.
                 async_dismiss(hass, log_notification_id)
             else:
+                probe_reason = log_check["reason"]
+                probe_error = log_check["error"]
                 _LOGGER.warning(
                     "Support bundle for %s will not include logs: %s (%s)",
                     address,
                     log_check["path"],
-                    log_check["reason"],
+                    probe_reason,
                 )
                 async_create(
                     hass,
@@ -753,7 +771,7 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
                 hass,
                 address=address,
                 capture_duration=capture_duration,
-                include_logs=include_logs,
+                include_logs=read_logs,
                 coordinator=coordinator,
                 entry=entry,
                 device_id=selected_device_id,
@@ -780,17 +798,23 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
         # A bundle without logs usually cannot explain why a command failed, and
         # the user only learns that after a maintainer asks for a second one. Say
         # it up front, at the moment they still have the bed in front of them.
-        logs_missing = include_logs and evidence.get("log_capture_status") == "unavailable"
+        # The probe's verdict counts too. An empty log file makes the capture
+        # report "empty" rather than "unavailable", and a timed-out probe skips
+        # the read entirely, so relying on the capture's status alone would drop
+        # the guidance and then dismiss the only notice that carried it.
+        logs_missing = include_logs and (
+            evidence.get("log_capture_status") == "unavailable" or probe_reason is not None
+        )
         logging_notice = ""
         if logs_missing:
-            log_error = evidence.get("log_capture_error")
+            log_error = evidence.get("log_capture_error") or probe_error
             _LOGGER.warning(
                 "Support bundle for %s was generated without logs: %s",
                 address,
                 log_error or "the Home Assistant log file could not be read",
             )
             logging_notice = "\n\n" + build_missing_log_notice(
-                evidence.get("log_capture_reason"), log_error
+                evidence.get("log_capture_reason") or probe_reason, log_error
             )
 
         async_create(

--- a/custom_components/adjustable_bed/services.py
+++ b/custom_components/adjustable_bed/services.py
@@ -610,7 +610,10 @@ async def handle_timed_move(call: ServiceCall) -> None:
 async def handle_generate_support_bundle(call: ServiceCall) -> None:
     """Handle generate_support_bundle service call."""
     hass = call.hass
-    from homeassistant.components.persistent_notification import async_create
+    from homeassistant.components.persistent_notification import (
+        async_create,
+        async_dismiss,
+    )
 
     from .download import register_download
     from .support_bundle import generate_support_bundle, save_support_bundle
@@ -682,9 +685,17 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
     # bundle without logs is missing the evidence that matters most for
     # connection problems, so warn while the user can still fix it and re-run
     # rather than only telling them afterwards (issue #385).
+    log_notification_id = (
+        f"adjustable_bed_support_bundle_logs_{address.replace(':', '_').lower()}"
+    )
     if include_logs:
         log_check = await async_check_log_file(hass)
-        if not log_check["available"]:
+        if log_check["available"]:
+            # A previous run may have warned about missing logs. That warning is
+            # device-stable and would otherwise sit there contradicting a bundle
+            # that does contain logs.
+            async_dismiss(hass, log_notification_id)
+        else:
             _LOGGER.warning(
                 "Support bundle for %s will not include logs: %s (%s)",
                 address,
@@ -699,10 +710,7 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
                 + "\n\nThe capture is running anyway, so you will still get a "
                 "bundle with Bluetooth diagnostics.",
                 title="Adjustable Bed: this bundle will have no logs",
-                notification_id=(
-                    "adjustable_bed_support_bundle_logs_"
-                    f"{address.replace(':', '_').lower()}"
-                ),
+                notification_id=log_notification_id,
             )
 
     try:
@@ -739,6 +747,9 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
         # the user only learns that after a maintainer asks for a second one. Say
         # it up front, at the moment they still have the bed in front of them.
         logs_missing = include_logs and evidence.get("log_capture_status") == "unavailable"
+        if not logs_missing:
+            # Logs became available during the capture, so retract any warning.
+            async_dismiss(hass, log_notification_id)
         logging_notice = ""
         if logs_missing:
             log_error = evidence.get("log_capture_error")

--- a/custom_components/adjustable_bed/services.py
+++ b/custom_components/adjustable_bed/services.py
@@ -692,6 +692,11 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
     log_notification_id = (
         f"adjustable_bed_support_bundle_logs_{address.replace(':', '_').lower()}"
     )
+    # Only retract a notice this invocation actually raised. The id is
+    # address-stable on purpose, so a later run can clear a stale warning, but
+    # that also means an unrelated overlapping call (an include_logs: false one,
+    # say) must not dismiss somebody else's live warning.
+    owns_log_notice = False
     if include_logs:
         try:
             # O_NONBLOCK does not make regular-file I/O asynchronous, so a
@@ -731,6 +736,7 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
                     title="Adjustable Bed: this bundle will have no logs",
                     notification_id=log_notification_id,
                 )
+                owns_log_notice = True
 
     try:
         report = await asyncio.wait_for(
@@ -820,9 +826,9 @@ async def handle_generate_support_bundle(call: ServiceCall) -> None:
         # pre-capture notice must not keep claiming that it is. A finally also
         # covers cancellation: CancelledError inherits from BaseException, so an
         # automation stopped mid-capture would skip an except Exception handler
-        # and strand the notice forever. Dismissing an id that was never created
-        # is a no-op.
-        async_dismiss(hass, log_notification_id)
+        # and strand the notice forever.
+        if owns_log_notice:
+            async_dismiss(hass, log_notification_id)
 
 async def async_register_services(hass: HomeAssistant) -> None:
     """Register the Adjustable Bed services (idempotent)."""

--- a/custom_components/adjustable_bed/support_report.py
+++ b/custom_components/adjustable_bed/support_report.py
@@ -332,8 +332,21 @@ def _open_regular_file(log_path: str) -> int:
     for a writer, and ``fstat`` describes the object actually opened, so the
     type check cannot be raced by a path swapped after a bare ``stat``.
     """
+    # Check before opening as well as after. O_NONBLOCK keeps *us* from waiting
+    # on a FIFO, but opening its read end can release a writer that was blocked
+    # waiting for a reader, and closing again immediately can then hand that
+    # writer EPIPE - disrupting the very log stream this is inspecting. Refuse
+    # special files without touching them.
+    # stat, not lstat: a symlink pointing at a real log file is a legitimate
+    # setup and must be followed, while a symlink to a FIFO resolves to the FIFO
+    # and is refused on its own merits.
+    if not stat.S_ISREG(os.stat(log_path).st_mode):  # noqa: PTH116 - HA config path
+        raise _NotARegularFile(f"{log_path} is not a regular file")
+
     fd = os.open(log_path, os.O_RDONLY | os.O_NONBLOCK)
     try:
+        # Re-check on the descriptor: the pre-check above races with anything
+        # that could swap the path between the two calls.
         if not stat.S_ISREG(os.fstat(fd).st_mode):
             raise _NotARegularFile(f"{log_path} is not a regular file")
     except BaseException:

--- a/custom_components/adjustable_bed/support_report.py
+++ b/custom_components/adjustable_bed/support_report.py
@@ -449,7 +449,22 @@ def _probe_log_file(log_path: str) -> tuple[bool, str | None, str | None]:
         # Covers fstat as well as open: every failure has to degrade into a
         # reason, because the caller probes outside its own error handling.
         return False, "unreadable", str(err)
-    os.close(fd)
+
+    try:
+        size = os.fstat(fd).st_size
+    except OSError as err:
+        return False, "unreadable", str(err)
+    finally:
+        os.close(fd)
+
+    if size == 0:
+        # A left-over empty file while the running instance logs to stdout is
+        # readable but will never yield evidence, so readability alone is not
+        # proof that logs will be captured. Home Assistant writes its startup
+        # banner immediately, so an empty file means nothing is writing here.
+        # Deliberately no mtime "liveness" check: a quiet instance can go a long
+        # time without a record, and a threshold would misreport it.
+        return False, "empty_file", f"{log_path} is empty"
     return True, None, None
 
 

--- a/custom_components/adjustable_bed/support_report.py
+++ b/custom_components/adjustable_bed/support_report.py
@@ -386,3 +386,74 @@ def _read_log_file(log_path: str) -> list[dict[str, str]]:
             current["message"] += "\n" + redact_pins_only({"msg": line})["msg"]
 
     return logs[-MAX_LOG_ENTRIES:]
+
+
+def _probe_log_file(log_path: str) -> tuple[bool, str | None, str | None]:
+    """Return ``(available, reason, error)`` for the Home Assistant log file.
+
+    Runs in an executor (blocking file I/O). ``reason`` is ``"missing"`` or
+    ``"unreadable"`` when the file cannot be used.
+    """
+    try:
+        with open(log_path, "rb") as handle:  # noqa: PTH123 - plain path from HA config
+            handle.read(1)
+    except FileNotFoundError as err:
+        return False, "missing", str(err)
+    except OSError as err:
+        return False, "unreadable", str(err)
+    return True, None, None
+
+
+async def async_check_log_file(hass: HomeAssistant) -> dict[str, Any]:
+    """Check up front whether a support bundle will be able to include logs.
+
+    The capture itself takes minutes, and a bundle without logs is missing the
+    single most useful evidence for connection problems (issue #385: every
+    bundle in that report had ``log_capture_status: "unavailable"``). Probing
+    first lets the caller tell the user *before* they wait for a useless
+    capture.
+    """
+    log_path = hass.config.path("home-assistant.log")
+    available, reason, error = await hass.async_add_executor_job(
+        _probe_log_file, log_path
+    )
+    return {
+        "available": available,
+        "reason": reason,
+        "path": log_path,
+        "error": error,
+    }
+
+
+def build_missing_log_notice(
+    reason: str | None, error: str | None, *, future: bool = False
+) -> str:
+    """Explain a bundle that has (or will have) no logs, and how to fix it.
+
+    Shared by the pre-capture warning and the finished-bundle notification so
+    both give the same remedy. Note what is deliberately absent: telling the
+    user to configure `logger:`. That only sets levels; it does not create a
+    file handler, so it cannot help an install that logs to stdout.
+    """
+    headline = (
+        "⚠️ **This bundle will contain no logs.**"
+        if future
+        else "⚠️ **This bundle contains no logs.**"
+    )
+    if reason == "unreadable":
+        return (
+            f"{headline} The Home Assistant log file could not be read "
+            f"(`{error}`), so the reason a command failed is usually not "
+            "recoverable from it. Check the file's permissions and the "
+            "configured log path, then run this service again."
+        )
+    return (
+        f"{headline} Home Assistant is not writing a `home-assistant.log` file "
+        "(common on container installs that log to stdout), so the reason a "
+        "command failed is usually not recoverable from it.\n\n"
+        "Use **Settings → Devices & services → Adjustable Bed → ⋮ → "
+        "Enable debug logging** instead, reproduce the problem, then "
+        "**Disable debug logging** to download the captured log and attach it "
+        "alongside this bundle. The full log is also available under "
+        "**Settings → System → Logs → Load full logs**."
+    )

--- a/custom_components/adjustable_bed/support_report.py
+++ b/custom_components/adjustable_bed/support_report.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import re
 import stat
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -478,9 +480,22 @@ async def async_check_log_file(hass: HomeAssistant) -> dict[str, Any]:
     capture.
     """
     log_path = hass.config.path("home-assistant.log")
-    available, reason, error = await hass.async_add_executor_job(
-        _probe_log_file, log_path
+    # Deliberately not hass.async_add_executor_job: os.open on a wedged network
+    # or FUSE mount cannot be cancelled, so the caller's timeout frees the
+    # service but not the worker. A stranded *shared* worker would starve
+    # unrelated Home Assistant work, so give the probe a private single-thread
+    # executor and abandon it instead.
+    executor = ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="adjustable_bed_log_probe"
     )
+    try:
+        available, reason, error = await asyncio.wrap_future(
+            executor.submit(_probe_log_file, log_path)
+        )
+    finally:
+        # wait=False returns immediately; a stuck thread keeps this private
+        # executor alive but nothing else ever waits on it.
+        executor.shutdown(wait=False)
     return {
         "available": available,
         "reason": reason,

--- a/custom_components/adjustable_bed/support_report.py
+++ b/custom_components/adjustable_bed/support_report.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
+import stat
 import sys
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -315,8 +317,18 @@ def _is_relevant_log_name(name: str) -> bool:
     return any(fragment in lowered for fragment in _RELEVANT_LOG_NAMES)
 
 
+class _NotARegularFile(OSError):
+    """The log path exists but is a FIFO, device, or similar."""
+
+
 def _tail_text(log_path: str, max_bytes: int) -> str:
-    """Read up to the last ``max_bytes`` of a UTF-8 log file as text."""
+    """Read up to the last ``max_bytes`` of a UTF-8 log file as text.
+
+    Refuses anything that is not a regular file: opening a FIFO blocks until a
+    writer appears, which would hang the capture in its executor thread.
+    """
+    if not stat.S_ISREG(os.stat(log_path).st_mode):  # noqa: PTH116 - HA config path
+        raise _NotARegularFile(f"{log_path} is not a regular file")
     with open(log_path, "rb") as handle:  # noqa: PTH123 - plain path from HA config
         handle.seek(0, 2)
         size = handle.tell()
@@ -345,7 +357,9 @@ def _read_log_file(log_path: str) -> list[dict[str, str]]:
         # A missing file and an unreadable one need different remedies, so keep
         # the distinction (and the original error) instead of always blaming
         # disabled logging.
-        missing = isinstance(err, FileNotFoundError)
+        # A FIFO (a container logging to stdout) needs the same remedy as a
+        # missing file: a real log to download, not a permissions fix.
+        missing = isinstance(err, FileNotFoundError | _NotARegularFile)
         hint = (
             "File logging may be disabled; enable it and reproduce the issue to "
             "capture logs."
@@ -391,14 +405,28 @@ def _read_log_file(log_path: str) -> list[dict[str, str]]:
 def _probe_log_file(log_path: str) -> tuple[bool, str | None, str | None]:
     """Return ``(available, reason, error)`` for the Home Assistant log file.
 
-    Runs in an executor (blocking file I/O). ``reason`` is ``"missing"`` or
-    ``"unreadable"`` when the file cannot be used.
+    Runs in an executor (blocking file I/O). ``reason`` is ``"missing"``,
+    ``"not_a_file"`` or ``"unreadable"`` when the file cannot be used.
+
+    ``os.stat`` comes first and the file is never read. If the path is a FIFO or
+    a device - which is exactly what a container redirecting its logs to stdout
+    can leave behind - then ``open()`` alone blocks until a writer appears, and
+    a read would also consume a byte of somebody else's stream. Statting cannot
+    block, so the hazard is settled before anything is opened.
     """
     try:
-        with open(log_path, "rb") as handle:  # noqa: PTH123 - plain path from HA config
-            handle.read(1)
+        info = os.stat(log_path)  # noqa: PTH116 - plain path from HA config
     except FileNotFoundError as err:
         return False, "missing", str(err)
+    except OSError as err:
+        return False, "unreadable", str(err)
+
+    if not stat.S_ISREG(info.st_mode):
+        return False, "not_a_file", f"{log_path} is not a regular file"
+
+    try:
+        with open(log_path, "rb"):  # noqa: PTH123 - plain path from HA config
+            pass
     except OSError as err:
         return False, "unreadable", str(err)
     return True, None, None

--- a/custom_components/adjustable_bed/support_report.py
+++ b/custom_components/adjustable_bed/support_report.py
@@ -321,16 +321,35 @@ class _NotARegularFile(OSError):
     """The log path exists but is a FIFO, device, or similar."""
 
 
+def _open_regular_file(log_path: str) -> int:
+    """Open ``log_path`` read-only and return a validated file descriptor.
+
+    Raises ``_NotARegularFile`` for a FIFO or device and ``OSError`` for
+    anything else; the caller owns the descriptor on success.
+
+    This is the one copy of the hang-prevention rule, because two copies of
+    safety-critical logic drift. ``O_NONBLOCK`` stops a FIFO open from waiting
+    for a writer, and ``fstat`` describes the object actually opened, so the
+    type check cannot be raced by a path swapped after a bare ``stat``.
+    """
+    fd = os.open(log_path, os.O_RDONLY | os.O_NONBLOCK)
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise _NotARegularFile(f"{log_path} is not a regular file")
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
+
+
 def _tail_text(log_path: str, max_bytes: int) -> str:
     """Read up to the last ``max_bytes`` of a UTF-8 log file as text.
 
     Refuses anything that is not a regular file: opening a FIFO blocks until a
     writer appears, which would hang the capture in its executor thread.
     """
-    fd = os.open(log_path, os.O_RDONLY | os.O_NONBLOCK)
+    fd = _open_regular_file(log_path)
     try:
-        if not stat.S_ISREG(os.fstat(fd).st_mode):
-            raise _NotARegularFile(f"{log_path} is not a regular file")
         handle = os.fdopen(fd, "rb")
     except BaseException:
         os.close(fd)
@@ -421,23 +440,16 @@ def _probe_log_file(log_path: str) -> tuple[bool, str | None, str | None]:
     block, so the hazard is settled before anything is opened.
     """
     try:
-        # O_NONBLOCK makes opening a FIFO return immediately instead of waiting
-        # for a writer, and fstat then describes the object actually opened.
-        # Statting the path first and opening it afterwards would leave a window
-        # where the path could be swapped for a FIFO in between.
-        handle = os.open(log_path, os.O_RDONLY | os.O_NONBLOCK)
+        fd = _open_regular_file(log_path)
     except FileNotFoundError as err:
         return False, "missing", str(err)
+    except _NotARegularFile as err:
+        return False, "not_a_file", str(err)
     except OSError as err:
+        # Covers fstat as well as open: every failure has to degrade into a
+        # reason, because the caller probes outside its own error handling.
         return False, "unreadable", str(err)
-
-    try:
-        info = os.fstat(handle)
-    finally:
-        os.close(handle)
-
-    if not stat.S_ISREG(info.st_mode):
-        return False, "not_a_file", f"{log_path} is not a regular file"
+    os.close(fd)
     return True, None, None
 
 

--- a/custom_components/adjustable_bed/support_report.py
+++ b/custom_components/adjustable_bed/support_report.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 import re
 import stat
 import sys
-from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -480,22 +478,19 @@ async def async_check_log_file(hass: HomeAssistant) -> dict[str, Any]:
     capture.
     """
     log_path = hass.config.path("home-assistant.log")
-    # Deliberately not hass.async_add_executor_job: os.open on a wedged network
-    # or FUSE mount cannot be cancelled, so the caller's timeout frees the
-    # service but not the worker. A stranded *shared* worker would starve
-    # unrelated Home Assistant work, so give the probe a private single-thread
-    # executor and abandon it instead.
-    executor = ThreadPoolExecutor(
-        max_workers=1, thread_name_prefix="adjustable_bed_log_probe"
+    # Uses Home Assistant's shared executor, deliberately.
+    #
+    # os.open on a wedged network or FUSE mount cannot be cancelled, so no
+    # arrangement here can free the worker; the only question is which pool it
+    # is stranded in. _get_recent_logs() already performs this same open on this
+    # same executor a few seconds later during the capture, so the probe adds no
+    # hazard that the capture did not already carry. A private executor would
+    # instead leave a thread that concurrent.futures joins at interpreter
+    # shutdown, which can block a clean Home Assistant restart: strictly worse.
+    # The caller's timeout is what keeps the *service* responsive.
+    available, reason, error = await hass.async_add_executor_job(
+        _probe_log_file, log_path
     )
-    try:
-        available, reason, error = await asyncio.wrap_future(
-            executor.submit(_probe_log_file, log_path)
-        )
-    finally:
-        # wait=False returns immediately; a stuck thread keeps this private
-        # executor alive but nothing else ever waits on it.
-        executor.shutdown(wait=False)
     return {
         "available": available,
         "reason": reason,

--- a/custom_components/adjustable_bed/support_report.py
+++ b/custom_components/adjustable_bed/support_report.py
@@ -327,9 +327,15 @@ def _tail_text(log_path: str, max_bytes: int) -> str:
     Refuses anything that is not a regular file: opening a FIFO blocks until a
     writer appears, which would hang the capture in its executor thread.
     """
-    if not stat.S_ISREG(os.stat(log_path).st_mode):  # noqa: PTH116 - HA config path
-        raise _NotARegularFile(f"{log_path} is not a regular file")
-    with open(log_path, "rb") as handle:  # noqa: PTH123 - plain path from HA config
+    fd = os.open(log_path, os.O_RDONLY | os.O_NONBLOCK)
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise _NotARegularFile(f"{log_path} is not a regular file")
+        handle = os.fdopen(fd, "rb")
+    except BaseException:
+        os.close(fd)
+        raise
+    with handle:
         handle.seek(0, 2)
         size = handle.tell()
         start = max(0, size - max_bytes)
@@ -415,20 +421,23 @@ def _probe_log_file(log_path: str) -> tuple[bool, str | None, str | None]:
     block, so the hazard is settled before anything is opened.
     """
     try:
-        info = os.stat(log_path)  # noqa: PTH116 - plain path from HA config
+        # O_NONBLOCK makes opening a FIFO return immediately instead of waiting
+        # for a writer, and fstat then describes the object actually opened.
+        # Statting the path first and opening it afterwards would leave a window
+        # where the path could be swapped for a FIFO in between.
+        handle = os.open(log_path, os.O_RDONLY | os.O_NONBLOCK)
     except FileNotFoundError as err:
         return False, "missing", str(err)
     except OSError as err:
         return False, "unreadable", str(err)
 
+    try:
+        info = os.fstat(handle)
+    finally:
+        os.close(handle)
+
     if not stat.S_ISREG(info.st_mode):
         return False, "not_a_file", f"{log_path} is not a regular file"
-
-    try:
-        with open(log_path, "rb"):  # noqa: PTH123 - plain path from HA config
-            pass
-    except OSError as err:
-        return False, "unreadable", str(err)
     return True, None, None
 
 

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -1471,6 +1471,24 @@ class TestSupportBundleLoggingWarning:
                 "homeassistant.components.persistent_notification.async_create",
                 _capture_notification,
             ),
+            # Pin the pre-capture probe: otherwise the ambient config dir
+            # decides whether a second (pre-capture) notification is raised, so
+            # this count would pass locally and fail in CI.
+            patch(
+                "custom_components.adjustable_bed.support_report.async_check_log_file",
+                AsyncMock(
+                    return_value={
+                        "available": True,
+                        "reason": None,
+                        "path": "/config/home-assistant.log",
+                        "error": None,
+                    }
+                ),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_dismiss",
+                lambda *a, **k: None,
+            ),
         ):
             await handle_generate_support_bundle(call)
 
@@ -1528,6 +1546,24 @@ class TestSupportBundleLoggingWarning:
             patch(
                 "homeassistant.components.persistent_notification.async_create",
                 lambda _hass, message, title=None, notification_id=None: created.append(message),
+            ),
+            # Pin the pre-capture probe: otherwise the ambient config dir
+            # decides whether a second (pre-capture) notification is raised, so
+            # this count would pass locally and fail in CI.
+            patch(
+                "custom_components.adjustable_bed.support_report.async_check_log_file",
+                AsyncMock(
+                    return_value={
+                        "available": True,
+                        "reason": None,
+                        "path": "/config/home-assistant.log",
+                        "error": None,
+                    }
+                ),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_dismiss",
+                lambda *a, **k: None,
             ),
         ):
             await handle_generate_support_bundle(call)
@@ -2051,80 +2087,6 @@ class TestSupportBundleLogProbeSafety:
         # It never raised a notice, so it owns nothing to retract.
         assert dismissed == []
 
-    async def test_only_the_current_owner_retracts_the_notice(self, hass):
-        """The first call to finish must not clear a newer capture's warning."""
-        from unittest.mock import AsyncMock, MagicMock, patch
-
-        from homeassistant.core import ServiceCall
-
-        from custom_components.adjustable_bed.services import (
-            _LOG_NOTICE_OWNERS,
-            handle_generate_support_bundle,
-        )
-
-        notice_id = "adjustable_bed_support_bundle_logs_aa_bb_cc_dd_ee_ff"
-        dismissed: list[str] = []
-        report = {
-            "notifications": [],
-            "evidence": {
-                "log_capture_status": "unavailable",
-                "log_capture_reason": "missing",
-                "log_capture_error": "boom",
-                "warnings": [],
-            },
-        }
-
-        async def _generate(*args, **kwargs):
-            # A concurrent capture re-raises the notice and takes ownership
-            # while this one is still running.
-            hass.data.setdefault(_LOG_NOTICE_OWNERS, {})[notice_id] = object()
-            return report
-
-        call = ServiceCall(
-            hass,
-            DOMAIN,
-            "generate_support_bundle",
-            {"target_address": "AA:BB:CC:DD:EE:FF", "capture_duration": 5},
-        )
-        with (
-            patch(
-                "custom_components.adjustable_bed.support_report.async_check_log_file",
-                AsyncMock(
-                    return_value={
-                        "available": False,
-                        "reason": "missing",
-                        "path": "/config/home-assistant.log",
-                        "error": "boom",
-                    }
-                ),
-            ),
-            patch(
-                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
-                _generate,
-            ),
-            patch(
-                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
-                MagicMock(return_value="/config/bundle.json"),
-            ),
-            patch(
-                "custom_components.adjustable_bed.download.register_download",
-                MagicMock(return_value="/api/download/bundle.json"),
-            ),
-            patch(
-                "homeassistant.components.persistent_notification.async_create",
-                lambda *a, **k: None,
-            ),
-            patch(
-                "homeassistant.components.persistent_notification.async_dismiss",
-                lambda _hass, nid: dismissed.append(nid),
-            ),
-        ):
-            await handle_generate_support_bundle(call)
-
-        # Ownership moved on, so this invocation must leave the notice up.
-        assert dismissed == []
-
-
     async def test_timed_out_probe_skips_the_capture_log_read(self, hass):
         """A wedged mount must not be opened twice, and must still explain itself."""
         import asyncio as _asyncio
@@ -2245,3 +2207,198 @@ class TestSupportBundleLogProbeSafety:
         ready = messages[-1]
         assert "contains no logs" in ready
         assert "Enable debug logging" in ready
+
+
+    async def test_skipped_read_records_the_reason_in_the_bundle(self, hass):
+        """The JSON is what reaches a maintainer, so the reason must live there."""
+        import asyncio as _asyncio
+        from unittest.mock import MagicMock, patch
+
+        from homeassistant.core import ServiceCall
+
+        from custom_components.adjustable_bed.services import (
+            handle_generate_support_bundle,
+        )
+
+        saved: dict = {}
+
+        async def _never_returns(_hass):
+            await _asyncio.sleep(3600)
+
+        async def _generate(*args, **kwargs):
+            return {"notifications": [], "evidence": {"warnings": []}}
+
+        def _save(_hass, report, _address):
+            saved.update(report)
+            return "/config/bundle.json"
+
+        call = ServiceCall(
+            hass,
+            DOMAIN,
+            "generate_support_bundle",
+            {"target_address": "AA:BB:CC:DD:EE:FF", "capture_duration": 5},
+        )
+        with (
+            patch("custom_components.adjustable_bed.services._LOG_PROBE_TIMEOUT", 0.01),
+            patch(
+                "custom_components.adjustable_bed.support_report.async_check_log_file",
+                _never_returns,
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+                _generate,
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
+                _save,
+            ),
+            patch(
+                "custom_components.adjustable_bed.download.register_download",
+                MagicMock(return_value="/api/download/bundle.json"),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_create",
+                lambda *a, **k: None,
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_dismiss",
+                lambda *a, **k: None,
+            ),
+        ):
+            await handle_generate_support_bundle(call)
+
+        evidence = saved["evidence"]
+        assert evidence["log_capture_status"] == "unavailable"
+        assert "timed out" in evidence["log_capture_error"]
+        assert any("skipped" in w for w in evidence["warnings"])
+
+    async def test_logs_appearing_during_capture_are_not_called_missing(self, hass):
+        """The capture is the authority once it has actually read the file."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from homeassistant.core import ServiceCall
+
+        from custom_components.adjustable_bed.services import (
+            handle_generate_support_bundle,
+        )
+
+        messages: list[str] = []
+        report = {
+            "notifications": [],
+            "evidence": {"log_capture_status": "available", "warnings": []},
+        }
+        call = ServiceCall(
+            hass,
+            DOMAIN,
+            "generate_support_bundle",
+            {"target_address": "AA:BB:CC:DD:EE:FF", "capture_duration": 5},
+        )
+        with (
+            patch(
+                "custom_components.adjustable_bed.support_report.async_check_log_file",
+                AsyncMock(
+                    return_value={
+                        "available": False,
+                        "reason": "missing",
+                        "path": "/config/home-assistant.log",
+                        "error": "gone",
+                    }
+                ),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+                AsyncMock(return_value=report),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
+                MagicMock(return_value="/config/bundle.json"),
+            ),
+            patch(
+                "custom_components.adjustable_bed.download.register_download",
+                MagicMock(return_value="/api/download/bundle.json"),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_create",
+                lambda _h, message, **k: messages.append(message),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_dismiss",
+                lambda *a, **k: None,
+            ),
+        ):
+            await handle_generate_support_bundle(call)
+
+        # The log turned up during the window, so the Ready notice must not
+        # claim the bundle has none.
+        assert "contains no logs" not in messages[-1]
+
+    async def test_notice_survives_until_the_last_overlapping_capture(self, hass):
+        """A short capture finishing first must not strand a longer one."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from homeassistant.core import ServiceCall
+
+        from custom_components.adjustable_bed.services import (
+            _LOG_NOTICE_OWNERS,
+            handle_generate_support_bundle,
+        )
+
+        notice_id = "adjustable_bed_support_bundle_logs_aa_bb_cc_dd_ee_ff"
+        dismissed: list[str] = []
+        # A longer logless capture is already running and owns the notice.
+        other = object()
+        hass.data.setdefault(_LOG_NOTICE_OWNERS, {})[notice_id] = {other}
+
+        report = {
+            "notifications": [],
+            "evidence": {
+                "log_capture_status": "unavailable",
+                "log_capture_reason": "missing",
+                "log_capture_error": "gone",
+                "warnings": [],
+            },
+        }
+        call = ServiceCall(
+            hass,
+            DOMAIN,
+            "generate_support_bundle",
+            {"target_address": "AA:BB:CC:DD:EE:FF", "capture_duration": 5},
+        )
+        with (
+            patch(
+                "custom_components.adjustable_bed.support_report.async_check_log_file",
+                AsyncMock(
+                    return_value={
+                        "available": False,
+                        "reason": "missing",
+                        "path": "/config/home-assistant.log",
+                        "error": "gone",
+                    }
+                ),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+                AsyncMock(return_value=report),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
+                MagicMock(return_value="/config/bundle.json"),
+            ),
+            patch(
+                "custom_components.adjustable_bed.download.register_download",
+                MagicMock(return_value="/api/download/bundle.json"),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_create",
+                lambda *a, **k: None,
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_dismiss",
+                lambda _hass, nid: dismissed.append(nid),
+            ),
+        ):
+            await handle_generate_support_bundle(call)
+
+        # The longer capture still owns it, so nothing was retracted.
+        assert dismissed == []
+        assert other in hass.data[_LOG_NOTICE_OWNERS][notice_id]

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -2087,67 +2087,6 @@ class TestSupportBundleLogProbeSafety:
         # It never raised a notice, so it owns nothing to retract.
         assert dismissed == []
 
-    async def test_timed_out_probe_skips_the_capture_log_read(self, hass):
-        """A wedged mount must not be opened twice, and must still explain itself."""
-        import asyncio as _asyncio
-        from unittest.mock import MagicMock, patch
-
-        from homeassistant.core import ServiceCall
-
-        from custom_components.adjustable_bed.services import (
-            handle_generate_support_bundle,
-        )
-
-        seen: dict = {}
-        messages: list[str] = []
-
-        async def _never_returns(_hass):
-            await _asyncio.sleep(3600)
-
-        async def _generate(*args, **kwargs):
-            seen.update(kwargs)
-            return {"notifications": [], "evidence": {"warnings": []}}
-
-        call = ServiceCall(
-            hass,
-            DOMAIN,
-            "generate_support_bundle",
-            {"target_address": "AA:BB:CC:DD:EE:FF", "capture_duration": 5},
-        )
-        with (
-            patch("custom_components.adjustable_bed.services._LOG_PROBE_TIMEOUT", 0.01),
-            patch(
-                "custom_components.adjustable_bed.support_report.async_check_log_file",
-                _never_returns,
-            ),
-            patch(
-                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
-                _generate,
-            ),
-            patch(
-                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
-                MagicMock(return_value="/config/bundle.json"),
-            ),
-            patch(
-                "custom_components.adjustable_bed.download.register_download",
-                MagicMock(return_value="/api/download/bundle.json"),
-            ),
-            patch(
-                "homeassistant.components.persistent_notification.async_create",
-                lambda _h, message, **k: messages.append(message),
-            ),
-            patch(
-                "homeassistant.components.persistent_notification.async_dismiss",
-                lambda *a, **k: None,
-            ),
-        ):
-            await handle_generate_support_bundle(call)
-
-        # The capture must not re-open the same wedged path.
-        assert seen["include_logs"] is False
-        # And the Ready notification still explains the missing logs.
-        assert any("contains no logs" in m for m in messages)
-
     async def test_empty_log_guidance_survives_to_the_ready_notice(self, hass):
         """An empty file reports "empty", which must not drop the explanation."""
         from unittest.mock import AsyncMock, MagicMock, patch
@@ -2208,69 +2147,6 @@ class TestSupportBundleLogProbeSafety:
         assert "contains no logs" in ready
         assert "Enable debug logging" in ready
 
-
-    async def test_skipped_read_records_the_reason_in_the_bundle(self, hass):
-        """The JSON is what reaches a maintainer, so the reason must live there."""
-        import asyncio as _asyncio
-        from unittest.mock import MagicMock, patch
-
-        from homeassistant.core import ServiceCall
-
-        from custom_components.adjustable_bed.services import (
-            handle_generate_support_bundle,
-        )
-
-        saved: dict = {}
-
-        async def _never_returns(_hass):
-            await _asyncio.sleep(3600)
-
-        async def _generate(*args, **kwargs):
-            return {"notifications": [], "evidence": {"warnings": []}}
-
-        def _save(_hass, report, _address):
-            saved.update(report)
-            return "/config/bundle.json"
-
-        call = ServiceCall(
-            hass,
-            DOMAIN,
-            "generate_support_bundle",
-            {"target_address": "AA:BB:CC:DD:EE:FF", "capture_duration": 5},
-        )
-        with (
-            patch("custom_components.adjustable_bed.services._LOG_PROBE_TIMEOUT", 0.01),
-            patch(
-                "custom_components.adjustable_bed.support_report.async_check_log_file",
-                _never_returns,
-            ),
-            patch(
-                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
-                _generate,
-            ),
-            patch(
-                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
-                _save,
-            ),
-            patch(
-                "custom_components.adjustable_bed.download.register_download",
-                MagicMock(return_value="/api/download/bundle.json"),
-            ),
-            patch(
-                "homeassistant.components.persistent_notification.async_create",
-                lambda *a, **k: None,
-            ),
-            patch(
-                "homeassistant.components.persistent_notification.async_dismiss",
-                lambda *a, **k: None,
-            ),
-        ):
-            await handle_generate_support_bundle(call)
-
-        evidence = saved["evidence"]
-        assert evidence["log_capture_status"] == "unavailable"
-        assert "timed out" in evidence["log_capture_error"]
-        assert any("skipped" in w for w in evidence["warnings"])
 
     async def test_logs_appearing_during_capture_are_not_called_missing(self, hass):
         """The capture is the authority once it has actually read the file."""
@@ -2402,3 +2278,83 @@ class TestSupportBundleLogProbeSafety:
         # The longer capture still owns it, so nothing was retracted.
         assert dismissed == []
         assert other in hass.data[_LOG_NOTICE_OWNERS][notice_id]
+
+
+    async def test_timed_out_probe_still_lets_the_capture_read_logs(self, hass):
+        """A timeout is inconclusive, so it must not disable logs for the capture.
+
+        Home Assistant's shared executor can be saturated enough that the probe
+        job never starts. Treating that as a wedged path would drop logs from a
+        minutes-long capture over a few seconds of queue delay.
+        """
+        import asyncio as _asyncio
+        from unittest.mock import MagicMock, patch
+
+        from homeassistant.core import ServiceCall
+
+        from custom_components.adjustable_bed.services import (
+            handle_generate_support_bundle,
+        )
+
+        seen: dict = {}
+        titles: list[str] = []
+
+        async def _never_returns(_hass):
+            await _asyncio.sleep(3600)
+
+        async def _generate(*args, **kwargs):
+            seen.update(kwargs)
+            return {
+                "notifications": [],
+                "evidence": {"log_capture_status": "available", "warnings": []},
+            }
+
+        call = ServiceCall(
+            hass,
+            DOMAIN,
+            "generate_support_bundle",
+            {"target_address": "AA:BB:CC:DD:EE:FF", "capture_duration": 5},
+        )
+        with (
+            patch("custom_components.adjustable_bed.services._LOG_PROBE_TIMEOUT", 0.01),
+            patch(
+                "custom_components.adjustable_bed.support_report.async_check_log_file",
+                _never_returns,
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+                _generate,
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
+                MagicMock(return_value="/config/bundle.json"),
+            ),
+            patch(
+                "custom_components.adjustable_bed.download.register_download",
+                MagicMock(return_value="/api/download/bundle.json"),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_create",
+                lambda _h, message, title=None, **k: titles.append(str(title)),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_dismiss",
+                lambda *a, **k: None,
+            ),
+        ):
+            await handle_generate_support_bundle(call)
+
+        assert seen["include_logs"] is True
+        # Nothing was concluded, so the user is not warned about missing logs.
+        assert not [t for t in titles if "no logs" in t]
+
+    async def test_a_symlinked_log_file_is_accepted(self, tmp_path):
+        """A symlink to a real log is a legitimate setup and must be followed."""
+        from custom_components.adjustable_bed.support_report import _probe_log_file
+
+        real = tmp_path / "real.log"
+        real.write_text("2026-07-26 00:00:00.000 INFO (MainThread) [x] hi\n")
+        link = tmp_path / "home-assistant.log"
+        link.symlink_to(real)
+
+        assert _probe_log_file(str(link)) == (True, None, None)

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -2000,3 +2000,79 @@ class TestSupportBundleLogProbeSafety:
             await handle_generate_support_bundle(call)
 
         assert "adjustable_bed_support_bundle_logs_aa_bb_cc_dd_ee_ff" in dismissed
+
+
+    async def test_a_call_without_logs_requested_leaves_the_notice_alone(self, hass):
+        """An include_logs: false call must not clear another capture's warning."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from homeassistant.core import ServiceCall
+
+        from custom_components.adjustable_bed.services import (
+            handle_generate_support_bundle,
+        )
+
+        dismissed: list[str] = []
+        report = {"notifications": [], "evidence": {"warnings": []}}
+        call = ServiceCall(
+            hass,
+            DOMAIN,
+            "generate_support_bundle",
+            {
+                "target_address": "AA:BB:CC:DD:EE:FF",
+                "capture_duration": 5,
+                "include_logs": False,
+            },
+        )
+        with (
+            patch(
+                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+                AsyncMock(return_value=report),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
+                MagicMock(return_value="/config/bundle.json"),
+            ),
+            patch(
+                "custom_components.adjustable_bed.download.register_download",
+                MagicMock(return_value="/api/download/bundle.json"),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_create",
+                lambda *a, **k: None,
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_dismiss",
+                lambda _hass, nid: dismissed.append(nid),
+            ),
+        ):
+            await handle_generate_support_bundle(call)
+
+        # It never raised a notice, so it owns nothing to retract.
+        assert dismissed == []
+
+    async def test_probe_uses_a_private_executor(self, hass, tmp_path):
+        """A wedged probe must not strand a shared Home Assistant worker."""
+        from unittest.mock import patch
+
+        from custom_components.adjustable_bed.support_report import (
+            async_check_log_file,
+        )
+
+        shared_used = False
+
+        def _fail_if_shared(*args, **kwargs):
+            nonlocal shared_used
+            shared_used = True
+            raise AssertionError("probe must not use the shared executor")
+
+        path = tmp_path / "home-assistant.log"
+        path.write_text("hello")
+        with (
+            patch.object(hass.config, "path", return_value=str(path)),
+            patch.object(hass, "async_add_executor_job", _fail_if_shared),
+        ):
+            check = await async_check_log_file(hass)
+
+        assert shared_used is False
+        assert check["available"] is True

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -2123,3 +2123,125 @@ class TestSupportBundleLogProbeSafety:
 
         # Ownership moved on, so this invocation must leave the notice up.
         assert dismissed == []
+
+
+    async def test_timed_out_probe_skips_the_capture_log_read(self, hass):
+        """A wedged mount must not be opened twice, and must still explain itself."""
+        import asyncio as _asyncio
+        from unittest.mock import MagicMock, patch
+
+        from homeassistant.core import ServiceCall
+
+        from custom_components.adjustable_bed.services import (
+            handle_generate_support_bundle,
+        )
+
+        seen: dict = {}
+        messages: list[str] = []
+
+        async def _never_returns(_hass):
+            await _asyncio.sleep(3600)
+
+        async def _generate(*args, **kwargs):
+            seen.update(kwargs)
+            return {"notifications": [], "evidence": {"warnings": []}}
+
+        call = ServiceCall(
+            hass,
+            DOMAIN,
+            "generate_support_bundle",
+            {"target_address": "AA:BB:CC:DD:EE:FF", "capture_duration": 5},
+        )
+        with (
+            patch("custom_components.adjustable_bed.services._LOG_PROBE_TIMEOUT", 0.01),
+            patch(
+                "custom_components.adjustable_bed.support_report.async_check_log_file",
+                _never_returns,
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+                _generate,
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
+                MagicMock(return_value="/config/bundle.json"),
+            ),
+            patch(
+                "custom_components.adjustable_bed.download.register_download",
+                MagicMock(return_value="/api/download/bundle.json"),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_create",
+                lambda _h, message, **k: messages.append(message),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_dismiss",
+                lambda *a, **k: None,
+            ),
+        ):
+            await handle_generate_support_bundle(call)
+
+        # The capture must not re-open the same wedged path.
+        assert seen["include_logs"] is False
+        # And the Ready notification still explains the missing logs.
+        assert any("contains no logs" in m for m in messages)
+
+    async def test_empty_log_guidance_survives_to_the_ready_notice(self, hass):
+        """An empty file reports "empty", which must not drop the explanation."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from homeassistant.core import ServiceCall
+
+        from custom_components.adjustable_bed.services import (
+            handle_generate_support_bundle,
+        )
+
+        messages: list[str] = []
+        report = {
+            "notifications": [],
+            "evidence": {"log_capture_status": "empty", "warnings": []},
+        }
+        call = ServiceCall(
+            hass,
+            DOMAIN,
+            "generate_support_bundle",
+            {"target_address": "AA:BB:CC:DD:EE:FF", "capture_duration": 5},
+        )
+        with (
+            patch(
+                "custom_components.adjustable_bed.support_report.async_check_log_file",
+                AsyncMock(
+                    return_value={
+                        "available": False,
+                        "reason": "empty_file",
+                        "path": "/config/home-assistant.log",
+                        "error": "/config/home-assistant.log is empty",
+                    }
+                ),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+                AsyncMock(return_value=report),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
+                MagicMock(return_value="/config/bundle.json"),
+            ),
+            patch(
+                "custom_components.adjustable_bed.download.register_download",
+                MagicMock(return_value="/api/download/bundle.json"),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_create",
+                lambda _h, message, **k: messages.append(message),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_dismiss",
+                lambda *a, **k: None,
+            ),
+        ):
+            await handle_generate_support_bundle(call)
+
+        ready = messages[-1]
+        assert "contains no logs" in ready
+        assert "Enable debug logging" in ready

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -1655,3 +1655,103 @@ class TestSupportBundlePreCaptureLogWarning:
         )
 
         assert not [t for t, _ in events if "will have no logs" in t]
+
+
+class TestSupportBundleLogProbeSafety:
+    """The pre-capture probe must never block or leave a stale warning."""
+
+    def test_probe_refuses_a_fifo_without_opening_it(self, tmp_path):
+        """A FIFO would block open() forever, hanging the executor thread."""
+        import os
+
+        from custom_components.adjustable_bed.support_report import _probe_log_file
+
+        fifo = tmp_path / "home-assistant.log"
+        os.mkfifo(fifo)
+        # No writer exists, so a probe that opens this would never return.
+        available, reason, error = _probe_log_file(str(fifo))
+
+        assert available is False
+        assert reason == "not_a_file"
+        assert "not a regular file" in error
+
+    def test_tail_refuses_a_fifo_too(self, tmp_path):
+        """The capture's own reader has the same hazard."""
+        import os
+
+        from custom_components.adjustable_bed.support_report import _read_log_file
+
+        fifo = tmp_path / "home-assistant.log"
+        os.mkfifo(fifo)
+        entries = _read_log_file(str(fifo))
+
+        # Treated like a missing file: the remedy is a downloadable log, not a
+        # permissions fix.
+        assert entries[0]["log_read_reason"] == "missing"
+
+    def test_probe_accepts_a_regular_file(self, tmp_path):
+        """A healthy install still reports available."""
+        from custom_components.adjustable_bed.support_report import _probe_log_file
+
+        path = tmp_path / "home-assistant.log"
+        path.write_text("2026-07-26 00:00:00.000 INFO (MainThread) [x] hi\n")
+
+        assert _probe_log_file(str(path)) == (True, None, None)
+
+    async def test_available_logs_dismiss_a_stale_warning(self, hass):
+        """A recovered install must not keep showing the old warning."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from homeassistant.core import ServiceCall
+
+        from custom_components.adjustable_bed.services import (
+            handle_generate_support_bundle,
+        )
+
+        dismissed: list[str] = []
+        report = {
+            "notifications": [],
+            "evidence": {"log_capture_status": "available", "warnings": []},
+        }
+        call = ServiceCall(
+            hass,
+            DOMAIN,
+            "generate_support_bundle",
+            {"target_address": "AA:BB:CC:DD:EE:FF", "capture_duration": 5},
+        )
+        with (
+            patch(
+                "custom_components.adjustable_bed.support_report.async_check_log_file",
+                AsyncMock(
+                    return_value={
+                        "available": True,
+                        "reason": None,
+                        "path": "/config/home-assistant.log",
+                        "error": None,
+                    }
+                ),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+                AsyncMock(return_value=report),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
+                MagicMock(return_value="/config/bundle.json"),
+            ),
+            patch(
+                "custom_components.adjustable_bed.download.register_download",
+                MagicMock(return_value="/api/download/bundle.json"),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_create",
+                lambda *a, **k: None,
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_dismiss",
+                lambda _hass, nid: dismissed.append(nid),
+            ),
+        ):
+            await handle_generate_support_bundle(call)
+
+        assert "adjustable_bed_support_bundle_logs_aa_bb_cc_dd_ee_ff" in dismissed

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -1535,3 +1535,123 @@ class TestSupportBundleLoggingWarning:
         assert len(created) == 1
         assert "[Errno 13] Permission denied" in created[0]
         assert "logger:" not in created[0]
+
+
+class TestSupportBundlePreCaptureLogWarning:
+    """The user must learn a bundle will be log-less before waiting for it."""
+
+    @staticmethod
+    def _report() -> dict:
+        return {
+            "notifications": [],
+            "evidence": {
+                "log_capture_status": "unavailable",
+                "log_capture_reason": "missing",
+                "log_capture_error": "[Errno 2] No such file or directory",
+                "warnings": [],
+            },
+        }
+
+    async def _run(self, hass, check: dict) -> list[tuple[str, str]]:
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from homeassistant.core import ServiceCall
+
+        from custom_components.adjustable_bed.services import (
+            handle_generate_support_bundle,
+        )
+
+        events: list[tuple[str, str]] = []
+
+        def _capture(_hass, message, title=None, notification_id=None):
+            events.append((str(title), message))
+
+        async def _generate(*args, **kwargs):
+            events.append(("__capture_ran__", ""))
+            return self._report()
+
+        call = ServiceCall(
+            hass,
+            DOMAIN,
+            "generate_support_bundle",
+            {"target_address": "AA:BB:CC:DD:EE:FF", "capture_duration": 5},
+        )
+        with (
+            patch(
+                "custom_components.adjustable_bed.support_report.async_check_log_file",
+                AsyncMock(return_value=check),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+                _generate,
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
+                MagicMock(return_value="/config/bundle.json"),
+            ),
+            patch(
+                "custom_components.adjustable_bed.download.register_download",
+                MagicMock(return_value="/api/download/bundle.json"),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_create",
+                _capture,
+            ),
+        ):
+            await handle_generate_support_bundle(call)
+        return events
+
+    async def test_warns_before_the_capture_runs(self, hass):
+        """The warning must land before the multi-minute capture, not after it."""
+        events = await self._run(
+            hass,
+            {
+                "available": False,
+                "reason": "missing",
+                "path": "/config/home-assistant.log",
+                "error": "[Errno 2] No such file or directory",
+            },
+        )
+
+        titles = [title for title, _ in events]
+        assert titles.index("Adjustable Bed: this bundle will have no logs") < titles.index(
+            "__capture_ran__"
+        )
+        pre_capture = next(msg for title, msg in events if "no logs" in title)
+        assert "will contain no logs" in pre_capture
+        assert "Enable debug logging" in pre_capture
+        # `logger:` only sets levels; it cannot create a missing log file.
+        assert "logger:" not in pre_capture
+        # The capture is not aborted: a Bluetooth-only bundle still has value.
+        assert "__capture_ran__" in titles
+
+    async def test_unreadable_log_reports_the_error_not_logging_advice(self, hass):
+        """A permission problem needs a different remedy than a missing file."""
+        events = await self._run(
+            hass,
+            {
+                "available": False,
+                "reason": "unreadable",
+                "path": "/config/home-assistant.log",
+                "error": "[Errno 13] Permission denied",
+            },
+        )
+
+        pre_capture = next(msg for title, msg in events if "no logs" in title)
+        assert "[Errno 13] Permission denied" in pre_capture
+        assert "permissions" in pre_capture
+        assert "Enable debug logging" not in pre_capture
+
+    async def test_no_warning_when_logs_are_available(self, hass):
+        """A healthy install must not be nagged."""
+        events = await self._run(
+            hass,
+            {
+                "available": True,
+                "reason": None,
+                "path": "/config/home-assistant.log",
+                "error": None,
+            },
+        )
+
+        assert not [t for t, _ in events if "will have no logs" in t]

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -1689,6 +1689,18 @@ class TestSupportBundleLogProbeSafety:
         # permissions fix.
         assert entries[0]["log_read_reason"] == "missing"
 
+    def test_probe_rejects_an_empty_log_file(self, tmp_path):
+        """A left-over empty file is readable but will never yield evidence."""
+        from custom_components.adjustable_bed.support_report import _probe_log_file
+
+        path = tmp_path / "home-assistant.log"
+        path.touch()
+        available, reason, error = _probe_log_file(str(path))
+
+        assert available is False
+        assert reason == "empty_file"
+        assert "is empty" in error
+
     def test_probe_accepts_a_regular_file(self, tmp_path):
         """A healthy install still reports available."""
         from custom_components.adjustable_bed.support_report import _probe_log_file

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -2051,28 +2051,75 @@ class TestSupportBundleLogProbeSafety:
         # It never raised a notice, so it owns nothing to retract.
         assert dismissed == []
 
-    async def test_probe_uses_a_private_executor(self, hass, tmp_path):
-        """A wedged probe must not strand a shared Home Assistant worker."""
-        from unittest.mock import patch
+    async def test_only_the_current_owner_retracts_the_notice(self, hass):
+        """The first call to finish must not clear a newer capture's warning."""
+        from unittest.mock import AsyncMock, MagicMock, patch
 
-        from custom_components.adjustable_bed.support_report import (
-            async_check_log_file,
+        from homeassistant.core import ServiceCall
+
+        from custom_components.adjustable_bed.services import (
+            _LOG_NOTICE_OWNERS,
+            handle_generate_support_bundle,
         )
 
-        shared_used = False
+        notice_id = "adjustable_bed_support_bundle_logs_aa_bb_cc_dd_ee_ff"
+        dismissed: list[str] = []
+        report = {
+            "notifications": [],
+            "evidence": {
+                "log_capture_status": "unavailable",
+                "log_capture_reason": "missing",
+                "log_capture_error": "boom",
+                "warnings": [],
+            },
+        }
 
-        def _fail_if_shared(*args, **kwargs):
-            nonlocal shared_used
-            shared_used = True
-            raise AssertionError("probe must not use the shared executor")
+        async def _generate(*args, **kwargs):
+            # A concurrent capture re-raises the notice and takes ownership
+            # while this one is still running.
+            hass.data.setdefault(_LOG_NOTICE_OWNERS, {})[notice_id] = object()
+            return report
 
-        path = tmp_path / "home-assistant.log"
-        path.write_text("hello")
+        call = ServiceCall(
+            hass,
+            DOMAIN,
+            "generate_support_bundle",
+            {"target_address": "AA:BB:CC:DD:EE:FF", "capture_duration": 5},
+        )
         with (
-            patch.object(hass.config, "path", return_value=str(path)),
-            patch.object(hass, "async_add_executor_job", _fail_if_shared),
+            patch(
+                "custom_components.adjustable_bed.support_report.async_check_log_file",
+                AsyncMock(
+                    return_value={
+                        "available": False,
+                        "reason": "missing",
+                        "path": "/config/home-assistant.log",
+                        "error": "boom",
+                    }
+                ),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+                _generate,
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
+                MagicMock(return_value="/config/bundle.json"),
+            ),
+            patch(
+                "custom_components.adjustable_bed.download.register_download",
+                MagicMock(return_value="/api/download/bundle.json"),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_create",
+                lambda *a, **k: None,
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_dismiss",
+                lambda _hass, nid: dismissed.append(nid),
+            ),
         ):
-            check = await async_check_log_file(hass)
+            await handle_generate_support_bundle(call)
 
-        assert shared_used is False
-        assert check["available"] is True
+        # Ownership moved on, so this invocation must leave the notice up.
+        assert dismissed == []

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -1808,3 +1808,129 @@ class TestSupportBundleLogProbeSafety:
             await handle_generate_support_bundle(call)
 
         assert "adjustable_bed_support_bundle_logs_aa_bb_cc_dd_ee_ff" in dismissed
+
+
+    async def test_a_slow_probe_does_not_block_the_capture(self, hass):
+        """A stalled mount must not hang the service before it even starts."""
+        import asyncio as _asyncio
+        from unittest.mock import MagicMock, patch
+
+        from homeassistant.core import ServiceCall
+
+        from custom_components.adjustable_bed.services import (
+            handle_generate_support_bundle,
+        )
+
+        captured = False
+
+        async def _never_returns(_hass):
+            await _asyncio.sleep(3600)
+
+        async def _generate(*args, **kwargs):
+            nonlocal captured
+            captured = True
+            return {"notifications": [], "evidence": {"warnings": []}}
+
+        call = ServiceCall(
+            hass,
+            DOMAIN,
+            "generate_support_bundle",
+            {"target_address": "AA:BB:CC:DD:EE:FF", "capture_duration": 5},
+        )
+        with (
+            patch(
+                "custom_components.adjustable_bed.services._LOG_PROBE_TIMEOUT", 0.01
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_report.async_check_log_file",
+                _never_returns,
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+                _generate,
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
+                MagicMock(return_value="/config/bundle.json"),
+            ),
+            patch(
+                "custom_components.adjustable_bed.download.register_download",
+                MagicMock(return_value="/api/download/bundle.json"),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_create",
+                lambda *a, **k: None,
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_dismiss",
+                lambda *a, **k: None,
+            ),
+        ):
+            await handle_generate_support_bundle(call)
+
+        assert captured is True
+
+    async def test_completed_logless_bundle_retracts_the_pre_capture_notice(
+        self, hass
+    ):
+        """The Ready notification repeats the guidance, so the old one must go."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from homeassistant.core import ServiceCall
+
+        from custom_components.adjustable_bed.services import (
+            handle_generate_support_bundle,
+        )
+
+        dismissed: list[str] = []
+        report = {
+            "notifications": [],
+            "evidence": {
+                "log_capture_status": "unavailable",
+                "log_capture_reason": "missing",
+                "log_capture_error": "[Errno 2] No such file or directory",
+                "warnings": [],
+            },
+        }
+        call = ServiceCall(
+            hass,
+            DOMAIN,
+            "generate_support_bundle",
+            {"target_address": "AA:BB:CC:DD:EE:FF", "capture_duration": 5},
+        )
+        with (
+            patch(
+                "custom_components.adjustable_bed.support_report.async_check_log_file",
+                AsyncMock(
+                    return_value={
+                        "available": False,
+                        "reason": "missing",
+                        "path": "/config/home-assistant.log",
+                        "error": "[Errno 2] No such file or directory",
+                    }
+                ),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+                AsyncMock(return_value=report),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.save_support_bundle",
+                MagicMock(return_value="/config/bundle.json"),
+            ),
+            patch(
+                "custom_components.adjustable_bed.download.register_download",
+                MagicMock(return_value="/api/download/bundle.json"),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_create",
+                lambda *a, **k: None,
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_dismiss",
+                lambda _hass, nid: dismissed.append(nid),
+            ),
+        ):
+            await handle_generate_support_bundle(call)
+
+        assert "adjustable_bed_support_bundle_logs_aa_bb_cc_dd_ee_ff" in dismissed

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -1934,3 +1934,57 @@ class TestSupportBundleLogProbeSafety:
             await handle_generate_support_bundle(call)
 
         assert "adjustable_bed_support_bundle_logs_aa_bb_cc_dd_ee_ff" in dismissed
+
+
+    async def test_cancelled_capture_retracts_the_notice(self, hass):
+        """CancelledError is a BaseException, so except Exception cannot catch it."""
+        import asyncio as _asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import pytest as _pytest
+        from homeassistant.core import ServiceCall
+
+        from custom_components.adjustable_bed.services import (
+            handle_generate_support_bundle,
+        )
+
+        dismissed: list[str] = []
+        call = ServiceCall(
+            hass,
+            DOMAIN,
+            "generate_support_bundle",
+            {"target_address": "AA:BB:CC:DD:EE:FF", "capture_duration": 5},
+        )
+        with (
+            patch(
+                "custom_components.adjustable_bed.support_report.async_check_log_file",
+                AsyncMock(
+                    return_value={
+                        "available": False,
+                        "reason": "missing",
+                        "path": "/config/home-assistant.log",
+                        "error": "[Errno 2] No such file or directory",
+                    }
+                ),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+                AsyncMock(side_effect=_asyncio.CancelledError()),
+            ),
+            patch(
+                "custom_components.adjustable_bed.download.register_download",
+                MagicMock(return_value="/api/download/bundle.json"),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_create",
+                lambda *a, **k: None,
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_dismiss",
+                lambda _hass, nid: dismissed.append(nid),
+            ),
+            _pytest.raises(_asyncio.CancelledError),
+        ):
+            await handle_generate_support_bundle(call)
+
+        assert "adjustable_bed_support_bundle_logs_aa_bb_cc_dd_ee_ff" in dismissed

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -1755,3 +1755,56 @@ class TestSupportBundleLogProbeSafety:
             await handle_generate_support_bundle(call)
 
         assert "adjustable_bed_support_bundle_logs_aa_bb_cc_dd_ee_ff" in dismissed
+
+
+    async def test_failed_capture_dismisses_the_warning(self, hass):
+        """No bundle means the "capture is running anyway" notice must go."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import pytest as _pytest
+        from homeassistant.core import ServiceCall
+
+        from custom_components.adjustable_bed.services import (
+            handle_generate_support_bundle,
+        )
+
+        dismissed: list[str] = []
+        call = ServiceCall(
+            hass,
+            DOMAIN,
+            "generate_support_bundle",
+            {"target_address": "AA:BB:CC:DD:EE:FF", "capture_duration": 5},
+        )
+        with (
+            patch(
+                "custom_components.adjustable_bed.support_report.async_check_log_file",
+                AsyncMock(
+                    return_value={
+                        "available": False,
+                        "reason": "missing",
+                        "path": "/config/home-assistant.log",
+                        "error": "[Errno 2] No such file or directory",
+                    }
+                ),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.generate_support_bundle",
+                AsyncMock(side_effect=RuntimeError("boom")),
+            ),
+            patch(
+                "custom_components.adjustable_bed.download.register_download",
+                MagicMock(return_value="/api/download/bundle.json"),
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_create",
+                lambda *a, **k: None,
+            ),
+            patch(
+                "homeassistant.components.persistent_notification.async_dismiss",
+                lambda _hass, nid: dismissed.append(nid),
+            ),
+            _pytest.raises(RuntimeError),
+        ):
+            await handle_generate_support_bundle(call)
+
+        assert "adjustable_bed_support_bundle_logs_aa_bb_cc_dd_ee_ff" in dismissed


### PR DESCRIPTION
## Problem

The support bundle already explains a missing log file, but only **after** the capture finishes. That capture runs for minutes (120s by default), so the user waits it out and only then learns the bundle is missing the evidence that matters most for connection and pairing problems.

Issue #385 is the worst case of this: every one of the five bundles in that thread came back with `log_capture_status: "unavailable"`, and each round cost the reporter another wait plus a round-trip asking for a better one.

## Change

Probe the log file **before** capturing and warn immediately, while the user still has the bed in front of them and can enable logging and re-run:

```
⚠️ This bundle will contain no logs.
...
The capture is running anyway, so you will still get a bundle with Bluetooth diagnostics.
```

The capture is not aborted, since a Bluetooth-only bundle still has value.

## Wording is deliberately unchanged

The finished-bundle notification keeps its existing text from #479, now shared with the new pre-capture warning via `build_missing_log_notice(reason, error, *, future=False)` so the two cannot drift apart.

That wording is worth preserving carefully: it avoids advising `logger:`, which only sets levels and does **not** create a file handler, so it cannot help a container install that logs to stdout. It points at the debug-logging download flow instead, which always yields a log. The unreadable-file case keeps its separate remedy (permissions and log path) rather than being told to enable debug logging.

Existing tests that assert on that exact text pass unchanged, which is what confirms the refactor preserved it.

## Tests

`2606 passed`, ruff and mypy clean. Three new tests:

- the warning lands **before** the capture (asserted by ordering, not just presence), and the capture still runs
- an unreadable log reports the OS error and the permissions remedy, not debug-logging advice
- a healthy install is not nagged

## Note

`crq preflight` could not run before this push: the CodeRabbit account was rate-limited (`waitTime: 34 minutes`). Skipping it costs no quota here, since the review has to happen against this PR either way.

Ref #385


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support-bundle generation now probes log availability before starting capture and tailors user messaging based on the probe result.
  * Shows a persistent warning when logs can’t be included, with guidance that varies for missing vs unreadable/empty logs.

* **Bug Fixes**
  * Hardened log reading to avoid blocking or accidentally consuming non-regular log sources (for example, FIFOs).
  * Persistent warnings are now correctly created and dismissed only for the relevant capture run, including on success, errors, and cancellations.

* **Tests**
  * Added coverage for log probing safety, timeout behavior, and notification lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->