### PR TITLE
Transport-aware Bluetooth setup with live progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ tests/test_apkpure_inventory.py
 
 # Claude Code instructions (symlink to AGENTS.md)
 CLAUDE.md
+
+# Local virtualenvs, including symlinks into a shared one from git worktrees.
+.venv
+venv/

--- a/custom_components/adjustable_bed/bluetooth_freshness.py
+++ b/custom_components/adjustable_bed/bluetooth_freshness.py
@@ -1,0 +1,349 @@
+"""Freshness gate for setup-time BLE probes and pairing attempts.
+
+Home Assistant keeps a bed in its Bluetooth history for a while after the bed
+stops advertising, and it hands out a ``BLEDevice`` built from that history. A
+bed that has gone to sleep, been unplugged or moved out of range therefore still
+*looks* present, and the probe or pairing attempt that follows spends its full
+connection timeout failing. Worse, that failure is easy to misread as "pairing
+is broken" or "the bond is stale", which is exactly the misdiagnosis issue #459
+forbids.
+
+So before any setup-time connection, ask a narrower question than "does Home
+Assistant know about this address": *has this bed advertised recently, on a
+connectable scanner, with a usable signal reading?* Only then resolve a fresh
+``BLEDevice`` and connect.
+
+Two signals matter:
+
+* **Age.** ``BluetoothServiceInfoBleak.time`` is a coarse monotonic timestamp of
+  the last advertisement. ``habluetooth`` will keep a connectable record for up
+  to ``CONNECTABLE_FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS`` (195 s) when it
+  has not learned the device's advertising interval, so "present in history" can
+  mean "last heard over three minutes ago".
+* **RSSI invalidation.** BlueZ reports ``-127`` when it has no valid reading for
+  a device — the value ``habluetooth`` also uses as its "no RSSI" sentinel. A
+  record carrying it proves the adapter is not currently hearing the bed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import math
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components import bluetooth
+from homeassistant.core import HomeAssistant, callback
+
+from .bluetooth_transport import ConnectionPath, async_path_for_source, async_resolve_ble_device
+
+if TYPE_CHECKING:
+    from bleak.backends.device import BLEDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+try:  # pragma: no cover - the fallback only matters if the dep changes
+    from bluetooth_data_tools import monotonic_time_coarse as _monotonic
+except ImportError:  # pragma: no cover
+    _monotonic = time.monotonic
+
+# BlueZ publishes -127 dBm when it has no valid RSSI for a device, and
+# habluetooth uses the same value as its "no reading" sentinel. Anything at or
+# below it is an absence of evidence, not a weak signal.
+RSSI_INVALIDATED: int = -127
+
+# How recently the bed must have advertised for a setup-time connection to be
+# worth attempting.
+#
+# Chosen well below habluetooth's 195 s connectable-history ceiling: within that
+# ceiling a record can be almost three minutes old, which is long enough for a
+# bed to have been unplugged or gone to sleep. It is also comfortably above the
+# advertising intervals seen from bed controllers (typically a few hundred ms
+# while awake, and a couple of seconds when idle), so a bed that is genuinely
+# present and reachable always passes. The gate only ever refuses a bed that has
+# been silent for a minute and a half.
+MAX_ADVERTISEMENT_AGE_SECONDS: float = 90.0
+
+
+# How long to keep listening for a new advertisement before giving up. A bed
+# that is merely between advertising intervals should not be reported as absent,
+# and unlike everything else here this wait has a known duration, so it is the
+# one phase that can honestly drive a determinate progress bar.
+ADVERTISEMENT_WAIT_SECONDS: float = 30.0
+
+
+class FreshnessStatus(StrEnum):
+    """Why a bed is, or is not, worth attempting a connection to right now.
+
+    The failures are kept apart rather than collapsed into one "not seen":
+    diagnostics need to distinguish "Home Assistant has never heard of this
+    address" from "the record it has carries a timestamp we cannot trust".
+    """
+
+    FRESH = "fresh"
+    STALE = "stale"
+    MISSING = "missing"
+    RSSI_INVALID = "rssi_invalid"
+    INVALID_TIMESTAMP = "invalid_timestamp"
+    SOURCE_UNAVAILABLE = "source_unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class _Sighting:
+    """The raw facts a single scanner reports about one address."""
+
+    source: str | None
+    rssi: int | None
+    seen_at: Any
+
+
+@dataclass(frozen=True, slots=True)
+class AdvertisementEvidence:
+    """What Home Assistant currently knows about a bed's advertising."""
+
+    status: FreshnessStatus
+    age_seconds: float | None = None
+    rssi: int | None = None
+    source: str | None = None
+    path: ConnectionPath | None = None
+
+    @property
+    def is_fresh(self) -> bool:
+        """Return True when a connection attempt is justified."""
+        return self.status is FreshnessStatus.FRESH
+
+    @property
+    def error_key(self) -> str:
+        """Return the translation key describing why the bed is unreachable."""
+        return "not_advertising"
+
+
+def _coerce_age(raw_time: Any) -> float | None:
+    """Return the age in seconds of a monotonic advertisement timestamp.
+
+    Returns None when the timestamp is missing, non-numeric, not finite, or in
+    the future — all cases where freshness cannot be proven and therefore must
+    not be claimed. ``NaN`` matters specifically because every comparison
+    against it is False, so an unchecked ``NaN`` would sail past the age limit.
+    """
+    try:
+        seen_at = float(raw_time)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seen_at):
+        return None
+    age = _monotonic() - seen_at
+    if age < 0:
+        # A future timestamp means the record was written against a different
+        # clock than ours; treat it as unproven rather than as brand new.
+        return None
+    return age
+
+
+@callback
+def _async_sighting_from_scanner(
+    hass: HomeAssistant,
+    address: str,
+    source: str,
+) -> _Sighting | None:
+    """Return what one specific scanner last heard from ``address``.
+
+    When a particular adapter or proxy has been chosen, its own view is what
+    matters: another scanner still hearing the bed says nothing about whether
+    the selected transport can reach it.
+    """
+    try:
+        scanner_devices = bluetooth.async_scanner_devices_by_address(
+            hass, address, connectable=True
+        )
+    except Exception:  # noqa: BLE001 - fall back to the merged history
+        _LOGGER.debug("Per-scanner freshness lookup failed for %s", address, exc_info=True)
+        return None
+
+    for scanner_device in scanner_devices:
+        scanner = getattr(scanner_device, "scanner", None)
+        if getattr(scanner, "source", None) != source:
+            continue
+        timestamps = getattr(scanner, "discovered_device_timestamps", None)
+        seen_at = timestamps.get(address) if isinstance(timestamps, dict) else None
+        return _Sighting(
+            source=source,
+            rssi=_coerce_rssi(
+                getattr(getattr(scanner_device, "advertisement", None), "rssi", None)
+            ),
+            seen_at=seen_at,
+        )
+    return None
+
+
+@callback
+def _async_sighting(hass: HomeAssistant, address: str, source: str | None) -> _Sighting | None:
+    """Return the newest connectable sighting from the merged history."""
+    try:
+        service_info = bluetooth.async_last_service_info(hass, address, connectable=True)
+    except Exception:  # noqa: BLE001 - absence of a manager is "no evidence"
+        _LOGGER.debug("Could not read advertisement history for %s", address, exc_info=True)
+        return None
+    if service_info is None:
+        return None
+    return _Sighting(
+        source=getattr(service_info, "source", None),
+        rssi=_coerce_rssi(getattr(service_info, "rssi", None)),
+        seen_at=getattr(service_info, "time", None),
+    )
+
+
+def _coerce_rssi(value: Any) -> int | None:
+    """Coerce an advertised RSSI to an int, or None when unusable."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+@callback
+def async_check_advertisement(
+    hass: HomeAssistant,
+    address: str,
+    *,
+    source: str | None = None,
+    max_age: float = MAX_ADVERTISEMENT_AGE_SECONDS,
+) -> AdvertisementEvidence:
+    """Return whether ``address`` has recent, valid connectable advertising.
+
+    ``source`` restricts the check to one scanner, so a preferred adapter that
+    can no longer hear the bed is reported as not advertising even while another
+    proxy still sees it.
+    """
+    normalized = address.upper()
+    if source:
+        sighting = _async_sighting_from_scanner(hass, normalized, source)
+        if sighting is None:
+            # The chosen transport cannot see the bed. Report that specifically
+            # rather than falling back to a scanner the user did not select: a
+            # proxy across the house still hearing the bed says nothing about
+            # whether the selected adapter can reach it.
+            _LOGGER.debug("Adapter %s can no longer see %s", source, address)
+            return AdvertisementEvidence(
+                status=FreshnessStatus.SOURCE_UNAVAILABLE, source=source
+            )
+    else:
+        sighting = _async_sighting(hass, normalized, source)
+        if sighting is None:
+            _LOGGER.debug("No connectable advertisement history for %s", address)
+            return AdvertisementEvidence(status=FreshnessStatus.MISSING, source=source)
+
+    info_source = sighting.source
+    rssi = sighting.rssi
+    path = async_path_for_source(hass, info_source, rssi=rssi)
+    age = _coerce_age(sighting.seen_at)
+
+    if age is None:
+        _LOGGER.debug(
+            "Advertisement for %s has no usable timestamp; treating it as unproven", address
+        )
+        return AdvertisementEvidence(
+            status=FreshnessStatus.INVALID_TIMESTAMP,
+            rssi=rssi,
+            source=info_source or source,
+            path=path,
+        )
+
+    if rssi is not None and rssi <= RSSI_INVALIDATED:
+        _LOGGER.debug(
+            "Advertisement for %s carries an invalidated RSSI (%s dBm)", address, rssi
+        )
+        return AdvertisementEvidence(
+            status=FreshnessStatus.RSSI_INVALID,
+            age_seconds=age,
+            rssi=rssi,
+            source=info_source or source,
+            path=path,
+        )
+
+    if age > max_age:
+        _LOGGER.debug(
+            "Last advertisement from %s is %.1fs old (limit %.0fs)", address, age, max_age
+        )
+        return AdvertisementEvidence(
+            status=FreshnessStatus.STALE,
+            age_seconds=age,
+            rssi=rssi,
+            source=info_source or source,
+            path=path,
+        )
+
+    return AdvertisementEvidence(
+        status=FreshnessStatus.FRESH,
+        age_seconds=age,
+        rssi=rssi,
+        source=info_source or source,
+        path=path,
+    )
+
+
+@callback
+def async_gate_connection(
+    hass: HomeAssistant,
+    address: str,
+    *,
+    source: str | None = None,
+    max_age: float = MAX_ADVERTISEMENT_AGE_SECONDS,
+) -> tuple[AdvertisementEvidence, BLEDevice | None]:
+    """Check freshness and, only if it passes, resolve a current BLEDevice.
+
+    The device is resolved *after* the check and never reused from discovery, so
+    a connection attempt always targets the scanner that just heard the bed.
+    """
+    evidence = async_check_advertisement(hass, address, source=source, max_age=max_age)
+    if not evidence.is_fresh:
+        return evidence, None
+    return evidence, async_resolve_ble_device(hass, address, evidence.source or source)
+
+
+async def async_wait_for_advertisement(
+    hass: HomeAssistant,
+    address: str,
+    *,
+    source: str | None = None,
+    max_age: float = MAX_ADVERTISEMENT_AGE_SECONDS,
+    wait_timeout: float = ADVERTISEMENT_WAIT_SECONDS,
+    poll_interval: float = 1.0,
+    on_progress: Callable[[float], None] | None = None,
+) -> tuple[AdvertisementEvidence, BLEDevice | None]:
+    """Gate a connection, listening a while longer before giving up.
+
+    A bed that is simply between advertising intervals, or that the user is
+    walking over to put into pairing mode, should not be reported as absent on
+    the strength of one glance at the history. This waits for a genuinely fresh
+    advertisement and only then resolves the device.
+
+    ``on_progress`` receives the fraction of the wait elapsed. It is the only
+    honest determinate progress in the whole setup path: the duration really is
+    known in advance, unlike a BLE connect.
+    """
+    evidence, device = async_gate_connection(hass, address, source=source, max_age=max_age)
+    if evidence.is_fresh:
+        return evidence, device
+
+    deadline = _monotonic() + wait_timeout
+    while True:
+        remaining = deadline - _monotonic()
+        if remaining <= 0:
+            return evidence, None
+        if on_progress is not None:
+            elapsed = wait_timeout - remaining
+            with contextlib.suppress(Exception):
+                on_progress(min(1.0, max(0.0, elapsed / wait_timeout)))
+        await asyncio.sleep(min(poll_interval, remaining))
+        evidence, device = async_gate_connection(hass, address, source=source, max_age=max_age)
+        if evidence.is_fresh:
+            if on_progress is not None:
+                with contextlib.suppress(Exception):
+                    on_progress(1.0)
+            return evidence, device

--- a/custom_components/adjustable_bed/bluetooth_freshness.py
+++ b/custom_components/adjustable_bed/bluetooth_freshness.py
@@ -215,6 +215,24 @@ def _coerce_rssi(value: Any) -> int | None:
         return None
 
 
+def _newest_sighting(*sightings: _Sighting | None) -> _Sighting | None:
+    """Return the freshest sighting whose timestamp can be compared."""
+    available = [sighting for sighting in sightings if sighting is not None]
+    if not available:
+        return None
+
+    aged = [
+        (age, sighting)
+        for sighting in available
+        if (age := _coerce_age(sighting.seen_at)) is not None
+    ]
+    if aged:
+        return min(aged, key=lambda item: item[0])[1]
+    # Preserve the existing invalid-timestamp result when neither view carries
+    # a timestamp that can prove freshness.
+    return available[0]
+
+
 @callback
 def async_check_advertisement(
     hass: HomeAssistant,
@@ -231,14 +249,15 @@ def async_check_advertisement(
     """
     normalized = address.upper()
     if source:
-        sighting = _async_sighting_from_scanner(hass, normalized, source)
-        if sighting is None:
-            # Same proxy quirk as below: a scanner can report a connectable bed
-            # as non-connectable, and a pinned adapter deserves that fallback
-            # just as much as the merged view does.
-            sighting = _async_sighting_from_scanner(
+        # A proxy can keep a stale connectable snapshot while publishing current
+        # advertisements only in its non-connectable view. Compare both so the
+        # stale record cannot hide the live one.
+        sighting = _newest_sighting(
+            _async_sighting_from_scanner(hass, normalized, source),
+            _async_sighting_from_scanner(
                 hass, normalized, source, connectable=False
-            )
+            ),
+        )
         if sighting is None:
             # The chosen transport cannot see the bed. Report that specifically
             # rather than falling back to a scanner the user did not select: a
@@ -249,14 +268,15 @@ def async_check_advertisement(
                 status=FreshnessStatus.SOURCE_UNAVAILABLE, source=source
             )
     else:
-        sighting = _async_sighting(hass, normalized)
-        if sighting is None:
-            # Some ESPHome proxies have been observed classifying a perfectly
-            # connectable bed as non-connectable. The integration has always
-            # allowed that fallback, so losing it here would stop setup working
-            # on exactly the hardware it was added for. The freshness rules
-            # still apply to whatever is found.
-            sighting = _async_sighting(hass, normalized, connectable=False)
+        # Some ESPHome proxies have been observed classifying a perfectly
+        # connectable bed as non-connectable. Compare both histories because an
+        # old connectable snapshot can coexist with a current non-connectable
+        # one; falling back only when the first view is empty would reject a bed
+        # that is actively advertising.
+        sighting = _newest_sighting(
+            _async_sighting(hass, normalized),
+            _async_sighting(hass, normalized, connectable=False),
+        )
         if sighting is None:
             _LOGGER.debug("No advertisement history for %s", address)
             return AdvertisementEvidence(status=FreshnessStatus.MISSING, source=source)

--- a/custom_components/adjustable_bed/bluetooth_freshness.py
+++ b/custom_components/adjustable_bed/bluetooth_freshness.py
@@ -150,6 +150,8 @@ def _async_sighting_from_scanner(
     hass: HomeAssistant,
     address: str,
     source: str,
+    *,
+    connectable: bool = True,
 ) -> _Sighting | None:
     """Return what one specific scanner last heard from ``address``.
 
@@ -159,7 +161,7 @@ def _async_sighting_from_scanner(
     """
     try:
         scanner_devices = bluetooth.async_scanner_devices_by_address(
-            hass, address, connectable=True
+            hass, address, connectable=connectable
         )
     except Exception:  # noqa: BLE001 - fall back to the merged history
         _LOGGER.debug("Per-scanner freshness lookup failed for %s", address, exc_info=True)
