### PR TITLE
fix(frontend): make Lovelace card loading resilient

### DIFF
--- a/custom_components/adjustable_bed/frontend.py
+++ b/custom_components/adjustable_bed/frontend.py
@@ -11,17 +11,22 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+from functools import partial
 from pathlib import Path
+from urllib.parse import urlsplit
 
+from homeassistant.components.frontend import DOMAIN as FRONTEND_DOMAIN
 from homeassistant.components.frontend import add_extra_js_url
 from homeassistant.components.http.server import StaticPathConfig
 from homeassistant.components.lovelace.const import (
     CONF_RESOURCE_TYPE_WS,
     LOVELACE_DATA,
 )
+from homeassistant.components.lovelace.const import DOMAIN as LOVELACE_DOMAIN
 from homeassistant.components.lovelace.resources import ResourceStorageCollection
 from homeassistant.const import CONF_ID, CONF_TYPE, CONF_URL
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_when_setup
 
 from .const import DOMAIN
 
@@ -68,6 +73,19 @@ def _gather() -> tuple[bool, str, str]:
     return exists, version, cache_key
 
 
+def _card_url(cache_key: str) -> str:
+    """Return a content-versioned URL whose path survives cache normalization."""
+    return f"{URL_BASE}/{cache_key}/{CARD_FILENAME}"
+
+
+def _is_card_resource(url: object) -> bool:
+    """Return whether a resource URL belongs to this integration's card."""
+    path = urlsplit(str(url)).path
+    return path == CARD_URL or (
+        path.startswith(f"{URL_BASE}/") and path.endswith(f"/{CARD_FILENAME}")
+    )
+
+
 async def _async_register_lovelace_resource(
     hass: HomeAssistant,
     card_url: str,
@@ -89,15 +107,12 @@ async def _async_register_lovelace_resource(
 
     # async_items() is synchronous and does not load storage itself.
     await resources.async_get_info()
-    existing = next(
-        (
-            item
-            for item in resources.async_items()
-            if str(item.get(CONF_URL, "")).partition("?")[0] == CARD_URL
-        ),
-        None,
-    )
-    if existing is None:
+    existing = [
+        item
+        for item in resources.async_items()
+        if _is_card_resource(item.get(CONF_URL, ""))
+    ]
+    if not existing:
         await resources.async_create_item(
             {
                 CONF_RESOURCE_TYPE_WS: "module",
@@ -106,31 +121,74 @@ async def _async_register_lovelace_resource(
         )
         return True
 
-    if existing.get(CONF_URL) != card_url or existing.get(CONF_TYPE) != "module":
+    current = next(
+        (
+            item
+            for item in existing
+            if item.get(CONF_URL) == card_url and item.get(CONF_TYPE) == "module"
+        ),
+        existing[0],
+    )
+    if current.get(CONF_URL) != card_url or current.get(CONF_TYPE) != "module":
         await resources.async_update_item(
-            existing[CONF_ID],
+            current[CONF_ID],
             {
                 CONF_RESOURCE_TYPE_WS: "module",
                 CONF_URL: card_url,
             },
         )
+
+    for duplicate in existing:
+        if duplicate[CONF_ID] != current[CONF_ID]:
+            await resources.async_delete_item(duplicate[CONF_ID])
     return True
+
+
+async def _async_add_frontend_module(
+    hass: HomeAssistant,
+    _component: str,
+    *,
+    card_url: str,
+) -> None:
+    """Add the module when Home Assistant's frontend is ready."""
+    try:
+        add_extra_js_url(hass, card_url)
+    except Exception:  # noqa: BLE001 - the durable resource may still load it
+        _LOGGER.warning(
+            "Could not add the Adjustable Bed frontend module hook; the "
+            "Lovelace resource will still be attempted",
+            exc_info=True,
+        )
+
+
+async def _async_add_lovelace_resource(
+    hass: HomeAssistant,
+    _component: str,
+    *,
+    card_url: str,
+) -> None:
+    """Persist the module when Home Assistant's Lovelace data is ready."""
+    try:
+        await _async_register_lovelace_resource(hass, card_url)
+    except Exception:  # noqa: BLE001 - the frontend module hook is independent
+        _LOGGER.warning(
+            "Could not register the Adjustable Bed card as a Lovelace resource; "
+            "the frontend module hook will still be attempted",
+            exc_info=True,
+        )
 
 
 async def async_register_frontend(hass: HomeAssistant) -> None:
     """Register the static path and auto-load the card on the frontend.
 
     The card is a convenience; registration must never break integration setup.
-    We attempt it at most once and swallow any failure (e.g. the frontend
-    component not being available in a minimal/test environment).
+    Static routes are registered once. Module and resource registration wait
+    for their optional Home Assistant components instead of depending on setup
+    order.
     """
     data = hass.data.setdefault(DOMAIN, {})
     if data.get(DATA_FRONTEND_REGISTERED):
         return
-    # Mark as attempted up front so a failure can't trigger repeated
-    # (and potentially double-registering) attempts across entry setups.
-    data[DATA_FRONTEND_REGISTERED] = True
-
     exists, version, cache_key = await hass.async_add_executor_job(_gather)
     if not exists:
         _LOGGER.warning(
@@ -141,9 +199,17 @@ async def async_register_frontend(hass: HomeAssistant) -> None:
         )
         return
 
+    card_url = _card_url(cache_key)
+    card_path = str(_dist_dir() / CARD_FILENAME)
     try:
         await hass.http.async_register_static_paths(
-            [StaticPathConfig(URL_BASE, str(_dist_dir()), False)]
+            [
+                # Preserve the legacy query-based URL while resources migrate.
+                StaticPathConfig(CARD_URL, card_path, False),
+                # Put the content identity in the path. Some webview and proxy
+                # caches normalize query parameters before looking up assets.
+                StaticPathConfig(card_url, card_path, True),
+            ]
         )
     except Exception:  # noqa: BLE001 - never let the card break setup
         _LOGGER.warning(
@@ -153,36 +219,21 @@ async def async_register_frontend(hass: HomeAssistant) -> None:
         )
         return
 
-    card_url = f"{CARD_URL}?v={cache_key}"
-    try:
-        resource_registered = await _async_register_lovelace_resource(hass, card_url)
-    except Exception:  # noqa: BLE001 - fall back to the frontend module hook
-        resource_registered = False
-        _LOGGER.warning(
-            "Could not register the Adjustable Bed card as a Lovelace resource; "
-            "falling back to frontend module loading",
-            exc_info=True,
-        )
+    data[DATA_FRONTEND_REGISTERED] = True
 
-    # Keep the frontend hook as well as the durable storage resource. Browsers
-    # deduplicate identical module imports, and this preserves early loading on
-    # fresh pages while the resource covers Lovelace's independent load path.
-    try:
-        add_extra_js_url(hass, card_url)
-    except Exception:  # noqa: BLE001 - never let the card break setup
-        if not resource_registered:
-            _LOGGER.warning(
-                "Could not auto-load the Adjustable Bed Lovelace card; bed "
-                "control is unaffected. Add %s manually as a dashboard resource "
-                "if needed",
-                card_url,
-                exc_info=True,
-            )
-            return
-        _LOGGER.debug(
-            "Could not add the Adjustable Bed frontend module hook; the "
-            "Lovelace resource is registered",
-            exc_info=True,
-        )
+    # Keep both loading paths. The frontend hook injects the card into new pages
+    # and notifies open pages, while the storage resource is durable. Waiting on
+    # the component lifecycle prevents a startup-order miss from becoming
+    # permanent for the rest of the Home Assistant process.
+    async_when_setup(
+        hass,
+        FRONTEND_DOMAIN,
+        partial(_async_add_frontend_module, card_url=card_url),
+    )
+    async_when_setup(
+        hass,
+        LOVELACE_DOMAIN,
+        partial(_async_add_lovelace_resource, card_url=card_url),
+    )
 
-    _LOGGER.debug("Registered Adjustable Bed Lovelace card (v%s)", version)
+    _LOGGER.debug("Registered Adjustable Bed card routes and loading hooks (v%s)", version)

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -13,15 +13,22 @@ from homeassistant.components.lovelace.resources import (
     ResourceStorageCollection,
     ResourceYAMLCollection,
 )
-from homeassistant.const import CONF_ID, CONF_TYPE, CONF_URL
+from homeassistant.const import (
+    CONF_ID,
+    CONF_TYPE,
+    CONF_URL,
+    EVENT_COMPONENT_LOADED,
+)
 from homeassistant.core import HomeAssistant
 
 from custom_components.adjustable_bed.const import DOMAIN
 from custom_components.adjustable_bed.frontend import (
+    CARD_FILENAME,
     CARD_URL,
     DATA_FRONTEND_REGISTERED,
     URL_BASE,
     _async_register_lovelace_resource,
+    _card_url,
     _gather,
     async_register_frontend,
 )
@@ -33,6 +40,7 @@ def _storage_resources(items: list[dict[str, str]]) -> MagicMock:
     resources.async_get_info = AsyncMock(return_value={"resources": len(items)})
     resources.async_items.return_value = items
     resources.async_create_item = AsyncMock()
+    resources.async_delete_item = AsyncMock()
     resources.async_update_item = AsyncMock()
     return resources
 
@@ -60,13 +68,20 @@ def test_gather_uses_bundle_digest_in_cache_key(
     assert changed_cache_key != first_cache_key
 
 
+def test_card_url_embeds_cache_key_in_path() -> None:
+    """Bundle identity does not depend on cache-sensitive query parameters."""
+    assert _card_url("3.5.0-abc123") == (
+        f"{URL_BASE}/3.5.0-abc123/{CARD_FILENAME}"
+    )
+
+
 async def test_register_lovelace_resource_creates_missing_resource(
     hass: HomeAssistant,
 ) -> None:
     """The card is persisted so Lovelace can load it independently."""
     resources = ResourceStorageCollection(hass, LovelaceStorage(hass, None))
     hass.data[LOVELACE_DATA] = LovelaceData("storage", {}, resources, {})
-    card_url = f"{CARD_URL}?v=3.3.0-abc123"
+    card_url = _card_url("3.5.0-abc123")
 
     assert await _async_register_lovelace_resource(hass, card_url)
 
@@ -79,7 +94,7 @@ async def test_register_lovelace_resource_creates_missing_resource(
 async def test_register_lovelace_resource_updates_stale_resource(
     hass: HomeAssistant,
 ) -> None:
-    """Lazy-loaded storage updates the card without touching other resources."""
+    """Lazy-loaded storage migrates the query-based card resource."""
     resources = ResourceStorageCollection(hass, LovelaceStorage(hass, None))
     await resources.store.async_save(
         {
@@ -99,7 +114,7 @@ async def test_register_lovelace_resource_updates_stale_resource(
     )
     hass.data[LOVELACE_DATA] = LovelaceData("storage", {}, resources, {})
     assert not resources.loaded
-    card_url = f"{CARD_URL}?v=3.3.0-def456"
+    card_url = _card_url("3.5.0-def456")
 
     assert await _async_register_lovelace_resource(hass, card_url)
 
@@ -122,7 +137,7 @@ async def test_register_lovelace_resource_leaves_current_resource_unchanged(
     hass: HomeAssistant,
 ) -> None:
     """Repeated setup is idempotent."""
-    card_url = f"{CARD_URL}?v=3.3.0-abc123"
+    card_url = _card_url("3.5.0-abc123")
     resources = _storage_resources(
         [
             {
@@ -137,7 +152,43 @@ async def test_register_lovelace_resource_leaves_current_resource_unchanged(
     assert await _async_register_lovelace_resource(hass, card_url)
 
     resources.async_create_item.assert_not_awaited()
+    resources.async_delete_item.assert_not_awaited()
     resources.async_update_item.assert_not_awaited()
+
+
+async def test_register_lovelace_resource_removes_duplicate_card_resources(
+    hass: HomeAssistant,
+) -> None:
+    """Only one integration-owned card resource survives reconciliation."""
+    card_url = _card_url("3.5.0-abc123")
+    resources = ResourceStorageCollection(hass, LovelaceStorage(hass, None))
+    await resources.store.async_save(
+        {
+            "items": [
+                {
+                    CONF_ID: "legacy-resource",
+                    CONF_TYPE: "module",
+                    CONF_URL: f"{CARD_URL}?v=3.4.0-old",
+                },
+                {
+                    CONF_ID: "current-resource",
+                    CONF_TYPE: "module",
+                    CONF_URL: card_url,
+                },
+            ]
+        }
+    )
+    hass.data[LOVELACE_DATA] = LovelaceData("storage", {}, resources, {})
+
+    assert await _async_register_lovelace_resource(hass, card_url)
+
+    assert resources.async_items() == [
+        {
+            CONF_ID: "current-resource",
+            CONF_TYPE: "module",
+            CONF_URL: card_url,
+        }
+    ]
 
 
 async def test_register_lovelace_resource_rejects_yaml_resources(
@@ -153,7 +204,7 @@ async def test_register_lovelace_resource_rejects_yaml_resources(
 
     assert not await _async_register_lovelace_resource(
         hass,
-        f"{CARD_URL}?v=3.3.0-abc123",
+        _card_url("3.5.0-abc123"),
     )
 
 
@@ -161,6 +212,78 @@ async def test_register_frontend_uses_resource_and_module_hook(
     hass: HomeAssistant,
 ) -> None:
     """Storage mode is durable while retaining early frontend module loading."""
+    hass.http = MagicMock()
+    hass.http.async_register_static_paths = AsyncMock()
+    hass.config.components.update({"frontend", "lovelace"})
+
+    with (
+        patch(
+            "custom_components.adjustable_bed.frontend._gather",
+            return_value=(True, "3.3.0", "3.3.0-abc123"),
+        ),
+        patch(
+            "custom_components.adjustable_bed.frontend._async_register_lovelace_resource",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as register_resource,
+        patch(
+            "custom_components.adjustable_bed.frontend.add_extra_js_url"
+        ) as add_extra_js_url,
+    ):
+        await async_register_frontend(hass)
+        await async_register_frontend(hass)
+        await hass.async_block_till_done()
+
+    card_url = _card_url("3.3.0-abc123")
+    register_resource.assert_awaited_once_with(hass, card_url)
+    add_extra_js_url.assert_called_once_with(hass, card_url)
+    static_paths = hass.http.async_register_static_paths.await_args.args[0]
+    assert [(item.url_path, item.cache_headers) for item in static_paths] == [
+        (CARD_URL, False),
+        (card_url, True),
+    ]
+    assert hass.data[DOMAIN][DATA_FRONTEND_REGISTERED] is True
+
+
+async def test_register_frontend_falls_back_for_yaml_resources(
+    hass: HomeAssistant,
+) -> None:
+    """YAML-mode installations retain zero-configuration module loading."""
+    hass.http = MagicMock()
+    hass.http.async_register_static_paths = AsyncMock()
+    hass.config.components.update({"frontend", "lovelace"})
+
+    with (
+        patch(
+            "custom_components.adjustable_bed.frontend._gather",
+            return_value=(True, "3.3.0", "3.3.0-abc123"),
+        ),
+        patch(
+            "custom_components.adjustable_bed.frontend._async_register_lovelace_resource",
+            new_callable=AsyncMock,
+            return_value=False,
+        ) as register_resource,
+        patch(
+            "custom_components.adjustable_bed.frontend.add_extra_js_url"
+        ) as add_extra_js_url,
+    ):
+        await async_register_frontend(hass)
+        await async_register_frontend(hass)
+        await hass.async_block_till_done()
+
+    add_extra_js_url.assert_called_once_with(
+        hass,
+        _card_url("3.3.0-abc123"),
+    )
+    register_resource.assert_awaited_once()
+    hass.http.async_register_static_paths.assert_awaited_once()
+    assert hass.data[DOMAIN][DATA_FRONTEND_REGISTERED] is True
+
+
+async def test_register_frontend_waits_for_late_dependencies(
+    hass: HomeAssistant,
+) -> None:
+    """A setup-order miss recovers when frontend and Lovelace become ready."""
     hass.http = MagicMock()
     hass.http.async_register_static_paths = AsyncMock()
 
@@ -179,43 +302,28 @@ async def test_register_frontend_uses_resource_and_module_hook(
         ) as add_extra_js_url,
     ):
         await async_register_frontend(hass)
-        await async_register_frontend(hass)
 
-    card_url = f"{CARD_URL}?v=3.3.0-abc123"
-    register_resource.assert_awaited_once_with(hass, card_url)
-    add_extra_js_url.assert_called_once_with(hass, card_url)
-    hass.http.async_register_static_paths.assert_awaited_once()
-    assert hass.data[DOMAIN][DATA_FRONTEND_REGISTERED] is True
+        register_resource.assert_not_awaited()
+        add_extra_js_url.assert_not_called()
 
+        hass.config.components.add("frontend")
+        hass.bus.async_fire_internal(
+            EVENT_COMPONENT_LOADED,
+            {"component": "frontend"},
+        )
+        await hass.async_block_till_done()
+        add_extra_js_url.assert_called_once_with(
+            hass,
+            _card_url("3.3.0-abc123"),
+        )
 
-async def test_register_frontend_falls_back_for_yaml_resources(
-    hass: HomeAssistant,
-) -> None:
-    """YAML-mode installations retain zero-configuration module loading."""
-    hass.http = MagicMock()
-    hass.http.async_register_static_paths = AsyncMock()
-
-    with (
-        patch(
-            "custom_components.adjustable_bed.frontend._gather",
-            return_value=(True, "3.3.0", "3.3.0-abc123"),
-        ),
-        patch(
-            "custom_components.adjustable_bed.frontend._async_register_lovelace_resource",
-            new_callable=AsyncMock,
-            return_value=False,
-        ) as register_resource,
-        patch(
-            "custom_components.adjustable_bed.frontend.add_extra_js_url"
-        ) as add_extra_js_url,
-    ):
-        await async_register_frontend(hass)
-        await async_register_frontend(hass)
-
-    add_extra_js_url.assert_called_once_with(
-        hass,
-        f"{URL_BASE}/adjustable-bed-card.js?v=3.3.0-abc123",
-    )
-    register_resource.assert_awaited_once()
-    hass.http.async_register_static_paths.assert_awaited_once()
-    assert hass.data[DOMAIN][DATA_FRONTEND_REGISTERED] is True
+        hass.config.components.add("lovelace")
+        hass.bus.async_fire_internal(
+            EVENT_COMPONENT_LOADED,
+            {"component": "lovelace"},
+        )
+        await hass.async_block_till_done()
+        register_resource.assert_awaited_once_with(
+            hass,
+            _card_url("3.3.0-abc123"),
+        )


### PR DESCRIPTION
The bundled Lovelace card can remain unavailable when a frontend cache normalizes the query-string cache key or when card registration runs before frontend or Lovelace is ready.

This moves the content identity into the asset path, keeps the legacy URL available during migration, reconciles duplicate stored resources, and registers each loading path when its Home Assistant component is ready.

Validation:
- `uv run pytest`: 2,755 passed
- focused frontend tests: 10 passed
- Ruff, mypy, and Pyright: clean
- local CodeRabbit preflight: clean

Ref #453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved frontend asset caching with versioned URLs.
  * Preserved compatibility with the existing card route.
  * Automatically removes duplicate or outdated dashboard resources.
  * Frontend resources now register reliably when required Home Assistant components become available.
  * Improved handling of registration errors so one failed resource does not block others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->