### PR TITLE
Point the press-and-hold comment at its follow-up issue

### DIFF
--- a/custom_components/adjustable_bed/frontend/src/hold.ts
+++ b/custom_components/adjustable_bed/frontend/src/hold.ts
@@ -64,7 +64,7 @@ export class MotorHold {
     // is finite and ends with the protocol's release burst, so a hold is a
     // train of pulses with a short stop between them. Making it continuous
     // needs a hold-until-released primitive in the integration, which does not
-    // exist yet.
+    // exist yet: see issue #483.
     while (generation === this._generation) {
       try {
         const pending = this.actions.pulse(motor, dir);


### PR DESCRIPTION
<!-- crq:skip-autoreview -->

One comment line. `hold.ts` explained that holds are a train of pulses and that
making them continuous needs a primitive the integration does not have. That
work is now tracked in #483, so the comment names it instead of leaving the next
reader to rediscover the reasoning or assume the pulsing is intentional.

No behaviour change. Frontend typechecks, builds, and its 31 tests pass.

Skipping fleet auto-review: this is a comment-only change and the CodeRabbit
quota is contended right now.

Ref #483.
