### PR TITLE
fix(richmat): add L&P QRRM preset profile

### DIFF
--- a/custom_components/adjustable_bed/beds/richmat.py
+++ b/custom_components/adjustable_bed/beds/richmat.py
@@ -25,6 +25,7 @@ from ..const import (
     RICHMAT_PROTOCOL_SINGLE,
     RICHMAT_PROTOCOL_WILINKE,
     RICHMAT_REMOTE_AUTO,
+    RICHMAT_REMOTE_LP_QRRM,
     RICHMAT_WILINKE_CHAR_UUIDS,
     RICHMAT_WILINKE_SERVICE_UUIDS,
     RICHMAT_WILINKE_STOP_COMPAT_REMOTE_CODES,
@@ -450,6 +451,13 @@ class RichmatController(BedController):
         if self._features & RichmatFeatures.PRESET_MEMORY_3:
             count += 1
         return count
+
+    @property
+    def memory_slot_names(self) -> tuple[str | None, ...]:
+        """Return model-specific names for Richmat memory slots."""
+        if self._remote_code.lower() == RICHMAT_REMOTE_LP_QRRM.lower():
+            return ("Custom 1", "Custom 2")
+        return ()
 
     @property
     def supports_memory_programming(self) -> bool:

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -2865,12 +2865,16 @@ class AdjustableBedOptionsFlow(OptionsFlowWithConfigEntry):
 
         # Add remote selection for Richmat beds
         if bed_type == BED_TYPE_RICHMAT:
+            current_remote = current_data.get(CONF_RICHMAT_REMOTE, RICHMAT_REMOTE_AUTO)
+            remote_options = dict(RICHMAT_REMOTES)
+            if current_remote not in remote_options:
+                remote_options[current_remote] = f"{current_remote.upper()} (current detected code)"
             schema_dict[
                 vol.Optional(
                     CONF_RICHMAT_REMOTE,
-                    default=current_data.get(CONF_RICHMAT_REMOTE, RICHMAT_REMOTE_AUTO),
+                    default=current_remote,
                 )
-            ] = vol.In(RICHMAT_REMOTES)
+            ] = vol.In(remote_options)
 
         if bed_type in MALOUF_BED_TYPES:
             schema_dict[

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -1201,7 +1201,7 @@ RICHMAT_REMOTE_LP_QRRM: Final = "LP-QRRM"
 # Most Richmat remotes use END=0x6E, but some devices require 0x5E to stop
 # movement: QRRM remotes and BedTech BT6500 beds (issue #194).
 RICHMAT_WILINKE_STOP_COMPAT_REMOTE_CODES: Final[frozenset[str]] = frozenset(
-    {"qrrm", "bt6500", RICHMAT_REMOTE_LP_QRRM.lower()}
+    {"qrrm", "bt6500"}
 )
 
 # Display names for remote selection

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -1291,8 +1291,9 @@ RICHMAT_REMOTE_FEATURES: Final = {
         | _F.MOTOR_PILLOW
         | _F.MOTOR_LUMBAR
     ),
-    # L&P QRRM surface reported in #504. QRRM alone is only a selector family,
-    # so keep this explicit instead of exposing these presets on every QRRM bed.
+    # L&P QRRM surface reported in #504. Current L&P and Richmat apps keep the
+    # generic QRRM profile empty until the user selects a physical remote, so
+    # keep this explicit instead of exposing these presets on every QRRM bed.
     RICHMAT_REMOTE_LP_QRRM: (
         _F.PRESET_FLAT
         | _F.PRESET_MEMORY_1
@@ -1463,8 +1464,8 @@ RICHMAT_REMOTE_FEATURES: Final = {
     ),
 }
 
-# Some Richmat OEM apps expose a generic QRRM family in BLE, then ask the user
-# to pick the actual retail model. Use entry/device names to recover those
+# Some Richmat OEM apps discover a generic QRRM name, then ask the user to pick
+# the actual product profile. Use entry/device names to recover those
 # model-specific surfaces when we have enough context.
 RICHMAT_MODEL_REMOTE_ALIASES: Final[dict[str, str]] = {
     "bt2000": "a7rm",
@@ -1486,10 +1487,9 @@ def resolve_richmat_remote_code(
 ) -> str:
     """Resolve a Richmat remote code using config and model-specific aliases.
 
-    QRRM is a selector family in OEM apps rather than a concrete remote surface.
-    If the config or device title includes a known retail model (for example
-    "BedTech BT6500"), prefer that model-specific surface over the generic QRRM
-    feature map.
+    QRRM does not identify a concrete remote surface. If the config or device
+    title includes a known retail model (for example "BedTech BT6500"), prefer
+    that model-specific surface over the generic QRRM feature map.
     """
     normalized = (remote_code or RICHMAT_REMOTE_AUTO).lower()
     if normalized not in {"", RICHMAT_REMOTE_AUTO, "qrrm"}:

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -1195,11 +1195,14 @@ RICHMAT_REMOTE_ZR60: Final = "ZR60"
 RICHMAT_REMOTE_I7RM: Final = "I7RM"
 RICHMAT_REMOTE_190_0055: Final = "190-0055"
 RICHMAT_REMOTE_BT6500: Final = "BT6500"
+RICHMAT_REMOTE_LP_QRRM: Final = "LP-QRRM"
 
 # Richmat WiLinke stop-byte compatibility.
 # Most Richmat remotes use END=0x6E, but some devices require 0x5E to stop
 # movement: QRRM remotes and BedTech BT6500 beds (issue #194).
-RICHMAT_WILINKE_STOP_COMPAT_REMOTE_CODES: Final[frozenset[str]] = frozenset({"qrrm", "bt6500"})
+RICHMAT_WILINKE_STOP_COMPAT_REMOTE_CODES: Final[frozenset[str]] = frozenset(
+    {"qrrm", "bt6500", RICHMAT_REMOTE_LP_QRRM.lower()}
+)
 
 # Display names for remote selection
 RICHMAT_REMOTES: Final = {
@@ -1216,6 +1219,7 @@ RICHMAT_REMOTES: Final = {
     RICHMAT_REMOTE_ZR60: "ZR60 (Head, Feet, Lights)",
     RICHMAT_REMOTE_I7RM: "I7RM / HJH85 / Sleep Function 2.0 (Head, Feet, Pillow, Lumbar, Massage, Lights)",
     RICHMAT_REMOTE_190_0055: "190-0055 (Head, Pillow, Feet, Massage, Lights)",
+    RICHMAT_REMOTE_LP_QRRM: "L&P QRRM (Head, Feet, Flat, Zero G, Custom 1/2)",
 }
 
 # Feature sets for each remote code
@@ -1286,6 +1290,16 @@ RICHMAT_REMOTE_FEATURES: Final = {
         | _F.MOTOR_FEET
         | _F.MOTOR_PILLOW
         | _F.MOTOR_LUMBAR
+    ),
+    # L&P QRRM surface reported in #504. QRRM alone is only a selector family,
+    # so keep this explicit instead of exposing these presets on every QRRM bed.
+    RICHMAT_REMOTE_LP_QRRM: (
+        _F.PRESET_FLAT
+        | _F.PRESET_MEMORY_1
+        | _F.PRESET_MEMORY_2
+        | _F.PRESET_ZERO_G
+        | _F.MOTOR_HEAD
+        | _F.MOTOR_FEET
     ),
     RICHMAT_REMOTE_BURM: (
         _F.PRESET_FLAT

--- a/custom_components/adjustable_bed/frontend.py
+++ b/custom_components/adjustable_bed/frontend.py
@@ -14,7 +14,7 @@ import logging
 from pathlib import Path
 
 from homeassistant.components.frontend import add_extra_js_url
-from homeassistant.components.http import StaticPathConfig
+from homeassistant.components.http.server import StaticPathConfig
 from homeassistant.components.lovelace.const import (
     CONF_RESOURCE_TYPE_WS,
     LOVELACE_DATA,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -298,9 +298,10 @@ Richmat beds have different feature sets based on the remote model. Selecting yo
 
 **Note:** The remote code is usually printed on the back of your physical remote.
 For an L&P bed that advertises as `QRRM` and has Flat, Zero G, Custom 1, and
-Custom 2 buttons, select **L&P QRRM**. A bare QRRM name does not identify the
-physical remote layout, so the integration cannot select this profile safely on
-its own.
+Custom 2 buttons, select **L&P QRRM**. Current L&P and Richmat apps also require
+a physical remote or product selection for QRRM devices. The BLE name and GATT
+services do not identify that profile, so the integration cannot select it
+safely on its own.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -294,8 +294,13 @@ Richmat beds have different feature sets based on the remote model. Selecting yo
 | **ZR60** | Head, Feet, Lights |
 | **I7RM** | Head, Feet, Pillow, Lumbar, Massage, Lights |
 | **190-0055** | Head, Pillow, Feet, Massage, Lights |
+| **L&P QRRM** | Head, Feet, Flat, Zero G, Custom 1/2 |
 
 **Note:** The remote code is usually printed on the back of your physical remote.
+For an L&P bed that advertises as `QRRM` and has Flat, Zero G, Custom 1, and
+Custom 2 buttons, select **L&P QRRM**. A bare QRRM name does not identify the
+physical remote layout, so the integration cannot select this profile safely on
+its own.
 
 ---
 

--- a/docs/beds/leggett-platt.md
+++ b/docs/beds/leggett-platt.md
@@ -15,27 +15,27 @@
 
 | Analyzed | App | Package ID |
 |----------|-----|------------|
-| ✅ | [L&P Adjustable Base](https://play.google.com/store/apps/details?id=com.richmat.lp2) | `com.richmat.lp2` |
+| ✅ | [L&P Adjustable Base](https://play.google.com/store/apps/details?id=com.richmat.lp2) 2.3.25 | `com.richmat.lp2` |
 | ✅ | L&P Adjustable Base 2.2.1 (legacy) | `com.richmat.lp` |
-| ✅ | [LP Control](https://play.google.com/store/apps/details?id=com.leggett.android.universal) (LP Comfort Connect) | `com.leggett.android.universal` |
+| ✅ | [LP Control](https://play.google.com/store/apps/details?id=com.leggett.android.universal) 2.9.0 (LP Comfort Connect) | `com.leggett.android.universal` |
 
 ## Features
 
-| Feature | Gen2 | Okin | MlRM |
-|---------|------|------|------|
-| Motor Control | ✅ (head, feet, pillow, lumbar) | ✅ (head, feet, tilt, lumbar) | ✅ (discrete) |
-| Position Feedback | ❌ | ❌ | ❌ |
-| Memory Presets | ✅ (4 slots) | ✅ (4 slots) | ✅ (2 slots) |
-| Massage | ✅ (0-10 levels) | ✅ (wave, timer) | ✅ (discrete UP/DOWN) |
-| Lighting | ✅ RGB | ✅ Toggle | ✅ Toggle |
-| Anti-Snore | ✅ | ❌ | ✅ |
-| Zero-G | ❌ | ✅ | ✅ |
-| TV Preset | ❌ | ❌ | ✅ |
-| Lounge Preset | ❌ | ❌ | ✅ |
+| Feature | Gen2 | Okin | MlRM | QRRM profile |
+|---------|------|------|------|--------------|
+| Motor Control | ✅ (head, feet, pillow, lumbar) | ✅ (head, feet, tilt, lumbar) | ✅ (discrete) | ✅ (head, feet) |
+| Position Feedback | ❌ | ❌ | ❌ | ❌ |
+| Memory Presets | ✅ (4 slots) | ✅ (4 slots) | ✅ (2 slots) | ✅ (2 slots) |
+| Massage | ✅ (0-10 levels) | ✅ (wave, timer) | ✅ (discrete UP/DOWN) | ❌ |
+| Lighting | ✅ RGB | ✅ Toggle | ✅ Toggle | ❌ |
+| Anti-Snore | ✅ | ❌ | ✅ | ❌ |
+| Zero-G | ❌ | ✅ | ✅ | ✅ |
+| TV Preset | ❌ | ❌ | ✅ | ❌ |
+| Lounge Preset | ❌ | ❌ | ✅ | ❌ |
 
 ## Detection
 
-Leggett & Platt beds have three protocol variants with different detection methods:
+Leggett & Platt beds have four protocol variants with different detection methods:
 
 ### QRRM Richmat Variant
 
@@ -43,9 +43,11 @@ Some L&P bases advertise as `QRRM` and are configured as the **Richmat** bed
 type, rather than one of the three Leggett-specific variants below. QRRM does
 not identify the physical remote layout. If the remote has Flat, Zero G,
 Custom 1, and Custom 2 buttons, select **L&P QRRM** as the Richmat remote in the
-integration options. Its command frames are recovered from the L&P app, but the
-profile still needs physical hardware validation. See [Richmat](richmat.md) for
-the protocol details.
+integration options. The current L&P and Richmat apps likewise require a typed,
+scanned, or previously saved physical remote profile because the BLE peripheral
+does not expose one. Flat is confirmed on the issue #504 hardware; the other
+command frames are recovered consistently from the current apps and still need
+physical validation. See [Richmat](richmat.md) for the protocol details.
 
 ### Gen2 Variant
 - **Service UUID:** `45e25100-...` (unique to Gen2), when advertised

--- a/docs/beds/leggett-platt.md
+++ b/docs/beds/leggett-platt.md
@@ -16,6 +16,7 @@
 | Analyzed | App | Package ID |
 |----------|-----|------------|
 | ✅ | [L&P Adjustable Base](https://play.google.com/store/apps/details?id=com.richmat.lp2) | `com.richmat.lp2` |
+| ✅ | L&P Adjustable Base 2.2.1 (legacy) | `com.richmat.lp` |
 | ✅ | [LP Control](https://play.google.com/store/apps/details?id=com.leggett.android.universal) (LP Comfort Connect) | `com.leggett.android.universal` |
 
 ## Features
@@ -35,6 +36,16 @@
 ## Detection
 
 Leggett & Platt beds have three protocol variants with different detection methods:
+
+### QRRM Richmat Variant
+
+Some L&P bases advertise as `QRRM` and are configured as the **Richmat** bed
+type, rather than one of the three Leggett-specific variants below. QRRM does
+not identify the physical remote layout. If the remote has Flat, Zero G,
+Custom 1, and Custom 2 buttons, select **L&P QRRM** as the Richmat remote in the
+integration options. Its command frames are recovered from the L&P app, but the
+profile still needs physical hardware validation. See [Richmat](richmat.md) for
+the protocol details.
 
 ### Gen2 Variant
 - **Service UUID:** `45e25100-...` (unique to Gen2), when advertised

--- a/docs/beds/richmat.md
+++ b/docs/beds/richmat.md
@@ -84,9 +84,9 @@ choose **L&P QRRM** under the integration options. It remains an explicit profil
 because the BLE name and GATT layout do not distinguish it from other QRRM
 surfaces.
 The current L&P and Richmat apps make the same explicit product-profile choice;
-their generic QRRM profiles contain no controls. Flat is confirmed on the issue
-#504 hardware. The other command frames are statically verified across the apps
-but have not yet been validated on that physical bed.
+their generic QRRM profiles contain no controls. On the hardware from
+issue #504, Flat is confirmed. The other command frames are statically verified
+across the apps but have not yet been validated on that physical bed.
 
 ### Prefix55 Variant
 **Format:** 5 bytes `[0x55, 0x01, 0x00, command, checksum]`

--- a/docs/beds/richmat.md
+++ b/docs/beds/richmat.md
@@ -42,11 +42,12 @@ Brands using Richmat actuators:
 
 | Analyzed | App | Package ID |
 |----------|-----|------------|
-| ✅ | [RMControl](https://play.google.com/store/apps/details?id=com.richmat.rmcontrol2) | `com.richmat.rmcontrol2` |
+| ✅ | [RMControl](https://play.google.com/store/apps/details?id=com.richmat.rmcontrol2) 21.3.2 | `com.richmat.rmcontrol2` |
 | ✅ | [BedTech](https://play.google.com/store/apps/details?id=com.bedtech) | `com.bedtech` |
 | ✅ | [SleepFunction Bed Control](https://play.google.com/store/apps/details?id=com.richmat.sleepfunction) | `com.richmat.sleepfunction` |
-| ✅ | [L&P Adjustable Base](https://play.google.com/store/apps/details?id=com.richmat.lp2) | `com.richmat.lp2` |
+| ✅ | [L&P Adjustable Base](https://play.google.com/store/apps/details?id=com.richmat.lp2) 2.3.25 | `com.richmat.lp2` |
 | ✅ | L&P Adjustable Base 2.2.1 (legacy) | `com.richmat.lp` |
+| ✅ | [LP Control](https://play.google.com/store/apps/details?id=com.leggett.android.universal) 2.9.0 | `com.leggett.android.universal` |
 | ✅ | [SVEN & SON](https://play.google.com/store/apps/details?id=com.richmat.svenson) | `com.richmat.svenson` |
 
 ## Features
@@ -77,12 +78,15 @@ FEE9/QRRM advertisements are shared with BedTech. A confirmed BedTech-specific
 manufacturer field (`0x4C57`) selects the BedTech protocol; QRRM devices without
 that field retain Richmat behavior, including the confirmed Casper RGB-light model.
 
-QRRM is a selector family, not a single physical remote layout. For the L&P
-surface reported in issue #504, with Flat, Zero G, Custom 1, and Custom 2, choose
-**L&P QRRM** under the integration options. It remains an explicit profile because
-the BLE name and GATT layout do not distinguish it from other QRRM surfaces.
-The command frames are recovered from the L&P app, but this profile has not yet
-been validated on physical hardware.
+QRRM is a generic controller name, not a single physical remote layout. For the
+L&P surface reported in issue #504, with Flat, Zero G, Custom 1, and Custom 2,
+choose **L&P QRRM** under the integration options. It remains an explicit profile
+because the BLE name and GATT layout do not distinguish it from other QRRM
+surfaces.
+The current L&P and Richmat apps make the same explicit product-profile choice;
+their generic QRRM profiles contain no controls. Flat is confirmed on the issue
+#504 hardware. The other command frames are statically verified across the apps
+but have not yet been validated on that physical bed.
 
 ### Prefix55 Variant
 **Format:** 5 bytes `[0x55, 0x01, 0x00, command, checksum]`

--- a/docs/beds/richmat.md
+++ b/docs/beds/richmat.md
@@ -46,6 +46,7 @@ Brands using Richmat actuators:
 | ✅ | [BedTech](https://play.google.com/store/apps/details?id=com.bedtech) | `com.bedtech` |
 | ✅ | [SleepFunction Bed Control](https://play.google.com/store/apps/details?id=com.richmat.sleepfunction) | `com.richmat.sleepfunction` |
 | ✅ | [L&P Adjustable Base](https://play.google.com/store/apps/details?id=com.richmat.lp2) | `com.richmat.lp2` |
+| ✅ | L&P Adjustable Base 2.2.1 (legacy) | `com.richmat.lp` |
 | ✅ | [SVEN & SON](https://play.google.com/store/apps/details?id=com.richmat.svenson) | `com.richmat.svenson` |
 
 ## Features
@@ -75,6 +76,13 @@ Brands using Richmat actuators:
 FEE9/QRRM advertisements are shared with BedTech. A confirmed BedTech-specific
 manufacturer field (`0x4C57`) selects the BedTech protocol; QRRM devices without
 that field retain Richmat behavior, including the confirmed Casper RGB-light model.
+
+QRRM is a selector family, not a single physical remote layout. For the L&P
+surface reported in issue #504, with Flat, Zero G, Custom 1, and Custom 2, choose
+**L&P QRRM** under the integration options. It remains an explicit profile because
+the BLE name and GATT layout do not distinguish it from other QRRM surfaces.
+The command frames are recovered from the L&P app, but this profile has not yet
+been validated on physical hardware.
 
 ### Prefix55 Variant
 **Format:** 5 bytes `[0x55, 0x01, 0x00, command, checksum]`

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -82,6 +82,7 @@ from custom_components.adjustable_bed.const import (
     CONF_PASSIVE_POSITION_RECONCILIATION,
     CONF_PREFERRED_ADAPTER,
     CONF_PROTOCOL_VARIANT,
+    CONF_RICHMAT_REMOTE,
     DOMAIN,
     KAIDI_VARIANT_SEAT_1,
     KEESON_VARIANT_ERGOMOTION,
@@ -89,6 +90,7 @@ from custom_components.adjustable_bed.const import (
     MALOUF_LAYOUT_HILO,
     OCTO_VARIANT_STANDARD,
     OCTO_VARIANT_STAR2,
+    RICHMAT_REMOTE_LP_QRRM,
     RICHMAT_WILINKE_SERVICE_UUIDS,
     RONDURE_VARIANT_SIDE_A,
     SBI_VARIANT_SIDE_B,
@@ -2278,6 +2280,47 @@ class TestUserFlow:
 
 class TestOptionsFlow:
     """Test options flow."""
+
+    async def test_richmat_options_can_replace_detected_qrrm_with_lp_profile(
+        self,
+        hass: HomeAssistant,
+        enable_custom_integrations,
+    ) -> None:
+        """Existing QRRM entries should be able to select the L&P preset surface."""
+        del enable_custom_integrations
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="QRRM106475",
+            data={
+                CONF_ADDRESS: "57:4C:54:00:2D:BE",
+                CONF_NAME: "QRRM106475",
+                CONF_BED_TYPE: BED_TYPE_RICHMAT,
+                CONF_MOTOR_COUNT: 2,
+                CONF_PROTOCOL_VARIANT: "auto",
+                CONF_RICHMAT_REMOTE: "qrrm",
+            },
+            unique_id="57:4C:54:00:2D:BE",
+        )
+        entry.add_to_hass(hass)
+        await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+        initial = await hass.config_entries.options.async_init(entry.entry_id)
+        markers = {marker.schema: marker for marker in initial["data_schema"].schema}
+        remote_marker = markers[CONF_RICHMAT_REMOTE]
+        remote_validator = initial["data_schema"].schema[remote_marker]
+
+        assert remote_marker.default() == "qrrm"
+        assert "qrrm" in remote_validator.container
+        assert RICHMAT_REMOTE_LP_QRRM in remote_validator.container
+
+        saved = await hass.config_entries.options.async_configure(
+            initial["flow_id"],
+            user_input={CONF_RICHMAT_REMOTE: RICHMAT_REMOTE_LP_QRRM},
+        )
+
+        assert saved["type"] == FlowResultType.CREATE_ENTRY
+        assert entry.data[CONF_RICHMAT_REMOTE] == RICHMAT_REMOTE_LP_QRRM
 
     async def test_options_flow_records_pulse_settings_as_user_owned(
         self,

--- a/tests/test_richmat.py
+++ b/tests/test_richmat.py
@@ -27,6 +27,7 @@ from custom_components.adjustable_bed.const import (
     RICHMAT_NORDIC_CHAR_UUID,
     RICHMAT_PROTOCOL_PREFIX55,
     RICHMAT_PROTOCOL_PREFIXAA,
+    RICHMAT_REMOTE_LP_QRRM,
     RICHMAT_VARIANT_NORDIC,
     get_richmat_features,
     get_richmat_motor_count,
@@ -486,6 +487,51 @@ class TestRichmatFeatureDetection:
         assert controller.supports_lights is True
         assert controller.has_pillow_support is True
         assert controller.has_lumbar_support is True
+
+    def test_lp_qrrm_profile_exposes_reported_presets_only(self):
+        """L&P QRRM should expose the four-position surface from issue #504."""
+        coordinator = MagicMock()
+        controller = RichmatController(
+            coordinator,
+            is_wilinke=True,
+            remote_code=RICHMAT_REMOTE_LP_QRRM,
+        )
+
+        assert controller.supports_preset_flat is True
+        assert controller.supports_preset_zero_g is True
+        assert controller.supports_memory_presets is True
+        assert controller.memory_slot_count == 2
+        assert controller.memory_slot_names == ("Custom 1", "Custom 2")
+        assert controller.supports_memory_programming is False
+        assert controller.supports_preset_anti_snore is False
+        assert controller.supports_preset_tv is False
+        assert controller.supports_preset_lounge is False
+        assert controller.supports_lights is False
+        assert controller.has_pillow_support is False
+        assert controller.has_lumbar_support is False
+
+    def test_lp_qrrm_profile_uses_recovered_wilinke_frames(self):
+        """L&P presets should match the clean-room recovered app packets."""
+        coordinator = MagicMock()
+        controller = RichmatController(
+            coordinator,
+            is_wilinke=True,
+            remote_code=RICHMAT_REMOTE_LP_QRRM,
+        )
+
+        assert controller._build_command(RichmatCommands.PRESET_FLAT) == bytes.fromhex(
+            "6e010031a0"
+        )
+        assert controller._build_command(RichmatCommands.PRESET_ZERO_G) == bytes.fromhex(
+            "6e010045b4"
+        )
+        assert controller._build_command(RichmatCommands.PRESET_MEMORY_1) == bytes.fromhex(
+            "6e01002e9d"
+        )
+        assert controller._build_command(RichmatCommands.PRESET_MEMORY_2) == bytes.fromhex(
+            "6e01002f9e"
+        )
+        assert controller._build_stop_command()[3] == RichmatCommands.END_COMPAT
 
     def test_resolve_bt6500_title_alias_from_qrrm_family(self):
         """BT6500 titles should resolve away from the generic QRRM profile."""

--- a/tests/test_richmat.py
+++ b/tests/test_richmat.py
@@ -511,7 +511,7 @@ class TestRichmatFeatureDetection:
         assert controller.has_lumbar_support is False
 
     def test_lp_qrrm_profile_uses_recovered_wilinke_frames(self):
-        """L&P presets should match the clean-room recovered app packets."""
+        """L&P commands should match the clean-room recovered app packets."""
         coordinator = MagicMock()
         controller = RichmatController(
             coordinator,
@@ -531,7 +531,7 @@ class TestRichmatFeatureDetection:
         assert controller._build_command(RichmatCommands.PRESET_MEMORY_2) == bytes.fromhex(
             "6e01002f9e"
         )
-        assert controller._build_stop_command()[3] == RichmatCommands.END_COMPAT
+        assert controller._build_stop_command() == bytes.fromhex("6e01006edd")
 
     def test_resolve_bt6500_title_alias_from_qrrm_family(self):
         """BT6500 titles should resolve away from the generic QRRM profile."""


### PR DESCRIPTION
Issue #504 reports that an L&P base advertising as QRRM only exposes Flat in Home Assistant, while its physical remote also has Zero G and two custom presets.

This adds an explicit L&P QRRM capability profile with the recovered WiLinke frames for Flat, Zero G, Custom 1, and Custom 2. Existing detected QRRM values also remain selectable in the options form.

Clean-room analysis covered the legacy L&P app plus the current L&P Adjustable Base, LP Control, and RMControl apps. They agree that the command opcodes are stable wherever bound, but QRRM does not expose a product profile through its BLE name or GATT services. The OEM apps require a typed, scanned, or previously saved product choice too, so the integration keeps this profile explicit instead of guessing for every QRRM bed.

Flat is confirmed on the issue hardware. The other frames are statically verified across the apps and remain pending physical validation on that bed.

Validation:
- `uv run pytest` (2734 passed)
- focused Richmat/config-flow suite (188 passed)
- `uvx ruff check` on changed Python files
- changed-file Pyright (0 errors)
- initial `crq preflight --type uncommitted` (clean)

Ref #504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for L&P QRRM adjustable bed remotes.
  * Added Flat, Zero-G, head, feet, and two custom memory controls.
  * Preserves detected QRRM selections and allows choosing the L&P profile.
* **Bug Fixes**
  * Existing QRRM remote selections remain available in configuration options.
* **Documentation**
  * Updated setup guidance, supported features, app versions, and QRRM profile details.
* **Tests**
  * Added coverage for QRRM controls, compatibility, and profile selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->