### PR TITLE
Let the user say two beds are separate

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 
+from .combine_suggestion import async_load_dismissal
 from .const import (
     BED_TYPE_BEDTECH,
     BED_TYPE_DIAGNOSTIC,
@@ -185,6 +186,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     # Clear obsolete "unsupported BLE device" Repairs issues from older versions
     # that nagged about every discovered non-bed device (feature removed).
     async_clear_unsupported_device_issues(hass)
+    await async_load_dismissal(hass)
     async_setup_combine_beds_issue(hass)
 
     from .download import SupportBundleDownloadView

--- a/custom_components/adjustable_bed/combine_suggestion.py
+++ b/custom_components/adjustable_bed/combine_suggestion.py
@@ -5,9 +5,9 @@ Ignore action for those: a fixable issue opens its fix flow, so the only way out
 of the dialog is to close it, which leaves the issue sitting in Repairs. For
 someone who genuinely owns two beds that is a permanent, unanswerable warning.
 
-The dismissal is recorded against the exact set of addresses that was suggested,
-not as a global "never ask" flag. Two beds the user has called separate stay
-separate, while adding a third bed later is a different question and gets asked
+Each dismissal is recorded against the exact set of addresses that was
+suggested, not as a global "never ask" flag. Beds the user has called separate
+stay separate, while adding another bed is a different question and gets asked
 again.
 """
 
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, override
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
@@ -24,11 +24,12 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-STORAGE_VERSION = 1
+STORAGE_VERSION = 2
 STORAGE_KEY = f"{DOMAIN}_combine_suggestion"
 _DATA_KEY = f"{DOMAIN}_combine_suggestion"
 
-KEY_DISMISSED = "dismissed_addresses"
+KEY_DISMISSED = "dismissed_address_sets"
+LEGACY_KEY_DISMISSED = "dismissed_addresses"
 
 
 def normalize_addresses(addresses: Iterable[str]) -> frozenset[str]:
@@ -36,18 +37,58 @@ def normalize_addresses(addresses: Iterable[str]) -> frozenset[str]:
     return frozenset(address.upper() for address in addresses if isinstance(address, str))
 
 
+def _normalize_address_sets(address_sets: object) -> frozenset[frozenset[str]]:
+    """Return valid normalized address sets from persisted JSON data."""
+    if not isinstance(address_sets, list):
+        return frozenset()
+
+    normalized_sets: list[frozenset[str]] = []
+    for addresses in address_sets:
+        if not isinstance(addresses, list):
+            continue
+        normalized = normalize_addresses(addresses)
+        if normalized:
+            normalized_sets.append(normalized)
+    return frozenset(normalized_sets)
+
+
+def _serialize_address_sets(
+    address_sets: Iterable[frozenset[str]],
+) -> list[list[str]]:
+    """Return stable JSON data for a collection of address sets."""
+    return sorted(sorted(addresses) for addresses in address_sets)
+
+
+class CombineSuggestionStore(Store[dict[str, Any]]):
+    """Store with migration from the original single-dismissal format."""
+
+    @override
+    async def _async_migrate_func(
+        self,
+        old_major_version: int,
+        old_minor_version: int,
+        old_data: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Migrate a v1 address list into the v2 dismissal history."""
+        if old_major_version != 1:
+            raise ValueError(f"Unsupported combine suggestion storage version {old_major_version}")
+
+        dismissed = normalize_addresses(old_data.get(LEGACY_KEY_DISMISSED) or ())
+        return {KEY_DISMISSED: [sorted(dismissed)] if dismissed else []}
+
+
 class CombineSuggestionState:
-    """The set of beds the user has already declared separate."""
+    """The bed sets the user has already declared separate."""
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialise the backing store; call ``async_load`` before reading."""
-        self._store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, STORAGE_KEY)
-        self._dismissed: frozenset[str] = frozenset()
+        self._store = CombineSuggestionStore(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._dismissed: frozenset[frozenset[str]] = frozenset()
         self._loaded = False
 
     @property
-    def dismissed(self) -> frozenset[str]:
-        """Return the dismissed address set.
+    def dismissed(self) -> frozenset[frozenset[str]]:
+        """Return the dismissed address sets.
 
         Cached deliberately. The Repairs refresh runs from synchronous entry
         lifecycle callbacks, which cannot await a store read.
@@ -60,16 +101,18 @@ class CombineSuggestionState:
             return
         loaded = await self._store.async_load()
         if isinstance(loaded, dict):
-            self._dismissed = normalize_addresses(loaded.get(KEY_DISMISSED) or ())
+            self._dismissed = _normalize_address_sets(loaded.get(KEY_DISMISSED))
         self._loaded = True
 
     async def async_dismiss(self, addresses: Iterable[str]) -> None:
         """Record that this exact set of beds is not one physical bed."""
         dismissed = normalize_addresses(addresses)
-        if dismissed == self._dismissed:
+        if not dismissed or dismissed in self._dismissed:
             return
-        self._dismissed = dismissed
-        await self._store.async_save({KEY_DISMISSED: sorted(dismissed)})
+        self._dismissed = self._dismissed | {dismissed}
+        await self._store.async_save(
+            {KEY_DISMISSED: _serialize_address_sets(self._dismissed)}
+        )
         _LOGGER.debug("Combine suggestion dismissed for %s", sorted(dismissed))
 
 
@@ -89,7 +132,7 @@ async def async_load_dismissal(hass: HomeAssistant) -> None:
 
 def async_is_dismissed(hass: HomeAssistant, addresses: Iterable[str]) -> bool:
     """Return True when the user already called exactly these beds separate."""
-    return _async_get_state(hass).dismissed == normalize_addresses(addresses)
+    return normalize_addresses(addresses) in _async_get_state(hass).dismissed
 
 
 async def async_dismiss(hass: HomeAssistant, addresses: Iterable[str]) -> None:

--- a/custom_components/adjustable_bed/combine_suggestion.py
+++ b/custom_components/adjustable_bed/combine_suggestion.py
@@ -1,0 +1,97 @@
+"""Remembers that the user said their beds are separate, not two sides of one.
+
+The Dual Bed suggestion is a fixable Repairs issue, and Home Assistant offers no
+Ignore action for those: a fixable issue opens its fix flow, so the only way out
+of the dialog is to close it, which leaves the issue sitting in Repairs. For
+someone who genuinely owns two beds that is a permanent, unanswerable warning.
+
+The dismissal is recorded against the exact set of addresses that was suggested,
+not as a global "never ask" flag. Two beds the user has called separate stay
+separate, while adding a third bed later is a different question and gets asked
+again.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STORAGE_VERSION = 1
+STORAGE_KEY = f"{DOMAIN}_combine_suggestion"
+_DATA_KEY = f"{DOMAIN}_combine_suggestion"
+
+KEY_DISMISSED = "dismissed_addresses"
+
+
+def normalize_addresses(addresses: Iterable[str]) -> frozenset[str]:
+    """Return a comparable address set, case and order independent."""
+    return frozenset(address.upper() for address in addresses if isinstance(address, str))
+
+
+class CombineSuggestionState:
+    """The set of beds the user has already declared separate."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialise the backing store; call ``async_load`` before reading."""
+        self._store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._dismissed: frozenset[str] = frozenset()
+        self._loaded = False
+
+    @property
+    def dismissed(self) -> frozenset[str]:
+        """Return the dismissed address set.
+
+        Cached deliberately. The Repairs refresh runs from synchronous entry
+        lifecycle callbacks, which cannot await a store read.
+        """
+        return self._dismissed
+
+    async def async_load(self) -> None:
+        """Read the persisted dismissal once, at integration setup."""
+        if self._loaded:
+            return
+        loaded = await self._store.async_load()
+        if isinstance(loaded, dict):
+            self._dismissed = normalize_addresses(loaded.get(KEY_DISMISSED) or ())
+        self._loaded = True
+
+    async def async_dismiss(self, addresses: Iterable[str]) -> None:
+        """Record that this exact set of beds is not one physical bed."""
+        dismissed = normalize_addresses(addresses)
+        if dismissed == self._dismissed:
+            return
+        self._dismissed = dismissed
+        await self._store.async_save({KEY_DISMISSED: sorted(dismissed)})
+        _LOGGER.debug("Combine suggestion dismissed for %s", sorted(dismissed))
+
+
+def _async_get_state(hass: HomeAssistant) -> CombineSuggestionState:
+    """Return the singleton dismissal state for this Home Assistant instance."""
+    state: CombineSuggestionState | None = hass.data.get(_DATA_KEY)
+    if state is None:
+        state = CombineSuggestionState(hass)
+        hass.data[_DATA_KEY] = state
+    return state
+
+
+async def async_load_dismissal(hass: HomeAssistant) -> None:
+    """Load the persisted dismissal so the sync refresh can consult it."""
+    await _async_get_state(hass).async_load()
+
+
+def async_is_dismissed(hass: HomeAssistant, addresses: Iterable[str]) -> bool:
+    """Return True when the user already called exactly these beds separate."""
+    return _async_get_state(hass).dismissed == normalize_addresses(addresses)
+
+
+async def async_dismiss(hass: HomeAssistant, addresses: Iterable[str]) -> None:
+    """Persist that this set of beds is separate and should not be suggested."""
+    await _async_get_state(hass).async_dismiss(addresses)

--- a/custom_components/adjustable_bed/combine_suggestion.py
+++ b/custom_components/adjustable_bed/combine_suggestion.py
@@ -5,10 +5,9 @@ Ignore action for those: a fixable issue opens its fix flow, so the only way out
 of the dialog is to close it, which leaves the issue sitting in Repairs. For
 someone who genuinely owns two beds that is a permanent, unanswerable warning.
 
-Each dismissal is recorded against the exact set of addresses that was
-suggested, not as a global "never ask" flag. Beds the user has called separate
-stay separate, while adding another bed is a different question and gets asked
-again.
+Each dismissal is recorded against the set of addresses that was suggested,
+not as a global "never ask" flag. Those beds and any remaining subset stay
+separate, while adding another bed is a different question and gets asked again.
 """
 
 from __future__ import annotations
@@ -131,8 +130,11 @@ async def async_load_dismissal(hass: HomeAssistant) -> None:
 
 
 def async_is_dismissed(hass: HomeAssistant, addresses: Iterable[str]) -> bool:
-    """Return True when the user already called exactly these beds separate."""
-    return normalize_addresses(addresses) in _async_get_state(hass).dismissed
+    """Return True when the user already called all these beds separate."""
+    candidates = normalize_addresses(addresses)
+    return bool(candidates) and any(
+        candidates <= dismissed for dismissed in _async_get_state(hass).dismissed
+    )
 
 
 async def async_dismiss(hass: HomeAssistant, addresses: Iterable[str]) -> None:

--- a/custom_components/adjustable_bed/repairs.py
+++ b/custom_components/adjustable_bed/repairs.py
@@ -94,7 +94,7 @@ def async_refresh_combine_beds_issue(hass: HomeAssistant) -> None:
     addresses = [entry.data[CONF_ADDRESS] for entry in candidates]
     if async_is_dismissed(hass, addresses):
         # The user has said these are separate beds. Asking again about the
-        # same set would make the answer meaningless.
+        # same beds or a remaining subset would make the answer meaningless.
         async_delete_issue(hass, DOMAIN, COMBINE_BEDS_ISSUE_ID)
         return
 
@@ -181,6 +181,10 @@ class CombineBedsRepairFlow(RepairsFlow):
         # RepairsFlowManager passes its internal {"issue_id": ...} payload to
         # the init step. It is flow metadata, not a submitted side assignment.
         candidates = active_pairing_candidates(self.hass)
+        if len(candidates) < 2:
+            async_refresh_combine_beds_issue(self.hass)
+            return self.async_abort(reason="not_enough_beds")
+
         self._candidate_addresses = normalize_addresses(
             entry.data[CONF_ADDRESS] for entry in candidates
         )

--- a/custom_components/adjustable_bed/repairs.py
+++ b/custom_components/adjustable_bed/repairs.py
@@ -51,6 +51,7 @@ from .bond_verification import (
     bond_owner_from_entry,
     build_bond_context,
 )
+from .combine_suggestion import async_dismiss, async_is_dismissed
 from .const import (
     ADAPTER_AUTO,
     CONF_BED_TYPE,
@@ -87,6 +88,13 @@ def async_refresh_combine_beds_issue(hass: HomeAssistant) -> None:
     """Create or clear the Dual Bed suggestion from current entry state."""
     candidates = active_pairing_candidates(hass)
     if len(candidates) < 2:
+        async_delete_issue(hass, DOMAIN, COMBINE_BEDS_ISSUE_ID)
+        return
+
+    addresses = [entry.data[CONF_ADDRESS] for entry in candidates]
+    if async_is_dismissed(hass, addresses):
+        # The user has said these are separate beds. Asking again about the
+        # same set would make the answer meaningless.
         async_delete_issue(hass, DOMAIN, COMBINE_BEDS_ISSUE_ID)
         return
 
@@ -160,10 +168,29 @@ class CombineBedsRepairFlow(RepairsFlow):
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Open the pairing selection directly from Repairs."""
+        """Ask which of the two answers applies before showing any form.
+
+        A fixable Repairs issue gets no Ignore action from Home Assistant, so
+        without this the only exit for someone who owns two separate beds is to
+        close the dialog, leaving the suggestion in Repairs forever.
+        """
         # RepairsFlowManager passes its internal {"issue_id": ...} payload to
         # the init step. It is flow metadata, not a submitted side assignment.
-        return await self.async_step_pair_beds()
+        return self.async_show_menu(
+            step_id="init",
+            menu_options=["pair_beds", "separate_beds"],
+        )
+
+    async def async_step_separate_beds(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Record that these beds are separate and stop suggesting them."""
+        addresses = [
+            entry.data[CONF_ADDRESS] for entry in active_pairing_candidates(self.hass)
+        ]
+        await async_dismiss(self.hass, addresses)
+        async_refresh_combine_beds_issue(self.hass)
+        return self.async_abort(reason="beds_are_separate")
 
     async def async_step_pair_beds(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/adjustable_bed/repairs.py
+++ b/custom_components/adjustable_bed/repairs.py
@@ -51,7 +51,7 @@ from .bond_verification import (
     bond_owner_from_entry,
     build_bond_context,
 )
-from .combine_suggestion import async_dismiss, async_is_dismissed
+from .combine_suggestion import async_dismiss, async_is_dismissed, normalize_addresses
 from .const import (
     ADAPTER_AUTO,
     CONF_BED_TYPE,
@@ -150,10 +150,14 @@ class CombineBedsRepairFlow(RepairsFlow):
     def __init__(self) -> None:
         """Track the delegated config flow across validation retries."""
         self._pairing_flow_id: str | None = None
+        self._candidate_addresses: frozenset[str] | None = None
 
-    def _description_placeholders(self) -> dict[str, str]:
-        """Describe the currently active candidates without exposing addresses."""
-        candidates = active_pairing_candidates(self.hass)
+    def _description_placeholders(
+        self, candidates: list[ConfigEntry] | None = None
+    ) -> dict[str, str]:
+        """Describe active candidates without exposing addresses."""
+        if candidates is None:
+            candidates = active_pairing_candidates(self.hass)
         return {
             "count": str(len(candidates)),
             "names": ", ".join(entry.title for entry in candidates),
@@ -176,19 +180,32 @@ class CombineBedsRepairFlow(RepairsFlow):
         """
         # RepairsFlowManager passes its internal {"issue_id": ...} payload to
         # the init step. It is flow metadata, not a submitted side assignment.
+        candidates = active_pairing_candidates(self.hass)
+        self._candidate_addresses = normalize_addresses(
+            entry.data[CONF_ADDRESS] for entry in candidates
+        )
         return self.async_show_menu(
             step_id="init",
             menu_options=["pair_beds", "separate_beds"],
+            description_placeholders=self._description_placeholders(candidates),
         )
 
     async def async_step_separate_beds(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Record that these beds are separate and stop suggesting them."""
-        addresses = [
-            entry.data[CONF_ADDRESS] for entry in active_pairing_candidates(self.hass)
-        ]
-        await async_dismiss(self.hass, addresses)
+        current_addresses = normalize_addresses(
+            entry.data[CONF_ADDRESS]
+            for entry in active_pairing_candidates(self.hass)
+        )
+        if (
+            self._candidate_addresses is None
+            or current_addresses != self._candidate_addresses
+        ):
+            async_refresh_combine_beds_issue(self.hass)
+            return self.async_abort(reason="beds_changed")
+
+        await async_dismiss(self.hass, self._candidate_addresses)
         async_refresh_combine_beds_issue(self.hass)
         return self.async_abort(reason="beds_are_separate")
 

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -2018,9 +2018,17 @@
       "title": "Combine two beds into one (Dual Bed)",
       "fix_flow": {
         "step": {
+          "init": {
+            "title": "Are these two sides of one bed?",
+            "description": "Home Assistant found {count} standalone beds: {names}.\n\nIf two entries control the independent sides of one physical bed, combine them into Left and Right. If they are separate beds, choose that and this suggestion will not come back.",
+            "menu_options": {
+              "pair_beds": "They are two sides of one bed",
+              "separate_beds": "They are separate beds"
+            }
+          },
           "pair_beds": {
             "title": "Combine two beds",
-            "description": "Home Assistant found {count} active standalone beds: {names}. If two entries control the independent sides of one physical bed, choose which is Left and Right. Their entity IDs, history, names, areas, and dashboard references are preserved. If these are separate beds, close and dismiss this suggestion.",
+            "description": "Combine two existing beds into one paired device with Left, Right and combined controls. The two original beds are removed; their entity history follows. Pairing is for sides that move independently: if a sync cable already keeps both sides together, keep a single bed instead.",
             "data": {
               "pair_selection": "Left and Right sides",
               "name": "Name for the combined bed"
@@ -2040,7 +2048,8 @@
         "abort": {
           "not_enough_beds": "Fewer than two active standalone beds remain, so this suggestion no longer applies.",
           "already_configured": "These beds already belong to a paired Adjustable Bed entry.",
-          "pairing_flow_failed": "The Dual Bed setup flow could not be started. Reload Repairs and try again."
+          "pairing_flow_failed": "The Dual Bed setup flow could not be started. Reload Repairs and try again.",
+          "beds_are_separate": "Noted, these are separate beds. The suggestion is gone and will not return for this pair. Adding another bed later is a new question, so it may be suggested again then."
         }
       }
     },

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -2019,11 +2019,11 @@
       "fix_flow": {
         "step": {
           "init": {
-            "title": "Are these two sides of one bed?",
-            "description": "Home Assistant found {count} standalone beds: {names}.\n\nIf two entries control the independent sides of one physical bed, combine them into Left and Right. If they are separate beds, choose that and this suggestion will not come back.",
+            "title": "Could any two be sides of one bed?",
+            "description": "Home Assistant found {count} standalone beds: {names}.\n\nIf any two entries control the independent sides of one physical bed, choose them as Left and Right. If none share a physical bed, mark the displayed beds as separate and this suggestion will not return for that same set.",
             "menu_options": {
-              "pair_beds": "They are two sides of one bed",
-              "separate_beds": "They are separate beds"
+              "pair_beds": "Choose two sides to combine",
+              "separate_beds": "All are separate beds"
             }
           },
           "pair_beds": {
@@ -2049,7 +2049,8 @@
           "not_enough_beds": "Fewer than two active standalone beds remain, so this suggestion no longer applies.",
           "already_configured": "These beds already belong to a paired Adjustable Bed entry.",
           "pairing_flow_failed": "The Dual Bed setup flow could not be started. Reload Repairs and try again.",
-          "beds_are_separate": "Noted, these are separate beds. The suggestion is gone and will not return for this pair. Adding another bed later is a new question, so it may be suggested again then."
+          "beds_changed": "The active standalone beds changed while this repair was open, so nothing was dismissed. Open the repair again to review the current set.",
+          "beds_are_separate": "Noted, the displayed beds are separate. The suggestion is gone and will not return for this same set. If the active standalone bed set changes, it may be suggested again."
         }
       }
     },

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -2020,7 +2020,7 @@
         "step": {
           "init": {
             "title": "Could any two be sides of one bed?",
-            "description": "Home Assistant found {count} standalone beds: {names}.\n\nIf any two entries control the independent sides of one physical bed, choose them as Left and Right. If none share a physical bed, mark the displayed beds as separate and this suggestion will not return for that same set.",
+            "description": "Home Assistant found {count} standalone beds: {names}.\n\nIf any two entries control the independent sides of one physical bed, choose them as Left and Right. If none share a physical bed, mark the displayed beds as separate and this suggestion will not return while only those beds remain.",
             "menu_options": {
               "pair_beds": "Choose two sides to combine",
               "separate_beds": "All are separate beds"
@@ -2050,7 +2050,7 @@
           "already_configured": "These beds already belong to a paired Adjustable Bed entry.",
           "pairing_flow_failed": "The Dual Bed setup flow could not be started. Reload Repairs and try again.",
           "beds_changed": "The active standalone beds changed while this repair was open, so nothing was dismissed. Open the repair again to review the current set.",
-          "beds_are_separate": "Noted, the displayed beds are separate. The suggestion is gone and will not return for this same set. If the active standalone bed set changes, it may be suggested again."
+          "beds_are_separate": "Noted, the displayed beds are separate. The suggestion is gone and will not return while only those beds remain. If a new standalone bed is added, it may be suggested again."
         }
       }
     },

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -2018,9 +2018,17 @@
       "title": "Combine two beds into one (Dual Bed)",
       "fix_flow": {
         "step": {
+          "init": {
+            "title": "Are these two sides of one bed?",
+            "description": "Home Assistant found {count} standalone beds: {names}.\n\nIf two entries control the independent sides of one physical bed, combine them into Left and Right. If they are separate beds, choose that and this suggestion will not come back.",
+            "menu_options": {
+              "pair_beds": "They are two sides of one bed",
+              "separate_beds": "They are separate beds"
+            }
+          },
           "pair_beds": {
             "title": "Combine two beds",
-            "description": "Home Assistant found {count} active standalone beds: {names}. If two entries control the independent sides of one physical bed, choose which is Left and Right. Their entity IDs, history, names, areas, and dashboard references are preserved. If these are separate beds, close and dismiss this suggestion.",
+            "description": "Combine two existing beds into one paired device with Left, Right and combined controls. The two original beds are removed; their entity history follows. Pairing is for sides that move independently: if a sync cable already keeps both sides together, keep a single bed instead.",
             "data": {
               "pair_selection": "Left and Right sides",
               "name": "Name for the combined bed"
@@ -2040,7 +2048,8 @@
         "abort": {
           "not_enough_beds": "Fewer than two active standalone beds remain, so this suggestion no longer applies.",
           "already_configured": "These beds already belong to a paired Adjustable Bed entry.",
-          "pairing_flow_failed": "The Dual Bed setup flow could not be started. Reload Repairs and try again."
+          "pairing_flow_failed": "The Dual Bed setup flow could not be started. Reload Repairs and try again.",
+          "beds_are_separate": "Noted, these are separate beds. The suggestion is gone and will not return for this pair. Adding another bed later is a new question, so it may be suggested again then."
         }
       }
     },

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -2019,11 +2019,11 @@
       "fix_flow": {
         "step": {
           "init": {
-            "title": "Are these two sides of one bed?",
-            "description": "Home Assistant found {count} standalone beds: {names}.\n\nIf two entries control the independent sides of one physical bed, combine them into Left and Right. If they are separate beds, choose that and this suggestion will not come back.",
+            "title": "Could any two be sides of one bed?",
+            "description": "Home Assistant found {count} standalone beds: {names}.\n\nIf any two entries control the independent sides of one physical bed, choose them as Left and Right. If none share a physical bed, mark the displayed beds as separate and this suggestion will not return for that same set.",
             "menu_options": {
-              "pair_beds": "They are two sides of one bed",
-              "separate_beds": "They are separate beds"
+              "pair_beds": "Choose two sides to combine",
+              "separate_beds": "All are separate beds"
             }
           },
           "pair_beds": {
@@ -2049,7 +2049,8 @@
           "not_enough_beds": "Fewer than two active standalone beds remain, so this suggestion no longer applies.",
           "already_configured": "These beds already belong to a paired Adjustable Bed entry.",
           "pairing_flow_failed": "The Dual Bed setup flow could not be started. Reload Repairs and try again.",
-          "beds_are_separate": "Noted, these are separate beds. The suggestion is gone and will not return for this pair. Adding another bed later is a new question, so it may be suggested again then."
+          "beds_changed": "The active standalone beds changed while this repair was open, so nothing was dismissed. Open the repair again to review the current set.",
+          "beds_are_separate": "Noted, the displayed beds are separate. The suggestion is gone and will not return for this same set. If the active standalone bed set changes, it may be suggested again."
         }
       }
     },

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -2020,7 +2020,7 @@
         "step": {
           "init": {
             "title": "Could any two be sides of one bed?",
-            "description": "Home Assistant found {count} standalone beds: {names}.\n\nIf any two entries control the independent sides of one physical bed, choose them as Left and Right. If none share a physical bed, mark the displayed beds as separate and this suggestion will not return for that same set.",
+            "description": "Home Assistant found {count} standalone beds: {names}.\n\nIf any two entries control the independent sides of one physical bed, choose them as Left and Right. If none share a physical bed, mark the displayed beds as separate and this suggestion will not return while only those beds remain.",
             "menu_options": {
               "pair_beds": "Choose two sides to combine",
               "separate_beds": "All are separate beds"
@@ -2050,7 +2050,7 @@
           "already_configured": "These beds already belong to a paired Adjustable Bed entry.",
           "pairing_flow_failed": "The Dual Bed setup flow could not be started. Reload Repairs and try again.",
           "beds_changed": "The active standalone beds changed while this repair was open, so nothing was dismissed. Open the repair again to review the current set.",
-          "beds_are_separate": "Noted, the displayed beds are separate. The suggestion is gone and will not return for this same set. If the active standalone bed set changes, it may be suggested again."
+          "beds_are_separate": "Noted, the displayed beds are separate. The suggestion is gone and will not return while only those beds remain. If a new standalone bed is added, it may be suggested again."
         }
       }
     },

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -221,6 +221,22 @@ async def test_combine_repair_flow_shows_active_bed_picker(
     )
 
 
+async def test_combine_repair_flow_aborts_when_issue_is_stale(
+    hass: HomeAssistant,
+) -> None:
+    """A stale issue cannot offer choices for fewer than two active beds."""
+    _bed_entry(hass, address="AA:BB:CC:DD:EE:01", name="Only bed")
+    async_refresh_combine_beds_issue(hass)
+    flow = CombineBedsRepairFlow()
+    flow.hass = hass
+
+    result = await flow.async_step_init({"issue_id": COMBINE_BEDS_ISSUE_ID})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "not_enough_beds"
+    assert ir.async_get(hass).async_get_issue(DOMAIN, COMBINE_BEDS_ISSUE_ID) is None
+
+
 async def test_combine_repair_opens_through_repairs_manager(
     hass: HomeAssistant,
     enable_custom_integrations,
@@ -1603,7 +1619,7 @@ async def test_combine_repair_does_not_dismiss_candidates_that_changed(
 async def test_a_new_bed_makes_the_combine_question_worth_asking_again(
     hass: HomeAssistant,
 ) -> None:
-    """Dismissal is recorded against that exact set, not as "never ask"."""
+    """Dismissal covers subsets, while a genuinely new bed asks again."""
     from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
 
     from custom_components.adjustable_bed.combine_suggestion import (
@@ -1649,6 +1665,31 @@ async def test_a_new_bed_makes_the_combine_question_worth_asking_again(
     third.mock_state(hass, ConfigEntryState.NOT_LOADED)
     async_refresh_combine_beds_issue(hass)
     assert registry.async_get_issue(DOMAIN, "combine_two_beds") is None
+
+
+async def test_dismissed_group_covers_a_remaining_subset(
+    hass: HomeAssistant,
+) -> None:
+    """Removing one dismissed separate bed does not recreate the suggestion."""
+    from custom_components.adjustable_bed.combine_suggestion import (
+        async_dismiss,
+        async_load_dismissal,
+    )
+    from custom_components.adjustable_bed.repairs import async_refresh_combine_beds_issue
+
+    entries = [
+        _bed_entry(hass, address=f"BB:BB:BB:BB:BB:0{idx}", name=f"Bed {idx}")
+        for idx in range(1, 4)
+    ]
+    await async_load_dismissal(hass)
+    await async_dismiss(hass, [entry.data[CONF_ADDRESS] for entry in entries])
+
+    entries[-1].mock_state(hass, ConfigEntryState.NOT_LOADED)
+    async_refresh_combine_beds_issue(hass)
+
+    assert (
+        ir.async_get(hass).async_get_issue(DOMAIN, COMBINE_BEDS_ISSUE_ID) is None
+    )
 
 
 async def test_combine_dismissal_storage_migrates_single_address_set(

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 from dataclasses import replace
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -197,6 +198,10 @@ async def test_combine_repair_flow_shows_active_bed_picker(
     menu = await flow.async_step_init({"issue_id": COMBINE_BEDS_ISSUE_ID})
     assert menu["type"] is FlowResultType.MENU
     assert menu["menu_options"] == ["pair_beds", "separate_beds"]
+    assert menu["description_placeholders"] == {
+        "count": "2",
+        "names": "Left, Right",
+    }
 
     result = await flow.async_step_pair_beds()
 
@@ -1576,6 +1581,25 @@ async def test_the_combine_suggestion_can_be_answered_with_separate_beds(
     assert registry.async_get_issue(DOMAIN, "combine_two_beds") is None
 
 
+async def test_combine_repair_does_not_dismiss_candidates_that_changed(
+    hass: HomeAssistant,
+) -> None:
+    """The separate-beds answer applies only to the set shown in the menu."""
+    _bed_entry(hass, address="AA:AA:AA:AA:AA:01", name="Bed 1")
+    _bed_entry(hass, address="AA:AA:AA:AA:AA:02", name="Bed 2")
+    flow = CombineBedsRepairFlow()
+    flow.hass = hass
+    await flow.async_step_init()
+
+    _bed_entry(hass, address="AA:AA:AA:AA:AA:03", name="Bed 3")
+
+    done = await flow.async_step_separate_beds()
+
+    assert done["type"] is FlowResultType.ABORT
+    assert done["reason"] == "beds_changed"
+    assert ir.async_get(hass).async_get_issue(DOMAIN, COMBINE_BEDS_ISSUE_ID) is not None
+
+
 async def test_a_new_bed_makes_the_combine_question_worth_asking_again(
     hass: HomeAssistant,
 ) -> None:
@@ -1617,3 +1641,42 @@ async def test_a_new_bed_makes_the_combine_question_worth_asking_again(
 
     async_refresh_combine_beds_issue(hass)
     assert registry.async_get_issue(DOMAIN, "combine_two_beds") is not None
+
+    await async_dismiss(hass, [*addresses, third.data[CONF_ADDRESS]])
+    async_refresh_combine_beds_issue(hass)
+    assert registry.async_get_issue(DOMAIN, "combine_two_beds") is None
+
+    third.mock_state(hass, ConfigEntryState.NOT_LOADED)
+    async_refresh_combine_beds_issue(hass)
+    assert registry.async_get_issue(DOMAIN, "combine_two_beds") is None
+
+
+async def test_combine_dismissal_storage_migrates_single_address_set(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """The v1 dismissal remains effective after migrating to history storage."""
+    from custom_components.adjustable_bed.combine_suggestion import (
+        KEY_DISMISSED,
+        LEGACY_KEY_DISMISSED,
+        STORAGE_KEY,
+        async_is_dismissed,
+        async_load_dismissal,
+    )
+
+    addresses = ["CC:CC:CC:CC:CC:01", "CC:CC:CC:CC:CC:02"]
+    hass_storage[STORAGE_KEY] = {
+        "version": 1,
+        "minor_version": 1,
+        "data": {LEGACY_KEY_DISMISSED: addresses},
+    }
+
+    await async_load_dismissal(hass)
+
+    assert async_is_dismissed(hass, addresses)
+    assert hass_storage[STORAGE_KEY] == {
+        "version": 2,
+        "minor_version": 1,
+        "key": STORAGE_KEY,
+        "data": {KEY_DISMISSED: [addresses]},
+    }

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -187,14 +187,18 @@ async def test_combine_suggestion_excludes_entries_claimed_by_pair(
 async def test_combine_repair_flow_shows_active_bed_picker(
     hass: HomeAssistant,
 ) -> None:
-    """The suggestion opens directly on the Left/Right selector."""
+    """Choosing to combine opens the Left/Right selector."""
     left = _bed_entry(hass, address="AA:BB:CC:DD:EE:01", name="Left")
     right = _bed_entry(hass, address="AA:BB:CC:DD:EE:02", name="Right")
     flow = CombineBedsRepairFlow()
     flow.hass = hass
 
     # RepairsFlowManager passes its internal issue payload to the init step.
-    result = await flow.async_step_init({"issue_id": COMBINE_BEDS_ISSUE_ID})
+    menu = await flow.async_step_init({"issue_id": COMBINE_BEDS_ISSUE_ID})
+    assert menu["type"] is FlowResultType.MENU
+    assert menu["menu_options"] == ["pair_beds", "separate_beds"]
+
+    result = await flow.async_step_pair_beds()
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "pair_beds"
@@ -225,9 +229,14 @@ async def test_combine_repair_opens_through_repairs_manager(
     manager = repairs_flow_manager(hass)
     assert manager is not None
 
-    result = await manager.async_init(
+    menu = await manager.async_init(
         DOMAIN,
         data={"issue_id": COMBINE_BEDS_ISSUE_ID},
+    )
+    assert menu["type"] is FlowResultType.MENU
+
+    result = await manager.async_configure(
+        menu["flow_id"], {"next_step_id": "pair_beds"}
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -1516,3 +1525,95 @@ async def test_a_one_connection_bed_with_a_proxy_bond_still_gets_proxy_guidance(
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "proxy_bond"
+
+
+async def test_the_combine_suggestion_can_be_answered_with_separate_beds(
+    hass: HomeAssistant,
+) -> None:
+    """A fixable Repairs issue gets no Ignore action from Home Assistant.
+
+    Without an answer inside the flow, someone who owns two genuinely separate
+    beds can only close the dialog, which leaves the suggestion in Repairs for
+    good.
+    """
+    from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
+
+    from custom_components.adjustable_bed.combine_suggestion import async_load_dismissal
+    from custom_components.adjustable_bed.repairs import (
+        CombineBedsRepairFlow,
+        async_refresh_combine_beds_issue,
+    )
+
+    for idx, address in enumerate(("AA:AA:AA:AA:AA:01", "AA:AA:AA:AA:AA:02")):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_ADDRESS: address, CONF_NAME: f"Bed {idx}", CONF_BED_TYPE: "linak"},
+            unique_id=address,
+            entry_id=f"separate_beds_{idx}",
+        )
+        entry.add_to_hass(hass)
+        entry.mock_state(hass, ConfigEntryState.LOADED)
+
+    await async_load_dismissal(hass)
+    async_refresh_combine_beds_issue(hass)
+    registry = async_get_issue_registry(hass)
+    assert registry.async_get_issue(DOMAIN, "combine_two_beds") is not None
+
+    flow = CombineBedsRepairFlow()
+    flow.hass = hass
+
+    menu = await flow.async_step_init()
+    assert menu["type"] == FlowResultType.MENU
+    assert "separate_beds" in menu["menu_options"]
+
+    done = await flow.async_step_separate_beds()
+    assert done["type"] == FlowResultType.ABORT
+    assert done["reason"] == "beds_are_separate"
+
+    # Gone, and it stays gone when the state is reconciled again.
+    assert registry.async_get_issue(DOMAIN, "combine_two_beds") is None
+    async_refresh_combine_beds_issue(hass)
+    assert registry.async_get_issue(DOMAIN, "combine_two_beds") is None
+
+
+async def test_a_new_bed_makes_the_combine_question_worth_asking_again(
+    hass: HomeAssistant,
+) -> None:
+    """Dismissal is recorded against that exact set, not as "never ask"."""
+    from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
+
+    from custom_components.adjustable_bed.combine_suggestion import (
+        async_dismiss,
+        async_load_dismissal,
+    )
+    from custom_components.adjustable_bed.repairs import async_refresh_combine_beds_issue
+
+    addresses = ("BB:BB:BB:BB:BB:01", "BB:BB:BB:BB:BB:02")
+    for idx, address in enumerate(addresses):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_ADDRESS: address, CONF_NAME: f"Bed {idx}", CONF_BED_TYPE: "linak"},
+            unique_id=address,
+            entry_id=f"regrouped_{idx}",
+        )
+        entry.add_to_hass(hass)
+        entry.mock_state(hass, ConfigEntryState.LOADED)
+
+    await async_load_dismissal(hass)
+    # Lower case on purpose: the comparison must not depend on formatting.
+    await async_dismiss(hass, [a.lower() for a in addresses])
+    async_refresh_combine_beds_issue(hass)
+    registry = async_get_issue_registry(hass)
+    assert registry.async_get_issue(DOMAIN, "combine_two_beds") is None
+
+    third = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_ADDRESS: "BB:BB:BB:BB:BB:03", CONF_NAME: "Bed 3", CONF_BED_TYPE: "linak"},
+        unique_id="BB:BB:BB:BB:BB:03",
+        entry_id="regrouped_3",
+    )
+    third.add_to_hass(hass)
+    third.mock_state(hass, ConfigEntryState.LOADED)
+
+    async_refresh_combine_beds_issue(hass)
+    assert registry.async_get_issue(DOMAIN, "combine_two_beds") is not None


### PR DESCRIPTION
The Dual Bed suggestion had no answer for "these are two different beds".

It is a fixable Repairs issue, and Home Assistant offers no Ignore action for those: a fixable issue opens its fix flow, so the only exit was the X, which closes the dialog and leaves the issue sitting in Repairs. For anyone who genuinely owns two beds that is a permanent, unanswerable warning. The description even instructed them to "close and dismiss this suggestion", which closing does not do.

## What changed

The flow opens on a menu with both answers rather than going straight to the Left/Right selector. Choosing "They are separate beds" records the dismissal, deletes the issue, and aborts with an explanation.

The dismissal is recorded against the exact set of addresses that was suggested, not as a global never-ask flag. Two beds the user has called separate stay separate; adding a third bed later is a different question and gets asked again. It lives in its own small `Store`, following the `discovery_settings.py` precedent, and is cached in memory at setup because the Repairs refresh runs from synchronous entry lifecycle callbacks that cannot await a store read.

The `pair_beds` description also drops the inaccurate "close and dismiss" instruction.

## Tests

- Answering "separate beds" clears the issue and it stays cleared when the state is reconciled again
- Adding a third bed re-suggests, and the address comparison is case insensitive
- The two existing tests that assumed `init` rendered the form now route through the menu

Full suite green at 3267.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a guided “combine two beds” choice: pair as a dual bed or mark the displayed beds as separate.
  - “Separate beds” decisions are now remembered per detected bed set, so the prompt doesn’t repeat while the same beds remain.
  - The prompt returns when the detected bed set genuinely changes (e.g., a new bed appears).

- **Bug Fixes**
  - Fixed combine-bed suggestions so dismissed states are applied correctly based on the current candidate bed set.

- **Documentation**
  - Updated the Dual Bed repair-flow text and outcomes to explain pairing vs separate-bed behavior more clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->