@@ -185,7 +187,6 @@ def _async_sighting_from_scanner(
 def _async_sighting(
     hass: HomeAssistant,
     address: str,
-    source: str | None,
     *,
     connectable: bool = True,
 ) -> _Sighting | None:
@@ -232,6 +233,13 @@ def async_check_advertisement(
     if source:
         sighting = _async_sighting_from_scanner(hass, normalized, source)
         if sighting is None:
+            # Same proxy quirk as below: a scanner can report a connectable bed
+            # as non-connectable, and a pinned adapter deserves that fallback
+            # just as much as the merged view does.
+            sighting = _async_sighting_from_scanner(
+                hass, normalized, source, connectable=False
+            )
+        if sighting is None:
             # The chosen transport cannot see the bed. Report that specifically
             # rather than falling back to a scanner the user did not select: a
             # proxy across the house still hearing the bed says nothing about
@@ -241,14 +249,14 @@ def async_check_advertisement(
                 status=FreshnessStatus.SOURCE_UNAVAILABLE, source=source
             )
     else:
-        sighting = _async_sighting(hass, normalized, source)
+        sighting = _async_sighting(hass, normalized)
         if sighting is None:
             # Some ESPHome proxies have been observed classifying a perfectly
             # connectable bed as non-connectable. The integration has always
             # allowed that fallback, so losing it here would stop setup working
             # on exactly the hardware it was added for. The freshness rules
             # still apply to whatever is found.
-            sighting = _async_sighting(hass, normalized, source, connectable=False)
+            sighting = _async_sighting(hass, normalized, connectable=False)
         if sighting is None:
             _LOGGER.debug("No advertisement history for %s", address)
             return AdvertisementEvidence(status=FreshnessStatus.MISSING, source=source)

--- a/custom_components/adjustable_bed/bluetooth_freshness.py
+++ b/custom_components/adjustable_bed/bluetooth_freshness.py
@@ -182,10 +182,18 @@ def _async_sighting_from_scanner(
 
 
 @callback
-def _async_sighting(hass: HomeAssistant, address: str, source: str | None) -> _Sighting | None:
-    """Return the newest connectable sighting from the merged history."""
+def _async_sighting(
+    hass: HomeAssistant,
+    address: str,
+    source: str | None,
+    *,
+    connectable: bool = True,
+) -> _Sighting | None:
+    """Return the newest sighting from the merged history."""
     try:
-        service_info = bluetooth.async_last_service_info(hass, address, connectable=True)
+        service_info = bluetooth.async_last_service_info(
+            hass, address, connectable=connectable
+        )
     except Exception:  # noqa: BLE001 - absence of a manager is "no evidence"
         _LOGGER.debug("Could not read advertisement history for %s", address, exc_info=True)
         return None
@@ -235,7 +243,14 @@ def async_check_advertisement(
     else:
         sighting = _async_sighting(hass, normalized, source)
         if sighting is None:
-            _LOGGER.debug("No connectable advertisement history for %s", address)
+            # Some ESPHome proxies have been observed classifying a perfectly
+            # connectable bed as non-connectable. The integration has always
+            # allowed that fallback, so losing it here would stop setup working
+            # on exactly the hardware it was added for. The freshness rules
+            # still apply to whatever is found.
+            sighting = _async_sighting(hass, normalized, source, connectable=False)
+        if sighting is None:
+            _LOGGER.debug("No advertisement history for %s", address)
             return AdvertisementEvidence(status=FreshnessStatus.MISSING, source=source)
 
     info_source = sighting.source

--- a/custom_components/adjustable_bed/bluetooth_freshness.py
+++ b/custom_components/adjustable_bed/bluetooth_freshness.py
@@ -358,6 +358,9 @@ async def async_wait_for_advertisement(
     while True:
         remaining = deadline - _monotonic()
         if remaining <= 0:
+            if on_progress is not None:
+                with contextlib.suppress(Exception):
+                    on_progress(1.0)
             return evidence, None
         if on_progress is not None:
             elapsed = wait_timeout - remaining

--- a/custom_components/adjustable_bed/bluetooth_freshness.py
+++ b/custom_components/adjustable_bed/bluetooth_freshness.py
@@ -371,7 +371,7 @@ async def async_wait_for_advertisement(
     known in advance, unlike a BLE connect.
     """
     evidence, device = async_gate_connection(hass, address, source=source, max_age=max_age)
-    if evidence.is_fresh:
+    if evidence.is_fresh and device is not None:
         return evidence, device
 
     deadline = _monotonic() + wait_timeout
@@ -388,7 +388,7 @@ async def async_wait_for_advertisement(
                 on_progress(min(1.0, max(0.0, elapsed / wait_timeout)))
         await asyncio.sleep(min(poll_interval, remaining))
         evidence, device = async_gate_connection(hass, address, source=source, max_age=max_age)
-        if evidence.is_fresh:
+        if evidence.is_fresh and device is not None:
             if on_progress is not None:
                 with contextlib.suppress(Exception):
                     on_progress(1.0)

--- a/custom_components/adjustable_bed/bluetooth_transport.py
+++ b/custom_components/adjustable_bed/bluetooth_transport.py
@@ -248,7 +248,7 @@ def _score(scanner_device: Any, rssi_diff: int) -> float | None:
 def _path_from_scanner_device(
     scanner_device: Any,
     registrations: dict[str, dict[str, Any]],
-    rssi_diff: int,
+    score: float | None,
 ) -> ConnectionPath | None:
     """Build a ConnectionPath from one habluetooth BluetoothScannerDevice."""
     scanner = getattr(scanner_device, "scanner", None)
@@ -267,7 +267,7 @@ def _path_from_scanner_device(
         rssi=_rssi(getattr(getattr(scanner_device, "advertisement", None), "rssi", None)),
         connectable=bool(getattr(scanner, "connectable", True)),
         can_connect=_can_connect(scanner, transport),
-        score=_score(scanner_device, rssi_diff),
+        score=score,
         source_domain=registration.get(_CONF_SOURCE_DOMAIN),
         source_model=registration.get(_CONF_SOURCE_MODEL),
     )
@@ -295,9 +295,11 @@ def async_connection_paths(hass: HomeAssistant, address: str) -> tuple[Connectio
 
     scanner_devices.sort(key=_sort_rssi, reverse=True)
     rssi_diff = 0
+    scores: dict[int, float | None] = {}
     if len(scanner_devices) > 1:
         rssi_diff = _sort_rssi(scanner_devices[0]) - _sort_rssi(scanner_devices[1])
         scored = [(_score(device, rssi_diff), device) for device in scanner_devices]
+        scores = {id(device): score for score, device in scored}
         # Keep the RSSI order for any device HA could not score, rather than
         # letting a None score reshuffle the list.
         if all(score is not None for score, _ in scored):
@@ -308,11 +310,13 @@ def async_connection_paths(hass: HomeAssistant, address: str) -> tuple[Connectio
             scanner_devices = [device for _, device in ranked]
 
     registrations = async_scanner_registrations(hass)
-    paths = [
-        path
-        for device in scanner_devices
-        if (path := _path_from_scanner_device(device, registrations, rssi_diff)) is not None
-    ]
+    paths: list[ConnectionPath] = []
+    for device in scanner_devices:
+        device_id = id(device)
+        score = scores[device_id] if device_id in scores else _score(device, rssi_diff)
+        path = _path_from_scanner_device(device, registrations, score)
+        if path is not None:
+            paths.append(path)
     return tuple(paths)
 
 
@@ -324,8 +328,8 @@ def async_predict_path(
 ) -> PathPrediction:
     """Predict which path Home Assistant will use for the next connection.
 
-    An explicitly selected adapter wins whenever it can currently see the bed;
-    when it cannot, the automatic ranking is returned and
+    An explicitly selected adapter wins whenever it can currently see the bed
+    and has connection capacity; when it cannot, the automatic ranking is returned and
     ``preferred_available`` is False so the UI can say so instead of silently
     showing a path the user did not choose.
     """
@@ -340,16 +344,16 @@ def async_predict_path(
 
     if preferred_adapter and preferred_adapter != ADAPTER_AUTO:
         for path in paths:
-            if path.source == preferred_adapter:
+            if path.source == preferred_adapter and path.can_connect:
                 return PathPrediction(
                     chosen=path,
                     paths=paths,
                     preferred_adapter=preferred_adapter,
                     preferred_available=True,
                 )
-        # The requested adapter cannot currently see the bed. Report the
-        # automatic choice, but flag that the preference is not in play so the
-        # UI can say so rather than quietly substituting a different transport.
+        # The requested adapter cannot currently see the bed or take another
+        # connection. Report the automatic choice, but flag that the preference
+        # is not in play so the UI does not quietly substitute another path.
         return PathPrediction(
             chosen=_first_usable(paths),
             paths=paths,
@@ -424,20 +428,31 @@ def async_resolve_ble_device(
     """
     normalized = address.upper()
     if source and source != ADAPTER_AUTO:
+        for connectable in (True, False):
+            try:
+                for scanner_device in bluetooth.async_scanner_devices_by_address(
+                    hass, normalized, connectable=connectable
+                ):
+                    scanner_source = getattr(
+                        getattr(scanner_device, "scanner", None), "source", None
+                    )
+                    if scanner_source == source:
+                        return getattr(scanner_device, "ble_device", None)
+            except Exception:  # noqa: BLE001 - fall through to the generic lookup
+                _LOGGER.debug(
+                    "Scanner-specific lookup failed for %s", address, exc_info=True
+                )
+    for connectable in (True, False):
         try:
-            for scanner_device in bluetooth.async_scanner_devices_by_address(
-                hass, normalized, connectable=True
-            ):
-                scanner_source = getattr(getattr(scanner_device, "scanner", None), "source", None)
-                if scanner_source == source:
-                    return getattr(scanner_device, "ble_device", None)
-        except Exception:  # noqa: BLE001 - fall through to the generic lookup
-            _LOGGER.debug("Scanner-specific lookup failed for %s", address, exc_info=True)
-    try:
-        return bluetooth.async_ble_device_from_address(hass, normalized, connectable=True)
-    except Exception:  # noqa: BLE001
-        _LOGGER.debug("Could not resolve a BLE device for %s", address, exc_info=True)
-        return None
+            device = bluetooth.async_ble_device_from_address(
+                hass, normalized, connectable=connectable
+            )
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug("Could not resolve a BLE device for %s", address, exc_info=True)
+            continue
+        if device is not None:
+            return device
+    return None
 
 
 def client_source(client: Any) -> str | None:
@@ -501,8 +516,9 @@ _DEFAULT_STRINGS: dict[str, str] = {
         "see it, with a weaker signal."
     ),
     "transport_preferred_unavailable": (
-        "⚠️ The selected adapter ({adapter}) cannot currently see this device, "
-        "so Home Assistant will choose a path automatically."
+        "⚠️ The selected adapter ({adapter}) is not currently available for this "
+        "connection. Select Automatic to let Home Assistant choose another path, "
+        "or restore the selected adapter before continuing."
     ),
     "transport_not_guaranteed": (
         "Home Assistant picks the path when it connects, so this is a "

--- a/custom_components/adjustable_bed/bluetooth_transport.py
+++ b/custom_components/adjustable_bed/bluetooth_transport.py
@@ -275,12 +275,14 @@ def _path_from_scanner_device(
 
 @callback
 def async_connection_paths(hass: HomeAssistant, address: str) -> tuple[ConnectionPath, ...]:
-    """Return every currently connectable path to ``address``, best first.
+    """Return every connection path Home Assistant may use, best first.
 
     The ordering reproduces ``habluetooth``'s routing: RSSI first, then a
     re-sort by ``score_connection_path`` using the gap between the two strongest
     signals, so slot exhaustion and recent failures move a path down exactly as
-    they would during a real connect.
+    they would during a real connect. When the connectable view is empty, use
+    the same non-connectable fallback as device resolution for proxies that
+    misclassify an otherwise connectable bed.
     """
     try:
         scanner_devices = list(
@@ -291,7 +293,19 @@ def async_connection_paths(hass: HomeAssistant, address: str) -> tuple[Connectio
         return ()
 
     if not scanner_devices:
-        return ()
+        try:
+            scanner_devices = list(
+                bluetooth.async_scanner_devices_by_address(
+                    hass, address.upper(), connectable=False
+                )
+            )
+        except Exception:  # noqa: BLE001 - a missing manager must not block setup
+            _LOGGER.debug(
+                "Could not enumerate fallback scanners for %s", address, exc_info=True
+            )
+            return ()
+        if not scanner_devices:
+            return ()
 
     scanner_devices.sort(key=_sort_rssi, reverse=True)
     rssi_diff = 0
@@ -512,8 +526,12 @@ _DEFAULT_STRINGS: dict[str, str] = {
         "appears."
     ),
     "transport_local_alternative": (
+        # Deliberately does not claim the local signal is weaker. Home Assistant
+        # ranks paths on connection slots and recent failures as well as signal,
+        # so a proxy can win while the host adapter is in fact stronger. The
+        # translations carry this same wording.
         "A Bluetooth adapter on this Home Assistant host ({scanner}) can also "
-        "see it, with a weaker signal."
+        "see it."
     ),
     "transport_preferred_unavailable": (
         "⚠️ The selected adapter ({adapter}) is not currently available for this "

--- a/custom_components/adjustable_bed/bluetooth_transport.py
+++ b/custom_components/adjustable_bed/bluetooth_transport.py
@@ -490,7 +490,7 @@ _DEFAULT_STRINGS: dict[str, str] = {
     "transport_proxy": "Bluetooth proxy",
     "transport_unknown": "Bluetooth",
     "transport_likely": "Likely connection: {kind} · {scanner}{signal}",
-    "transport_signal": " · {rssi} dBm",
+    "transport_signal": "· {rssi} dBm",
     "transport_none": (
         "⚠️ No Bluetooth adapter or proxy can currently see this device. "
         "You can still finish setup; Home Assistant will connect when it "
@@ -557,7 +557,11 @@ async def _async_describe_path(hass: HomeAssistant, path: ConnectionPath, key: s
     """Render one path as "<kind> · <scanner> · <rssi> dBm"."""
     signal = ""
     if path.rssi is not None:
-        signal = (await _async_string(hass, "transport_signal")).format(rssi=path.rssi)
+        # The separator lives here rather than in the string, because hassfest
+        # rejects translation values with leading or trailing spaces.
+        signal = " " + (await _async_string(hass, "transport_signal")).format(
+            rssi=path.rssi
+        )
     return (await _async_string(hass, key)).format(
         kind=await _async_kind(hass, path),
         scanner=path.display_name,

--- a/custom_components/adjustable_bed/bluetooth_transport.py
+++ b/custom_components/adjustable_bed/bluetooth_transport.py
@@ -1,0 +1,623 @@
+"""Transport-aware view of the Bluetooth paths that can reach a bed.
+
+Home Assistant can reach a bed either through an adapter plugged into the host
+(BlueZ) or through a remote scanner such as an ESPHome Bluetooth proxy. The two
+are not interchangeable for anything security related: a BLE bond is stored by
+whichever transport created it, so a bond made through a proxy is invisible to
+the host's BlueZ and vice versa (issue #459).
+
+Everything in this module therefore classifies a path from Home Assistant's own
+scanner objects rather than from the shape of the ``source`` string. Substring
+tests like ``"esphome" in source`` are wrong in both directions: a proxy from
+another integration is not named "esphome", and a local adapter's source is its
+MAC address, which merely *looks* remote.
+
+Path ranking mirrors ``habluetooth``'s connection routing (see
+``habluetooth.wrappers._async_get_best_available_backend_and_device``): sort the
+candidate scanners by advertised RSSI, derive the RSSI gap between the best two,
+then re-sort by ``BluetoothScannerDevice.score_connection_path(rssi_diff)``,
+which folds in connection slots, in-flight connects and recent failures. Using
+the same inputs is what makes the prediction shown during setup match the path
+Home Assistant actually takes.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components import bluetooth
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.core import HomeAssistant, callback
+
+from .const import ADAPTER_AUTO
+
+if TYPE_CHECKING:
+    from bleak.backends.device import BLEDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+# Config-entry domain/keys used to name a remote scanner's owning integration.
+_BLUETOOTH_DOMAIN = "bluetooth"
+_ESPHOME_DOMAIN = "esphome"
+_CONF_SOURCE = "source"
+_CONF_SOURCE_DOMAIN = "source_domain"
+_CONF_SOURCE_MODEL = "source_model"
+
+
+class TransportClass(StrEnum):
+    """Which kind of Bluetooth transport a connection path uses.
+
+    ``LOCAL`` means an adapter owned by the Home Assistant host, so bonds live in
+    the host's BlueZ and are inspectable and removable from here. ``PROXY`` means
+    a remote scanner (ESPHome and friends), which owns its own bond store that
+    the host cannot read or clear. ``UNKNOWN`` is used when Home Assistant does
+    not expose enough information; callers must treat it as "not proven local"
+    and never run a host-side destructive action on it.
+    """
+
+    LOCAL = "local"
+    PROXY = "proxy"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectionPath:
+    """One way Home Assistant can currently reach a bed."""
+
+    source: str
+    transport: TransportClass = TransportClass.UNKNOWN
+    scanner_name: str | None = None
+    adapter: str | None = None
+    rssi: int | None = None
+    connectable: bool = True
+    can_connect: bool = True
+    score: float | None = None
+    source_domain: str | None = None
+    source_model: str | None = None
+
+    @property
+    def owns_host_bond(self) -> bool:
+        """Return True only when a bond over this path is stored by the host.
+
+        Deliberately False for ``UNKNOWN``: a host-side unpair must never run on
+        a path we could not prove is local.
+        """
+        return self.transport is TransportClass.LOCAL
+
+    @property
+    def display_name(self) -> str:
+        """Return the friendliest identifier we have for this path."""
+        return self.scanner_name or self.adapter or self.source
+
+
+@dataclass(frozen=True, slots=True)
+class PathPrediction:
+    """What Home Assistant is expected to do, plus the paths it could take.
+
+    ``preferred_adapter`` is what the user *requested*, and requesting is not
+    the same as pinning: ``HaBleakClientWrapper`` keeps only the address and
+    re-ranks every scanner inside ``connect()``, so a ``BLEDevice`` taken from a
+    chosen source does not force Home Assistant to use it. The UI must therefore
+    present this as the likely path, never as a guarantee, and the actual path is
+    only known once a connection exists.
+    """
+
+    chosen: ConnectionPath | None
+    paths: tuple[ConnectionPath, ...]
+    preferred_adapter: str | None = None
+    preferred_available: bool = True
+
+    @property
+    def local_alternative(self) -> ConnectionPath | None:
+        """Return the best local path when the chosen path is a proxy.
+
+        Surfaced during setup so a user who is about to pair through a proxy can
+        see that a host adapter is also in range (issue #456).
+        """
+        if self.chosen is None or self.chosen.transport is not TransportClass.PROXY:
+            return None
+        for path in self.paths:
+            if path.transport is TransportClass.LOCAL:
+                return path
+        return None
+
+    @property
+    def proxy_pairing_risk(self) -> bool:
+        """Return True when a pairing-required bed would pair over a proxy."""
+        return self.chosen is not None and self.chosen.transport is TransportClass.PROXY
+
+
+def classify_scanner(scanner: Any) -> TransportClass:
+    """Classify a Home Assistant scanner object as local or remote.
+
+    Two signals are combined because neither alone is reliable.
+    ``HaScannerDetails.scanner_type`` is authoritative for ``REMOTE`` (habluetooth
+    sets it from the class hierarchy) but degrades to ``UNKNOWN`` for a local
+    adapter that is missing from the cached adapter table — and demoting a real
+    host adapter to ``UNKNOWN`` would block a legitimate host-side unpair. The
+    class check covers exactly that gap.
+
+    The order matters: prove ``PROXY`` first, so a scanner that is somehow both
+    is never mistaken for a host adapter.
+    """
+    try:
+        from habluetooth import BaseHaRemoteScanner, HaScanner
+    except ImportError:  # pragma: no cover - habluetooth ships with HA
+        BaseHaRemoteScanner = HaScanner = None  # type: ignore[assignment]
+
+    if BaseHaRemoteScanner is not None and isinstance(scanner, BaseHaRemoteScanner):
+        return TransportClass.PROXY
+
+    scanner_type = getattr(getattr(scanner, "details", None), "scanner_type", None)
+    value = getattr(scanner_type, "value", scanner_type)
+    if value == "remote":
+        return TransportClass.PROXY
+
+    if HaScanner is not None and isinstance(scanner, HaScanner):
+        return TransportClass.LOCAL
+    if value in ("usb", "uart"):
+        return TransportClass.LOCAL
+
+    return TransportClass.UNKNOWN
+
+
+def _can_connect(scanner: Any, transport: TransportClass) -> bool:
+    """Return whether this scanner could take a connection right now.
+
+    Home Assistant skips a remote scanner whose connector reports no free slot,
+    and a local adapter that cannot allocate one. Reflecting that here keeps a
+    prediction from naming a path Home Assistant would immediately reject.
+    Unknowable means "assume yes": refusing to show a usable path is worse than
+    showing one that turns out to be busy.
+    """
+    if transport is TransportClass.PROXY:
+        connector = getattr(scanner, "connector", None)
+        checker = getattr(connector, "can_connect", None)
+        if callable(checker):
+            try:
+                return bool(checker())
+            except Exception:  # noqa: BLE001 - advisory only
+                return True
+        return True
+
+    allocations = getattr(scanner, "get_allocations", None)
+    if callable(allocations):
+        try:
+            allocation = allocations()
+        except Exception:  # noqa: BLE001 - advisory only
+            return True
+        slots = getattr(allocation, "slots", 0) or 0
+        if slots > 0:
+            return bool(getattr(allocation, "free", 0))
+    return True
+
+
+@callback
+def async_scanner_registrations(hass: HomeAssistant) -> dict[str, dict[str, Any]]:
+    """Return the bluetooth config-entry data for each registered scanner source.
+
+    Remote scanners are registered by their owning integration (ESPHome, Shelly,
+    …), and that registration is the only place the owning domain and model are
+    recorded. Used purely for labelling.
+    """
+    registrations: dict[str, dict[str, Any]] = {}
+    try:
+        entries = hass.config_entries.async_entries(_BLUETOOTH_DOMAIN)
+    except Exception:  # noqa: BLE001 - labelling must never break setup
+        return registrations
+    for entry in entries:
+        source = entry.data.get(_CONF_SOURCE)
+        if isinstance(source, str):
+            registrations[source] = dict(entry.data)
+    return registrations
+
+
+def _rssi(value: Any) -> int | None:
+    """Coerce an advertised RSSI to an int, or None when unusable."""
+    try:
+        rssi = int(value)
+    except (TypeError, ValueError):
+        return None
+    return rssi
+
+
+def _sort_rssi(scanner_device: Any) -> int:
+    """Return a sortable RSSI for a scanner device (missing sorts last)."""
+    rssi = _rssi(getattr(getattr(scanner_device, "advertisement", None), "rssi", None))
+    # habluetooth uses -127 as its "no RSSI" sentinel; match it so a device with
+    # no reading never outranks one with a real, weak reading.
+    return rssi if rssi is not None else -127
+
+
+def _score(scanner_device: Any, rssi_diff: int) -> float | None:
+    """Return HA's own connection-path score, or None when unavailable."""
+    scorer = getattr(scanner_device, "score_connection_path", None)
+    if not callable(scorer):
+        return None
+    try:
+        score: Any = scorer(rssi_diff)
+        return float(score)
+    except Exception:  # noqa: BLE001 - scoring is advisory
+        _LOGGER.debug("Could not score connection path", exc_info=True)
+        return None
+
+
+def _path_from_scanner_device(
+    scanner_device: Any,
+    registrations: dict[str, dict[str, Any]],
+    rssi_diff: int,
+) -> ConnectionPath | None:
+    """Build a ConnectionPath from one habluetooth BluetoothScannerDevice."""
+    scanner = getattr(scanner_device, "scanner", None)
+    if scanner is None:
+        return None
+    source = getattr(scanner, "source", None)
+    if not isinstance(source, str) or not source:
+        return None
+    registration = registrations.get(source, {})
+    transport = classify_scanner(scanner)
+    return ConnectionPath(
+        source=source,
+        transport=transport,
+        scanner_name=getattr(scanner, "name", None) or None,
+        adapter=getattr(scanner, "adapter", None) or None,
+        rssi=_rssi(getattr(getattr(scanner_device, "advertisement", None), "rssi", None)),
+        connectable=bool(getattr(scanner, "connectable", True)),
+        can_connect=_can_connect(scanner, transport),
+        score=_score(scanner_device, rssi_diff),
+        source_domain=registration.get(_CONF_SOURCE_DOMAIN),
+        source_model=registration.get(_CONF_SOURCE_MODEL),
+    )
+
+
+@callback
+def async_connection_paths(hass: HomeAssistant, address: str) -> tuple[ConnectionPath, ...]:
+    """Return every currently connectable path to ``address``, best first.
+
+    The ordering reproduces ``habluetooth``'s routing: RSSI first, then a
+    re-sort by ``score_connection_path`` using the gap between the two strongest
+    signals, so slot exhaustion and recent failures move a path down exactly as
+    they would during a real connect.
+    """
+    try:
+        scanner_devices = list(
+            bluetooth.async_scanner_devices_by_address(hass, address.upper(), connectable=True)
+        )
+    except Exception:  # noqa: BLE001 - a missing manager must not block setup
+        _LOGGER.debug("Could not enumerate scanners for %s", address, exc_info=True)
+        return ()
+
+    if not scanner_devices:
+        return ()
+
+    scanner_devices.sort(key=_sort_rssi, reverse=True)
+    rssi_diff = 0
+    if len(scanner_devices) > 1:
+        rssi_diff = _sort_rssi(scanner_devices[0]) - _sort_rssi(scanner_devices[1])
+        scored = [(_score(device, rssi_diff), device) for device in scanner_devices]
+        # Keep the RSSI order for any device HA could not score, rather than
+        # letting a None score reshuffle the list.
+        if all(score is not None for score, _ in scored):
+            ranked: list[tuple[float, Any]] = [
+                (score, device) for score, device in scored if score is not None
+            ]
+            ranked.sort(key=lambda item: item[0], reverse=True)
+            scanner_devices = [device for _, device in ranked]
+
+    registrations = async_scanner_registrations(hass)
+    paths = [
+        path
+        for device in scanner_devices
+        if (path := _path_from_scanner_device(device, registrations, rssi_diff)) is not None
+    ]
+    return tuple(paths)
+
+
+@callback
+def async_predict_path(
+    hass: HomeAssistant,
+    address: str,
+    preferred_adapter: str | None = None,
+) -> PathPrediction:
+    """Predict which path Home Assistant will use for the next connection.
+
+    An explicitly selected adapter wins whenever it can currently see the bed;
+    when it cannot, the automatic ranking is returned and
+    ``preferred_available`` is False so the UI can say so instead of silently
+    showing a path the user did not choose.
+    """
+    paths = async_connection_paths(hass, address)
+    if not paths:
+        return PathPrediction(
+            chosen=None,
+            paths=(),
+            preferred_adapter=preferred_adapter,
+            preferred_available=False,
+        )
+
+    if preferred_adapter and preferred_adapter != ADAPTER_AUTO:
+        for path in paths:
+            if path.source == preferred_adapter:
+                return PathPrediction(
+                    chosen=path,
+                    paths=paths,
+                    preferred_adapter=preferred_adapter,
+                    preferred_available=True,
+                )
+        # The requested adapter cannot currently see the bed. Report the
+        # automatic choice, but flag that the preference is not in play so the
+        # UI can say so rather than quietly substituting a different transport.
+        return PathPrediction(
+            chosen=_first_usable(paths),
+            paths=paths,
+            preferred_adapter=preferred_adapter,
+            preferred_available=False,
+        )
+
+    return PathPrediction(
+        chosen=_first_usable(paths),
+        paths=paths,
+        preferred_adapter=preferred_adapter,
+    )
+
+
+def _first_usable(paths: tuple[ConnectionPath, ...]) -> ConnectionPath | None:
+    """Return the best path that could take a connection now.
+
+    Mirrors Home Assistant, which walks its ranked list and skips any scanner
+    with no free connection slot. If every path is busy the best-ranked one is
+    still returned: "all adapters are full" is a truer prediction than "no path".
+    """
+    for path in paths:
+        if path.can_connect:
+            return path
+    return paths[0] if paths else None
+
+
+@callback
+def async_path_for_source(
+    hass: HomeAssistant,
+    source: str | None,
+    *,
+    rssi: int | None = None,
+) -> ConnectionPath | None:
+    """Resolve the path actually used, given the source a connection reported.
+
+    Called after a connect so the UI and diagnostics can show the real transport
+    rather than only the prediction.
+    """
+    if not source or source == "unknown":
+        return None
+    try:
+        scanner = bluetooth.async_scanner_by_source(hass, source)
+    except Exception:  # noqa: BLE001 - diagnostics must not raise
+        scanner = None
+    if scanner is None:
+        return ConnectionPath(source=source, rssi=rssi)
+    registration = async_scanner_registrations(hass).get(source, {})
+    return ConnectionPath(
+        source=source,
+        transport=classify_scanner(scanner),
+        scanner_name=getattr(scanner, "name", None) or None,
+        adapter=getattr(scanner, "adapter", None) or None,
+        rssi=rssi,
+        connectable=bool(getattr(scanner, "connectable", True)),
+        source_domain=registration.get(_CONF_SOURCE_DOMAIN),
+        source_model=registration.get(_CONF_SOURCE_MODEL),
+    )
+
+
+@callback
+def async_resolve_ble_device(
+    hass: HomeAssistant,
+    address: str,
+    source: str | None = None,
+) -> BLEDevice | None:
+    """Return a freshly resolved BLEDevice, preferring a specific scanner.
+
+    Never reuse the ``BLEDevice`` captured during discovery: Home Assistant
+    replaces it as advertisements arrive, and a frozen one can point at a
+    scanner that has since stopped seeing the bed (issue #458).
+    """
+    normalized = address.upper()
+    if source and source != ADAPTER_AUTO:
+        try:
+            for scanner_device in bluetooth.async_scanner_devices_by_address(
+                hass, normalized, connectable=True
+            ):
+                scanner_source = getattr(getattr(scanner_device, "scanner", None), "source", None)
+                if scanner_source == source:
+                    return getattr(scanner_device, "ble_device", None)
+        except Exception:  # noqa: BLE001 - fall through to the generic lookup
+            _LOGGER.debug("Scanner-specific lookup failed for %s", address, exc_info=True)
+    try:
+        return bluetooth.async_ble_device_from_address(hass, normalized, connectable=True)
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("Could not resolve a BLE device for %s", address, exc_info=True)
+        return None
+
+
+def client_source(client: Any) -> str | None:
+    """Return the scanner source a connected client is actually routed through.
+
+    This is the only reliable moment to learn the real transport: Home Assistant
+    chooses it inside ``connect()``, after every prediction has been made. Ask
+    the wrapper for the scanner it settled on, and fall back to the backend
+    device's details for a plain bleak client.
+    """
+    scanner_source = getattr(getattr(client, "_connected_scanner", None), "source", None)
+    if isinstance(scanner_source, str) and scanner_source:
+        return scanner_source
+
+    details = getattr(getattr(getattr(client, "_backend", None), "_device", None), "details", None)
+    if isinstance(details, dict):
+        source = details.get("source")
+        if isinstance(source, str) and source:
+            return source
+    return None
+
+
+def path_from_service_info(
+    hass: HomeAssistant,
+    service_info: BluetoothServiceInfoBleak | None,
+) -> ConnectionPath | None:
+    """Build a path from an advertisement snapshot (used by the freshness gate)."""
+    if service_info is None:
+        return None
+    return async_path_for_source(
+        hass,
+        getattr(service_info, "source", None),
+        rssi=_rssi(getattr(service_info, "rssi", None)),
+    )
+
+
+# --- User-facing description -------------------------------------------------
+#
+# The sentences live in ``strings.json`` under the discovery step's
+# ``data_description`` (the same place this integration already keeps its
+# pairing instructions), because hassfest only allows ``flow_title``, ``step``,
+# ``error``, ``abort``, ``progress`` and ``create_entry`` under ``config``.
+# Only the dynamic parts — scanner name, signal, adapter id — are interpolated
+# here; the prose itself is translated.
+
+_TRANSPORT_STRINGS_PREFIX = "step.bluetooth_confirm.data_description"
+
+_DEFAULT_STRINGS: dict[str, str] = {
+    "transport_direct": "Direct Bluetooth",
+    "transport_proxy": "Bluetooth proxy",
+    "transport_unknown": "Bluetooth",
+    "transport_likely": "Likely connection: {kind} · {scanner}{signal}",
+    "transport_signal": " · {rssi} dBm",
+    "transport_none": (
+        "⚠️ No Bluetooth adapter or proxy can currently see this device. "
+        "You can still finish setup; Home Assistant will connect when it "
+        "appears."
+    ),
+    "transport_local_alternative": (
+        "A Bluetooth adapter on this Home Assistant host ({scanner}) can also "
+        "see it, with a weaker signal."
+    ),
+    "transport_preferred_unavailable": (
+        "⚠️ The selected adapter ({adapter}) cannot currently see this device, "
+        "so Home Assistant will choose a path automatically."
+    ),
+    "transport_not_guaranteed": (
+        "Home Assistant picks the path when it connects, so this is a "
+        "prediction rather than a guarantee."
+    ),
+    "transport_proxy_pairing_warning": (
+        "⚠️ This bed needs Bluetooth pairing, and pairing over a proxy stores "
+        "the bond on the proxy rather than on Home Assistant. If you later move "
+        "the bed to a different proxy or to a Home Assistant adapter, you will "
+        "have to pair again. Home Assistant also cannot remove a bond that "
+        "lives on a proxy."
+    ),
+    "transport_all_busy": (
+        "⚠️ Every adapter that can see this device is currently out of free "
+        "Bluetooth connections."
+    ),
+    "transport_actual": "Connected over: {kind} · {scanner}{signal}",
+    "transport_actual_differs": (
+        "Home Assistant used a different path than predicted ({predicted})."
+    ),
+}
+
+
+async def _async_string(hass: HomeAssistant, key: str) -> str:
+    """Return a translated fragment, falling back to English."""
+    default = _DEFAULT_STRINGS[key]
+    try:
+        from homeassistant.helpers.translation import async_get_translations
+
+        from .const import DOMAIN
+
+        translations = await async_get_translations(
+            hass, hass.config.language, "config", {DOMAIN}
+        )
+    except Exception:  # noqa: BLE001 - a missing translation must not block setup
+        return default
+    return translations.get(
+        f"component.{DOMAIN}.config.{_TRANSPORT_STRINGS_PREFIX}.{key}", default
+    )
+
+
+async def _async_kind(hass: HomeAssistant, path: ConnectionPath) -> str:
+    """Return the localized name of a path's transport class."""
+    key = {
+        TransportClass.LOCAL: "transport_direct",
+        TransportClass.PROXY: "transport_proxy",
+    }.get(path.transport, "transport_unknown")
+    return await _async_string(hass, key)
+
+
+async def _async_describe_path(hass: HomeAssistant, path: ConnectionPath, key: str) -> str:
+    """Render one path as "<kind> · <scanner> · <rssi> dBm"."""
+    signal = ""
+    if path.rssi is not None:
+        signal = (await _async_string(hass, "transport_signal")).format(rssi=path.rssi)
+    return (await _async_string(hass, key)).format(
+        kind=await _async_kind(hass, path),
+        scanner=path.display_name,
+        signal=signal,
+    )
+
+
+async def async_describe_prediction(
+    hass: HomeAssistant,
+    prediction: PathPrediction,
+    *,
+    pairing_required: bool = False,
+) -> str:
+    """Describe the path setup is expected to take, and its consequences.
+
+    Recomputed on every render rather than cached: scanner visibility changes
+    from one moment to the next, and a stale prediction is worse than none.
+    """
+    chosen = prediction.chosen
+    if chosen is None:
+        return await _async_string(hass, "transport_none")
+
+    lines = [await _async_describe_path(hass, chosen, "transport_likely")]
+
+    if not prediction.preferred_available and prediction.preferred_adapter:
+        lines.append(
+            (await _async_string(hass, "transport_preferred_unavailable")).format(
+                adapter=prediction.preferred_adapter
+            )
+        )
+
+    if not any(path.can_connect for path in prediction.paths):
+        lines.append(await _async_string(hass, "transport_all_busy"))
+
+    local_alternative = prediction.local_alternative
+    if local_alternative is not None:
+        lines.append(
+            (await _async_string(hass, "transport_local_alternative")).format(
+                scanner=local_alternative.display_name
+            )
+        )
+
+    if pairing_required and prediction.proxy_pairing_risk:
+        lines.append(await _async_string(hass, "transport_proxy_pairing_warning"))
+
+    lines.append(await _async_string(hass, "transport_not_guaranteed"))
+    return "\n".join(lines)
+
+
+async def async_describe_actual(
+    hass: HomeAssistant,
+    actual: ConnectionPath,
+    predicted: ConnectionPath | None = None,
+) -> str:
+    """Describe the path a connection really used, noting any surprise."""
+    lines = [await _async_describe_path(hass, actual, "transport_actual")]
+    if predicted is not None and predicted.source != actual.source:
+        lines.append(
+            (await _async_string(hass, "transport_actual_differs")).format(
+                predicted=predicted.display_name
+            )
+        )
+    return "\n".join(lines)

--- a/custom_components/adjustable_bed/bluetooth_transport.py
+++ b/custom_components/adjustable_bed/bluetooth_transport.py
@@ -342,10 +342,10 @@ def async_predict_path(
 ) -> PathPrediction:
     """Predict which path Home Assistant will use for the next connection.
 
-    An explicitly selected adapter wins whenever it can currently see the bed
-    and has connection capacity; when it cannot, the automatic ranking is returned and
-    ``preferred_available`` is False so the UI can say so instead of silently
-    showing a path the user did not choose.
+    Home Assistant re-ranks every connectable scanner inside ``connect()``, so
+    selecting an adapter does not pin the connection to it. Preserve that
+    selection as requested metadata and report whether it is available, while
+    always deriving ``chosen`` from the same automatic ranking as the wrapper.
     """
     paths = async_connection_paths(hass, address)
     if not paths:
@@ -356,29 +356,17 @@ def async_predict_path(
             preferred_available=False,
         )
 
+    preferred_available = True
     if preferred_adapter and preferred_adapter != ADAPTER_AUTO:
-        for path in paths:
-            if path.source == preferred_adapter and path.can_connect:
-                return PathPrediction(
-                    chosen=path,
-                    paths=paths,
-                    preferred_adapter=preferred_adapter,
-                    preferred_available=True,
-                )
-        # The requested adapter cannot currently see the bed or take another
-        # connection. Report the automatic choice, but flag that the preference
-        # is not in play so the UI does not quietly substitute another path.
-        return PathPrediction(
-            chosen=_first_usable(paths),
-            paths=paths,
-            preferred_adapter=preferred_adapter,
-            preferred_available=False,
+        preferred_available = any(
+            path.source == preferred_adapter and path.can_connect for path in paths
         )
 
     return PathPrediction(
         chosen=_first_usable(paths),
         paths=paths,
         preferred_adapter=preferred_adapter,
+        preferred_available=preferred_available,
     )
 
 

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -1829,7 +1829,10 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
                 "address": address,
                 "setup_note": f"\n{octo_split_note}" if octo_split_note else "",
                 "transport": await self._async_transport_note(
-                    address, ADAPTER_AUTO, defaults_bed_type
+                    address,
+                    discovery_source,
+                    defaults_bed_type,
+                    preselected_protocol_variant,
                 ),
             },
         )

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -2178,6 +2178,12 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
                 self._manual_data.get(CONF_BED_TYPE),
                 self._manual_data.get(CONF_PROTOCOL_VARIANT),
             ),
+            "transport": await self._async_transport_note(
+                self._manual_data[CONF_ADDRESS],
+                self._manual_data.get(CONF_PREFERRED_ADAPTER, ADAPTER_AUTO),
+                self._manual_data.get(CONF_BED_TYPE),
+                self._manual_data.get(CONF_PROTOCOL_VARIANT),
+            ),
         }
 
         if user_input is not None:
@@ -2222,6 +2228,12 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
         description_placeholders = {
             "name": self._manual_data.get(CONF_NAME, "Unknown"),
             "pairing_instructions": await self._get_pairing_instructions(
+                self._manual_data.get(CONF_BED_TYPE),
+                self._manual_data.get(CONF_PROTOCOL_VARIANT),
+            ),
+            "transport": await self._async_transport_note(
+                self._manual_data[CONF_ADDRESS],
+                self._manual_data.get(CONF_PREFERRED_ADAPTER, ADAPTER_AUTO),
                 self._manual_data.get(CONF_BED_TYPE),
                 self._manual_data.get(CONF_PROTOCOL_VARIANT),
             ),
@@ -2444,14 +2456,7 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
             address=address,
             prediction=async_predict_path(self.hass, address, preferred),
             action=SetupAction.LOCATING,
-            policy=(
-                ConnectionLifetimePolicy.KEEP_FIRST_LINK
-                if _skips_setup_connection_probe(
-                    self._pending_entry.get(CONF_BED_TYPE),
-                    self._pending_entry.get(CONF_PROTOCOL_VARIANT),
-                )
-                else ConnectionLifetimePolicy.ORDINARY
-            ),
+            policy=ConnectionLifetimePolicy.ORDINARY,
             placeholders={
                 "name": self._pending_entry.get(CONF_NAME) or address,
                 "address": address,

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -2681,7 +2681,7 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
             )
             lines.append(
                 "Wake it (press a button on the remote), put it in pairing mode, or move it "
-                "closer to an adapter or proxy, then select **Retry**."
+                "closer to an adapter or proxy, then select **Check again**."
             )
             return "\n".join(lines)
 

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -41,9 +41,17 @@ from .adapter import (
     find_service_info_by_address,
     get_discovered_service_info,
     read_ble_device_info,
-    select_adapter,
 )
 from .address_lock import async_get_connect_lock
+from .bluetooth_freshness import FreshnessStatus, async_gate_connection
+from .bluetooth_transport import (
+    ConnectionPath,
+    async_describe_actual,
+    async_describe_prediction,
+    async_path_for_source,
+    async_predict_path,
+    client_source,
+)
 from .const import (
     ADAPTER_AUTO,
     ALL_PROTOCOL_VARIANTS,
@@ -297,6 +305,14 @@ class CapabilityReport:
     model: str | None = None
     position_feedback: bool = False
     error: str | None = None
+    # Which path the probe expected to take, and which one it really took. They
+    # can differ: Home Assistant re-ranks every scanner when it connects, so a
+    # prediction is never a promise (issue #456).
+    predicted_path: ConnectionPath | None = None
+    actual_path: ConnectionPath | None = None
+    # Set when the bed had not advertised recently enough to be worth calling
+    # establish_connection on at all (issue #458).
+    freshness: FreshnessStatus | None = None
 
 
 class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -422,6 +438,33 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             self.hass, self.hass.config.language, "config", {DOMAIN}
         )
         return translations.get(f"component.{DOMAIN}.config.{key}", default)
+
+    async def _async_transport_note(
+        self,
+        address: str,
+        preferred_adapter: str | None,
+        bed_type: str | None = None,
+        protocol_variant: str | None = None,
+    ) -> str:
+        """Describe the Bluetooth path setup will most likely take.
+
+        Recomputed on every render of the form rather than captured once when
+        the flow started: which adapters and proxies can see a bed changes from
+        moment to moment, and showing a path that has since disappeared is worse
+        than showing none.
+        """
+        try:
+            prediction = async_predict_path(self.hass, address, preferred_adapter)
+            return await async_describe_prediction(
+                self.hass,
+                prediction,
+                pairing_required=bool(
+                    bed_type and requires_pairing(bed_type, protocol_variant)
+                ),
+            )
+        except Exception:  # noqa: BLE001 - never block setup on a preview
+            _LOGGER.debug("Could not describe the connection path for %s", address, exc_info=True)
+            return ""
 
     async def _get_pairing_instructions(
         self, bed_type: str | None, protocol_variant: str | None = None
@@ -1114,6 +1157,12 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         description_placeholders = {
             "name": self._discovery_info.name or "Unknown",
             "address": self._discovery_info.address.upper(),
+            "transport": await self._async_transport_note(
+                self._discovery_info.address,
+                ADAPTER_AUTO,
+                bed_type,
+                VARIANT_AUTO,
+            ),
         }
 
         # Add detection confidence info for ambiguous cases
@@ -1756,6 +1805,9 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                 "name": device_name,
                 "address": address,
                 "setup_note": f"\n{octo_split_note}" if octo_split_note else "",
+                "transport": await self._async_transport_note(
+                    address, ADAPTER_AUTO, defaults_bed_type
+                ),
             },
         )
 
@@ -2371,6 +2423,11 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         coordinator can take the bed's single BLE connection afterwards, and it
         never raises: any failure is captured in ``report.error`` so setup stays
         non-blocking.
+
+        Before connecting it checks that the bed has actually advertised
+        recently. Without that check a bed that is asleep or unplugged still
+        looks present in Home Assistant's history, and the probe burns its whole
+        timeout producing a failure that reads like a pairing problem (#458).
         """
         from bleak import BleakClient
         from bleak_retry_connector import establish_connection
@@ -2378,25 +2435,41 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         has_position_feedback = bed_type_has_position_feedback(bed_type, protocol_variant)
         report = CapabilityReport(position_feedback=has_position_feedback)
 
-        try:
-            selection = await select_adapter(self.hass, address, preferred_adapter)
-        except Exception as err:  # noqa: BLE001 - probe is best-effort
-            report.error = str(err) or err.__class__.__name__
-            return report
+        prediction = async_predict_path(self.hass, address, preferred_adapter)
+        report.predicted_path = prediction.chosen
 
-        device = selection.device
-        if device is None:
-            report.error = "device_not_found"
+        evidence, device = async_gate_connection(
+            self.hass,
+            address,
+            source=(
+                preferred_adapter
+                if preferred_adapter and preferred_adapter != ADAPTER_AUTO
+                else None
+            ),
+        )
+        report.freshness = evidence.status
+        report.rssi = evidence.rssi
+        if not evidence.is_fresh or device is None:
+            report.error = "not_advertising"
+            _LOGGER.debug(
+                "Skipping the capability probe for %s: %s", address, evidence.status
+            )
             return report
 
         report.device_found = True
-        report.source = selection.source
-        report.rssi = selection.rssi
-        report.via_proxy = bool(selection.source and "esphome" in selection.source.lower())
+        report.source = evidence.source or (
+            prediction.chosen.source if prediction.chosen else None
+        )
+        report.via_proxy = bool(
+            evidence.path is not None and not evidence.path.owns_host_bond
+        )
 
         client: BleakClient | None = None
         # Hold the address lock until the probe has fully released the client,
         # so its disconnect cannot abort a connect attempt started elsewhere.
+        # Everything for this client's lifetime stays in this one task: the
+        # address lock is reentrant per task, so a helper task would block
+        # rather than re-enter.
         try:
             async with async_get_connect_lock(self.hass, address):
                 try:
@@ -2408,6 +2481,17 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                         timeout=_PROBE_TIMEOUT_SECONDS,
                     )
                     report.connected = bool(client.is_connected)
+                    # Record the real path straight after the connect, before
+                    # anything else can fail: it is the only moment the routed
+                    # source is known for *this* attempt.
+                    actual_source = client_source(client)
+                    if actual_source:
+                        report.source = actual_source
+                        report.actual_path = async_path_for_source(
+                            self.hass, actual_source, rssi=evidence.rssi
+                        )
+                        if report.actual_path is not None:
+                            report.via_proxy = not report.actual_path.owns_host_bond
                     await discover_services(client, address)
                     services = list(client.services) if client.services else []
                     report.service_count = len(services)
@@ -2435,10 +2519,22 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return report
 
-    @staticmethod
-    def _format_capabilities(report: CapabilityReport) -> str:
+    async def _format_capabilities(self, report: CapabilityReport) -> str:
         """Build the ✅/❌/⚠️/ℹ️ markdown checklist shown in verify_connection."""
         lines: list[str] = []
+
+        if report.freshness is not None and report.freshness is not FreshnessStatus.FRESH:
+            # Distinguished from a failed connection on purpose: the bed never
+            # answered a scan, so telling the user to check the bond or the
+            # adapter would send them after the wrong thing (#458).
+            lines.append(
+                "❌ This bed is not currently advertising, so no connection was attempted."
+            )
+            lines.append(
+                "Wake it (press a button on the remote), put it in pairing mode, or move it "
+                "closer to an adapter or proxy, then select **Retry**."
+            )
+            return "\n".join(lines)
 
         if not report.device_found:
             lines.append("❌ Device not found - it may be out of range or not advertising.")
@@ -2455,14 +2551,22 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             return "\n".join(lines)
 
-        connected_parts = ["✅ Connected"]
-        if report.source:
-            connected_parts.append(f"via {report.source}")
-        if report.via_proxy:
-            connected_parts.append("(ESPHome proxy)")
-        if report.rssi is not None:
-            connected_parts.append(f"(RSSI {report.rssi} dBm)")
-        lines.append(" ".join(connected_parts))
+        if report.actual_path is not None:
+            lines.append(
+                "✅ "
+                + await async_describe_actual(
+                    self.hass, report.actual_path, report.predicted_path
+                )
+            )
+        else:
+            connected_parts = ["✅ Connected"]
+            if report.source:
+                connected_parts.append(f"via {report.source}")
+            if report.via_proxy:
+                connected_parts.append("(Bluetooth proxy)")
+            if report.rssi is not None:
+                connected_parts.append(f"(RSSI {report.rssi} dBm)")
+            lines.append(" ".join(connected_parts))
 
         if report.service_count:
             services_word = "service" if report.service_count == 1 else "services"
@@ -2514,10 +2618,14 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         Shown after the confirm/manual step for non-PIN/non-pairing beds. The
         Submit button always finishes setup - a failed probe is informational
         only and never blocks entry creation.
+
+        When the bed was not advertising, the form also offers Retry, which
+        re-runs the check in place. The user can wake the bed and try again
+        without losing everything they already filled in (#458).
         """
         assert self._pending_entry is not None
 
-        if user_input is not None:
+        if user_input is not None and user_input.get("action") != "retry":
             return self.async_create_entry(
                 title=self._pending_title or self._pending_entry.get(CONF_NAME, "Adjustable Bed"),
                 data=self._pending_entry,
@@ -2530,12 +2638,27 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             self._pending_entry.get(CONF_PROTOCOL_VARIANT),
         )
 
+        schema: dict[vol.Marker, Any] = {}
+        if report.freshness is not None and report.freshness is not FreshnessStatus.FRESH:
+            # "Finish" stays the default so Submit keeps meaning what it always
+            # meant here: setup is never blocked by a failed check. Retry is one
+            # click away for the common case of "let me go wake the bed first".
+            schema[vol.Required("action", default="finish")] = SelectSelector(
+                SelectSelectorConfig(
+                    options=[
+                        SelectOptionDict(value="finish", label="Finish setup anyway"),
+                        SelectOptionDict(value="retry", label="Check again"),
+                    ],
+                    mode=SelectSelectorMode.LIST,
+                )
+            )
+
         return self.async_show_form(
             step_id="verify_connection",
-            data_schema=vol.Schema({}),
+            data_schema=vol.Schema(schema),
             description_placeholders={
                 "name": self._pending_entry.get(CONF_NAME) or self._pending_entry[CONF_ADDRESS],
-                "capabilities": self._format_capabilities(report),
+                "capabilities": await self._format_capabilities(report),
             },
         )
 

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -1182,9 +1182,13 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
             "address": self._discovery_info.address.upper(),
             "transport": await self._async_transport_note(
                 self._discovery_info.address,
-                ADAPTER_AUTO,
-                bed_type,
-                VARIANT_AUTO,
+                # On a redisplay after a validation error the user's adapter and
+                # protocol choices are known. Previewing the defaults instead
+                # can warn about a proxy for someone who picked a local adapter,
+                # or drop the pairing warning for the type they actually chose.
+                (user_input or {}).get(CONF_PREFERRED_ADAPTER, ADAPTER_AUTO),
+                (user_input or {}).get(CONF_BED_TYPE) or bed_type,
+                (user_input or {}).get(CONF_PROTOCOL_VARIANT, VARIANT_AUTO),
             ),
         }
 
@@ -1830,9 +1834,11 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
                 "setup_note": f"\n{octo_split_note}" if octo_split_note else "",
                 "transport": await self._async_transport_note(
                     address,
-                    discovery_source,
-                    defaults_bed_type,
-                    preselected_protocol_variant,
+                    (user_input or {}).get(CONF_PREFERRED_ADAPTER, discovery_source),
+                    (user_input or {}).get(CONF_BED_TYPE) or defaults_bed_type,
+                    (user_input or {}).get(
+                        CONF_PROTOCOL_VARIANT, preselected_protocol_variant
+                    ),
                 ),
             },
         )
@@ -2503,7 +2509,7 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
         (issue #457).
         """
         assert self._pending_entry is not None
-        if self._operation is None or self._operation.terminal_consumed:
+        if self._operation is None:
             self._async_start_probe_operation()
         return await self.async_run_operation_step(
             step_id="setup_progress",

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -51,6 +51,7 @@ from .bluetooth_freshness import (
 )
 from .bluetooth_transport import (
     ConnectionPath,
+    TransportClass,
     async_describe_actual,
     async_describe_prediction,
     async_path_for_source,
@@ -418,6 +419,10 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
         # Carries the finalized entry across the optional verify_connection step
         self._pending_entry: dict[str, Any] | None = None
         self._pending_title: str | None = None
+        # True once the verify_connection form has actually been rendered, so a
+        # replayed submission from the previous form cannot be read as a
+        # confirmation of a result the user never saw.
+        self._verify_form_shown: bool = False
         _LOGGER.debug("AdjustableBedConfigFlow initialized")
 
     def _set_device_title_placeholders(self, name: str | None, address: str) -> None:
@@ -2546,7 +2551,9 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
         _report(SetupAction.LOCATING)
         source = (
             preferred_adapter
-            if preferred_adapter and preferred_adapter != ADAPTER_AUTO
+            if preferred_adapter
+            and preferred_adapter != ADAPTER_AUTO
+            and prediction.preferred_available
             else None
         )
         if wait_progress is not None:
@@ -2575,7 +2582,7 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
             prediction.chosen.source if prediction.chosen else None
         )
         report.via_proxy = bool(
-            evidence.path is not None and not evidence.path.owns_host_bond
+            evidence.path is not None and evidence.path.transport is TransportClass.PROXY
         )
 
         client: BleakClient | None = None
@@ -2603,10 +2610,18 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
                     if actual_source:
                         report.source = actual_source
                         report.actual_path = async_path_for_source(
-                            self.hass, actual_source, rssi=evidence.rssi
+                            self.hass,
+                            actual_source,
+                            # Only carry the measured signal over when the same
+                            # scanner measured it.
+                            rssi=(
+                                evidence.rssi if actual_source == evidence.source else None
+                            ),
                         )
                         if report.actual_path is not None:
-                            report.via_proxy = not report.actual_path.owns_host_bond
+                            report.via_proxy = (
+                                report.actual_path.transport is TransportClass.PROXY
+                            )
                         if path_reporter is not None:
                             path_reporter(report.actual_path)
                     _report(SetupAction.DISCOVERING_SERVICES)
@@ -2742,15 +2757,18 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
         which re-runs the check in place, so the user can go wake the bed
         without losing everything they already filled in (#458).
 
-        It must never create an entry on ``user_input is None``. Home Assistant
-        re-enters a flow's current step on its own (the progress task's
-        done-callback, a frontend refresh), and an entry created from one of
-        those would be an entry the user never confirmed.
+        It creates an entry only from input submitted against *this* form.
+        ``FlowManager.async_configure`` re-passes the caller's original
+        ``user_input`` on every iteration of its progress-done loop, so a
+        duplicated submission of the previous form arriving just as the probe
+        finishes would otherwise be replayed here and read as confirmation -
+        creating an entry the user never saw a result for.
         """
         assert self._pending_entry is not None
 
-        if user_input is not None:
+        if user_input is not None and self._verify_form_shown:
             if user_input.get("action") == "retry":
+                self._verify_form_shown = False
                 self._async_start_probe_operation()
                 return await self.async_step_setup_progress()
             return self.async_create_entry(
@@ -2761,14 +2779,10 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
         result = self.operation.result
         report = result.payload if result is not None else None
         if not isinstance(report, CapabilityReport):
-            # No operation ran (a direct call, or state lost). Fall back to a
-            # blocking probe rather than showing an empty checklist.
-            report = await self._probe_capabilities(
-                self._pending_entry[CONF_ADDRESS],
-                self._pending_entry.get(CONF_PREFERRED_ADAPTER, ADAPTER_AUTO),
-                self._pending_entry.get(CONF_BED_TYPE),
-                self._pending_entry.get(CONF_PROTOCOL_VARIANT),
-            )
+            # The operation state is gone (a direct call, or a flow restored
+            # without it). Say so rather than running a blocking probe here:
+            # this is the step that exists so that nothing blocks.
+            report = CapabilityReport(freshness=FreshnessStatus.MISSING)
 
         schema: dict[vol.Marker, Any] = {}
         if report.freshness is not None and report.freshness is not FreshnessStatus.FRESH:
@@ -2777,14 +2791,13 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
             # click away for the common case of "let me go wake the bed first".
             schema[vol.Required("action", default="finish")] = SelectSelector(
                 SelectSelectorConfig(
-                    options=[
-                        SelectOptionDict(value="finish", label="Finish setup anyway"),
-                        SelectOptionDict(value="retry", label="Check again"),
-                    ],
+                    options=["finish", "retry"],
                     mode=SelectSelectorMode.LIST,
+                    translation_key="verify_action",
                 )
             )
 
+        self._verify_form_shown = True
         return self.async_show_form(
             step_id="verify_connection",
             data_schema=vol.Schema(schema),

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -43,7 +44,11 @@ from .adapter import (
     read_ble_device_info,
 )
 from .address_lock import async_get_connect_lock
-from .bluetooth_freshness import FreshnessStatus, async_gate_connection
+from .bluetooth_freshness import (
+    FreshnessStatus,
+    async_gate_connection,
+    async_wait_for_advertisement,
+)
 from .bluetooth_transport import (
     ConnectionPath,
     async_describe_actual,
@@ -149,6 +154,13 @@ from .discovery_settings import (
     async_set_discovery_disabled,
 )
 from .kaidi_metadata import add_kaidi_entry_metadata, resolve_kaidi_advertisement
+from .setup_operation import (
+    BluetoothOperationMixin,
+    ConnectionLifetimePolicy,
+    OperationOutcome,
+    OperationResult,
+    SetupAction,
+)
 from .unsupported import (
     build_misidentified_issue_url,
     capture_device_info,
@@ -275,6 +287,12 @@ def _add_malouf_entry_data(
 # blocks entry creation.
 _PROBE_TIMEOUT_SECONDS = 15.0
 
+# How long the setup probe waits for the bed to advertise before reporting it as
+# absent. Deliberately shorter than the pairing wait: someone who just put a bed
+# into pairing mode is standing at the bed and expects to wait, while someone
+# finishing a setup form is not, and the result step offers Retry either way.
+_PROBE_ADVERTISEMENT_WAIT_SECONDS = 10.0
+
 
 def _skips_setup_connection_probe(bed_type: str | None, variant: str | None) -> bool:
     """Return True when setup should avoid a redundant Gen2 connection cycle.
@@ -315,7 +333,7 @@ class CapabilityReport:
     freshness: FreshnessStatus | None = None
 
 
-class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
+class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Adjustable Bed."""
 
     VERSION = 3
@@ -2406,7 +2424,79 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(title=title, data=entry_data)
         self._pending_entry = entry_data
         self._pending_title = title
-        return await self.async_step_verify_connection()
+        return await self.async_step_setup_progress()
+
+    def _async_start_probe_operation(self) -> None:
+        """Prepare the shared operation state for a capability probe."""
+        assert self._pending_entry is not None
+        address = self._pending_entry[CONF_ADDRESS]
+        preferred = self._pending_entry.get(CONF_PREFERRED_ADAPTER, ADAPTER_AUTO)
+        self.async_begin_operation(
+            name=self._pending_entry.get(CONF_NAME) or address,
+            address=address,
+            prediction=async_predict_path(self.hass, address, preferred),
+            action=SetupAction.LOCATING,
+            policy=(
+                ConnectionLifetimePolicy.KEEP_FIRST_LINK
+                if _skips_setup_connection_probe(
+                    self._pending_entry.get(CONF_BED_TYPE),
+                    self._pending_entry.get(CONF_PROTOCOL_VARIANT),
+                )
+                else ConnectionLifetimePolicy.ORDINARY
+            ),
+            placeholders={
+                "name": self._pending_entry.get(CONF_NAME) or address,
+                "address": address,
+            },
+        )
+
+    async def _async_probe_worker(self) -> OperationResult:
+        """Run the capability probe as a tracked background operation.
+
+        Everything the client touches happens in this one task: the per-address
+        connect lock is reentrant per ``asyncio.Task``, so splitting the connect
+        and the disconnect across tasks would deadlock rather than re-enter.
+        """
+        assert self._pending_entry is not None
+        report = await self._probe_capabilities(
+            self._pending_entry[CONF_ADDRESS],
+            self._pending_entry.get(CONF_PREFERRED_ADAPTER, ADAPTER_AUTO),
+            self._pending_entry.get(CONF_BED_TYPE),
+            self._pending_entry.get(CONF_PROTOCOL_VARIANT),
+            reporter=self.async_report_action,
+            wait_progress=self.async_report_progress,
+            path_reporter=self.async_report_path,
+        )
+        if report.freshness is not None and report.freshness is not FreshnessStatus.FRESH:
+            outcome = OperationOutcome.NOT_ADVERTISING
+        elif not report.connected:
+            outcome = OperationOutcome.CONNECTION_FAILED
+        else:
+            outcome = OperationOutcome.SUCCESS
+        return OperationResult(
+            outcome=outcome,
+            detail=report.error,
+            path=report.actual_path or report.predicted_path,
+            payload=report,
+        )
+
+    async def async_step_setup_progress(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Run the read-only capability probe behind a live progress view.
+
+        Without this the form the user just submitted sits there frozen for as
+        long as the BLE stack takes, which is indistinguishable from a hang
+        (issue #457).
+        """
+        assert self._pending_entry is not None
+        if self._operation is None or self._operation.terminal_consumed:
+            self._async_start_probe_operation()
+        return await self.async_run_operation_step(
+            step_id="setup_progress",
+            worker=self._async_probe_worker,
+            next_step_id="verify_connection",
+        )
 
     async def _probe_capabilities(
         self,
@@ -2414,6 +2504,10 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         preferred_adapter: str | None,
         bed_type: str | None,
         protocol_variant: str | None = None,
+        *,
+        reporter: Callable[[SetupAction], None] | None = None,
+        wait_progress: Callable[[float], None] | None = None,
+        path_reporter: Callable[[ConnectionPath | None], None] | None = None,
     ) -> CapabilityReport:
         """Connect once (read-only) and report what was detected.
 
@@ -2428,9 +2522,20 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         recently. Without that check a bed that is asleep or unplugged still
         looks present in Home Assistant's history, and the probe burns its whole
         timeout producing a failure that reads like a pairing problem (#458).
+
+        ``reporter`` receives the current phase so a progress view can name what
+        is happening. ``wait_progress`` drives the numeric bar, and is passed
+        only to the advertisement wait: that is the one step whose duration is
+        known in advance, so it is the only one where a percentage is honest.
+        ``path_reporter`` is called the moment the routed transport is known, so
+        the progress view can name it while the probe is still running.
         """
         from bleak import BleakClient
         from bleak_retry_connector import establish_connection
+
+        def _report(action: SetupAction) -> None:
+            if reporter is not None:
+                reporter(action)
 
         has_position_feedback = bed_type_has_position_feedback(bed_type, protocol_variant)
         report = CapabilityReport(position_feedback=has_position_feedback)
@@ -2438,15 +2543,24 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         prediction = async_predict_path(self.hass, address, preferred_adapter)
         report.predicted_path = prediction.chosen
 
-        evidence, device = async_gate_connection(
-            self.hass,
-            address,
-            source=(
-                preferred_adapter
-                if preferred_adapter and preferred_adapter != ADAPTER_AUTO
-                else None
-            ),
+        _report(SetupAction.LOCATING)
+        source = (
+            preferred_adapter
+            if preferred_adapter and preferred_adapter != ADAPTER_AUTO
+            else None
         )
+        if wait_progress is not None:
+            # Give a bed that is merely between advertising intervals, or that
+            # the user is walking over to wake, a chance before refusing.
+            evidence, device = await async_wait_for_advertisement(
+                self.hass,
+                address,
+                source=source,
+                wait_timeout=_PROBE_ADVERTISEMENT_WAIT_SECONDS,
+                on_progress=wait_progress,
+            )
+        else:
+            evidence, device = async_gate_connection(self.hass, address, source=source)
         report.freshness = evidence.status
         report.rssi = evidence.rssi
         if not evidence.is_fresh or device is None:
@@ -2473,6 +2587,7 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
         try:
             async with async_get_connect_lock(self.hass, address):
                 try:
+                    _report(SetupAction.CONNECTING)
                     client = await establish_connection(
                         BleakClient,
                         device,
@@ -2492,6 +2607,9 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                         )
                         if report.actual_path is not None:
                             report.via_proxy = not report.actual_path.owns_host_bond
+                        if path_reporter is not None:
+                            path_reporter(report.actual_path)
+                    _report(SetupAction.DISCOVERING_SERVICES)
                     await discover_services(client, address)
                     services = list(client.services) if client.services else []
                     report.service_count = len(services)
@@ -2504,11 +2622,13 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
                             ):
                                 writable += 1
                     report.writable_count = writable
+                    _report(SetupAction.READING_CAPABILITIES)
                     report.manufacturer, report.model = await read_ble_device_info(
                         client, address
                     )
                 finally:
                     if client is not None:
+                        _report(SetupAction.DISCONNECTING)
                         try:
                             await client.disconnect()
                         except Exception:  # noqa: BLE001 - cleanup must not raise
@@ -2613,30 +2733,42 @@ class AdjustableBedConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_verify_connection(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Probe the bed once (read-only) and show a capability checklist.
+        """Show the capability checklist produced by the setup_progress step.
 
-        Shown after the confirm/manual step for non-PIN/non-pairing beds. The
-        Submit button always finishes setup - a failed probe is informational
-        only and never blocks entry creation.
-
-        When the bed was not advertising, the form also offers Retry, which
-        re-runs the check in place. The user can wake the bed and try again
+        This is a result step: the probe itself ran as a background task behind
+        a progress view, so this only renders what it found. Submit always
+        finishes setup - a failed probe is informational and never blocks entry
+        creation. When the bed was not advertising the form also offers Retry,
+        which re-runs the check in place, so the user can go wake the bed
         without losing everything they already filled in (#458).
+
+        It must never create an entry on ``user_input is None``. Home Assistant
+        re-enters a flow's current step on its own (the progress task's
+        done-callback, a frontend refresh), and an entry created from one of
+        those would be an entry the user never confirmed.
         """
         assert self._pending_entry is not None
 
-        if user_input is not None and user_input.get("action") != "retry":
+        if user_input is not None:
+            if user_input.get("action") == "retry":
+                self._async_start_probe_operation()
+                return await self.async_step_setup_progress()
             return self.async_create_entry(
                 title=self._pending_title or self._pending_entry.get(CONF_NAME, "Adjustable Bed"),
                 data=self._pending_entry,
             )
 
-        report = await self._probe_capabilities(
-            self._pending_entry[CONF_ADDRESS],
-            self._pending_entry.get(CONF_PREFERRED_ADAPTER, ADAPTER_AUTO),
-            self._pending_entry.get(CONF_BED_TYPE),
-            self._pending_entry.get(CONF_PROTOCOL_VARIANT),
-        )
+        result = self.operation.result
+        report = result.payload if result is not None else None
+        if not isinstance(report, CapabilityReport):
+            # No operation ran (a direct call, or state lost). Fall back to a
+            # blocking probe rather than showing an empty checklist.
+            report = await self._probe_capabilities(
+                self._pending_entry[CONF_ADDRESS],
+                self._pending_entry.get(CONF_PREFERRED_ADAPTER, ADAPTER_AUTO),
+                self._pending_entry.get(CONF_BED_TYPE),
+                self._pending_entry.get(CONF_PROTOCOL_VARIANT),
+            )
 
         schema: dict[vol.Marker, Any] = {}
         if report.freshness is not None and report.freshness is not FreshnessStatus.FRESH:

--- a/custom_components/adjustable_bed/setup_operation.py
+++ b/custom_components/adjustable_bed/setup_operation.py
@@ -135,9 +135,6 @@ class OperationResult:
 class SetupOperationState:
     """Everything a progress view and its result step need to know."""
 
-    # Bumped for every new operation, so a refresh scheduled by an operation the
-    # user has already moved on from cannot write into the current one.
-    generation: int = 0
     action: SetupAction = SetupAction.LOCATING
     prediction: PathPrediction | None = None
     actual: ConnectionPath | None = None
@@ -237,7 +234,6 @@ class BluetoothOperationMixin:
         an explicit Retry — never on re-entry while a task is running, which is
         what makes double submits harmless.
         """
-        previous = self._operation
         # Defensive: a caller should only start an operation when none is
         # running, but replacing the state while a task still holds a client
         # would orphan both, so tear the old one down first.
@@ -249,7 +245,6 @@ class BluetoothOperationMixin:
             if hass is not None:
                 hass.async_create_task(_async_disconnect_quietly(stray))
         self._operation = SetupOperationState(
-            generation=(previous.generation + 1) if previous is not None else 1,
             action=action,
             prediction=prediction,
             name=name,
@@ -293,7 +288,7 @@ class BluetoothOperationMixin:
         state = self.operation
         state.progress = progress
         with contextlib.suppress(Exception):
-            self.async_update_progress(progress)  # type: ignore[attr-defined]
+            self.async_update_progress(progress)
 
     @callback
     def async_report_path(self, path: ConnectionPath | None) -> None:

--- a/custom_components/adjustable_bed/setup_operation.py
+++ b/custom_components/adjustable_bed/setup_operation.py
@@ -252,6 +252,10 @@ class BluetoothOperationMixin:
         state = self.operation
         changed = state.action is not action
         state.action = action
+        if changed:
+            # Drop any bar left over from the previous phase. Carrying it would
+            # show a full bar through a phase whose duration is unknowable.
+            state.progress = None
         if progress is not None:
             state.progress = progress
             with contextlib.suppress(Exception):

--- a/custom_components/adjustable_bed/setup_operation.py
+++ b/custom_components/adjustable_bed/setup_operation.py
@@ -57,6 +57,7 @@ from .bluetooth_transport import ConnectionPath, PathPrediction, TransportClass
 
 if TYPE_CHECKING:
     from bleak import BleakClient
+    from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -192,6 +193,19 @@ class BluetoothOperationMixin:
     _operation: SetupOperationState | None = None
     _operation_task: asyncio.Task[OperationResult] | None = None
     _operation_client: BleakClient | None = None
+
+    if TYPE_CHECKING:
+        # Supplied by the flow handler this is mixed into. Declared rather than
+        # inherited so the mixin stays usable with ConfigFlow, OptionsFlow and
+        # RepairsFlow, which do not share a base that carries these.
+        hass: HomeAssistant
+        flow_id: str
+
+        def async_update_progress(self, progress: float) -> None: ...
+
+        def async_show_progress(self, **kwargs: Any) -> Any: ...
+
+        def async_show_progress_done(self, *, next_step_id: str) -> Any: ...
     _refresh_task: asyncio.Task[None] | None = None
     _refresh_pending: bool = False
 
@@ -224,6 +238,16 @@ class BluetoothOperationMixin:
         what makes double submits harmless.
         """
         previous = self._operation
+        # Defensive: a caller should only start an operation when none is
+        # running, but replacing the state while a task still holds a client
+        # would orphan both, so tear the old one down first.
+        if self._operation_task is not None and not self._operation_task.done():
+            self._operation_task.cancel()
+        if self._operation_client is not None:
+            stray, self._operation_client = self._operation_client, None
+            hass = getattr(self, "hass", None)
+            if hass is not None:
+                hass.async_create_task(_async_disconnect_quietly(stray))
         self._operation = SetupOperationState(
             generation=(previous.generation + 1) if previous is not None else 1,
             action=action,
@@ -259,7 +283,7 @@ class BluetoothOperationMixin:
         if progress is not None:
             state.progress = progress
             with contextlib.suppress(Exception):
-                self.async_update_progress(progress)  # type: ignore[attr-defined]
+                self.async_update_progress(progress)
         if changed:
             self.async_refresh_progress_view()
 
@@ -365,14 +389,14 @@ class BluetoothOperationMixin:
         state = self.operation
 
         if self._operation_task is None and not state.terminal_consumed:
-            self._operation_task = self.hass.async_create_task(  # type: ignore[attr-defined]
+            self._operation_task = self.hass.async_create_task(
                 self._async_guarded_worker(worker),
                 eager_start=False,
             )
 
         task = self._operation_task
         if task is not None and not task.done():
-            return self.async_show_progress(  # type: ignore[attr-defined]
+            return self.async_show_progress(
                 step_id=step_id,
                 progress_action=state.action.value,
                 progress_task=task,
@@ -399,7 +423,7 @@ class BluetoothOperationMixin:
                     detail=str(err) or err.__class__.__name__,
                 )
 
-        return self.async_show_progress_done(next_step_id=next_step_id)  # type: ignore[attr-defined]
+        return self.async_show_progress_done(next_step_id=next_step_id)
 
     async def _async_guarded_worker(self, worker: OperationWorker) -> OperationResult:
         """Run a worker, guaranteeing the BLE client is released afterwards."""

--- a/custom_components/adjustable_bed/setup_operation.py
+++ b/custom_components/adjustable_bed/setup_operation.py
@@ -1,0 +1,456 @@
+"""Shared state and progress plumbing for slow Bluetooth setup operations.
+
+Locating a bed, connecting to it, discovering its GATT tree, pairing, verifying a
+bond and unpairing all take seconds, sometimes tens of seconds. Running them
+inline leaves the form the user just submitted sitting there looking frozen, and
+a frozen form is indistinguishable from a broken one.
+
+Every such operation therefore runs as a tracked background task behind a Home
+Assistant progress view. This module owns what all of those operations share:
+
+* ``SetupAction`` — the vocabulary of phases, one translation key each.
+* ``SetupOperationState`` — what the flow is doing, over which transport, how far
+  along, and how it ended.
+* ``BluetoothOperationMixin`` — the step behaviour.
+
+Three things here are subtle enough to be worth stating outright.
+
+**Progress text versus progress bar.** A numeric bar comes from
+``async_update_progress``, which fires an event without re-running the step.
+Changing the *label* requires the step to run again and return a different
+``progress_action``, so a phase change schedules a re-configure of the flow. Both
+patterns come from Home Assistant core (``components/airos`` and
+``components/cloud/repairs``).
+
+**Determinate progress is nearly always a lie.** A BLE connect can take 200 ms or
+20 s and offers no completion signal, so "phase 2 of 4 = 50%" is invented
+precision. Only the advertisement wait, whose duration really is known up front,
+drives the bar; every other phase is a spinner with honest status text.
+
+**Completion races.** When the worker finishes, Home Assistant schedules its own
+``_async_configure()`` via the progress task's done-callback
+(``data_entry_flow.py``). That can land at the same moment as one of our phase
+refreshes, so both the terminal transition and the refresh driver are built to be
+safe when they overlap: the result is consumed once, and only one refresh is ever
+in flight.
+
+**Task identity.** ``ReentrantAddressLock`` keys reentrancy on
+``asyncio.current_task()``, so everything for one BLE client's lifetime —
+connect, use, disconnect — must happen inside the single worker task. Delegating
+part of it to a helper task would block on the lock rather than re-enter it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import UnknownFlow
+
+from .bluetooth_transport import ConnectionPath, PathPrediction, TransportClass
+
+if TYPE_CHECKING:
+    from bleak import BleakClient
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SetupAction(StrEnum):
+    """A phase of a Bluetooth setup operation, shown while it is running.
+
+    Each value is also the ``progress_action`` translation key, so adding a phase
+    means adding a string in every language.
+    """
+
+    LOCATING = "locating"
+    CONNECTING = "connecting"
+    DISCOVERING_SERVICES = "discovering_services"
+    READING_CAPABILITIES = "reading_capabilities"
+    PAIRING = "pairing"
+    VERIFYING_BOND = "verifying_bond"
+    DISCONNECTING = "disconnecting"
+    UNPAIRING = "unpairing"
+
+
+class OperationOutcome(StrEnum):
+    """How a Bluetooth setup operation ended.
+
+    Deliberately narrower than "it failed": each value maps to different advice,
+    and issue #461 requires that a plain connection failure is never presented as
+    a pairing failure.
+    """
+
+    SUCCESS = "success"
+    NOT_ADVERTISING = "not_advertising"
+    CONNECTION_FAILED = "connection_failed"
+    CONNECTION_IN_USE = "connection_in_use"
+    NO_CONNECTION_SLOTS = "no_connection_slots"
+    TIMEOUT = "timeout"
+    PAIRING_NOT_SUPPORTED = "pairing_not_supported"
+    AUTHENTICATION_FAILED = "authentication_failed"
+    BOND_VERIFICATION_FAILED = "bond_verification_failed"
+    PROXY_OWNED_BOND = "proxy_owned_bond"
+    UNPAIR_FAILED = "unpair_failed"
+    CANCELLED = "cancelled"
+
+
+class ConnectionLifetimePolicy(StrEnum):
+    """How freely an operation may spend BLE connections to this bed.
+
+    ``KEEP_FIRST_LINK`` marks a bed that grants roughly one usable connection per
+    power cycle (LP Comfort Connect / Leggett & Platt Gen2, issue #385). For such
+    a bed a throwaway probe or a standalone pairing connect consumes the only
+    connection the coordinator was going to get, and reconnecting to "do it
+    properly" strands the bed until the user unplugs it. Operations must consult
+    this before opening anything.
+    """
+
+    ORDINARY = "ordinary"
+    KEEP_FIRST_LINK = "keep_first_link"
+
+
+@dataclass(frozen=True, slots=True)
+class OperationResult:
+    """The terminal state of one operation."""
+
+    outcome: OperationOutcome
+    detail: str | None = None
+    path: ConnectionPath | None = None
+    payload: Any = None
+
+    @property
+    def succeeded(self) -> bool:
+        """Return True only for an unambiguous success."""
+        return self.outcome is OperationOutcome.SUCCESS
+
+
+@dataclass
+class SetupOperationState:
+    """Everything a progress view and its result step need to know."""
+
+    # Bumped for every new operation, so a refresh scheduled by an operation the
+    # user has already moved on from cannot write into the current one.
+    generation: int = 0
+    action: SetupAction = SetupAction.LOCATING
+    prediction: PathPrediction | None = None
+    actual: ConnectionPath | None = None
+    progress: float | None = None
+    result: OperationResult | None = None
+    terminal_consumed: bool = False
+    name: str = ""
+    address: str = ""
+    policy: ConnectionLifetimePolicy = ConnectionLifetimePolicy.ORDINARY
+    placeholders: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def predicted(self) -> ConnectionPath | None:
+        """Return the path Home Assistant was expected to use."""
+        return self.prediction.chosen if self.prediction is not None else None
+
+    @property
+    def path_changed(self) -> bool:
+        """Return True when the connection did not take the predicted path."""
+        predicted = self.predicted
+        return (
+            predicted is not None
+            and self.actual is not None
+            and predicted.source != self.actual.source
+        )
+
+    @property
+    def effective_path(self) -> ConnectionPath | None:
+        """Return the real path when known, else the prediction."""
+        return self.actual or self.predicted
+
+    @property
+    def transport(self) -> TransportClass:
+        """Return the transport class currently believed to be in use."""
+        path = self.effective_path
+        return path.transport if path is not None else TransportClass.UNKNOWN
+
+
+# A worker returns the terminal result for its operation. It must never raise for
+# an expected BLE failure — expected failures are outcomes, not exceptions — but
+# the mixin still catches anything that escapes so a bug cannot wedge a flow.
+OperationWorker = Callable[[], Awaitable[OperationResult]]
+
+
+class BluetoothOperationMixin:
+    """Progress-step behaviour shared by the config, options and repair flows.
+
+    The host class must be a Home Assistant flow handler: this uses ``self.hass``,
+    ``self.flow_id``, ``async_show_progress``, ``async_show_progress_done`` and
+    ``async_update_progress``.
+    """
+
+    _operation: SetupOperationState | None = None
+    _operation_task: asyncio.Task[OperationResult] | None = None
+    _operation_client: BleakClient | None = None
+    _refresh_task: asyncio.Task[None] | None = None
+    _refresh_pending: bool = False
+
+    # -- state ---------------------------------------------------------------
+
+    @property
+    def operation(self) -> SetupOperationState:
+        """Return the current operation state, creating an empty one if needed."""
+        state = self._operation
+        if state is None:
+            state = SetupOperationState()
+            self._operation = state
+        return state
+
+    @callback
+    def async_begin_operation(
+        self,
+        *,
+        name: str = "",
+        address: str = "",
+        prediction: PathPrediction | None = None,
+        action: SetupAction = SetupAction.LOCATING,
+        policy: ConnectionLifetimePolicy = ConnectionLifetimePolicy.ORDINARY,
+        placeholders: dict[str, str] | None = None,
+    ) -> SetupOperationState:
+        """Start a new operation, discarding any state from a previous one.
+
+        Call this when a step is entered with user input — a fresh submission or
+        an explicit Retry — never on re-entry while a task is running, which is
+        what makes double submits harmless.
+        """
+        previous = self._operation
+        self._operation = SetupOperationState(
+            generation=(previous.generation + 1) if previous is not None else 1,
+            action=action,
+            prediction=prediction,
+            name=name,
+            address=address,
+            policy=policy,
+            placeholders=dict(placeholders or {}),
+        )
+        self._operation_task = None
+        self._operation_client = None
+        return self._operation
+
+    # -- progress reporting (called from inside the worker) -------------------
+
+    @callback
+    def async_report_action(
+        self, action: SetupAction, *, progress: float | None = None
+    ) -> None:
+        """Record the current phase and push it to the frontend.
+
+        ``progress`` should be supplied only where the fraction is genuinely
+        measurable. Everything here is best-effort: a UI update must never be
+        able to fail the operation it is describing.
+        """
+        state = self.operation
+        changed = state.action is not action
+        state.action = action
+        if progress is not None:
+            state.progress = progress
+            with contextlib.suppress(Exception):
+                self.async_update_progress(progress)  # type: ignore[attr-defined]
+        if changed:
+            self.async_refresh_progress_view()
+
+    @callback
+    def async_report_progress(self, progress: float) -> None:
+        """Update only the numeric bar, without re-rendering the step."""
+        state = self.operation
+        state.progress = progress
+        with contextlib.suppress(Exception):
+            self.async_update_progress(progress)  # type: ignore[attr-defined]
+
+    @callback
+    def async_report_path(self, path: ConnectionPath | None) -> None:
+        """Record the transport a connection actually used."""
+        if path is None:
+            return
+        self.operation.actual = path
+        self.async_refresh_progress_view()
+
+    @callback
+    def async_track_client(self, client: BleakClient | None) -> None:
+        """Remember the client an operation opened so cancellation can close it."""
+        self._operation_client = client
+
+    # -- refresh driver ------------------------------------------------------
+
+    @callback
+    def _async_flow_manager(self) -> Any:
+        """Return the flow manager driving this flow.
+
+        Home Assistant does not hand a handler a reference to its own manager,
+        and the three managers are distinct objects: config flows, options flows
+        and repair flows each have their own. This default is the config-flow
+        manager; hosts elsewhere override it.
+        """
+        hass = getattr(self, "hass", None)
+        if hass is None:
+            return None
+        return hass.config_entries.flow
+
+    @callback
+    def async_refresh_progress_view(self) -> None:
+        """Ask Home Assistant to re-render the running progress step.
+
+        Coalesced deliberately. Several phases can change in quick succession,
+        and each re-configure re-runs the step; letting them pile up would mean
+        many concurrent invocations racing each other and the flow manager's own
+        completion callback. At most one refresh is ever in flight, and a request
+        that arrives while one is running just marks the next round.
+        """
+        hass = getattr(self, "hass", None)
+        if hass is None or not getattr(self, "flow_id", None):
+            return
+        if self._refresh_task is not None and not self._refresh_task.done():
+            self._refresh_pending = True
+            return
+        self._refresh_pending = False
+        self._refresh_task = hass.async_create_task(self._async_refresh_loop())
+
+    async def _async_refresh_loop(self) -> None:
+        """Re-configure the flow until no further refresh has been requested."""
+        manager = self._async_flow_manager()
+        flow_id = getattr(self, "flow_id", None)
+        if manager is None or not flow_id:
+            return
+        while True:
+            self._refresh_pending = False
+            try:
+                await manager.async_configure(flow_id=flow_id)
+            except UnknownFlow:
+                # The user closed the dialog while we were mid-phase. Nothing to
+                # update, and nothing worth logging.
+                return
+            except Exception:  # noqa: BLE001 - a redraw must never break the flow
+                _LOGGER.debug("Could not refresh the setup progress view", exc_info=True)
+                return
+            if not self._refresh_pending:
+                return
+
+    # -- the progress step ---------------------------------------------------
+
+    async def async_run_operation_step(
+        self,
+        *,
+        step_id: str,
+        worker: OperationWorker,
+        next_step_id: str,
+        description_placeholders: dict[str, str] | None = None,
+    ) -> Any:
+        """Render a progress view for ``worker``, then hand off to a result step.
+
+        Returns ``Any`` rather than ``FlowResult`` because the three host flows
+        each have their own narrower result type (``ConfigFlowResult`` and
+        friends); the type is checked where it matters, at the step that returns
+        it.
+
+        Re-entering while the task runs returns the same task rather than
+        starting a second one, so a double submit, a frontend reconnect and a
+        phase refresh cannot open two BLE connections. Completion transitions to
+        ``next_step_id`` once and only once, whether the worker succeeded, failed
+        or raised.
+        """
+        state = self.operation
+
+        if self._operation_task is None and not state.terminal_consumed:
+            self._operation_task = self.hass.async_create_task(  # type: ignore[attr-defined]
+                self._async_guarded_worker(worker),
+                eager_start=False,
+            )
+
+        task = self._operation_task
+        if task is not None and not task.done():
+            return self.async_show_progress(  # type: ignore[attr-defined]
+                step_id=step_id,
+                progress_action=state.action.value,
+                progress_task=task,
+                description_placeholders={
+                    **state.placeholders,
+                    **(description_placeholders or {}),
+                },
+            )
+
+        if task is not None:
+            # Read the result exactly once. Home Assistant's own done-callback and
+            # a phase refresh can both arrive here; the second one must not try to
+            # re-read a task that has already been cleared.
+            self._operation_task = None
+            state.terminal_consumed = True
+            try:
+                state.result = task.result()
+            except asyncio.CancelledError:
+                state.result = OperationResult(outcome=OperationOutcome.CANCELLED)
+            except Exception as err:  # noqa: BLE001 - a bug must not wedge the flow
+                _LOGGER.exception("Bluetooth setup operation failed unexpectedly")
+                state.result = OperationResult(
+                    outcome=OperationOutcome.CONNECTION_FAILED,
+                    detail=str(err) or err.__class__.__name__,
+                )
+
+        return self.async_show_progress_done(next_step_id=next_step_id)  # type: ignore[attr-defined]
+
+    async def _async_guarded_worker(self, worker: OperationWorker) -> OperationResult:
+        """Run a worker, guaranteeing the BLE client is released afterwards."""
+        try:
+            return await worker()
+        finally:
+            await self._async_release_client()
+
+    async def _async_release_client(self) -> None:
+        """Disconnect any client the operation still holds.
+
+        Shielded so a cancelled flow still completes the disconnect: leaving the
+        link open would hold the bed's single BLE connection and block both the
+        coordinator and the physical remote.
+        """
+        client = self._operation_client
+        self._operation_client = None
+        if client is None:
+            return
+        with contextlib.suppress(Exception):
+            await asyncio.shield(client.disconnect())
+
+    # -- teardown ------------------------------------------------------------
+
+    @callback
+    def async_remove(self) -> None:
+        """Clean up when the flow is abandoned.
+
+        Home Assistant cancels the registered progress task itself before calling
+        this, which runs the worker's own ``finally``. What is left is the
+        refresh driver, a task we started but never registered, and a client
+        opened outside a running task.
+        """
+        refresh_task = self._refresh_task
+        self._refresh_task = None
+        self._refresh_pending = False
+        if refresh_task is not None and not refresh_task.done():
+            refresh_task.cancel()
+
+        task = self._operation_task
+        self._operation_task = None
+        if task is not None and not task.done():
+            task.cancel()
+
+        client = self._operation_client
+        self._operation_client = None
+        if client is not None:
+            hass = getattr(self, "hass", None)
+            if hass is not None:
+                # async_remove is a callback and cannot await, so the disconnect
+                # is handed to a task of its own.
+                hass.async_create_task(_async_disconnect_quietly(client))
+
+
+async def _async_disconnect_quietly(client: BleakClient) -> None:
+    """Disconnect a client, swallowing anything that goes wrong."""
+    with contextlib.suppress(Exception):
+        await client.disconnect()

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -97,7 +97,7 @@
           "transport_signal": "· {rssi} dBm",
           "transport_none": "⚠️ No Bluetooth adapter or proxy can currently see this device. You can still finish setup; Home Assistant will connect when it appears.",
           "transport_local_alternative": "A Bluetooth adapter on this Home Assistant host ({scanner}) can also see it.",
-          "transport_preferred_unavailable": "⚠️ The selected adapter ({adapter}) cannot currently see this device, so Home Assistant will choose a path automatically.",
+          "transport_preferred_unavailable": "⚠️ The selected adapter ({adapter}) is not currently available for this connection. Select Automatic to let Home Assistant choose another path, or restore the selected adapter before continuing.",
           "transport_not_guaranteed": "Home Assistant picks the path when it connects, so this is a prediction rather than a guarantee.",
           "transport_proxy_pairing_warning": "⚠️ This bed needs Bluetooth pairing, and pairing over a proxy stores the bond on the proxy rather than on Home Assistant. If you later move the bed to a different proxy or to a Home Assistant adapter, you will have to pair again. Home Assistant also cannot remove a bond that lives on a proxy.",
           "transport_all_busy": "⚠️ Every adapter that can see this device is currently out of free Bluetooth connections.",
@@ -244,7 +244,7 @@
       },
       "bluetooth_pairing": {
         "title": "Bluetooth Pairing Required",
-        "description": "**{name}** requires Bluetooth pairing.\n\n**To pair:**\n{pairing_instructions}\n\nIf you've already paired manually via system Bluetooth settings, click 'Skip'.",
+        "description": "**{name}** requires Bluetooth pairing.\n\n{transport}\n\n**To pair:**\n{pairing_instructions}\n\nIf you've already paired manually via system Bluetooth settings, click 'Skip'.",
         "data": {
           "action": "Action",
           "pairing_instructions_generic": "Pairing instructions (generic)",
@@ -261,14 +261,14 @@
       },
       "manual_pairing": {
         "title": "Bluetooth Pairing Required",
-        "description": "**{name}** requires Bluetooth pairing.\n\n**To pair:**\n{pairing_instructions}\n\nIf you've already paired manually via system Bluetooth settings, click 'Skip'.",
+        "description": "**{name}** requires Bluetooth pairing.\n\n{transport}\n\n**To pair:**\n{pairing_instructions}\n\nIf you've already paired manually via system Bluetooth settings, click 'Skip'.",
         "data": {
           "action": "Action"
         }
       },
       "verify_connection": {
         "title": "Verify Connection",
-        "description": "Checked the connection to **{name}** before finishing setup:\n\n{capabilities}\n\nSelect **Submit** to finish. You can finish even if something failed - the integration will keep trying to connect afterwards.",
+        "description": "Checked the connection to **{name}** before finishing setup:\n\n{capabilities}\n\nChoose what to do next, then submit. You can finish even if something failed, or retry the connection checks without losing your settings.",
         "submit": "Finish setup",
         "data": {
           "action": "What next"

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -94,7 +94,7 @@
           "transport_proxy": "Bluetooth proxy",
           "transport_unknown": "Bluetooth",
           "transport_likely": "Likely connection: {kind} · {scanner}{signal}",
-          "transport_signal": " · {rssi} dBm",
+          "transport_signal": "· {rssi} dBm",
           "transport_none": "⚠️ No Bluetooth adapter or proxy can currently see this device. You can still finish setup; Home Assistant will connect when it appears.",
           "transport_local_alternative": "A Bluetooth adapter on this Home Assistant host ({scanner}) can also see it.",
           "transport_preferred_unavailable": "⚠️ The selected adapter ({adapter}) cannot currently see this device, so Home Assistant will choose a path automatically.",

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -268,7 +268,7 @@
       },
       "verify_connection": {
         "title": "Verify Connection",
-        "description": "Checked the connection to **{name}** before finishing setup:\n\n{capabilities}\n\nChoose what to do next, then submit. You can finish even if something failed, or retry the connection checks without losing your settings.",
+        "description": "Checked the connection to **{name}** before finishing setup:\n\n{capabilities}\n\nSubmitting finishes setup. A failed check never blocks it, and the integration keeps trying to connect afterwards.",
         "submit": "Finish setup",
         "data": {
           "action": "What next"

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -42,7 +42,7 @@
       },
       "bluetooth_confirm": {
         "title": "Confirm Adjustable Bed",
-        "description": "Do you want to set up {name} ({address})?\n{detection_note}\n\n{report_note}",
+        "description": "Do you want to set up {name} ({address})?\n{detection_note}\n\n{transport}\n\n{report_note}",
         "data": {
           "bed_type": "Bed type",
           "name": "Name",
@@ -63,7 +63,7 @@
           "auto_detect_option": "Auto-detect (recommended)"
         },
         "data_description": {
-          "bed_type": "Auto-detected bed type. Change if detection was incorrect.",
+          "bed_type": "Auto-detected bed type. Change if detection was incorrect. Options are controller protocols, not mattress brands; example beds are shown in parentheses. See the Supported Actuators guide if unsure.",
           "motor_count": "Number of physical actuators. Malouf/Lucid beds use the separate actuator-layout setting below.",
           "malouf_layout": "Physical controls on the remote. This is independent of BLE protocol: Lucid L600 beds have shipped with multiple protocols.",
           "malouf_memory_slots": "Number of memory buttons on the physical remote. Auto exposes one for a two-motor L600-style layout and two for other layouts.",
@@ -76,7 +76,20 @@
           "disconnect_after_command": "Disconnect from the bed immediately after each command to free up the BLE connection for the physical remote. Recommended for beds that only allow one connection at a time.",
           "idle_disconnect_seconds": "How many seconds to wait before automatically disconnecting when idle (10-300). Lower values free up the connection faster for the physical remote, higher values reduce reconnection overhead.",
           "octo_pin": "PIN code for Octo bed authentication. Required to maintain connection. Leave empty if your bed doesn't require a PIN.",
-          "jensen_pin": "PIN code for Jensen bed authentication. Default PIN is 3060."
+          "jensen_pin": "PIN code for Jensen bed authentication. Default PIN is 3060.",
+          "transport_direct": "Direct Bluetooth",
+          "transport_proxy": "Bluetooth proxy",
+          "transport_unknown": "Bluetooth",
+          "transport_likely": "Likely connection: {kind} · {scanner}{signal}",
+          "transport_signal": " · {rssi} dBm",
+          "transport_none": "⚠️ No Bluetooth adapter or proxy can currently see this device. You can still finish setup; Home Assistant will connect when it appears.",
+          "transport_local_alternative": "A Bluetooth adapter on this Home Assistant host ({scanner}) can also see it, with a weaker signal.",
+          "transport_preferred_unavailable": "⚠️ The selected adapter ({adapter}) cannot currently see this device, so Home Assistant will choose a path automatically.",
+          "transport_not_guaranteed": "Home Assistant picks the path when it connects, so this is a prediction rather than a guarantee.",
+          "transport_proxy_pairing_warning": "⚠️ This bed needs Bluetooth pairing, and pairing over a proxy stores the bond on the proxy rather than on Home Assistant. If you later move the bed to a different proxy or to a Home Assistant adapter, you will have to pair again. Home Assistant also cannot remove a bond that lives on a proxy.",
+          "transport_all_busy": "⚠️ Every adapter that can see this device is currently out of free Bluetooth connections.",
+          "transport_actual": "Connected over: {kind} · {scanner}{signal}",
+          "transport_actual_differs": "Home Assistant used a different path than predicted ({predicted})."
         }
       },
       "manual": {
@@ -88,7 +101,7 @@
       },
       "manual_config": {
         "title": "Configure Bed - {name}",
-        "description": "Configure the bed at {address}.{setup_note}",
+        "description": "Configure the bed at {address}.{setup_note}\n\n{transport}",
         "data": {
           "bed_type": "Bed type",
           "protocol_variant": "Protocol variant",
@@ -105,6 +118,7 @@
           "idle_disconnect_seconds": "Idle disconnect timeout (seconds)"
         },
         "data_description": {
+          "bed_type": "Options are controller protocols, not mattress brands; example beds are shown in parentheses. See the Supported Actuators guide if unsure.",
           "protocol_variant": "Leave as 'auto' unless you know the specific protocol. Keeson: base (Member's Mark/Purple) or ksbt (KSBT03/KSBT04, including some Ergomotion Sync beds). Leggett: gen2 (most common) or okin. Richmat: auto-detected.",
           "motor_count": "Number of physical actuators. Malouf/Lucid beds use the separate actuator-layout setting below.",
           "malouf_layout": "Physical controls on the remote. This is independent of BLE protocol: Lucid L600 beds have shipped with multiple protocols.",
@@ -138,6 +152,7 @@
         },
         "data_description": {
           "address": "MAC address in format XX:XX:XX:XX:XX:XX (found in the bed's Bluetooth settings or on a label).",
+          "bed_type": "Options are controller protocols, not mattress brands; example beds are shown in parentheses. See the Supported Actuators guide if unsure.",
           "protocol_variant": "Leave as 'auto' unless you know the specific protocol. Keeson: base (Member's Mark/Purple) or ksbt (KSBT03/KSBT04, including some Ergomotion Sync beds). Leggett: gen2 (most common) or okin. Richmat: auto-detected.",
           "motor_count": "Number of physical actuators. Malouf/Lucid beds use the separate actuator-layout setting below.",
           "malouf_layout": "Physical controls on the remote. This is independent of BLE protocol: Lucid L600 beds have shipped with multiple protocols.",
@@ -241,7 +256,13 @@
       "verify_connection": {
         "title": "Verify Connection",
         "description": "Checked the connection to **{name}** before finishing setup:\n\n{capabilities}\n\nSelect **Submit** to finish. You can finish even if something failed - the integration will keep trying to connect afterwards.",
-        "submit": "Finish setup"
+        "submit": "Finish setup",
+        "data": {
+          "action": "What next"
+        },
+        "data_description": {
+          "action": "Retry checks the bed again without losing the settings you just entered."
+        }
       },
       "diagnostic": {
         "title": "Browse Unsupported BLE Devices",
@@ -854,6 +875,9 @@
     },
     "invalid_position_range": {
       "message": "Position {position} is out of range for motor \"{motor}\". Valid range: 0-{max_value}{unit}."
+    },
+    "multiple_device_targets_not_supported": {
+      "message": "Support bundle generation only supports one configured device at a time. Select a single device or use target_address for an unconfigured bed."
     }
   },
   "issues": {

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -60,7 +60,20 @@
           "idle_disconnect_seconds": "Idle disconnect timeout (seconds)",
           "octo_pin": "Octo PIN",
           "jensen_pin": "Jensen PIN",
-          "auto_detect_option": "Auto-detect (recommended)"
+          "auto_detect_option": "Auto-detect (recommended)",
+          "transport_direct": "Transport: direct Bluetooth",
+          "transport_proxy": "Transport: Bluetooth proxy",
+          "transport_unknown": "Transport: Bluetooth",
+          "transport_likely": "Likely connection",
+          "transport_signal": "Signal strength",
+          "transport_none": "No adapter can see this device",
+          "transport_local_alternative": "Local adapter also in range",
+          "transport_preferred_unavailable": "Selected adapter unavailable",
+          "transport_not_guaranteed": "Path is a prediction",
+          "transport_proxy_pairing_warning": "Pairing over a proxy",
+          "transport_all_busy": "No free Bluetooth connections",
+          "transport_actual": "Connected over",
+          "transport_actual_differs": "Path differed from the prediction"
         },
         "data_description": {
           "bed_type": "Auto-detected bed type. Change if detection was incorrect. Options are controller protocols, not mattress brands; example beds are shown in parentheses. See the Supported Actuators guide if unsure.",
@@ -83,7 +96,7 @@
           "transport_likely": "Likely connection: {kind} · {scanner}{signal}",
           "transport_signal": " · {rssi} dBm",
           "transport_none": "⚠️ No Bluetooth adapter or proxy can currently see this device. You can still finish setup; Home Assistant will connect when it appears.",
-          "transport_local_alternative": "A Bluetooth adapter on this Home Assistant host ({scanner}) can also see it, with a weaker signal.",
+          "transport_local_alternative": "A Bluetooth adapter on this Home Assistant host ({scanner}) can also see it.",
           "transport_preferred_unavailable": "⚠️ The selected adapter ({adapter}) cannot currently see this device, so Home Assistant will choose a path automatically.",
           "transport_not_guaranteed": "Home Assistant picks the path when it connects, so this is a prediction rather than a guarantee.",
           "transport_proxy_pairing_warning": "⚠️ This bed needs Bluetooth pairing, and pairing over a proxy stores the bond on the proxy rather than on Home Assistant. If you later move the bed to a different proxy or to a Home Assistant adapter, you will have to pair again. Home Assistant also cannot remove a bond that lives on a proxy.",
@@ -912,6 +925,14 @@
     "octo_pin_required": {
       "title": "PIN required for {name}",
       "description": "**{name}** ({address}) is an Octo receiver whose PIN lock is engaged, and no PIN is configured in Home Assistant.\n\nA locked receiver still connects and still reports its capabilities, but it will not act on commands until it is authenticated, so the controls appear to work while the bed does nothing.\n\n**If you know the PIN:** open the OCTO Smart Control app (or your bed brand's version of it) to look it up, then enter it under **Settings → Devices & services → Adjustable Bed → Configure → Octo PIN**.\n\n**If the PIN is lost:** there is no factory-default PIN. OCTO publishes a reset procedure per receiver at {recovery_url} — select yours by its photo. The two common ones are pressing the button on the controller *10 times in quick succession* (Receiver II / RC2, BrickMini Basic), or *once briefly then once long for about 10 seconds* (Brick 2 and others). Micro Lift receivers are reset from the remote instead.\n\n⚠️ Every one of those is a full factory reset: all settings are irrevocably deleted and the remotes must be re-taught. A reset receiver has no PIN and is no longer locked."
+    }
+  },
+  "selector": {
+    "verify_action": {
+      "options": {
+        "finish": "Finish setup anyway",
+        "retry": "Check again"
+      }
     }
   }
 }

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -288,7 +288,21 @@
         "data_description": {
           "address": "MAC address in format XX:XX:XX:XX:XX:XX"
         }
+      },
+      "setup_progress": {
+        "title": "Checking the connection",
+        "description": "Checking **{name}** ({address})…"
       }
+    },
+    "progress": {
+      "locating": "Looking for the bed…",
+      "connecting": "Connecting over Bluetooth…",
+      "discovering_services": "Discovering Bluetooth services…",
+      "reading_capabilities": "Reading device information…",
+      "pairing": "Pairing with the bed…",
+      "verifying_bond": "Verifying the Bluetooth bond…",
+      "disconnecting": "Disconnecting…",
+      "unpairing": "Removing the Bluetooth bond…"
     },
     "abort": {
       "already_configured": "This Bluetooth address already belongs to an Adjustable Bed entry. Check both active and ignored Adjustable Bed entries under Settings > Devices & services, then reload or reconfigure that entry instead of adding it again.",

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -97,7 +97,7 @@
           "transport_signal": "· {rssi} dBm",
           "transport_none": "⚠️ No Bluetooth adapter or proxy can currently see this device. You can still finish setup; Home Assistant will connect when it appears.",
           "transport_local_alternative": "A Bluetooth adapter on this Home Assistant host ({scanner}) can also see it.",
-          "transport_preferred_unavailable": "⚠️ The selected adapter ({adapter}) cannot currently see this device, so Home Assistant will choose a path automatically.",
+          "transport_preferred_unavailable": "⚠️ The selected adapter ({adapter}) is not currently available for this connection. Select Automatic to let Home Assistant choose another path, or restore the selected adapter before continuing.",
           "transport_not_guaranteed": "Home Assistant picks the path when it connects, so this is a prediction rather than a guarantee.",
           "transport_proxy_pairing_warning": "⚠️ This bed needs Bluetooth pairing, and pairing over a proxy stores the bond on the proxy rather than on Home Assistant. If you later move the bed to a different proxy or to a Home Assistant adapter, you will have to pair again. Home Assistant also cannot remove a bond that lives on a proxy.",
           "transport_all_busy": "⚠️ Every adapter that can see this device is currently out of free Bluetooth connections.",
@@ -244,7 +244,7 @@
       },
       "bluetooth_pairing": {
         "title": "Bluetooth Pairing Required",
-        "description": "**{name}** requires Bluetooth pairing.\n\n**To pair:**\n{pairing_instructions}\n\nIf you've already paired manually via system Bluetooth settings, click 'Skip'.",
+        "description": "**{name}** requires Bluetooth pairing.\n\n{transport}\n\n**To pair:**\n{pairing_instructions}\n\nIf you've already paired manually via system Bluetooth settings, click 'Skip'.",
         "data": {
           "action": "Action",
           "pairing_instructions_generic": "Pairing instructions (generic)",
@@ -261,14 +261,14 @@
       },
       "manual_pairing": {
         "title": "Bluetooth Pairing Required",
-        "description": "**{name}** requires Bluetooth pairing.\n\n**To pair:**\n{pairing_instructions}\n\nIf you've already paired manually via system Bluetooth settings, click 'Skip'.",
+        "description": "**{name}** requires Bluetooth pairing.\n\n{transport}\n\n**To pair:**\n{pairing_instructions}\n\nIf you've already paired manually via system Bluetooth settings, click 'Skip'.",
         "data": {
           "action": "Action"
         }
       },
       "verify_connection": {
         "title": "Verify Connection",
-        "description": "Checked the connection to **{name}** before finishing setup:\n\n{capabilities}\n\nSelect **Submit** to finish. You can finish even if something failed - the integration will keep trying to connect afterwards.",
+        "description": "Checked the connection to **{name}** before finishing setup:\n\n{capabilities}\n\nChoose what to do next, then submit. You can finish even if something failed, or retry the connection checks without losing your settings.",
         "submit": "Finish setup",
         "data": {
           "action": "What next"

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -94,7 +94,7 @@
           "transport_proxy": "Bluetooth proxy",
           "transport_unknown": "Bluetooth",
           "transport_likely": "Likely connection: {kind} · {scanner}{signal}",
-          "transport_signal": " · {rssi} dBm",
+          "transport_signal": "· {rssi} dBm",
           "transport_none": "⚠️ No Bluetooth adapter or proxy can currently see this device. You can still finish setup; Home Assistant will connect when it appears.",
           "transport_local_alternative": "A Bluetooth adapter on this Home Assistant host ({scanner}) can also see it.",
           "transport_preferred_unavailable": "⚠️ The selected adapter ({adapter}) cannot currently see this device, so Home Assistant will choose a path automatically.",

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -42,7 +42,7 @@
       },
       "bluetooth_confirm": {
         "title": "Confirm Adjustable Bed",
-        "description": "Do you want to set up {name} ({address})?\n{detection_note}\n\n{report_note}",
+        "description": "Do you want to set up {name} ({address})?\n{detection_note}\n\n{transport}\n\n{report_note}",
         "data": {
           "bed_type": "Bed type",
           "name": "Name",
@@ -76,7 +76,20 @@
           "disconnect_after_command": "Disconnect from the bed immediately after each command to free up the BLE connection for the physical remote. Recommended for beds that only allow one connection at a time.",
           "idle_disconnect_seconds": "How many seconds to wait before automatically disconnecting when idle (10-300). Lower values free up the connection faster for the physical remote, higher values reduce reconnection overhead.",
           "octo_pin": "PIN code for Octo bed authentication. Required to maintain connection. Leave empty if your bed doesn't require a PIN.",
-          "jensen_pin": "PIN code for Jensen bed authentication. Default PIN is 3060."
+          "jensen_pin": "PIN code for Jensen bed authentication. Default PIN is 3060.",
+          "transport_direct": "Direct Bluetooth",
+          "transport_proxy": "Bluetooth proxy",
+          "transport_unknown": "Bluetooth",
+          "transport_likely": "Likely connection: {kind} · {scanner}{signal}",
+          "transport_signal": " · {rssi} dBm",
+          "transport_none": "⚠️ No Bluetooth adapter or proxy can currently see this device. You can still finish setup; Home Assistant will connect when it appears.",
+          "transport_local_alternative": "A Bluetooth adapter on this Home Assistant host ({scanner}) can also see it, with a weaker signal.",
+          "transport_preferred_unavailable": "⚠️ The selected adapter ({adapter}) cannot currently see this device, so Home Assistant will choose a path automatically.",
+          "transport_not_guaranteed": "Home Assistant picks the path when it connects, so this is a prediction rather than a guarantee.",
+          "transport_proxy_pairing_warning": "⚠️ This bed needs Bluetooth pairing, and pairing over a proxy stores the bond on the proxy rather than on Home Assistant. If you later move the bed to a different proxy or to a Home Assistant adapter, you will have to pair again. Home Assistant also cannot remove a bond that lives on a proxy.",
+          "transport_all_busy": "⚠️ Every adapter that can see this device is currently out of free Bluetooth connections.",
+          "transport_actual": "Connected over: {kind} · {scanner}{signal}",
+          "transport_actual_differs": "Home Assistant used a different path than predicted ({predicted})."
         }
       },
       "manual": {
@@ -88,7 +101,7 @@
       },
       "manual_config": {
         "title": "Configure Bed - {name}",
-        "description": "Configure the bed at {address}.{setup_note}",
+        "description": "Configure the bed at {address}.{setup_note}\n\n{transport}",
         "data": {
           "bed_type": "Bed type",
           "protocol_variant": "Protocol variant",
@@ -243,7 +256,13 @@
       "verify_connection": {
         "title": "Verify Connection",
         "description": "Checked the connection to **{name}** before finishing setup:\n\n{capabilities}\n\nSelect **Submit** to finish. You can finish even if something failed - the integration will keep trying to connect afterwards.",
-        "submit": "Finish setup"
+        "submit": "Finish setup",
+        "data": {
+          "action": "What next"
+        },
+        "data_description": {
+          "action": "Retry checks the bed again without losing the settings you just entered."
+        }
       },
       "diagnostic": {
         "title": "Browse Unsupported BLE Devices",

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -268,7 +268,7 @@
       },
       "verify_connection": {
         "title": "Verify Connection",
-        "description": "Checked the connection to **{name}** before finishing setup:\n\n{capabilities}\n\nChoose what to do next, then submit. You can finish even if something failed, or retry the connection checks without losing your settings.",
+        "description": "Checked the connection to **{name}** before finishing setup:\n\n{capabilities}\n\nSubmitting finishes setup. A failed check never blocks it, and the integration keeps trying to connect afterwards.",
         "submit": "Finish setup",
         "data": {
           "action": "What next"

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -60,7 +60,20 @@
           "idle_disconnect_seconds": "Idle disconnect timeout (seconds)",
           "octo_pin": "Octo PIN",
           "jensen_pin": "Jensen PIN",
-          "auto_detect_option": "Auto-detect (recommended)"
+          "auto_detect_option": "Auto-detect (recommended)",
+          "transport_direct": "Transport: direct Bluetooth",
+          "transport_proxy": "Transport: Bluetooth proxy",
+          "transport_unknown": "Transport: Bluetooth",
+          "transport_likely": "Likely connection",
+          "transport_signal": "Signal strength",
+          "transport_none": "No adapter can see this device",
+          "transport_local_alternative": "Local adapter also in range",
+          "transport_preferred_unavailable": "Selected adapter unavailable",
+          "transport_not_guaranteed": "Path is a prediction",
+          "transport_proxy_pairing_warning": "Pairing over a proxy",
+          "transport_all_busy": "No free Bluetooth connections",
+          "transport_actual": "Connected over",
+          "transport_actual_differs": "Path differed from the prediction"
         },
         "data_description": {
           "bed_type": "Auto-detected bed type. Change if detection was incorrect. Options are controller protocols, not mattress brands; example beds are shown in parentheses. See the Supported Actuators guide if unsure.",
@@ -83,7 +96,7 @@
           "transport_likely": "Likely connection: {kind} · {scanner}{signal}",
           "transport_signal": " · {rssi} dBm",
           "transport_none": "⚠️ No Bluetooth adapter or proxy can currently see this device. You can still finish setup; Home Assistant will connect when it appears.",
-          "transport_local_alternative": "A Bluetooth adapter on this Home Assistant host ({scanner}) can also see it, with a weaker signal.",
+          "transport_local_alternative": "A Bluetooth adapter on this Home Assistant host ({scanner}) can also see it.",
           "transport_preferred_unavailable": "⚠️ The selected adapter ({adapter}) cannot currently see this device, so Home Assistant will choose a path automatically.",
           "transport_not_guaranteed": "Home Assistant picks the path when it connects, so this is a prediction rather than a guarantee.",
           "transport_proxy_pairing_warning": "⚠️ This bed needs Bluetooth pairing, and pairing over a proxy stores the bond on the proxy rather than on Home Assistant. If you later move the bed to a different proxy or to a Home Assistant adapter, you will have to pair again. Home Assistant also cannot remove a bond that lives on a proxy.",
@@ -912,6 +925,14 @@
     "octo_pin_required": {
       "title": "PIN required for {name}",
       "description": "**{name}** ({address}) is an Octo receiver whose PIN lock is engaged, and no PIN is configured in Home Assistant.\n\nA locked receiver still connects and still reports its capabilities, but it will not act on commands until it is authenticated, so the controls appear to work while the bed does nothing.\n\n**If you know the PIN:** open the OCTO Smart Control app (or your bed brand's version of it) to look it up, then enter it under **Settings → Devices & services → Adjustable Bed → Configure → Octo PIN**.\n\n**If the PIN is lost:** there is no factory-default PIN. OCTO publishes a reset procedure per receiver at {recovery_url} — select yours by its photo. The two common ones are pressing the button on the controller *10 times in quick succession* (Receiver II / RC2, BrickMini Basic), or *once briefly then once long for about 10 seconds* (Brick 2 and others). Micro Lift receivers are reset from the remote instead.\n\n⚠️ Every one of those is a full factory reset: all settings are irrevocably deleted and the remotes must be re-taught. A reset receiver has no PIN and is no longer locked."
+    }
+  },
+  "selector": {
+    "verify_action": {
+      "options": {
+        "finish": "Finish setup anyway",
+        "retry": "Check again"
+      }
     }
   }
 }

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -288,7 +288,21 @@
         "data_description": {
           "address": "MAC address in format XX:XX:XX:XX:XX:XX"
         }
+      },
+      "setup_progress": {
+        "title": "Checking the connection",
+        "description": "Checking **{name}** ({address})…"
       }
+    },
+    "progress": {
+      "locating": "Looking for the bed…",
+      "connecting": "Connecting over Bluetooth…",
+      "discovering_services": "Discovering Bluetooth services…",
+      "reading_capabilities": "Reading device information…",
+      "pairing": "Pairing with the bed…",
+      "verifying_bond": "Verifying the Bluetooth bond…",
+      "disconnecting": "Disconnecting…",
+      "unpairing": "Removing the Bluetooth bond…"
     },
     "abort": {
       "already_configured": "This Bluetooth address already belongs to an Adjustable Bed entry. Check both active and ignored Adjustable Bed entries under Settings > Devices & services, then reload or reconfigure that entry instead of adding it again.",

--- a/custom_components/adjustable_bed/translations/nb.json
+++ b/custom_components/adjustable_bed/translations/nb.json
@@ -10,7 +10,7 @@
           "transport_signal": "· {rssi} dBm",
           "transport_none": "⚠️ Ingen Bluetooth-adapter eller proxy ser denne enheten akkurat nå. Du kan likevel fullføre oppsettet; Home Assistant kobler til når sengen dukker opp.",
           "transport_local_alternative": "En Bluetooth-adapter på denne Home Assistant-verten ({scanner}) ser den også.",
-          "transport_preferred_unavailable": "⚠️ Den valgte adapteren ({adapter}) ser ikke denne enheten akkurat nå, så Home Assistant velger vei automatisk.",
+          "transport_preferred_unavailable": "⚠️ Den valgte adapteren ({adapter}) er ikke tilgjengelig for denne tilkoblingen akkurat nå. Velg Automatisk for å la Home Assistant velge en annen vei, eller gjør den valgte adapteren tilgjengelig før du fortsetter.",
           "transport_not_guaranteed": "Home Assistant velger vei når den kobler til, så dette er en antakelse og ingen garanti.",
           "transport_proxy_pairing_warning": "⚠️ Denne sengen krever Bluetooth-paring, og paring via en proxy lagrer koblingen på proxyen i stedet for på Home Assistant. Flytter du senere sengen til en annen proxy eller til en adapter på Home Assistant, må du pare på nytt. Home Assistant kan heller ikke fjerne en kobling som ligger på en proxy.",
           "transport_all_busy": "⚠️ Ingen av adapterne som ser denne enheten har ledige Bluetooth-tilkoblinger.",

--- a/custom_components/adjustable_bed/translations/nb.json
+++ b/custom_components/adjustable_bed/translations/nb.json
@@ -8,12 +8,12 @@
           "transport_unknown": "Bluetooth",
           "transport_likely": "Sannsynlig tilkobling: {kind} · {scanner}{signal}",
           "transport_signal": "· {rssi} dBm",
-          "transport_none": "⚠️ Ingen Bluetooth-adapter eller proxy ser denne enheten akkurat nå. Du kan likevel fullføre oppsettet; Home Assistant kobler til når den dukker opp.",
+          "transport_none": "⚠️ Ingen Bluetooth-adapter eller proxy ser denne enheten akkurat nå. Du kan likevel fullføre oppsettet; Home Assistant kobler til når sengen dukker opp.",
           "transport_local_alternative": "En Bluetooth-adapter på denne Home Assistant-verten ({scanner}) ser den også.",
           "transport_preferred_unavailable": "⚠️ Den valgte adapteren ({adapter}) ser ikke denne enheten akkurat nå, så Home Assistant velger vei automatisk.",
-          "transport_not_guaranteed": "Home Assistant velger vei i det den kobler til, så dette er en antakelse og ingen garanti.",
+          "transport_not_guaranteed": "Home Assistant velger vei når den kobler til, så dette er en antakelse og ingen garanti.",
           "transport_proxy_pairing_warning": "⚠️ Denne sengen krever Bluetooth-paring, og paring via en proxy lagrer koblingen på proxyen i stedet for på Home Assistant. Flytter du senere sengen til en annen proxy eller til en adapter på Home Assistant, må du pare på nytt. Home Assistant kan heller ikke fjerne en kobling som ligger på en proxy.",
-          "transport_all_busy": "⚠️ Alle adaptere som ser denne enheten er tomme for ledige Bluetooth-tilkoblinger.",
+          "transport_all_busy": "⚠️ Ingen av adapterne som ser denne enheten har ledige Bluetooth-tilkoblinger.",
           "transport_actual": "Koblet til via: {kind} · {scanner}{signal}",
           "transport_actual_differs": "Home Assistant brukte en annen vei enn antatt ({predicted})."
         }
@@ -23,7 +23,7 @@
           "action": "Hva nå"
         },
         "data_description": {
-          "action": "Prøv igjen sjekker sengen på nytt uten at du mister innstillingene du nettopp fylte ut."
+          "action": "«Sjekk på nytt» sjekker sengen en gang til uten at du mister innstillingene du nettopp fylte ut."
         }
       },
       "setup_progress": {

--- a/custom_components/adjustable_bed/translations/nb.json
+++ b/custom_components/adjustable_bed/translations/nb.json
@@ -1,0 +1,31 @@
+{
+  "config": {
+    "step": {
+      "bluetooth_confirm": {
+        "data_description": {
+          "transport_direct": "Direkte Bluetooth",
+          "transport_proxy": "Bluetooth-proxy",
+          "transport_unknown": "Bluetooth",
+          "transport_likely": "Sannsynlig tilkobling: {kind} · {scanner}{signal}",
+          "transport_signal": " · {rssi} dBm",
+          "transport_none": "⚠️ Ingen Bluetooth-adapter eller proxy ser denne enheten akkurat nå. Du kan likevel fullføre oppsettet; Home Assistant kobler til når den dukker opp.",
+          "transport_local_alternative": "En Bluetooth-adapter på denne Home Assistant-verten ({scanner}) ser den også, med svakere signal.",
+          "transport_preferred_unavailable": "⚠️ Den valgte adapteren ({adapter}) ser ikke denne enheten akkurat nå, så Home Assistant velger vei automatisk.",
+          "transport_not_guaranteed": "Home Assistant velger vei i det den kobler til, så dette er en antakelse og ingen garanti.",
+          "transport_proxy_pairing_warning": "⚠️ Denne sengen krever Bluetooth-paring, og paring via en proxy lagrer koblingen på proxyen i stedet for på Home Assistant. Flytter du senere sengen til en annen proxy eller til en adapter på Home Assistant, må du pare på nytt. Home Assistant kan heller ikke fjerne en kobling som ligger på en proxy.",
+          "transport_all_busy": "⚠️ Alle adaptere som ser denne enheten er tomme for ledige Bluetooth-tilkoblinger.",
+          "transport_actual": "Koblet til via: {kind} · {scanner}{signal}",
+          "transport_actual_differs": "Home Assistant brukte en annen vei enn antatt ({predicted})."
+        }
+      },
+      "verify_connection": {
+        "data": {
+          "action": "Hva nå"
+        },
+        "data_description": {
+          "action": "Prøv igjen sjekker sengen på nytt uten at du mister innstillingene du nettopp fylte ut."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/adjustable_bed/translations/nb.json
+++ b/custom_components/adjustable_bed/translations/nb.json
@@ -7,7 +7,7 @@
           "transport_proxy": "Bluetooth-proxy",
           "transport_unknown": "Bluetooth",
           "transport_likely": "Sannsynlig tilkobling: {kind} · {scanner}{signal}",
-          "transport_signal": " · {rssi} dBm",
+          "transport_signal": "· {rssi} dBm",
           "transport_none": "⚠️ Ingen Bluetooth-adapter eller proxy ser denne enheten akkurat nå. Du kan likevel fullføre oppsettet; Home Assistant kobler til når den dukker opp.",
           "transport_local_alternative": "En Bluetooth-adapter på denne Home Assistant-verten ({scanner}) ser den også.",
           "transport_preferred_unavailable": "⚠️ Den valgte adapteren ({adapter}) ser ikke denne enheten akkurat nå, så Home Assistant velger vei automatisk.",

--- a/custom_components/adjustable_bed/translations/nb.json
+++ b/custom_components/adjustable_bed/translations/nb.json
@@ -24,7 +24,8 @@
         },
         "data_description": {
           "action": "«Sjekk på nytt» sjekker sengen en gang til uten at du mister innstillingene du nettopp fylte ut."
-        }
+        },
+        "description": "Sjekket tilkoblingen til **{name}** før oppsettet fullføres:\n\n{capabilities}\n\nÅ sende inn fullfører oppsettet. En mislykket sjekk blokkerer det aldri, og integrasjonen fortsetter å prøve å koble til etterpå."
       },
       "setup_progress": {
         "title": "Sjekker tilkoblingen",

--- a/custom_components/adjustable_bed/translations/nb.json
+++ b/custom_components/adjustable_bed/translations/nb.json
@@ -25,7 +25,21 @@
         "data_description": {
           "action": "Prøv igjen sjekker sengen på nytt uten at du mister innstillingene du nettopp fylte ut."
         }
+      },
+      "setup_progress": {
+        "title": "Sjekker tilkoblingen",
+        "description": "Sjekker **{name}** ({address})…"
       }
+    },
+    "progress": {
+      "locating": "Leter etter sengen…",
+      "connecting": "Kobler til over Bluetooth…",
+      "discovering_services": "Finner Bluetooth-tjenester…",
+      "reading_capabilities": "Leser enhetsinformasjon…",
+      "pairing": "Parer med sengen…",
+      "verifying_bond": "Bekrefter Bluetooth-koblingen…",
+      "disconnecting": "Kobler fra…",
+      "unpairing": "Fjerner Bluetooth-koblingen…"
     }
   }
 }

--- a/custom_components/adjustable_bed/translations/nb.json
+++ b/custom_components/adjustable_bed/translations/nb.json
@@ -9,7 +9,7 @@
           "transport_likely": "Sannsynlig tilkobling: {kind} · {scanner}{signal}",
           "transport_signal": " · {rssi} dBm",
           "transport_none": "⚠️ Ingen Bluetooth-adapter eller proxy ser denne enheten akkurat nå. Du kan likevel fullføre oppsettet; Home Assistant kobler til når den dukker opp.",
-          "transport_local_alternative": "En Bluetooth-adapter på denne Home Assistant-verten ({scanner}) ser den også, med svakere signal.",
+          "transport_local_alternative": "En Bluetooth-adapter på denne Home Assistant-verten ({scanner}) ser den også.",
           "transport_preferred_unavailable": "⚠️ Den valgte adapteren ({adapter}) ser ikke denne enheten akkurat nå, så Home Assistant velger vei automatisk.",
           "transport_not_guaranteed": "Home Assistant velger vei i det den kobler til, så dette er en antakelse og ingen garanti.",
           "transport_proxy_pairing_warning": "⚠️ Denne sengen krever Bluetooth-paring, og paring via en proxy lagrer koblingen på proxyen i stedet for på Home Assistant. Flytter du senere sengen til en annen proxy eller til en adapter på Home Assistant, må du pare på nytt. Home Assistant kan heller ikke fjerne en kobling som ligger på en proxy.",
@@ -40,6 +40,14 @@
       "verifying_bond": "Bekrefter Bluetooth-koblingen…",
       "disconnecting": "Kobler fra…",
       "unpairing": "Fjerner Bluetooth-koblingen…"
+    }
+  },
+  "selector": {
+    "verify_action": {
+      "options": {
+        "finish": "Fullfør oppsettet likevel",
+        "retry": "Sjekk på nytt"
+      }
     }
   }
 }

--- a/custom_components/adjustable_bed/validators.py
+++ b/custom_components/adjustable_bed/validators.py
@@ -112,6 +112,8 @@ def get_available_adapters(hass: HomeAssistant) -> dict[str, str]:
     try:
         from homeassistant.components.bluetooth import async_current_scanners
 
+        from .bluetooth_transport import TransportClass, classify_scanner
+
         for scanner in async_current_scanners(hass):
             source = getattr(scanner, "source", None)
             name = getattr(scanner, "name", None)
@@ -124,10 +126,17 @@ def get_available_adapters(hass: HomeAssistant) -> dict[str, str]:
                         adapters[source] = name
                     else:
                         adapters[source] = f"{name} ({source})"
-                elif ":" in source:
-                    adapters[source] = f"Bluetooth Proxy ({source})"
                 else:
-                    adapters[source] = f"Local Adapter ({source})"
+                    # Classify from the scanner object. The old test here was
+                    # `":" in source`, which reads a local adapter's own MAC
+                    # address as evidence of a remote proxy.
+                    transport = classify_scanner(scanner)
+                    if transport is TransportClass.PROXY:
+                        adapters[source] = f"Bluetooth Proxy ({source})"
+                    elif transport is TransportClass.LOCAL:
+                        adapters[source] = f"Local Adapter ({source})"
+                    else:
+                        adapters[source] = f"Bluetooth Adapter ({source})"
     except ImportError:
         _LOGGER.debug("async_current_scanners not available")
     except Exception as err:

--- a/tests/test_bluetooth_freshness.py
+++ b/tests/test_bluetooth_freshness.py
@@ -1,0 +1,356 @@
+"""Tests for the fresh-advertisement gate (issue #458)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.adjustable_bed.bluetooth_freshness import (
+    MAX_ADVERTISEMENT_AGE_SECONDS,
+    RSSI_INVALIDATED,
+    FreshnessStatus,
+    async_check_advertisement,
+    async_gate_connection,
+    async_wait_for_advertisement,
+)
+
+TEST_ADDRESS = "AA:BB:CC:DD:EE:FF"
+
+_FRESHNESS = "custom_components.adjustable_bed.bluetooth_freshness"
+
+# A fixed "now" keeps the age arithmetic exact instead of racing the clock.
+NOW = 10_000.0
+
+
+@pytest.fixture(autouse=True)
+def _frozen_clock():
+    """Freeze the coarse monotonic clock the gate compares against."""
+    with patch(f"{_FRESHNESS}._monotonic", return_value=NOW):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _no_path_lookup():
+    """Transport labelling is covered by its own tests."""
+    with patch(f"{_FRESHNESS}.async_path_for_source", return_value=None):
+        yield
+
+
+def _service_info(*, age: float | None, rssi: int | None = -60, source: str = "hci0") -> Any:
+    """Build a stand-in advertisement snapshot with a chosen age."""
+    return SimpleNamespace(
+        source=source,
+        rssi=rssi,
+        time=None if age is None else NOW - age,
+        address=TEST_ADDRESS,
+    )
+
+
+def _patch_last_service_info(service_info: Any):
+    return patch(
+        f"{_FRESHNESS}.bluetooth.async_last_service_info",
+        return_value=service_info,
+    )
+
+
+class TestFreshnessStatus:
+    """The gate must only pass evidence it can actually stand behind."""
+
+    async def test_recent_advertisement_is_fresh(self, hass: HomeAssistant) -> None:
+        with _patch_last_service_info(_service_info(age=2.0)):
+            evidence = async_check_advertisement(hass, TEST_ADDRESS)
+        assert evidence.status is FreshnessStatus.FRESH
+        assert evidence.is_fresh
+        assert evidence.age_seconds == pytest.approx(2.0)
+
+    async def test_expired_advertisement_is_stale(self, hass: HomeAssistant) -> None:
+        with _patch_last_service_info(
+            _service_info(age=MAX_ADVERTISEMENT_AGE_SECONDS + 1)
+        ):
+            evidence = async_check_advertisement(hass, TEST_ADDRESS)
+        assert evidence.status is FreshnessStatus.STALE
+        assert not evidence.is_fresh
+
+    async def test_advertisement_exactly_at_the_limit_still_passes(
+        self, hass: HomeAssistant
+    ) -> None:
+        with _patch_last_service_info(_service_info(age=MAX_ADVERTISEMENT_AGE_SECONDS)):
+            evidence = async_check_advertisement(hass, TEST_ADDRESS)
+        assert evidence.status is FreshnessStatus.FRESH
+
+    async def test_missing_history_is_missing(self, hass: HomeAssistant) -> None:
+        with _patch_last_service_info(None):
+            evidence = async_check_advertisement(hass, TEST_ADDRESS)
+        assert evidence.status is FreshnessStatus.MISSING
+
+    async def test_invalidated_rssi_blocks_even_when_recent(
+        self, hass: HomeAssistant
+    ) -> None:
+        """BlueZ publishes -127 when it has no reading; that is not a weak signal."""
+        with _patch_last_service_info(_service_info(age=1.0, rssi=RSSI_INVALIDATED)):
+            evidence = async_check_advertisement(hass, TEST_ADDRESS)
+        assert evidence.status is FreshnessStatus.RSSI_INVALID
+        assert evidence.rssi == RSSI_INVALIDATED
+
+    async def test_rssi_below_the_invalidation_value_also_blocks(
+        self, hass: HomeAssistant
+    ) -> None:
+        with _patch_last_service_info(_service_info(age=1.0, rssi=-130)):
+            evidence = async_check_advertisement(hass, TEST_ADDRESS)
+        assert evidence.status is FreshnessStatus.RSSI_INVALID
+
+    async def test_a_weak_but_valid_signal_passes(self, hass: HomeAssistant) -> None:
+        with _patch_last_service_info(_service_info(age=1.0, rssi=-126)):
+            evidence = async_check_advertisement(hass, TEST_ADDRESS)
+        assert evidence.status is FreshnessStatus.FRESH
+
+    async def test_missing_rssi_does_not_block_a_recent_advertisement(
+        self, hass: HomeAssistant
+    ) -> None:
+        with _patch_last_service_info(_service_info(age=1.0, rssi=None)):
+            evidence = async_check_advertisement(hass, TEST_ADDRESS)
+        assert evidence.status is FreshnessStatus.FRESH
+        assert evidence.rssi is None
+
+    @pytest.mark.parametrize(
+        "bad_time", [None, "not-a-number", object(), float("nan"), float("inf")]
+    )
+    async def test_malformed_timestamp_is_unproven(
+        self, hass: HomeAssistant, bad_time: Any
+    ) -> None:
+        """Without a usable timestamp we cannot claim freshness, so we do not."""
+        info = _service_info(age=1.0)
+        info.time = bad_time
+        with _patch_last_service_info(info):
+            evidence = async_check_advertisement(hass, TEST_ADDRESS)
+        assert evidence.status is FreshnessStatus.INVALID_TIMESTAMP
+        assert not evidence.is_fresh
+
+    async def test_future_timestamp_is_unproven(self, hass: HomeAssistant) -> None:
+        """A timestamp from a different clock is not evidence of a fresh sighting."""
+        with _patch_last_service_info(_service_info(age=-30.0)):
+            evidence = async_check_advertisement(hass, TEST_ADDRESS)
+        assert evidence.status is FreshnessStatus.INVALID_TIMESTAMP
+
+    async def test_history_lookup_failure_is_treated_as_missing(
+        self, hass: HomeAssistant
+    ) -> None:
+        with patch(
+            f"{_FRESHNESS}.bluetooth.async_last_service_info",
+            side_effect=RuntimeError("no manager"),
+        ):
+            evidence = async_check_advertisement(hass, TEST_ADDRESS)
+        assert evidence.status is FreshnessStatus.MISSING
+
+
+class TestPerScannerFreshness:
+    """A chosen adapter's own view is what decides whether it can reach the bed."""
+
+    def _scanner_device(self, source: str, *, seen_at: float | None, rssi: int) -> Any:
+        return SimpleNamespace(
+            scanner=SimpleNamespace(
+                source=source,
+                discovered_device_timestamps=(
+                    {} if seen_at is None else {TEST_ADDRESS: seen_at}
+                ),
+            ),
+            advertisement=SimpleNamespace(rssi=rssi),
+        )
+
+    async def test_selected_scanner_view_is_used(self, hass: HomeAssistant) -> None:
+        devices = [
+            self._scanner_device("proxy", seen_at=NOW - 1.0, rssi=-50),
+            self._scanner_device("hci0", seen_at=NOW - 5.0, rssi=-70),
+        ]
+        with patch(
+            f"{_FRESHNESS}.bluetooth.async_scanner_devices_by_address",
+            return_value=devices,
+        ):
+            evidence = async_check_advertisement(hass, TEST_ADDRESS, source="hci0")
+        assert evidence.status is FreshnessStatus.FRESH
+        assert evidence.rssi == -70
+        assert evidence.age_seconds == pytest.approx(5.0)
+
+    async def test_stale_on_the_selected_scanner_blocks_despite_another_seeing_it(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Another proxy hearing the bed says nothing about the chosen adapter."""
+        devices = [
+            self._scanner_device("proxy", seen_at=NOW - 1.0, rssi=-50),
+            self._scanner_device(
+                "hci0", seen_at=NOW - MAX_ADVERTISEMENT_AGE_SECONDS - 10, rssi=-90
+            ),
+        ]
+        with patch(
+            f"{_FRESHNESS}.bluetooth.async_scanner_devices_by_address",
+            return_value=devices,
+        ):
+            evidence = async_check_advertisement(hass, TEST_ADDRESS, source="hci0")
+        assert evidence.status is FreshnessStatus.STALE
+
+    async def test_selected_scanner_no_longer_sees_the_bed(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Distinct from MISSING: the bed is there, the chosen adapter is not."""
+        devices = [self._scanner_device("proxy", seen_at=NOW - 1.0, rssi=-50)]
+        with patch(
+            f"{_FRESHNESS}.bluetooth.async_scanner_devices_by_address",
+            return_value=devices,
+        ):
+            evidence = async_check_advertisement(hass, TEST_ADDRESS, source="hci0")
+        assert evidence.status is FreshnessStatus.SOURCE_UNAVAILABLE
+
+
+class TestGateConnection:
+    """The BLEDevice must be resolved after the gate, never before it."""
+
+    async def test_fresh_evidence_resolves_a_current_device(
+        self, hass: HomeAssistant
+    ) -> None:
+        device = SimpleNamespace(address=TEST_ADDRESS)
+        with (
+            _patch_last_service_info(_service_info(age=1.0)),
+            patch(
+                f"{_FRESHNESS}.async_resolve_ble_device", return_value=device
+            ) as resolve,
+        ):
+            evidence, resolved = async_gate_connection(hass, TEST_ADDRESS)
+        assert evidence.is_fresh
+        assert resolved is device
+        resolve.assert_called_once()
+
+    async def test_stale_evidence_never_resolves_a_device(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Nothing may reach establish_connection once the gate has refused."""
+        with (
+            _patch_last_service_info(
+                _service_info(age=MAX_ADVERTISEMENT_AGE_SECONDS + 60)
+            ),
+            patch(f"{_FRESHNESS}.async_resolve_ble_device") as resolve,
+        ):
+            evidence, resolved = async_gate_connection(hass, TEST_ADDRESS)
+        assert not evidence.is_fresh
+        assert resolved is None
+        resolve.assert_not_called()
+
+    async def test_missing_evidence_never_resolves_a_device(
+        self, hass: HomeAssistant
+    ) -> None:
+        with (
+            _patch_last_service_info(None),
+            patch(f"{_FRESHNESS}.async_resolve_ble_device") as resolve,
+        ):
+            _evidence, resolved = async_gate_connection(hass, TEST_ADDRESS)
+        assert resolved is None
+        resolve.assert_not_called()
+
+    async def test_a_fresh_advertisement_after_a_refusal_allows_the_next_attempt(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Retry must work without restarting the flow."""
+        stale = _service_info(age=MAX_ADVERTISEMENT_AGE_SECONDS + 5)
+        fresh = _service_info(age=1.0)
+        with patch(
+            f"{_FRESHNESS}.bluetooth.async_last_service_info",
+            side_effect=[stale, fresh],
+        ):
+            assert not async_check_advertisement(hass, TEST_ADDRESS).is_fresh
+            assert async_check_advertisement(hass, TEST_ADDRESS).is_fresh
+
+
+class TestWaitForAdvertisement:
+    """A bed between advertising intervals deserves a second look, not a refusal."""
+
+    @staticmethod
+    def _advancing_clock(step: float = 1.0):
+        """Return a monotonic stand-in that moves forward on every read.
+
+        The module-level fixture freezes time so ages are exact; the wait loop
+        needs the opposite, since its only exit condition is the clock.
+        """
+        state = {"now": NOW}
+
+        def _now() -> float:
+            value = state["now"]
+            state["now"] += step
+            return value
+
+        return patch(f"{_FRESHNESS}._monotonic", side_effect=_now)
+
+    async def test_an_already_fresh_bed_returns_without_waiting(
+        self, hass: HomeAssistant
+    ) -> None:
+        device = SimpleNamespace(address=TEST_ADDRESS)
+        with (
+            _patch_last_service_info(_service_info(age=1.0)) as lookup,
+            patch(f"{_FRESHNESS}.async_resolve_ble_device", return_value=device),
+        ):
+            evidence, resolved = await async_wait_for_advertisement(hass, TEST_ADDRESS)
+        assert evidence.is_fresh
+        assert resolved is device
+        # One glance at the history, no polling.
+        assert lookup.call_count == 1
+
+    async def test_an_advertisement_arriving_during_the_wait_is_accepted(
+        self, hass: HomeAssistant
+    ) -> None:
+        device = SimpleNamespace(address=TEST_ADDRESS)
+        stale = _service_info(age=MAX_ADVERTISEMENT_AGE_SECONDS + 5)
+        fresh = _service_info(age=1.0)
+        with (
+            self._advancing_clock(step=0.0),
+            patch(
+                f"{_FRESHNESS}.bluetooth.async_last_service_info",
+                side_effect=[stale, stale, fresh],
+            ),
+            patch(f"{_FRESHNESS}.async_resolve_ble_device", return_value=device),
+        ):
+            evidence, resolved = await async_wait_for_advertisement(
+                hass, TEST_ADDRESS, wait_timeout=60.0, poll_interval=0.001
+            )
+        assert evidence.is_fresh
+        assert resolved is device
+
+    async def test_a_silent_bed_gives_up_without_resolving_a_device(
+        self, hass: HomeAssistant
+    ) -> None:
+        with (
+            self._advancing_clock(step=5.0),
+            _patch_last_service_info(
+                _service_info(age=MAX_ADVERTISEMENT_AGE_SECONDS + 5)
+            ),
+            patch(f"{_FRESHNESS}.async_resolve_ble_device") as resolve,
+        ):
+            evidence, resolved = await async_wait_for_advertisement(
+                hass, TEST_ADDRESS, wait_timeout=10.0, poll_interval=0.001
+            )
+        assert evidence.status is FreshnessStatus.STALE
+        assert resolved is None
+        resolve.assert_not_called()
+
+    async def test_progress_is_reported_over_the_known_wait(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The wait is the only setup phase whose duration is genuinely known."""
+        seen: list[float] = []
+        with (
+            self._advancing_clock(step=2.0),
+            _patch_last_service_info(
+                _service_info(age=MAX_ADVERTISEMENT_AGE_SECONDS + 5)
+            ),
+        ):
+            await async_wait_for_advertisement(
+                hass,
+                TEST_ADDRESS,
+                wait_timeout=20.0,
+                poll_interval=0.001,
+                on_progress=seen.append,
+            )
+        assert seen
+        assert all(0.0 <= value <= 1.0 for value in seen)
+        assert seen == sorted(seen)

--- a/tests/test_bluetooth_freshness.py
+++ b/tests/test_bluetooth_freshness.py
@@ -354,3 +354,4 @@ class TestWaitForAdvertisement:
         assert seen
         assert all(0.0 <= value <= 1.0 for value in seen)
         assert seen == sorted(seen)
+        assert seen[-1] == 1.0

--- a/tests/test_bluetooth_freshness.py
+++ b/tests/test_bluetooth_freshness.py
@@ -340,6 +340,27 @@ class TestWaitForAdvertisement:
         assert evidence.is_fresh
         assert resolved is device
 
+    async def test_fresh_evidence_without_a_device_keeps_waiting(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Scanner history can change between freshness and device resolution."""
+        device = SimpleNamespace(address=TEST_ADDRESS)
+        with (
+            self._advancing_clock(step=0.0),
+            _patch_last_service_info(_service_info(age=1.0)),
+            patch(
+                f"{_FRESHNESS}.async_resolve_ble_device",
+                side_effect=[None, device],
+            ) as resolve,
+        ):
+            evidence, resolved = await async_wait_for_advertisement(
+                hass, TEST_ADDRESS, wait_timeout=60.0, poll_interval=0.001
+            )
+
+        assert evidence.is_fresh
+        assert resolved is device
+        assert resolve.call_count == 2
+
     async def test_a_silent_bed_gives_up_without_resolving_a_device(
         self, hass: HomeAssistant
     ) -> None:

--- a/tests/test_bluetooth_freshness.py
+++ b/tests/test_bluetooth_freshness.py
@@ -75,6 +75,29 @@ class TestFreshnessStatus:
         assert evidence.status is FreshnessStatus.STALE
         assert not evidence.is_fresh
 
+    async def test_fresh_non_connectable_view_wins_over_stale_connectable_history(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A stale strict snapshot must not hide a proxy's current fallback view."""
+
+        def lookup(
+            _hass: HomeAssistant, _address: str, *, connectable: bool
+        ) -> Any:
+            return _service_info(
+                age=1.0 if not connectable else MAX_ADVERTISEMENT_AGE_SECONDS + 1,
+                source="proxy",
+            )
+
+        with patch(
+            f"{_FRESHNESS}.bluetooth.async_last_service_info",
+            side_effect=lookup,
+        ):
+            evidence = async_check_advertisement(hass, TEST_ADDRESS)
+
+        assert evidence.status is FreshnessStatus.FRESH
+        assert evidence.source == "proxy"
+        assert evidence.age_seconds == pytest.approx(1.0)
+
     async def test_advertisement_exactly_at_the_limit_still_passes(
         self, hass: HomeAssistant
     ) -> None:
@@ -255,9 +278,10 @@ class TestGateConnection:
         """Retry must work without restarting the flow."""
         stale = _service_info(age=MAX_ADVERTISEMENT_AGE_SECONDS + 5)
         fresh = _service_info(age=1.0)
+        # Each check consults both scanner views, so two lookups per call.
         with patch(
             f"{_FRESHNESS}.bluetooth.async_last_service_info",
-            side_effect=[stale, fresh],
+            side_effect=[stale, stale, fresh, fresh],
         ):
             assert not async_check_advertisement(hass, TEST_ADDRESS).is_fresh
             assert async_check_advertisement(hass, TEST_ADDRESS).is_fresh
@@ -293,8 +317,8 @@ class TestWaitForAdvertisement:
             evidence, resolved = await async_wait_for_advertisement(hass, TEST_ADDRESS)
         assert evidence.is_fresh
         assert resolved is device
-        # One glance at the history, no polling.
-        assert lookup.call_count == 1
+        # One glance at the history - both scanner views, but no polling.
+        assert lookup.call_count == 2
 
     async def test_an_advertisement_arriving_during_the_wait_is_accepted(
         self, hass: HomeAssistant

--- a/tests/test_bluetooth_transport.py
+++ b/tests/test_bluetooth_transport.py
@@ -1,0 +1,388 @@
+"""Tests for the transport-aware Bluetooth path model (issue #456)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.adjustable_bed.bluetooth_transport import (
+    ConnectionPath,
+    TransportClass,
+    async_connection_paths,
+    async_path_for_source,
+    async_predict_path,
+    classify_scanner,
+)
+
+TEST_ADDRESS = "AA:BB:CC:DD:EE:FF"
+
+_TRANSPORT = "custom_components.adjustable_bed.bluetooth_transport"
+
+
+def _scanner(
+    source: str,
+    *,
+    scanner_type: str,
+    name: str | None = None,
+    adapter: str | None = None,
+    connectable: bool = True,
+) -> SimpleNamespace:
+    """Build a stand-in for a Home Assistant scanner object.
+
+    Deliberately not a habluetooth instance: that forces ``classify_scanner``
+    down its declared-type path, which is the branch a non-habluetooth scanner
+    (or a future scanner class) would take.
+    """
+    return SimpleNamespace(
+        source=source,
+        name=name or source,
+        adapter=adapter,
+        connectable=connectable,
+        details=SimpleNamespace(scanner_type=scanner_type),
+    )
+
+
+def _scanner_device(scanner: Any, rssi: int | None, score: float | None = None) -> SimpleNamespace:
+    """Build a stand-in for habluetooth's BluetoothScannerDevice."""
+    return SimpleNamespace(
+        scanner=scanner,
+        ble_device=SimpleNamespace(address=TEST_ADDRESS),
+        advertisement=SimpleNamespace(rssi=rssi),
+        score_connection_path=(lambda _diff, score=score: score) if score is not None else None,
+    )
+
+
+def _patch_scanner_devices(devices: list[Any]):
+    """Patch the HA lookup that returns every scanner seeing an address."""
+    return patch(
+        f"{_TRANSPORT}.bluetooth.async_scanner_devices_by_address",
+        return_value=devices,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_scanner_registrations():
+    """Skip config-entry lookups; naming is not what these tests exercise."""
+    with patch(f"{_TRANSPORT}.async_scanner_registrations", return_value={}):
+        yield
+
+
+class TestClassifyScanner:
+    """Transport class must come from scanner objects, never from name shape."""
+
+    def test_remote_scanner_type_is_a_proxy(self) -> None:
+        assert classify_scanner(_scanner("x", scanner_type="remote")) is TransportClass.PROXY
+
+    @pytest.mark.parametrize("scanner_type", ["usb", "uart"])
+    def test_host_adapter_types_are_local(self, scanner_type: str) -> None:
+        assert classify_scanner(_scanner("x", scanner_type=scanner_type)) is TransportClass.LOCAL
+
+    def test_unclassifiable_scanner_is_unknown(self) -> None:
+        """Unknown must not silently become local: it gates destructive actions."""
+        scanner = _scanner("x", scanner_type="something-new")
+        assert classify_scanner(scanner) is TransportClass.UNKNOWN
+
+    def test_local_adapter_mac_source_is_not_mistaken_for_a_proxy(self) -> None:
+        """A host adapter's source is a MAC, which only looks remote."""
+        scanner = _scanner("AA:BB:CC:11:22:33", scanner_type="usb")
+        assert classify_scanner(scanner) is TransportClass.LOCAL
+
+    def test_proxy_named_without_esphome_is_still_a_proxy(self) -> None:
+        """Substring matching on "esphome" misses proxies from other integrations."""
+        scanner = _scanner("shelly-hall", scanner_type="remote", name="Hall Shelly")
+        assert classify_scanner(scanner) is TransportClass.PROXY
+
+    def test_real_remote_scanner_class_is_detected_without_details(self) -> None:
+        """The class hierarchy is authoritative when habluetooth is in play."""
+        from habluetooth import BaseHaRemoteScanner
+
+        class _Remote(BaseHaRemoteScanner):
+            pass
+
+        scanner = _Remote.__new__(_Remote)
+        assert classify_scanner(scanner) is TransportClass.PROXY
+
+
+class TestConnectionPaths:
+    """Ranking must reproduce Home Assistant's own connection routing."""
+
+    async def test_no_scanner_data_returns_no_paths(self, hass: HomeAssistant) -> None:
+        with _patch_scanner_devices([]):
+            assert async_connection_paths(hass, TEST_ADDRESS) == ()
+
+    async def test_local_only(self, hass: HomeAssistant) -> None:
+        devices = [_scanner_device(_scanner("hci0", scanner_type="usb"), -55)]
+        with _patch_scanner_devices(devices):
+            paths = async_connection_paths(hass, TEST_ADDRESS)
+        assert [path.transport for path in paths] == [TransportClass.LOCAL]
+        assert paths[0].rssi == -55
+
+    async def test_proxy_only(self, hass: HomeAssistant) -> None:
+        devices = [_scanner_device(_scanner("proxy", scanner_type="remote"), -70)]
+        with _patch_scanner_devices(devices):
+            paths = async_connection_paths(hass, TEST_ADDRESS)
+        assert [path.transport for path in paths] == [TransportClass.PROXY]
+
+    async def test_mixed_paths_rank_by_signal(self, hass: HomeAssistant) -> None:
+        devices = [
+            _scanner_device(_scanner("hci0", scanner_type="usb"), -80),
+            _scanner_device(_scanner("proxy", scanner_type="remote"), -50),
+        ]
+        with _patch_scanner_devices(devices):
+            paths = async_connection_paths(hass, TEST_ADDRESS)
+        assert [path.source for path in paths] == ["proxy", "hci0"]
+
+    async def test_score_overrides_raw_signal(self, hass: HomeAssistant) -> None:
+        """A busy adapter with the best RSSI loses, exactly as it does in HA."""
+        devices = [
+            _scanner_device(_scanner("busy", scanner_type="usb"), -50, score=-127.0),
+            _scanner_device(_scanner("free", scanner_type="remote"), -60, score=-60.0),
+        ]
+        with _patch_scanner_devices(devices):
+            paths = async_connection_paths(hass, TEST_ADDRESS)
+        assert [path.source for path in paths] == ["free", "busy"]
+
+    async def test_missing_rssi_sorts_last_and_reports_none(
+        self, hass: HomeAssistant
+    ) -> None:
+        devices = [
+            _scanner_device(_scanner("no-signal", scanner_type="usb"), None),
+            _scanner_device(_scanner("proxy", scanner_type="remote"), -90),
+        ]
+        with _patch_scanner_devices(devices):
+            paths = async_connection_paths(hass, TEST_ADDRESS)
+        assert [path.source for path in paths] == ["proxy", "no-signal"]
+        assert paths[1].rssi is None
+
+    async def test_unscorable_devices_keep_signal_order(self, hass: HomeAssistant) -> None:
+        """A partially scorable set must not be reshuffled by a missing score."""
+        devices = [
+            _scanner_device(_scanner("weak", scanner_type="usb"), -90, score=10.0),
+            _scanner_device(_scanner("strong", scanner_type="remote"), -40),
+        ]
+        with _patch_scanner_devices(devices):
+            paths = async_connection_paths(hass, TEST_ADDRESS)
+        assert [path.source for path in paths] == ["strong", "weak"]
+
+    async def test_lookup_failure_is_not_fatal(self, hass: HomeAssistant) -> None:
+        with patch(
+            f"{_TRANSPORT}.bluetooth.async_scanner_devices_by_address",
+            side_effect=RuntimeError("no manager"),
+        ):
+            assert async_connection_paths(hass, TEST_ADDRESS) == ()
+
+
+class TestPathPrediction:
+    """The prediction shown before setup must match what HA will really do."""
+
+    async def test_best_path_is_chosen_automatically(self, hass: HomeAssistant) -> None:
+        devices = [
+            _scanner_device(_scanner("hci0", scanner_type="usb"), -80),
+            _scanner_device(_scanner("proxy", scanner_type="remote"), -50),
+        ]
+        with _patch_scanner_devices(devices):
+            prediction = async_predict_path(hass, TEST_ADDRESS, "auto")
+        assert prediction.chosen is not None
+        assert prediction.chosen.source == "proxy"
+        assert prediction.proxy_pairing_risk is True
+
+    async def test_local_alternative_is_offered_when_a_proxy_wins(
+        self, hass: HomeAssistant
+    ) -> None:
+        devices = [
+            _scanner_device(_scanner("hci0", scanner_type="usb"), -80),
+            _scanner_device(_scanner("proxy", scanner_type="remote"), -50),
+        ]
+        with _patch_scanner_devices(devices):
+            prediction = async_predict_path(hass, TEST_ADDRESS, "auto")
+        assert prediction.local_alternative is not None
+        assert prediction.local_alternative.source == "hci0"
+
+    async def test_no_local_alternative_when_local_already_wins(
+        self, hass: HomeAssistant
+    ) -> None:
+        devices = [
+            _scanner_device(_scanner("hci0", scanner_type="usb"), -40),
+            _scanner_device(_scanner("proxy", scanner_type="remote"), -70),
+        ]
+        with _patch_scanner_devices(devices):
+            prediction = async_predict_path(hass, TEST_ADDRESS, "auto")
+        assert prediction.local_alternative is None
+        assert prediction.proxy_pairing_risk is False
+
+    async def test_preferred_adapter_overrides_ranking(self, hass: HomeAssistant) -> None:
+        devices = [
+            _scanner_device(_scanner("hci0", scanner_type="usb"), -80),
+            _scanner_device(_scanner("proxy", scanner_type="remote"), -50),
+        ]
+        with _patch_scanner_devices(devices):
+            prediction = async_predict_path(hass, TEST_ADDRESS, "hci0")
+        assert prediction.chosen is not None
+        assert prediction.chosen.source == "hci0"
+        assert prediction.preferred_available is True
+
+    async def test_preferred_adapter_that_cannot_see_the_bed_is_reported(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A disappeared preferred scanner must be visible, not silently replaced."""
+        devices = [_scanner_device(_scanner("proxy", scanner_type="remote"), -50)]
+        with _patch_scanner_devices(devices):
+            prediction = async_predict_path(hass, TEST_ADDRESS, "hci0")
+        assert prediction.preferred_available is False
+        assert prediction.chosen is not None
+        assert prediction.chosen.source == "proxy"
+
+    async def test_no_visible_scanner_predicts_nothing(self, hass: HomeAssistant) -> None:
+        with _patch_scanner_devices([]):
+            prediction = async_predict_path(hass, TEST_ADDRESS, "auto")
+        assert prediction.chosen is None
+        assert prediction.local_alternative is None
+        assert prediction.proxy_pairing_risk is False
+
+
+class TestActualPath:
+    """After connecting, the real transport must be resolvable from its source."""
+
+    async def test_source_resolves_to_a_classified_path(self, hass: HomeAssistant) -> None:
+        with patch(
+            f"{_TRANSPORT}.bluetooth.async_scanner_by_source",
+            return_value=_scanner("proxy", scanner_type="remote", name="Hall proxy"),
+        ):
+            path = async_path_for_source(hass, "proxy", rssi=-61)
+        assert path is not None
+        assert path.transport is TransportClass.PROXY
+        assert path.scanner_name == "Hall proxy"
+        assert path.rssi == -61
+
+    async def test_unknown_source_still_yields_a_path(self, hass: HomeAssistant) -> None:
+        """A source HA no longer knows is reported, not dropped."""
+        with patch(f"{_TRANSPORT}.bluetooth.async_scanner_by_source", return_value=None):
+            path = async_path_for_source(hass, "gone")
+        assert path is not None
+        assert path.transport is TransportClass.UNKNOWN
+
+    async def test_missing_source_is_none(self, hass: HomeAssistant) -> None:
+        assert async_path_for_source(hass, None) is None
+        assert async_path_for_source(hass, "unknown") is None
+
+
+class TestBondOwnership:
+    """Only a proven local path may be treated as owning a host bond."""
+
+    @pytest.mark.parametrize(
+        ("transport", "expected"),
+        [
+            (TransportClass.LOCAL, True),
+            (TransportClass.PROXY, False),
+            (TransportClass.UNKNOWN, False),
+        ],
+    )
+    def test_owns_host_bond(self, transport: TransportClass, expected: bool) -> None:
+        assert ConnectionPath(source="s", transport=transport).owns_host_bond is expected
+
+
+class TestConnectionAvailability:
+    """A path with no free connection slot is not a usable prediction."""
+
+    def _busy_local(self, source: str, free: int, slots: int = 3) -> SimpleNamespace:
+        scanner = _scanner(source, scanner_type="usb")
+        scanner.get_allocations = lambda: SimpleNamespace(slots=slots, free=free)
+        return scanner
+
+    def _proxy(self, source: str, *, can_connect: bool) -> SimpleNamespace:
+        scanner = _scanner(source, scanner_type="remote")
+        scanner.connector = SimpleNamespace(can_connect=lambda: can_connect)
+        return scanner
+
+    async def test_a_full_local_adapter_is_skipped_for_a_free_proxy(
+        self, hass: HomeAssistant
+    ) -> None:
+        devices = [
+            _scanner_device(self._busy_local("hci0", free=0), -40),
+            _scanner_device(self._proxy("proxy", can_connect=True), -80),
+        ]
+        with _patch_scanner_devices(devices):
+            prediction = async_predict_path(hass, TEST_ADDRESS, "auto")
+        assert prediction.chosen is not None
+        assert prediction.chosen.source == "proxy"
+
+    async def test_a_full_proxy_is_skipped_for_a_free_local_adapter(
+        self, hass: HomeAssistant
+    ) -> None:
+        devices = [
+            _scanner_device(self._proxy("proxy", can_connect=False), -40),
+            _scanner_device(self._busy_local("hci0", free=2), -80),
+        ]
+        with _patch_scanner_devices(devices):
+            prediction = async_predict_path(hass, TEST_ADDRESS, "auto")
+        assert prediction.chosen is not None
+        assert prediction.chosen.source == "hci0"
+
+    async def test_all_paths_busy_still_predicts_the_best_one(
+        self, hass: HomeAssistant
+    ) -> None:
+        """"Everything is full" is a truer answer than "nothing can see it"."""
+        devices = [
+            _scanner_device(self._busy_local("hci0", free=0), -40),
+            _scanner_device(self._proxy("proxy", can_connect=False), -80),
+        ]
+        with _patch_scanner_devices(devices):
+            prediction = async_predict_path(hass, TEST_ADDRESS, "auto")
+        assert prediction.chosen is not None
+        assert prediction.chosen.source == "hci0"
+        assert not any(path.can_connect for path in prediction.paths)
+
+    async def test_an_unknowable_slot_state_is_treated_as_available(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Hiding a usable path is worse than showing one that turns out busy."""
+        devices = [_scanner_device(_scanner("hci0", scanner_type="usb"), -40)]
+        with _patch_scanner_devices(devices):
+            paths = async_connection_paths(hass, TEST_ADDRESS)
+        assert paths[0].can_connect is True
+
+
+class TestAdapterPickerLabels:
+    """The adapter picker must not label a host adapter as a proxy."""
+
+    async def test_local_adapter_with_a_mac_source_is_labelled_local(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The old test was `":" in source`, which every local MAC satisfies."""
+        from custom_components.adjustable_bed.validators import get_available_adapters
+
+        scanner = _scanner("AA:BB:CC:11:22:33", scanner_type="usb")
+        scanner.name = scanner.source  # no friendlier name available
+        with patch(
+            "homeassistant.components.bluetooth.async_current_scanners",
+            return_value=[scanner],
+        ):
+            adapters = get_available_adapters(hass)
+        assert adapters["AA:BB:CC:11:22:33"] == "Local Adapter (AA:BB:CC:11:22:33)"
+
+    async def test_remote_scanner_is_labelled_a_proxy(self, hass: HomeAssistant) -> None:
+        from custom_components.adjustable_bed.validators import get_available_adapters
+
+        scanner = _scanner("proxy-1", scanner_type="remote")
+        scanner.name = scanner.source
+        with patch(
+            "homeassistant.components.bluetooth.async_current_scanners",
+            return_value=[scanner],
+        ):
+            adapters = get_available_adapters(hass)
+        assert adapters["proxy-1"] == "Bluetooth Proxy (proxy-1)"
+
+    async def test_a_friendly_name_is_still_preferred(self, hass: HomeAssistant) -> None:
+        from custom_components.adjustable_bed.validators import get_available_adapters
+
+        scanner = _scanner("proxy-1", scanner_type="remote", name="Hall proxy")
+        with patch(
+            "homeassistant.components.bluetooth.async_current_scanners",
+            return_value=[scanner],
+        ):
+            adapters = get_available_adapters(hass)
+        assert adapters["proxy-1"] == "Hall proxy (proxy-1)"

--- a/tests/test_bluetooth_transport.py
+++ b/tests/test_bluetooth_transport.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -15,6 +15,7 @@ from custom_components.adjustable_bed.bluetooth_transport import (
     async_connection_paths,
     async_path_for_source,
     async_predict_path,
+    async_resolve_ble_device,
     classify_scanner,
 )
 
@@ -146,6 +147,27 @@ class TestConnectionPaths:
             paths = async_connection_paths(hass, TEST_ADDRESS)
         assert [path.source for path in paths] == ["free", "busy"]
 
+    async def test_each_path_is_scored_once(self, hass: HomeAssistant) -> None:
+        """Ranking and path construction must share one slot-state snapshot."""
+        scorers = [MagicMock(return_value=-40.0), MagicMock(return_value=-60.0)]
+        devices = [
+            SimpleNamespace(
+                scanner=_scanner("hci0", scanner_type="usb"),
+                ble_device=SimpleNamespace(address=TEST_ADDRESS),
+                advertisement=SimpleNamespace(rssi=-40),
+                score_connection_path=scorers[0],
+            ),
+            SimpleNamespace(
+                scanner=_scanner("proxy", scanner_type="remote"),
+                ble_device=SimpleNamespace(address=TEST_ADDRESS),
+                advertisement=SimpleNamespace(rssi=-60),
+                score_connection_path=scorers[1],
+            ),
+        ]
+        with _patch_scanner_devices(devices):
+            async_connection_paths(hass, TEST_ADDRESS)
+        assert [scorer.call_count for scorer in scorers] == [1, 1]
+
     async def test_missing_rssi_sorts_last_and_reports_none(
         self, hass: HomeAssistant
     ) -> None:
@@ -244,6 +266,47 @@ class TestPathPrediction:
         assert prediction.proxy_pairing_risk is False
 
 
+class TestDeviceResolution:
+    """Freshness fallbacks must still produce a device that can be connected."""
+
+    async def test_preferred_source_uses_the_non_connectable_view(
+        self, hass: HomeAssistant
+    ) -> None:
+        device = SimpleNamespace(address=TEST_ADDRESS)
+        scanner_device = SimpleNamespace(
+            scanner=_scanner("proxy", scanner_type="remote"),
+            ble_device=device,
+        )
+
+        def scanner_lookup(
+            _hass: HomeAssistant, _address: str, *, connectable: bool
+        ) -> list[Any]:
+            return [] if connectable else [scanner_device]
+
+        with patch(
+            f"{_TRANSPORT}.bluetooth.async_scanner_devices_by_address",
+            side_effect=scanner_lookup,
+        ):
+            resolved = async_resolve_ble_device(hass, TEST_ADDRESS, "proxy")
+        assert resolved is device
+
+    async def test_generic_lookup_uses_the_non_connectable_view(
+        self, hass: HomeAssistant
+    ) -> None:
+        device = SimpleNamespace(address=TEST_ADDRESS)
+        lookup = MagicMock(side_effect=[None, device])
+        with patch(
+            f"{_TRANSPORT}.bluetooth.async_ble_device_from_address",
+            lookup,
+        ):
+            resolved = async_resolve_ble_device(hass, TEST_ADDRESS)
+        assert resolved is device
+        assert [call.kwargs["connectable"] for call in lookup.call_args_list] == [
+            True,
+            False,
+        ]
+
+
 class TestActualPath:
     """After connecting, the real transport must be resolvable from its source."""
 
@@ -319,6 +382,20 @@ class TestConnectionAvailability:
         ]
         with _patch_scanner_devices(devices):
             prediction = async_predict_path(hass, TEST_ADDRESS, "auto")
+        assert prediction.chosen is not None
+        assert prediction.chosen.source == "hci0"
+
+    async def test_a_full_preferred_adapter_is_skipped_for_a_free_path(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A preference cannot override HA's live connection-capacity gate."""
+        devices = [
+            _scanner_device(self._proxy("proxy", can_connect=False), -40),
+            _scanner_device(self._busy_local("hci0", free=2), -80),
+        ]
+        with _patch_scanner_devices(devices):
+            prediction = async_predict_path(hass, TEST_ADDRESS, "proxy")
+        assert prediction.preferred_available is False
         assert prediction.chosen is not None
         assert prediction.chosen.source == "hci0"
 

--- a/tests/test_bluetooth_transport.py
+++ b/tests/test_bluetooth_transport.py
@@ -197,6 +197,30 @@ class TestConnectionPaths:
         ):
             assert async_connection_paths(hass, TEST_ADDRESS) == ()
 
+    async def test_empty_connectable_view_uses_non_connectable_proxy_paths(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Prediction must describe the same fallback path resolution can use."""
+        scanner_device = _scanner_device(
+            _scanner("proxy", scanner_type="remote", connectable=False), -55
+        )
+
+        def lookup(
+            _hass: HomeAssistant, _address: str, *, connectable: bool
+        ) -> list[Any]:
+            return [] if connectable else [scanner_device]
+
+        with patch(
+            f"{_TRANSPORT}.bluetooth.async_scanner_devices_by_address",
+            side_effect=lookup,
+        ):
+            paths = async_connection_paths(hass, TEST_ADDRESS)
+
+        assert len(paths) == 1
+        assert paths[0].source == "proxy"
+        assert paths[0].transport is TransportClass.PROXY
+        assert paths[0].connectable is False
+
 
 class TestPathPrediction:
     """The prediction shown before setup must match what HA will really do."""

--- a/tests/test_bluetooth_transport.py
+++ b/tests/test_bluetooth_transport.py
@@ -260,7 +260,10 @@ class TestPathPrediction:
         assert prediction.local_alternative is None
         assert prediction.proxy_pairing_risk is False
 
-    async def test_preferred_adapter_overrides_ranking(self, hass: HomeAssistant) -> None:
+    async def test_preferred_adapter_does_not_override_ranking(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The wrapper re-ranks scanners even when resolution preferred one."""
         devices = [
             _scanner_device(_scanner("hci0", scanner_type="usb"), -80),
             _scanner_device(_scanner("proxy", scanner_type="remote"), -50),
@@ -268,7 +271,8 @@ class TestPathPrediction:
         with _patch_scanner_devices(devices):
             prediction = async_predict_path(hass, TEST_ADDRESS, "hci0")
         assert prediction.chosen is not None
-        assert prediction.chosen.source == "hci0"
+        assert prediction.chosen.source == "proxy"
+        assert prediction.preferred_adapter == "hci0"
         assert prediction.preferred_available is True
 
     async def test_preferred_adapter_that_cannot_see_the_bed_is_reported(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3248,6 +3248,7 @@ async def test_a_not_advertising_bed_offers_retry_and_still_allows_finishing(
         assert verify["step_id"] == "verify_connection"
         caps = verify["description_placeholders"]["capabilities"]
         assert "not currently advertising" in caps
+        assert "select **Check again**" in caps
         # Nothing may reach the BLE stack once the gate has refused.
         connects.assert_not_called()
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -168,10 +168,12 @@ async def _advance_progress(hass: HomeAssistant, result: Any) -> Any:
     Setup now runs its BLE work as a background task behind a progress view, so
     a submitted form returns SHOW_PROGRESS rather than the next form.
     """
-    while result["type"] == FlowResultType.SHOW_PROGRESS:
+    for _ in range(20):
+        if result["type"] != FlowResultType.SHOW_PROGRESS:
+            return result
         await hass.async_block_till_done()
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    return result
+    raise AssertionError("the setup progress step never completed")
 
 
 
@@ -286,6 +288,30 @@ class TestPairingPersistence:
         }
         flow.context = {"source": SOURCE_USER}
         return flow
+
+    @pytest.mark.parametrize(
+        "step", ["async_step_bluetooth_pairing", "async_step_manual_pairing"]
+    )
+    async def test_pairing_step_recomputes_transport_warning(
+        self, hass: HomeAssistant, step: str
+    ) -> None:
+        """The warning must reflect the adapter and protocol the user submitted."""
+        flow = self._new_pairing_flow(hass)
+        flow._manual_data[CONF_PREFERRED_ADAPTER] = "bedroom_proxy"
+        describe = AsyncMock(return_value="Pairing over the selected proxy")
+
+        with patch.object(flow, "_async_transport_note", new=describe):
+            result = await getattr(flow, step)()
+
+        assert result["description_placeholders"]["transport"] == (
+            "Pairing over the selected proxy"
+        )
+        describe.assert_awaited_once_with(
+            "AA:BB:CC:DD:EE:01",
+            "bedroom_proxy",
+            BED_TYPE_OKIMAT,
+            None,
+        )
 
     async def test_bluetooth_pairing_marks_bond_as_established(self, hass: HomeAssistant) -> None:
         """Pair Now should persist that the bed is already bonded."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from copy import copy
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -141,6 +143,36 @@ def test_octo_one_motor_count_is_limited_to_standard_tv_lifts() -> None:
     assert _is_valid_motor_count(BED_TYPE_OCTO, "auto", 1)
     assert not _is_valid_motor_count(BED_TYPE_OCTO, OCTO_VARIANT_STAR2, 1)
     assert not _is_valid_motor_count(BED_TYPE_LINAK, "auto", 1)
+
+
+@pytest.fixture(autouse=True)
+def _no_advertisement_wait():
+    """Do not spend the real advertisement wait in tests.
+
+    The probe waits a few seconds for a bed that is between advertising
+    intervals. Every test here runs against a Bluetooth manager that has no
+    history at all, so the wait can only ever time out - it would add seconds
+    per test and prove nothing. The wait itself is covered in
+    tests/test_bluetooth_freshness.py.
+    """
+    with patch(
+        "custom_components.adjustable_bed.config_flow._PROBE_ADVERTISEMENT_WAIT_SECONDS",
+        0.0,
+    ):
+        yield
+
+
+async def _advance_progress(hass: HomeAssistant, result: Any) -> Any:
+    """Drive a progress result through to the step that follows it.
+
+    Setup now runs its BLE work as a background task behind a progress view, so
+    a submitted form returns SHOW_PROGRESS rather than the next form.
+    """
+    while result["type"] == FlowResultType.SHOW_PROGRESS:
+        await hass.async_block_till_done()
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    return result
+
 
 
 class TestPairingInstructions:
@@ -916,7 +948,10 @@ class TestBluetoothDiscoveryFlow:
             },
         )
 
-        # A connectable scanner is mocked, so the verify_connection step appears.
+        # A connectable scanner is mocked, so setup runs the probe behind a
+        # progress view and then shows the verify_connection result step.
+        assert result["type"] == FlowResultType.SHOW_PROGRESS
+        result = await _advance_progress(hass, result)
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "verify_connection"
         result = await hass.config_entries.flow.async_configure(
@@ -1021,7 +1056,10 @@ class TestBluetoothDiscoveryFlow:
             },
         )
 
-        # A connectable scanner is mocked, so the verify_connection step appears.
+        # A connectable scanner is mocked, so setup runs the probe behind a
+        # progress view and then shows the verify_connection result step.
+        assert result["type"] == FlowResultType.SHOW_PROGRESS
+        result = await _advance_progress(hass, result)
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "verify_connection"
         result = await hass.config_entries.flow.async_configure(
@@ -1067,6 +1105,8 @@ class TestBluetoothDiscoveryFlow:
             )
 
             # The probe failed, but the verify step is informational only.
+            assert result["type"] == FlowResultType.SHOW_PROGRESS
+            result = await _advance_progress(hass, result)
             assert result["type"] == FlowResultType.FORM
             assert result["step_id"] == "verify_connection"
             result = await hass.config_entries.flow.async_configure(
@@ -1107,7 +1147,9 @@ class TestBluetoothDiscoveryFlow:
         )
 
         # A connectable scanner is mocked, so accepted input proceeds through
-        # the non-blocking verify_connection step before creating the entry.
+        # the non-blocking progress + verify_connection steps before creating
+        # the entry.
+        result = await _advance_progress(hass, result)
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "verify_connection"
         result = await hass.config_entries.flow.async_configure(
@@ -1439,7 +1481,10 @@ class TestBluetoothDiscoveryFlow:
             },
         )
 
-        # A connectable scanner is mocked, so the verify_connection step appears.
+        # A connectable scanner is mocked, so setup runs the probe behind a
+        # progress view and then shows the verify_connection result step.
+        assert result["type"] == FlowResultType.SHOW_PROGRESS
+        result = await _advance_progress(hass, result)
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "verify_connection"
         result = await hass.config_entries.flow.async_configure(
@@ -2845,12 +2890,41 @@ def _fresh_gate(
     return evidence, MagicMock()
 
 
+class _PatchGate:
+    """Make the capability probe see a bed that is advertising right now.
+
+    The probe reaches the gate by two routes: directly when it runs inline, and
+    through the wait helper when it runs behind a progress view. Both are
+    patched so a test does not have to know which one it took.
+    """
+
+    def __init__(
+        self, source: str, rssi: int, transport: TransportClass = TransportClass.LOCAL
+    ) -> None:
+        self._result = _fresh_gate(source, rssi, transport)
+        self._patches = [
+            patch(
+                "custom_components.adjustable_bed.config_flow.async_gate_connection",
+                return_value=self._result,
+            ),
+            patch(
+                "custom_components.adjustable_bed.config_flow.async_wait_for_advertisement",
+                AsyncMock(return_value=self._result),
+            ),
+        ]
+
+    def __enter__(self) -> None:
+        for item in self._patches:
+            item.start()
+
+    def __exit__(self, *exc: object) -> None:
+        for item in reversed(self._patches):
+            item.stop()
+
+
 def _patch_gate(source: str, rssi: int, transport: TransportClass = TransportClass.LOCAL):
     """Patch the freshness gate used by the capability probe."""
-    return patch(
-        "custom_components.adjustable_bed.config_flow.async_gate_connection",
-        return_value=_fresh_gate(source, rssi, transport),
-    )
+    return _PatchGate(source, rssi, transport)
 
 
 def _fake_connected_client() -> MagicMock:
@@ -2899,6 +2973,7 @@ async def test_verify_connection_success_then_creates_entry(
         verify = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_PREFERRED_ADAPTER: "auto"}
         )
+        verify = await _advance_progress(hass, verify)
         assert verify["type"] == FlowResultType.FORM
         assert verify["step_id"] == "verify_connection"
         caps = verify["description_placeholders"]["capabilities"]
@@ -2959,6 +3034,7 @@ async def test_verify_connection_warns_when_no_writable_characteristic(
         verify = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_PREFERRED_ADAPTER: "auto"}
         )
+        verify = await _advance_progress(hass, verify)
         assert verify["step_id"] == "verify_connection"
         caps = verify["description_placeholders"]["capabilities"]
         assert "No writable characteristic found" in caps
@@ -2992,6 +3068,7 @@ async def test_verify_connection_failure_still_creates_entry(
         verify = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_PREFERRED_ADAPTER: "auto"}
         )
+        verify = await _advance_progress(hass, verify)
         assert verify["step_id"] == "verify_connection"
         assert "Could not connect" in verify["description_placeholders"]["capabilities"]
 
@@ -3019,3 +3096,161 @@ async def test_verify_connection_skipped_without_scanner(
 
     assert created["type"] == FlowResultType.CREATE_ENTRY
     assert created["data"][CONF_BED_TYPE] == BED_TYPE_LINAK
+
+
+# ---------------------------------------------------------------------------
+# setup_progress step, driven through the real flow manager (issues #457, #460)
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_shows_a_progress_view_before_the_result(
+    hass: HomeAssistant,
+    mock_bluetooth_service_info: BluetoothServiceInfoBleak,
+    enable_custom_integrations,
+) -> None:
+    """Submitting setup must render an active progress view, not a frozen form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_BLUETOOTH}, data=mock_bluetooth_service_info
+    )
+    with (
+        patch.object(AdjustableBedConfigFlow, "_verification_possible", return_value=True),
+        _patch_gate("hci0", -55),
+        patch("bleak_retry_connector.establish_connection", AsyncMock(return_value=_fake_connected_client())),
+        patch("custom_components.adjustable_bed.config_flow.discover_services", AsyncMock(return_value=True)),
+        patch(
+            "custom_components.adjustable_bed.config_flow.read_ble_device_info",
+            AsyncMock(return_value=(None, None)),
+        ),
+    ):
+        progress = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PREFERRED_ADAPTER: "auto"}
+        )
+        assert progress["type"] == FlowResultType.SHOW_PROGRESS
+        assert progress["step_id"] == "setup_progress"
+        # The view names the bed and the Bluetooth action under way.
+        assert progress["progress_action"] in {
+            "locating",
+            "connecting",
+            "discovering_services",
+            "reading_capabilities",
+            "disconnecting",
+        }
+        assert progress["description_placeholders"]["name"] == "Test Bed"
+
+        done = await _advance_progress(hass, progress)
+        assert done["step_id"] == "verify_connection"
+
+        created = await hass.config_entries.flow.async_configure(done["flow_id"], user_input={})
+    assert created["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_the_probe_runs_once_even_if_the_progress_step_is_re_entered(
+    hass: HomeAssistant,
+    mock_bluetooth_service_info: BluetoothServiceInfoBleak,
+    enable_custom_integrations,
+) -> None:
+    """A refresh or a double submit must not open a second BLE connection."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_BLUETOOTH}, data=mock_bluetooth_service_info
+    )
+    connects = AsyncMock(return_value=_fake_connected_client())
+    with (
+        patch.object(AdjustableBedConfigFlow, "_verification_possible", return_value=True),
+        _patch_gate("hci0", -55),
+        patch("bleak_retry_connector.establish_connection", connects),
+        patch("custom_components.adjustable_bed.config_flow.discover_services", AsyncMock(return_value=True)),
+        patch(
+            "custom_components.adjustable_bed.config_flow.read_ble_device_info",
+            AsyncMock(return_value=(None, None)),
+        ),
+    ):
+        progress = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PREFERRED_ADAPTER: "auto"}
+        )
+        # Poll the running step the way a reconnecting frontend would.
+        again = await hass.config_entries.flow.async_configure(progress["flow_id"])
+        assert again["type"] in (FlowResultType.SHOW_PROGRESS, FlowResultType.FORM)
+        await _advance_progress(hass, again)
+
+    assert connects.await_count == 1
+
+
+async def test_a_not_advertising_bed_offers_retry_and_still_allows_finishing(
+    hass: HomeAssistant,
+    mock_bluetooth_service_info: BluetoothServiceInfoBleak,
+    enable_custom_integrations,
+) -> None:
+    """The gate refusal is explained, retryable, and never blocks setup (#458)."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_BLUETOOTH}, data=mock_bluetooth_service_info
+    )
+    with (
+        patch.object(AdjustableBedConfigFlow, "_verification_possible", return_value=True),
+        patch("bleak_retry_connector.establish_connection") as connects,
+    ):
+        progress = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PREFERRED_ADAPTER: "auto"}
+        )
+        verify = await _advance_progress(hass, progress)
+        assert verify["step_id"] == "verify_connection"
+        caps = verify["description_placeholders"]["capabilities"]
+        assert "not currently advertising" in caps
+        # Nothing may reach the BLE stack once the gate has refused.
+        connects.assert_not_called()
+
+        # Retry re-runs the check in place rather than restarting the flow.
+        retried = await hass.config_entries.flow.async_configure(
+            verify["flow_id"], user_input={"action": "retry"}
+        )
+        assert retried["type"] == FlowResultType.SHOW_PROGRESS
+        retried = await _advance_progress(hass, retried)
+        assert retried["step_id"] == "verify_connection"
+
+        created = await hass.config_entries.flow.async_configure(
+            retried["flow_id"], user_input={"action": "finish"}
+        )
+    assert created["type"] == FlowResultType.CREATE_ENTRY
+    assert created["data"][CONF_ADDRESS] == mock_bluetooth_service_info.address
+
+
+async def test_abandoning_the_flow_mid_probe_leaves_no_connected_client(
+    hass: HomeAssistant,
+    mock_bluetooth_service_info: BluetoothServiceInfoBleak,
+    enable_custom_integrations,
+) -> None:
+    """Cancellation must not leak the bed's single BLE connection."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_BLUETOOTH}, data=mock_bluetooth_service_info
+    )
+    client = _fake_connected_client()
+    release = asyncio.Event()
+    reached_gatt = asyncio.Event()
+
+    async def _slow_discover(*_args, **_kwargs):
+        reached_gatt.set()
+        await release.wait()
+        return True
+
+    with (
+        patch.object(AdjustableBedConfigFlow, "_verification_possible", return_value=True),
+        _patch_gate("hci0", -55),
+        patch("bleak_retry_connector.establish_connection", AsyncMock(return_value=client)),
+        patch(
+            "custom_components.adjustable_bed.config_flow.discover_services",
+            _slow_discover,
+        ),
+    ):
+        progress = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PREFERRED_ADAPTER: "auto"}
+        )
+        assert progress["type"] == FlowResultType.SHOW_PROGRESS
+
+        # Abort only once the worker is genuinely holding an open client.
+        async with asyncio.timeout(5):
+            await reached_gatt.wait()
+
+        hass.config_entries.flow.async_abort(progress["flow_id"])
+        release.set()
+        await hass.async_block_till_done()
+
+    client.disconnect.assert_awaited()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -21,7 +21,14 @@ from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.adjustable_bed.adapter import AdapterSelectionResult
+from custom_components.adjustable_bed.bluetooth_freshness import (
+    AdvertisementEvidence,
+    FreshnessStatus,
+)
+from custom_components.adjustable_bed.bluetooth_transport import (
+    ConnectionPath,
+    TransportClass,
+)
 from custom_components.adjustable_bed.config_flow import (
     AdjustableBedConfigFlow,
     _default_motor_count,
@@ -2816,6 +2823,36 @@ class TestOptionsFlow:
 # ---------------------------------------------------------------------------
 
 
+def _fresh_gate(
+    source: str,
+    rssi: int,
+    transport: TransportClass = TransportClass.LOCAL,
+) -> tuple[AdvertisementEvidence, MagicMock]:
+    """Return a passing freshness gate result over a given transport.
+
+    The probe no longer picks an adapter itself: it asks the freshness gate
+    whether the bed has actually advertised recently, and only then resolves a
+    device to connect to (issue #458).
+    """
+    path = ConnectionPath(source=source, transport=transport, scanner_name=source, rssi=rssi)
+    evidence = AdvertisementEvidence(
+        status=FreshnessStatus.FRESH,
+        age_seconds=1.0,
+        rssi=rssi,
+        source=source,
+        path=path,
+    )
+    return evidence, MagicMock()
+
+
+def _patch_gate(source: str, rssi: int, transport: TransportClass = TransportClass.LOCAL):
+    """Patch the freshness gate used by the capability probe."""
+    return patch(
+        "custom_components.adjustable_bed.config_flow.async_gate_connection",
+        return_value=_fresh_gate(source, rssi, transport),
+    )
+
+
 def _fake_connected_client() -> MagicMock:
     """Fake BleakClient with one service and a writable characteristic."""
     char = MagicMock()
@@ -2843,19 +2880,9 @@ async def test_verify_connection_success_then_creates_entry(
     assert result["step_id"] == "bluetooth_confirm"
 
     client = _fake_connected_client()
-    selection = AdapterSelectionResult(
-        device=MagicMock(),
-        source="esphome_bedroom",
-        rssi=-60,
-        connectable=True,
-        available_sources=[],
-    )
     with (
         patch.object(AdjustableBedConfigFlow, "_verification_possible", return_value=True),
-        patch(
-            "custom_components.adjustable_bed.config_flow.select_adapter",
-            AsyncMock(return_value=selection),
-        ),
+        _patch_gate("esphome_bedroom", -60, TransportClass.PROXY),
         patch(
             "bleak_retry_connector.establish_connection",
             AsyncMock(return_value=client),
@@ -2877,7 +2904,7 @@ async def test_verify_connection_success_then_creates_entry(
         caps = verify["description_placeholders"]["capabilities"]
         assert "Connected" in caps
         assert "esphome_bedroom" in caps
-        assert "ESPHome proxy" in caps
+        assert "Bluetooth proxy" in caps
         # GATT + device-info details surface in the checklist.
         assert "writable characteristic" in caps
         assert "OKIN" in caps
@@ -2913,19 +2940,9 @@ async def test_verify_connection_warns_when_no_writable_characteristic(
     client.services = [service]
     client.disconnect = AsyncMock()
 
-    selection = AdapterSelectionResult(
-        device=MagicMock(),
-        source="hci0",
-        rssi=-55,
-        connectable=True,
-        available_sources=[],
-    )
     with (
         patch.object(AdjustableBedConfigFlow, "_verification_possible", return_value=True),
-        patch(
-            "custom_components.adjustable_bed.config_flow.select_adapter",
-            AsyncMock(return_value=selection),
-        ),
+        _patch_gate("hci0", -55),
         patch(
             "bleak_retry_connector.establish_connection",
             AsyncMock(return_value=client),
@@ -2964,19 +2981,9 @@ async def test_verify_connection_failure_still_creates_entry(
     )
     assert result["step_id"] == "bluetooth_confirm"
 
-    selection = AdapterSelectionResult(
-        device=MagicMock(),
-        source="hci0",
-        rssi=-72,
-        connectable=True,
-        available_sources=[],
-    )
     with (
         patch.object(AdjustableBedConfigFlow, "_verification_possible", return_value=True),
-        patch(
-            "custom_components.adjustable_bed.config_flow.select_adapter",
-            AsyncMock(return_value=selection),
-        ),
+        _patch_gate("hci0", -72),
         patch(
             "bleak_retry_connector.establish_connection",
             AsyncMock(side_effect=Exception("device busy")),

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3201,6 +3201,33 @@ async def test_the_probe_runs_once_even_if_the_progress_step_is_re_entered(
     assert connects.await_count == 1
 
 
+async def test_consumed_setup_progress_does_not_start_another_probe(
+    hass: HomeAssistant,
+) -> None:
+    """A late completion callback must keep returning progress-done."""
+    flow = AdjustableBedConfigFlow()
+    flow.hass = hass
+    flow._pending_entry = {
+        CONF_ADDRESS: "AA:BB:CC:DD:EE:01",
+        CONF_NAME: "Test Bed",
+    }
+    flow.async_begin_operation()
+    flow.operation.terminal_consumed = True
+
+    with (
+        patch.object(flow, "_async_start_probe_operation") as start_probe,
+        patch.object(
+            flow,
+            "async_run_operation_step",
+            new=AsyncMock(return_value={"type": FlowResultType.SHOW_PROGRESS_DONE}),
+        ),
+    ):
+        result = await flow.async_step_setup_progress()
+
+    assert result["type"] == FlowResultType.SHOW_PROGRESS_DONE
+    start_probe.assert_not_called()
+
+
 async def test_a_not_advertising_bed_offers_retry_and_still_allows_finishing(
     hass: HomeAssistant,
     mock_bluetooth_service_info: BluetoothServiceInfoBleak,

--- a/tests/test_setup_operation.py
+++ b/tests/test_setup_operation.py
@@ -381,13 +381,6 @@ class TestCleanup:
 class TestOperationState:
     """The shared state is what both the progress view and the result step read."""
 
-    async def test_a_new_operation_bumps_the_generation(
-        self, hass: HomeAssistant, flow: _Flow
-    ) -> None:
-        first = flow.async_begin_operation()
-        second = flow.async_begin_operation()
-        assert second.generation == first.generation + 1
-
     async def test_a_retry_clears_the_previous_terminal_state(
         self, hass: HomeAssistant, flow: _Flow
     ) -> None:

--- a/tests/test_setup_operation.py
+++ b/tests/test_setup_operation.py
@@ -1,0 +1,428 @@
+"""Tests for the Bluetooth setup progress plumbing (issues #457, #460)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType, UnknownFlow
+
+from custom_components.adjustable_bed.bluetooth_transport import (
+    ConnectionPath,
+    PathPrediction,
+    TransportClass,
+)
+from custom_components.adjustable_bed.setup_operation import (
+    BluetoothOperationMixin,
+    ConnectionLifetimePolicy,
+    OperationOutcome,
+    OperationResult,
+    SetupAction,
+)
+
+
+class _Flow(BluetoothOperationMixin):
+    """Minimal stand-in for a Home Assistant flow handler.
+
+    Only the handful of methods the mixin actually calls are provided, so the
+    tests exercise the mixin's own logic rather than the flow machinery.
+    """
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self.hass = hass
+        self.flow_id = "test-flow"
+        self.shown: list[dict[str, Any]] = []
+        self.progress_values: list[float] = []
+        self.manager = MagicMock()
+        self.manager.async_configure = _AsyncNoop()
+
+    def _async_flow_manager(self) -> Any:
+        return self.manager
+
+    def async_update_progress(self, progress: float) -> None:
+        self.progress_values.append(progress)
+
+    def async_show_progress(self, **kwargs: Any) -> dict[str, Any]:
+        result = {"type": FlowResultType.SHOW_PROGRESS, **kwargs}
+        self.shown.append(result)
+        return result
+
+    def async_show_progress_done(self, *, next_step_id: str) -> dict[str, Any]:
+        result = {"type": FlowResultType.SHOW_PROGRESS_DONE, "next_step_id": next_step_id}
+        self.shown.append(result)
+        return result
+
+
+class _AsyncNoop:
+    """An awaitable stand-in that records how often it was called."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(self, **_kwargs: Any) -> None:
+        self.calls += 1
+
+
+@pytest.fixture
+def flow(hass: HomeAssistant) -> _Flow:
+    return _Flow(hass)
+
+
+async def _drain(hass: HomeAssistant) -> None:
+    """Let every scheduled task settle."""
+    await hass.async_block_till_done()
+
+
+class TestTaskLifecycle:
+    """One submission means one BLE operation, however often the step re-runs."""
+
+    async def test_the_step_shows_progress_while_the_worker_runs(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        gate = asyncio.Event()
+
+        async def worker() -> OperationResult:
+            await gate.wait()
+            return OperationResult(outcome=OperationOutcome.SUCCESS)
+
+        flow.async_begin_operation(name="Bed", address="AA:BB")
+        result = await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        assert result["type"] == FlowResultType.SHOW_PROGRESS
+        assert result["progress_action"] == SetupAction.LOCATING.value
+        gate.set()
+        await _drain(hass)
+
+    async def test_re_entering_reuses_the_same_task(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        """A double submit must not open a second BLE connection."""
+        started = 0
+        gate = asyncio.Event()
+
+        async def worker() -> OperationResult:
+            nonlocal started
+            started += 1
+            await gate.wait()
+            return OperationResult(outcome=OperationOutcome.SUCCESS)
+
+        flow.async_begin_operation()
+        first = await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        second = await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        assert first["progress_task"] is second["progress_task"]
+        gate.set()
+        await _drain(hass)
+        assert started == 1
+
+    async def test_completion_routes_to_the_result_step(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        async def worker() -> OperationResult:
+            return OperationResult(outcome=OperationOutcome.SUCCESS, detail="ok")
+
+        flow.async_begin_operation()
+        await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        await _drain(hass)
+        done = await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        assert done["type"] == FlowResultType.SHOW_PROGRESS_DONE
+        assert done["next_step_id"] == "setup_result"
+        assert flow.operation.result is not None
+        assert flow.operation.result.succeeded
+
+    async def test_the_terminal_result_is_consumed_exactly_once(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        """HA's own done-callback and a phase refresh can both land here."""
+        runs = 0
+
+        async def worker() -> OperationResult:
+            nonlocal runs
+            runs += 1
+            return OperationResult(outcome=OperationOutcome.SUCCESS)
+
+        flow.async_begin_operation()
+        await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        await _drain(hass)
+
+        first = await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        second = await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        assert first["type"] == FlowResultType.SHOW_PROGRESS_DONE
+        assert second["type"] == FlowResultType.SHOW_PROGRESS_DONE
+        # The second pass must not restart the operation.
+        assert runs == 1
+
+    async def test_a_raising_worker_becomes_a_failure_result(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        async def worker() -> OperationResult:
+            raise RuntimeError("boom")
+
+        flow.async_begin_operation()
+        await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        await _drain(hass)
+        done = await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        assert done["type"] == FlowResultType.SHOW_PROGRESS_DONE
+        assert flow.operation.result is not None
+        assert flow.operation.result.outcome is OperationOutcome.CONNECTION_FAILED
+        assert flow.operation.result.detail == "boom"
+
+    async def test_a_cancelled_worker_reports_cancelled(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        async def worker() -> OperationResult:
+            raise asyncio.CancelledError
+
+        flow.async_begin_operation()
+        await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        await _drain(hass)
+        await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        assert flow.operation.result is not None
+        assert flow.operation.result.outcome is OperationOutcome.CANCELLED
+
+
+class TestProgressReporting:
+    """Phase text re-renders the step; the numeric bar does not."""
+
+    async def test_a_phase_change_refreshes_the_view(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        flow.async_begin_operation()
+        flow.async_report_action(SetupAction.CONNECTING)
+        await _drain(hass)
+        assert flow.operation.action is SetupAction.CONNECTING
+        assert flow.manager.async_configure.calls == 1
+
+    async def test_an_unchanged_phase_does_not_refresh(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        flow.async_begin_operation(action=SetupAction.CONNECTING)
+        flow.async_report_action(SetupAction.CONNECTING)
+        await _drain(hass)
+        assert flow.manager.async_configure.calls == 0
+
+    async def test_the_numeric_bar_does_not_re_render_the_step(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        """Only the advertisement wait is determinate, and it must stay cheap."""
+        flow.async_begin_operation()
+        flow.async_report_progress(0.25)
+        flow.async_report_progress(0.5)
+        await _drain(hass)
+        assert flow.progress_values == [0.25, 0.5]
+        assert flow.manager.async_configure.calls == 0
+
+    async def test_refreshes_never_overlap_and_are_coalesced(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        """Concurrent re-configures would race each other and HA's own callback.
+
+        Three phase changes while one refresh is still in flight must collapse
+        into that one plus a single follow-up carrying the latest phase - never
+        three overlapping invocations.
+        """
+        release = asyncio.Event()
+        calls = 0
+        concurrent = 0
+        peak = 0
+
+        async def _slow_configure(**_kwargs: Any) -> None:
+            nonlocal calls, concurrent, peak
+            calls += 1
+            concurrent += 1
+            peak = max(peak, concurrent)
+            try:
+                await release.wait()
+            finally:
+                concurrent -= 1
+
+        flow.manager.async_configure = _slow_configure
+        flow.async_begin_operation()
+
+        flow.async_report_action(SetupAction.CONNECTING)
+        await asyncio.sleep(0)
+        flow.async_report_action(SetupAction.DISCOVERING_SERVICES)
+        flow.async_report_action(SetupAction.READING_CAPABILITIES)
+        await asyncio.sleep(0)
+
+        assert calls == 1
+        release.set()
+        await _drain(hass)
+
+        assert peak == 1
+        assert calls == 2
+        # The follow-up carries the newest phase, so nothing is rendered stale.
+        assert flow.operation.action is SetupAction.READING_CAPABILITIES
+
+    async def test_a_closed_dialog_does_not_raise(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        async def _gone(**_kwargs: Any) -> None:
+            raise UnknownFlow
+
+        flow.manager.async_configure = _gone
+        flow.async_begin_operation()
+        flow.async_report_action(SetupAction.CONNECTING)
+        await _drain(hass)
+
+    async def test_reporting_the_actual_path_refreshes_the_view(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        flow.async_begin_operation(
+            prediction=PathPrediction(
+                chosen=ConnectionPath(source="hci0", transport=TransportClass.LOCAL),
+                paths=(),
+            )
+        )
+        flow.async_report_path(
+            ConnectionPath(source="proxy", transport=TransportClass.PROXY)
+        )
+        await _drain(hass)
+        assert flow.operation.path_changed is True
+        assert flow.operation.transport is TransportClass.PROXY
+
+
+class TestCleanup:
+    """Abandoning a flow must not leave a connection or a task behind."""
+
+    async def test_the_client_is_disconnected_when_the_worker_finishes(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        client = MagicMock()
+        client.disconnect = _AsyncNoop()
+
+        async def worker() -> OperationResult:
+            flow.async_track_client(client)
+            return OperationResult(outcome=OperationOutcome.SUCCESS)
+
+        flow.async_begin_operation()
+        await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        await _drain(hass)
+        assert client.disconnect.calls == 1
+
+    async def test_the_client_is_disconnected_when_the_worker_fails(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        client = MagicMock()
+        client.disconnect = _AsyncNoop()
+
+        async def worker() -> OperationResult:
+            flow.async_track_client(client)
+            raise RuntimeError("boom")
+
+        flow.async_begin_operation()
+        await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        await _drain(hass)
+        assert client.disconnect.calls == 1
+
+    async def test_removing_the_flow_cancels_the_task_and_the_refresh(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        gate = asyncio.Event()
+
+        async def worker() -> OperationResult:
+            await gate.wait()
+            return OperationResult(outcome=OperationOutcome.SUCCESS)
+
+        flow.async_begin_operation()
+        result = await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        task = result["progress_task"]
+        flow.async_report_action(SetupAction.CONNECTING)
+
+        flow.async_remove()
+        await _drain(hass)
+        assert task.cancelled() or task.done()
+        assert flow._refresh_task is None
+
+    async def test_removing_the_flow_disconnects_a_stray_client(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        client = MagicMock()
+        client.disconnect = _AsyncNoop()
+        flow.async_begin_operation()
+        flow.async_track_client(client)
+
+        flow.async_remove()
+        await _drain(hass)
+        assert client.disconnect.calls == 1
+
+
+class TestOperationState:
+    """The shared state is what both the progress view and the result step read."""
+
+    async def test_a_new_operation_bumps_the_generation(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        first = flow.async_begin_operation()
+        second = flow.async_begin_operation()
+        assert second.generation == first.generation + 1
+
+    async def test_a_retry_clears_the_previous_terminal_state(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        async def worker() -> OperationResult:
+            return OperationResult(outcome=OperationOutcome.NOT_ADVERTISING)
+
+        flow.async_begin_operation()
+        await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        await _drain(hass)
+        await flow.async_run_operation_step(
+            step_id="setup_progress", worker=worker, next_step_id="setup_result"
+        )
+        assert flow.operation.result is not None
+
+        flow.async_begin_operation()
+        assert flow.operation.result is None
+        assert flow.operation.terminal_consumed is False
+
+    async def test_the_lifetime_policy_is_carried_on_the_state(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        """Gen2 beds must be recognisable before anything opens a connection."""
+        state = flow.async_begin_operation(
+            policy=ConnectionLifetimePolicy.KEEP_FIRST_LINK
+        )
+        assert state.policy is ConnectionLifetimePolicy.KEEP_FIRST_LINK
+
+    async def test_predicted_path_survives_until_the_real_one_is_known(
+        self, hass: HomeAssistant, flow: _Flow
+    ) -> None:
+        predicted = ConnectionPath(source="hci0", transport=TransportClass.LOCAL)
+        flow.async_begin_operation(
+            prediction=PathPrediction(chosen=predicted, paths=(predicted,))
+        )
+        assert flow.operation.effective_path is predicted
+        assert flow.operation.path_changed is False


### PR DESCRIPTION
Ref #454, #456, #458, #457, #460

First of two PRs for the Bluetooth setup and pairing UX epic. This one covers the non-destructive half: knowing which Bluetooth path will be used, refusing to connect to a bed that is not there, and never leaving a form looking frozen. The bond ownership, unpair and pairing-flow work (#459, #455, #461) follows in a second PR so the destructive changes are not reviewed alongside scanner rendering.

## Transport awareness (#456)

Home Assistant can reach a bed through an adapter on the host or through a remote proxy, and the two are not interchangeable: a BLE bond is stored by whichever transport created it. The integration decided which was which by looking for `esphome` in the source string, which misses proxies from other integrations and reads a local adapter's own MAC address as evidence of a remote one. `get_available_adapters` had the same problem and labelled host adapters as proxies.

`bluetooth_transport.py` classifies from Home Assistant's scanner objects instead, and ranks candidate paths the way habluetooth does when it actually connects: by advertised RSSI, then re-sorted by `score_connection_path()` using the gap between the two strongest signals, so connection slots and recent failures move a path down exactly as they will during the real connect.

The setup forms now name the likely transport, scanner and signal, warn before a pairing-required bed would bond over a proxy, and say plainly that this is a prediction. That last part matters: `HaBleakClientWrapper` keeps only the address and re-ranks every scanner inside `connect()`, so passing it a `BLEDevice` from a chosen adapter does not pin the route. The capability result reports the path that was really used, captured immediately after the connect succeeds.

## Fresh-advertisement gate (#458)

Home Assistant keeps a connectable record for up to 195 seconds, so an asleep or unplugged bed still looks present and the probe burns its whole timeout producing a failure that reads like a pairing problem.

`bluetooth_freshness.py` requires evidence it can stand behind: recent (90s), a valid RSSI (BlueZ publishes -127 when it has none), and a timestamp that is numeric, finite and not in the future. Failures are kept apart rather than collapsed, because diagnostics need to tell "never heard of it" from "the clock is wrong". A refusal is reported as not advertising with a Retry that re-checks in place, and the `BLEDevice` is resolved after the gate rather than reused from discovery.

Setup is still never blocked: Finish stays the default action.

## Live progress (#457, #460)

The capability probe ran inline, so the form the user had just submitted sat unchanged for as long as the BLE stack took. `setup_operation.py` holds the shared pieces and the config flow routes through a progress step that names the bed and the current Bluetooth action.

Three details are load-bearing:

- Home Assistant registers its own done-callback on the progress task, so its completion transition can land at the same moment as one of our phase refreshes. The terminal result is consumed exactly once, refreshes are coalesced so only one is ever in flight, and the result step accepts input only once it has actually rendered its form. Without that last guard, `FlowManager.async_configure` re-passing the caller's original `user_input` through its progress-done loop meant a duplicated submission could create an entry the user never saw a result for.
- The per-address connect lock is reentrant per asyncio task, so the whole client lifetime stays inside one worker task.
- Only the advertisement wait drives a numeric bar, because it is the only phase whose duration is known in advance. A BLE connect can take 200ms or 20s and offers no completion signal, so counting phases would be invented precision. The bar is cleared when the phase changes.

Beds that grant one connection per pairing window (Leggett & Platt Gen2) still skip the probe entirely.

## Also

`strings.json` had drifted behind `translations/en.json` by three keys and one value; it is synced before anything is added. Norwegian covers every new string, and the Retry/Finish labels are translated rather than hardcoded.

## Testing

`uv run pytest`: 2840 passed. Ruff and pyright clean. 88 new tests across `test_bluetooth_transport.py`, `test_bluetooth_freshness.py`, `test_setup_operation.py` and `test_config_flow.py`, covering local-only, proxy-only and mixed paths, missing RSSI, preferred-adapter override and disappearance, scoring beating raw signal, every freshness status including NaN and future timestamps, progress-task reuse, exactly-once completion, refresh coalescing, and cancellation leaving no connected client.

## Review notes

Design and implementation were both cross-reviewed with GPT-5.6 (high reasoning) before landing; its findings on false-success verification, progress-completion races, determinate-progress honesty and the lost non-connectable proxy fallback are all addressed here. A CodeRabbit preflight ran before the first push and its findings are in the final commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Live Bluetooth setup progress during discovery and verification, with **Check again** or **Finish setup anyway**.
  - Transport-aware connection explanations and previews (local vs proxy), including adapter availability and pairing-risk warnings, using a `{transport}` placeholder in the UI copy.
  - Display now distinguishes predicted vs actual connection path.

- **Bug Fixes**
  - Prevents misleading connection attempts caused by stale or invalid Bluetooth advertisement evidence.
  - Improved reliability and cleanup when setup is cancelled or fails during Bluetooth probing/connection.

- **Tests**
  - Added extensive coverage for freshness gating and transport path prediction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->