### PR TITLE
fix: correct Okin CST controls for MFirm 900-O

### DIFF
--- a/custom_components/adjustable_bed/beds/okin_cst.py
+++ b/custom_components/adjustable_bed/beds/okin_cst.py
@@ -21,11 +21,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from bleak.exc import BleakError
 
-from ..const import OKIMAT_WRITE_CHAR_UUID
+from ..const import OKIMAT_NOTIFY_CHAR_UUID, OKIMAT_WRITE_CHAR_UUID
 from .base import BedController, MotorControlSpec
 from .okin_protocol import build_cst_command
 
@@ -187,6 +188,41 @@ class OkinCstController(BedController):
     def stale_motor_entity_keys(self) -> frozenset[str]:
         """Remove motor covers exposed by the former four-axis assumption."""
         return frozenset({"back", "legs", "tilt"})
+
+    async def start_notify(
+        self, callback: Callable[[str, float], None] | None = None
+    ) -> None:
+        """Subscribe to CST notifications for raw diagnostic capture."""
+        self._notify_callback = callback
+        client = self.client
+        if client is None or not client.is_connected:
+            _LOGGER.warning("Cannot start CST notifications: not connected")
+            return
+
+        try:
+            async with self._ble_lock:
+                await client.start_notify(
+                    OKIMAT_NOTIFY_CHAR_UUID,
+                    self._handle_notification,
+                )
+        except BleakError as err:
+            _LOGGER.debug("Could not start CST notifications: %s", err)
+
+    def _handle_notification(self, _: object, data: bytearray) -> None:
+        """Forward CST notifications without interpreting them as positions."""
+        self.forward_raw_notification(OKIMAT_NOTIFY_CHAR_UUID, bytes(data))
+
+    async def stop_notify(self) -> None:
+        """Stop the raw CST diagnostic notification subscription."""
+        client = self.client
+        if client is None or not client.is_connected:
+            return
+
+        try:
+            async with self._ble_lock:
+                await client.stop_notify(OKIMAT_NOTIFY_CHAR_UUID)
+        except BleakError as err:
+            _LOGGER.debug("Could not stop CST notifications: %s", err)
 
     # Motor movement helpers
 

--- a/custom_components/adjustable_bed/beds/okin_cst.py
+++ b/custom_components/adjustable_bed/beds/okin_cst.py
@@ -21,27 +21,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.exc import BleakError
 
-from ..const import (
-    OKIMAT_WRITE_CHAR_UUID,
-    OKIN_CST_POSITION_AXES,
-    OKIN_FOOT_MAX_ANGLE,
-    OKIN_FOOT_MAX_RAW,
-    OKIN_HEAD_MAX_ANGLE,
-    OKIN_HEAD_MAX_RAW,
-    OKIN_POSITION_NOTIFY_CHAR_UUID,
-)
-from .base import (
-    POSITION_UNIT_DEGREES,
-    BedController,
-    PositionNumberSpec,
-    build_position_number_spec,
-)
+from ..const import OKIMAT_WRITE_CHAR_UUID
+from .base import BedController, MotorControlSpec
 from .okin_protocol import build_cst_command
 
 if TYPE_CHECKING:
@@ -49,10 +34,9 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-_NOT_CONNECTED_MSG = "Not connected to bed"
-_PRESET_REPEAT_COUNT = 100
-_PRESET_REPEAT_DELAY_MS = 300
-_BUTTON_PRESS_REPEAT_COUNT = 3
+_PRESET_REPEAT_COUNT = 6
+_PRESET_REPEAT_DELAY_MS = 100
+_BUTTON_PRESS_REPEAT_COUNT = 6
 _BUTTON_PRESS_REPEAT_DELAY_MS = 100
 _STOP_REPEAT_COUNT = 2
 _STOP_REPEAT_DELAY_MS = 100
@@ -66,10 +50,8 @@ class CstMotorCommands:
     HEAD_DOWN = 0x00000002
     FOOT_UP = 0x00000004
     FOOT_DOWN = 0x00000008
-    HEAD_TILT_UP = 0x00000010
-    HEAD_TILT_DOWN = 0x00000020
-    LUMBAR_UP = 0x00000040
-    LUMBAR_DOWN = 0x00000080
+    LUMBAR_UP = 0x00000010
+    LUMBAR_DOWN = 0x00000020
 
 
 class CstRemoteCommands:
@@ -85,21 +67,15 @@ class CstRemoteCommands:
     LOUNGE = 0x00002000
     INCLINE = 0x00004000
     ANTI_SNORE = 0x00008000
-    APP_MEMORY = 0x00010000
     SAVE_ZERO_G = FLAT | ZERO_G
     SAVE_LOUNGE = FLAT | LOUNGE
     SAVE_INCLINE = FLAT | INCLINE
     LIGHT_TOGGLE = 0x00020000
     LIGHT_ON = 0x00000040
     LIGHT_OFF = 0x00000080
-    MASSAGE_TOGGLE = 0x04000000
     MASSAGE_OFF = 0x02000000
     MASSAGE_INTENSITY = 0x00000C00
     MASSAGE_INTENSITY_MINUS = 0x01800000
-    MASSAGE_HEAD = 0x00000800
-    MASSAGE_FEET = 0x00000400
-    MASSAGE_HEAD_MINUS = 0x00800000
-    MASSAGE_FEET_MINUS = 0x01000000
     MASSAGE_WAVE_1 = 0x00080000
     MASSAGE_WAVE_2 = 0x00100000
     MASSAGE_WAVE_3 = 0x00200000
@@ -118,7 +94,6 @@ class OkinCstController(BedController):
     def __init__(self, coordinator: AdjustableBedCoordinator) -> None:
         """Initialize the OKIN CST controller."""
         super().__init__(coordinator)
-        self._notify_callback: Callable[[str, float], None] | None = None
         self._motor_state: dict[str, int] = {}
         self._massage_wave_index = 0
 
@@ -146,24 +121,6 @@ class OkinCstController(BedController):
     @property
     def supports_preset_incline(self) -> bool:
         return True
-
-    @property
-    def position_number_specs(self) -> tuple[PositionNumberSpec, ...]:
-        """Expose only the axes CST publishes feedback for.
-
-        CST reports angles for back and legs only, whatever motor count the user
-        configured, so this does not fall back to the standard motor_count gate.
-        """
-        return tuple(
-            build_position_number_spec(
-                axis,
-                max_value=self._coordinator.get_max_angle(axis),
-                unit=POSITION_UNIT_DEGREES,
-            )
-            # sorted() because OKIN_CST_POSITION_AXES is a frozenset and entity
-            # creation order must not vary between runs.
-            for axis in sorted(OKIN_CST_POSITION_AXES)
-        )
 
     @property
     def supports_memory_presets(self) -> bool:
@@ -197,118 +154,39 @@ class OkinCstController(BedController):
     def supports_stop_all(self) -> bool:
         return True
 
-    async def write_command(
-        self,
-        command: bytes,
-        repeat_count: int = 1,
-        repeat_delay_ms: int = 100,
-        cancel_event: asyncio.Event | None = None,
-    ) -> None:
-        """Write a command to the bed."""
-        if self.client is None or not self.client.is_connected:
-            _LOGGER.error("Cannot write command: BLE client not connected")
-            raise ConnectionError(_NOT_CONNECTED_MSG)
-
-        effective_cancel = cancel_event or self._coordinator.cancel_command
-
-        _LOGGER.debug(
-            "Writing CST command (%s): %s (repeat: %d, delay: %dms, response=True)",
-            OKIMAT_WRITE_CHAR_UUID,
-            command.hex(),
-            repeat_count,
-            repeat_delay_ms,
+    @property
+    def motor_control_specs(self) -> tuple[MotorControlSpec, ...]:
+        """Expose the app's fixed three-axis head, foot, and lumbar layout."""
+        return (
+            MotorControlSpec(
+                key="head",
+                translation_key="head",
+                open_fn=lambda ctrl: ctrl.move_head_up(),
+                close_fn=lambda ctrl: ctrl.move_head_down(),
+                stop_fn=lambda ctrl: ctrl.move_head_stop(),
+            ),
+            MotorControlSpec(
+                key="feet",
+                translation_key="feet",
+                open_fn=lambda ctrl: ctrl.move_feet_up(),
+                close_fn=lambda ctrl: ctrl.move_feet_down(),
+                stop_fn=lambda ctrl: ctrl.move_feet_stop(),
+                max_angle=45,
+            ),
+            MotorControlSpec(
+                key="lumbar",
+                translation_key="lumbar",
+                open_fn=lambda ctrl: ctrl.move_lumbar_up(),
+                close_fn=lambda ctrl: ctrl.move_lumbar_down(),
+                stop_fn=lambda ctrl: ctrl.move_lumbar_stop(),
+                max_angle=30,
+            ),
         )
 
-        for i in range(repeat_count):
-            if effective_cancel is not None and effective_cancel.is_set():
-                _LOGGER.info("Command cancelled after %d/%d writes", i, repeat_count)
-                return
-
-            try:
-                async with self._ble_lock:
-                    await self.client.write_gatt_char(
-                        OKIMAT_WRITE_CHAR_UUID, command, response=True
-                    )
-            except BleakError:
-                _LOGGER.exception("Failed to write command")
-                raise
-
-            if i < repeat_count - 1:
-                await asyncio.sleep(repeat_delay_ms / 1000)
-
-    # Position feedback (same as OkinUuidController)
-
-    async def start_notify(
-        self, callback: Callable[[str, float], None] | None = None
-    ) -> None:
-        """Start listening for position notifications."""
-        self._notify_callback = callback
-
-        if self.client is None or not self.client.is_connected:
-            _LOGGER.warning("Cannot start position notifications: not connected")
-            return
-
-        try:
-            async with self._ble_lock:
-                await self.client.start_notify(
-                    OKIN_POSITION_NOTIFY_CHAR_UUID,
-                    self._handle_position_notification,
-                )
-            _LOGGER.info("Position notifications active for OKIN CST bed")
-        except BleakError as err:
-            _LOGGER.debug(
-                "Could not start position notifications: %s",
-                err,
-            )
-
-    def _handle_position_notification(self, _: BleakGATTCharacteristic, data: bytearray) -> None:
-        """Handle position notification data."""
-        self.forward_raw_notification(OKIN_POSITION_NOTIFY_CHAR_UUID, bytes(data))
-
-        if len(data) < 7:
-            return
-
-        _LOGGER.debug("OKIN CST position notification: %s", data.hex())
-
-        head_raw = data[3] | (data[4] << 8)
-        head_angle = min(
-            round((head_raw / OKIN_HEAD_MAX_RAW) * OKIN_HEAD_MAX_ANGLE, 1),
-            OKIN_HEAD_MAX_ANGLE,
-        )
-
-        foot_raw = data[5] | (data[6] << 8)
-        foot_angle = min(
-            round((foot_raw / OKIN_FOOT_MAX_RAW) * OKIN_FOOT_MAX_ANGLE, 1),
-            OKIN_FOOT_MAX_ANGLE,
-        )
-
-        if self._notify_callback:
-            self._notify_callback("back", head_angle)
-            self._notify_callback("legs", foot_angle)
-
-    async def stop_notify(self) -> None:
-        """Stop listening for position notifications."""
-        if self.client is None or not self.client.is_connected:
-            return
-
-        try:
-            async with self._ble_lock:
-                await self.client.stop_notify(OKIN_POSITION_NOTIFY_CHAR_UUID)
-        except BleakError:
-            pass
-
-    async def read_positions(self, motor_count: int = 2) -> None:  # noqa: ARG002
-        """Read current position data."""
-        if self.client is None or not self.client.is_connected:
-            return
-
-        try:
-            async with self._ble_lock:
-                data = await self.client.read_gatt_char(OKIN_POSITION_NOTIFY_CHAR_UUID)
-            if data:
-                self._handle_position_notification(0, bytearray(data))  # type: ignore[arg-type]
-        except BleakError as err:
-            _LOGGER.debug("Could not read position data: %s", err)
+    @property
+    def stale_motor_entity_keys(self) -> frozenset[str]:
+        """Remove motor covers exposed by the former four-axis assumption."""
+        return frozenset({"back", "legs", "tilt"})
 
     # Motor movement helpers
 
@@ -316,7 +194,7 @@ class OkinCstController(BedController):
         """Calculate combined motor command from active motor states."""
         command = 0
         for value in self._motor_state.values():
-            command += value
+            command |= value
         return command
 
     async def _move_motor(self, motor: str, command_value: int | None) -> None:
@@ -327,8 +205,7 @@ class OkinCstController(BedController):
             self._motor_state[motor] = command_value
 
         combined = self._get_motor_command()
-        pulse_count = getattr(self._coordinator, "motor_pulse_count", 25)
-        pulse_delay = getattr(self._coordinator, "motor_pulse_delay_ms", 200)
+        pulse_count, pulse_delay = self.motor_pulse_settings()
 
         try:
             if combined:
@@ -345,9 +222,8 @@ class OkinCstController(BedController):
     async def _send_stop_sequence(self) -> None:
         """Send the app-style CST STOP sequence."""
         stop_event = asyncio.Event()
-        for index in range(_STOP_REPEAT_COUNT):
-            if index:
-                await asyncio.sleep(_STOP_REPEAT_DELAY_MS / 1000)
+        for _ in range(_STOP_REPEAT_COUNT):
+            await asyncio.sleep(_STOP_REPEAT_DELAY_MS / 1000)
             await self.write_command(build_cst_command(), cancel_event=stop_event)
 
     async def _send_repeated_command(
@@ -442,20 +318,6 @@ class OkinCstController(BedController):
         """Stop feet motor."""
         await self._move_motor("legs", None)
 
-    # Motor control - Tilt (head tilt / 4th motor)
-
-    async def move_tilt_up(self) -> None:
-        """Move head tilt up."""
-        await self._move_motor("head", CstMotorCommands.HEAD_TILT_UP)
-
-    async def move_tilt_down(self) -> None:
-        """Move head tilt down."""
-        await self._move_motor("head", CstMotorCommands.HEAD_TILT_DOWN)
-
-    async def move_tilt_stop(self) -> None:
-        """Stop tilt motor."""
-        await self._move_motor("head", None)
-
     # Motor control - Lumbar
 
     async def move_lumbar_up(self) -> None:
@@ -541,10 +403,6 @@ class OkinCstController(BedController):
         """Turn massage off."""
         await self._send_button_press(motor_value=CstRemoteCommands.MASSAGE_OFF)
 
-    async def massage_toggle(self) -> None:
-        """Toggle massage on/off."""
-        await self._send_button_press(motor_value=CstRemoteCommands.MASSAGE_TOGGLE)
-
     async def massage_intensity_up(self) -> None:
         """Increase overall massage intensity."""
         await self._send_button_press(motor_value=CstRemoteCommands.MASSAGE_INTENSITY)
@@ -553,26 +411,6 @@ class OkinCstController(BedController):
         """Decrease overall massage intensity."""
         await self._send_button_press(
             motor_value=CstRemoteCommands.MASSAGE_INTENSITY_MINUS
-        )
-
-    async def massage_head_up(self) -> None:
-        """Increase head massage intensity."""
-        await self._send_button_press(motor_value=CstRemoteCommands.MASSAGE_HEAD)
-
-    async def massage_head_down(self) -> None:
-        """Decrease head massage intensity."""
-        await self._send_button_press(
-            motor_value=CstRemoteCommands.MASSAGE_HEAD_MINUS
-        )
-
-    async def massage_foot_up(self) -> None:
-        """Increase foot massage intensity."""
-        await self._send_button_press(motor_value=CstRemoteCommands.MASSAGE_FEET)
-
-    async def massage_foot_down(self) -> None:
-        """Decrease foot massage intensity."""
-        await self._send_button_press(
-            motor_value=CstRemoteCommands.MASSAGE_FEET_MINUS
         )
 
     async def massage_mode_step(self) -> None:

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -178,6 +178,8 @@ def _motor_count_options(
     """Return motor counts supported by the selected protocol."""
     if bed_type == BED_TYPE_OCTO and protocol_variant != OCTO_VARIANT_STAR2:
         return [1, 2, 3, 4]
+    if bed_type == BED_TYPE_OKIN_CST:
+        return [3]
     return [2, 3, 4]
 
 
@@ -215,6 +217,8 @@ def _default_motor_count(
         and device_name.strip().lower().startswith("rtv")
     ):
         return 1
+    if bed_type == BED_TYPE_OKIN_CST:
+        return 3
     return DEFAULT_MOTOR_COUNT
 
 

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -148,8 +148,6 @@ BED_TYPE_LEGGETT_GEN2: Final = "leggett_gen2"  # Leggett Gen2 ASCII protocol
 BED_TYPE_LEGGETT_OKIN: Final = "leggett_okin"  # Leggett Okin binary protocol
 BED_TYPE_LEGGETT_WILINKE: Final = "leggett_wilinke"  # Leggett WiLinke 5-byte
 
-OKIN_CST_POSITION_AXES: Final = frozenset({"back", "legs"})
-
 # Bed types - Legacy naming (backwards compatibility)
 # These map to the protocol-based types above
 BED_TYPE_LINAK: Final = "linak"
@@ -1997,7 +1995,6 @@ BEDS_WITH_ANGLE_SENSING: Final = frozenset(
     {
         BED_TYPE_LINAK,
         BED_TYPE_OKIMAT,
-        BED_TYPE_OKIN_CST,
         BED_TYPE_OKIN_UUID,  # Same protocol as Okimat
         BED_TYPE_REVERIE,
         BED_TYPE_REVERIE_NIGHTSTAND,
@@ -2015,7 +2012,6 @@ BEDS_WITH_POSITION_FEEDBACK: Final = frozenset(
     {
         BED_TYPE_LINAK,
         BED_TYPE_OKIMAT,
-        BED_TYPE_OKIN_CST,
         BED_TYPE_OKIN_UUID,  # Same protocol as Okimat
         BED_TYPE_REVERIE,
         BED_TYPE_REVERIE_NIGHTSTAND,
@@ -2047,13 +2043,12 @@ def bed_type_has_position_feedback(
         return True
     return bed_type == BED_TYPE_KEESON and protocol_variant == KEESON_VARIANT_ERGOMOTION
 
-# Bed types that may have angle sensing enabled but report NO degree-angle data.
-# Sleep Number MCR/BAM beds only report sleep-number values and bed presence over BLE
-# (no motor angle feedback at all), so degree angle sensors would sit at "unknown"
-# forever. These are skipped during angle-sensor creation regardless of the
-# disable_angle_sensing option, which also fixes existing installs whose stored config
-# still has angle sensing enabled (#322).
-BEDS_WITHOUT_ANGLE_FEEDBACK: Final = frozenset({BED_TYPE_SLEEP_NUMBER_MCR})
+# Bed types that may have angle sensing enabled in an existing entry but report no
+# degree-angle data. These are skipped during entity creation so stale sensors do
+# not remain "unknown" forever (#322, #501).
+BEDS_WITHOUT_ANGLE_FEEDBACK: Final = frozenset(
+    {BED_TYPE_OKIN_CST, BED_TYPE_SLEEP_NUMBER_MCR}
+)
 
 # Bed types that report positions as 0-100 percentages (not angle degrees)
 # These bed types return percentage values directly, so no angle-to-percent conversion is needed.

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -128,9 +128,6 @@ from .const import (
     MALOUF_LAYOUT_AUTO,
     MALOUF_MEMORY_SLOTS_AUTO,
     OKIMAT_SERVICE_UUID,
-    OKIN_CST_POSITION_AXES,
-    OKIN_FOOT_MAX_ANGLE,
-    OKIN_HEAD_MAX_ANGLE,
     POSITION_MODE_ACCURACY,
     POSITION_OVERSHOOT_TOLERANCE,
     POSITION_SEEK_TIMEOUT,
@@ -491,10 +488,7 @@ class AdjustableBedCoordinator:
             entry_data.pop(CONF_RICHMAT_REMOTE, None)
         angle_sensing_defaulted = CONF_DISABLE_ANGLE_SENSING not in self.entry.data or (
             self.entry.data.get(CONF_DISABLE_ANGLE_SENSING) is True
-            and (
-                previous_bed_type not in BEDS_WITH_POSITION_FEEDBACK
-                or previous_bed_type == BED_TYPE_OKIN_CST
-            )
+            and previous_bed_type not in BEDS_WITH_POSITION_FEEDBACK
         )
         # Config flow defaults disable_angle_sensing from BEDS_WITH_POSITION_FEEDBACK,
         # so the correction must use the same set: a repaired entry (e.g. CB35 ->
@@ -630,14 +624,10 @@ class AdjustableBedCoordinator:
         # set_position validation still rejects a target the frame cannot reach
         # when the controller is momentarily absent.
         if position_key in ("back", "head"):
-            if self._bed_type == BED_TYPE_OKIN_CST:
-                return OKIN_HEAD_MAX_ANGLE
             if self._bed_type in (BED_TYPE_REVERIE, BED_TYPE_REVERIE_NIGHTSTAND):
                 return REVERIE_BACK_MAX_ANGLE
             return self.back_max_angle
         if position_key in ("legs", "feet"):
-            if self._bed_type == BED_TYPE_OKIN_CST:
-                return OKIN_FOOT_MAX_ANGLE
             return self.legs_max_angle
         # Unknown motor, return back max as default
         return self.back_max_angle
@@ -2953,9 +2943,6 @@ class AdjustableBedCoordinator:
         """Return the logical position axes that startup hydration should populate."""
         if self._motor_count <= 0:
             return set()
-        if self._bed_type == BED_TYPE_OKIN_CST:
-            return set(OKIN_CST_POSITION_AXES)
-
         expected_axes = {"back", "legs"}
         if self._motor_count > 2:
             expected_axes.add("head")

--- a/custom_components/adjustable_bed/sensor.py
+++ b/custom_components/adjustable_bed/sensor.py
@@ -20,7 +20,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import (
     BED_TYPE_ERGOMOTION,
     BED_TYPE_KEESON,
-    BED_TYPE_OKIN_CST,
     BEDS_WITH_PERCENTAGE_POSITIONS,
     BEDS_WITHOUT_ANGLE_FEEDBACK,
     CONF_BED_TYPE,
@@ -30,7 +29,6 @@ from .const import (
     DEFAULT_MOTOR_COUNT,
     DOMAIN,
     KEESON_VARIANT_ERGOMOTION,
-    OKIN_CST_POSITION_AXES,
 )
 from .coordinator import AdjustableBedCoordinator
 from .entity import AdjustableBedEntity
@@ -159,14 +157,7 @@ async def async_setup_entry(
         elif bed_type in BEDS_WITHOUT_ANGLE_FEEDBACK:
             _LOGGER.debug("Skipping angle sensors for %s - no angle feedback", bed_type)
         else:
-            sensor_descriptions = SENSOR_DESCRIPTIONS
-            if bed_type == BED_TYPE_OKIN_CST:
-                sensor_descriptions = tuple(
-                    description
-                    for description in SENSOR_DESCRIPTIONS
-                    if description.position_key in OKIN_CST_POSITION_AXES
-                )
-            for description in sensor_descriptions:
+            for description in SENSOR_DESCRIPTIONS:
                 if motor_count >= description.min_motors:
                     entities.append(AdjustableBedAngleSensor(coordinator, description))
     else:

--- a/custom_components/adjustable_bed/services.py
+++ b/custom_components/adjustable_bed/services.py
@@ -24,14 +24,12 @@ from .const import (
     BED_TYPE_ERGOMOTION,
     BED_TYPE_KAIDI,
     BED_TYPE_KEESON,
-    BED_TYPE_OKIN_CST,
     BED_TYPE_SLEEPYS_BOX25,
     CONF_BED_TYPE,
     CONF_MOTOR_COUNT,
     CONF_PROTOCOL_VARIANT,
     DEFAULT_MOTOR_COUNT,
     DOMAIN,
-    OKIN_CST_POSITION_AXES,
     bed_type_has_position_feedback,
 )
 from .coordinator import AdjustableBedCoordinator
@@ -329,7 +327,6 @@ async def handle_set_position(call: ServiceCall) -> None:
         # Define motor configurations.
         # For Keeson/Ergomotion: only head and feet are valid, they map to back/legs keys.
         # For BOX25: only head and feet are valid, using direct percentage positions.
-        # For CST: only back and legs publish position feedback.
         # For Kaidi: direct position writes expose back/legs percentage targets.
         # For standard beds: based on motor_count (2=back/legs, 3=+head, 4=+feet).
         uses_percentage_positions = bed_type in (
@@ -391,24 +388,6 @@ async def handle_set_position(call: ServiceCall) -> None:
                     "move_down_fn": lambda ctrl: ctrl.move_feet_down(),
                     "move_stop_fn": lambda ctrl: ctrl.move_feet_stop(),
                     "max_value": 100.0,
-                },
-            }
-        elif bed_type == BED_TYPE_OKIN_CST:
-            valid_motors = set(OKIN_CST_POSITION_AXES)
-            motor_configs = {
-                "back": {
-                    "position_key": "back",
-                    "move_up_fn": lambda ctrl: ctrl.move_back_up(),
-                    "move_down_fn": lambda ctrl: ctrl.move_back_down(),
-                    "move_stop_fn": lambda ctrl: ctrl.move_back_stop(),
-                    "max_value": coordinator.get_max_angle("back"),  # Degrees
-                },
-                "legs": {
-                    "position_key": "legs",
-                    "move_up_fn": lambda ctrl: ctrl.move_legs_up(),
-                    "move_down_fn": lambda ctrl: ctrl.move_legs_down(),
-                    "move_stop_fn": lambda ctrl: ctrl.move_legs_stop(),
-                    "max_value": coordinator.get_max_angle("legs"),  # Degrees
                 },
             }
         else:

--- a/docs/beds/okin-cst.md
+++ b/docs/beds/okin-cst.md
@@ -1,7 +1,7 @@
 # Okin CST (CSTProtocol)
 
-**Status:** Needs testing
-**Ref:** Reverse-engineered from `com.okin.bedding.rizemf900` APK
+**Status:** Static analysis complete; hardware validation pending
+**Ref:** Phase 4 clean-room analysis of `com.okin.bedding.rizemf900` 1.1.2
 
 ## Known Brands
 
@@ -30,13 +30,12 @@ exposes CSS and Nordic DFU services. See [Leggett & Platt](leggett-platt.md).
 
 ## Pairing
 
-These bases require an OS-level Bluetooth **bond** before commands are accepted.
-Pairing is "Just Works" — **no PIN** and **no dedicated Bluetooth pairing button**.
-The bond is negotiated automatically by the OS when a client accesses one of the
-firmware's encrypted characteristics; on a real device every read/notify and
-Device Information characteristic returns GATT `error=5` "Insufficient
-authentication" until the link is bonded, while the command write characteristic
-(`62741525-…`) is reachable unbonded.
+The captured MFirm receiver gates its reads and notification characteristics behind
+an OS-level Bluetooth **bond**. Pairing is "Just Works": **no PIN** and **no
+dedicated Bluetooth pairing button**. Before bonding, those characteristics return
+GATT `error=5` "Insufficient authentication". The command characteristic
+(`62741525-...`) itself was readable unbonded, but the integration still establishes
+the bond so the connection matches the official app's full GATT session.
 
 **To enter pairing mode, power-cycle the control box:** unplug it for ~30 seconds,
 then plug it back in. The status light blinks blue, then turns green after ~20 s —
@@ -58,12 +57,14 @@ Uses a 14-byte command format with two separate 32-bit fields:
 [0x0C, 0x02, primary[4], secondary[4], 0x00, 0x00, 0x00, 0x00]
 ```
 
-- **Primary field** (bytes 2-5): Head, foot, tilt, lumbar motor control plus
-  several remote actions, including presets, memory, light toggle, and most
-  massage controls
+- **Primary field** (bytes 2-5): Head, foot, and lumbar motor control plus
+  presets, memory-save chords, light toggle, massage stop, and intensity
 - **Secondary field** (bytes 6-9): Discrete light on/off and massage wave modes
-- **Write characteristic:** `62741525-...` (write-with-response)
-- **Position notify:** `62741524-...` (same as Okimat)
+- **Write characteristic:** `62741525-...`; the app leaves the characteristic's
+  runtime/default write type unchanged, while the captured hardware advertises
+  the `write` property
+- **Notify characteristic:** `62741625-...`; the app only watches byte 10 for a
+  generic change and does not decode motor positions
 
 Field placement is app-specific. Do not assume all presets, lights, or massage
 commands use the secondary field.
@@ -77,10 +78,8 @@ commands use the secondary field.
 | Head Down | `0x00000002` |
 | Foot Up | `0x00000004` |
 | Foot Down | `0x00000008` |
-| Head Tilt Up | `0x00000010` |
-| Head Tilt Down | `0x00000020` |
-| Lumbar Up | `0x00000040` |
-| Lumbar Down | `0x00000080` |
+| Lumbar Up | `0x00000010` |
+| Lumbar Down | `0x00000020` |
 
 Multiple motor bits can be OR'd together for simultaneous movement.
 
@@ -93,19 +92,13 @@ Multiple motor bits can be OR'd together for simultaneous movement.
 | Lounge | `0x00002000` |
 | Incline / TV | `0x00004000` |
 | Anti-snore | `0x00008000` |
-| App Memory button | `0x00010000` |
 | Save Zero-G | `0x08001000` |
 | Save Lounge | `0x08002000` |
 | Save Incline | `0x08004000` |
 | Light Toggle | `0x00020000` |
-| Massage Toggle | `0x04000000` |
 | Massage Off | `0x02000000` |
 | Massage All + | `0x00000C00` |
 | Massage All - | `0x01800000` |
-| Massage Head + | `0x00000800` |
-| Massage Head - | `0x00800000` |
-| Massage Feet + | `0x00000400` |
-| Massage Feet - | `0x01000000` |
 
 ### Remote Actions (secondary field)
 
@@ -119,11 +112,12 @@ Multiple motor bits can be OR'd together for simultaneous movement.
 
 ### Timing
 
-The Android app repeats the active remote button command while the button is
-held, then sends STOP twice after release. The integration mirrors that behavior
-by sending cleanup STOP packets after movement, preset, light, and massage
-commands. Preset recalls are held longer so a Home Assistant button press can
-complete the move; light and massage controls use a short simulated press.
+The Android app sends the active command immediately and every 100 ms while a
+button is held. On release it sends the all-zero STOP frame twice, at +100 ms and
++200 ms. For one-shot voice actions such as presets, lights, and massage, the app
+streams for 500 ms before the same delayed STOP cleanup. Home Assistant uses that
+fixed one-shot cadence for button entities and keeps motor movement duration
+configurable.
 
 ### Memory Slots
 
@@ -138,12 +132,13 @@ memories. Home Assistant exposes those as numbered memory slots:
 
 ## Features
 
-- 4 motors: head, foot, tilt, lumbar
+- 3 motors: head, foot, lumbar
 - Flat, Zero-G, anti-snore, lounge, and incline presets
 - 3 programmable preset memory slots: Zero-G, Incline, and Lounge
 - Discrete light on/off plus toggle
-- Massage with head/foot intensity control and wave modes
-- Position feedback (same as Okimat)
+- Massage with global intensity control, stop, and three wave modes
+- Under-bed light toggle and discrete on/off; no RGB command was found in the app
+- No decoded motor-position feedback
 
 ## Relationship to Other Okin Protocols
 
@@ -153,9 +148,14 @@ and in which 32-bit field carries each remote action.
 ## App
 
 - **Android:** Mattress Firm 900 - O / MFirm 900-O (`com.okin.bedding.rizemf900`)
-- **Android:** `com.okin.bedding.nectarmotion`
+- **Android:** `com.okin.bedding.nectarmotion` (historically associated with this
+  profile; not part of this clean-room run)
 
 ## Source
 
-Protocol reverse-engineered from `CSTProtocol.java` in the Rize MF900 and
-Nectar Motion APKs.
+The command table and timing above come from a COMPLETE Phase 4 clean-room
+analysis of the frozen MFirm 900-O 1.1.2 XAPK, archive SHA-256
+`a4f5ae67b2b9b870e6413d08597364041ac6947c7ba5445eb1979498895ff46f`.
+The analysis covered all 24 reachable control frames and independently checked
+the Java decompilation against smali bytecode. Physical behavior still needs
+validation on target hardware.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -58,6 +58,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_TIMOTION_AHF,
     BED_TYPE_VIBRADORM,
     BEDS_WITH_POSITION_FEEDBACK,
+    BEDS_WITHOUT_ANGLE_FEEDBACK,
     CONF_BACK_MAX_ANGLE,
     CONF_BED_TYPE,
     CONF_BLE_BOND_ESTABLISHED,
@@ -195,10 +196,10 @@ class TestPairingInstructions:
         "bed_type",
         [BED_TYPE_OKIN_UUID, BED_TYPE_OKIN_CST, BED_TYPE_OKIN_RF_ECO_BT],
     )
-    async def test_okin_pairing_instructions_use_receiver_button(
+    async def test_okin_pairing_instructions_use_power_cycle_guidance(
         self, hass: HomeAssistant, bed_type: str
     ) -> None:
-        """Okin UUID/CST/RF ECO BT beds should show receiver pairing guidance."""
+        """Okin UUID/CST/RF ECO BT beds should not suggest the RF pairing button."""
         flow = AdjustableBedConfigFlow()
         flow.hass = hass
 
@@ -210,24 +211,33 @@ class TestPairingInstructions:
                         "component.adjustable_bed.config.step.bluetooth_pairing."
                         "data_description.pairing_instructions_okin"
                     ): (
-                        "1. Put the OKIN receiver/control box in pairing mode (press or hold the receiver pairing button until the LED blinks)\n"
-                        "2. Click 'Pair Now'"
+                        "1. Power-cycle the OKIN control box, or hold the under-bed lamp button "
+                        "until its light blinks. The Pair/Learn button only syncs the RF remote.\n"
+                        "2. While the light is active, click 'Pair Now'."
                     )
                 }
             ),
         ):
             instructions = await flow._get_pairing_instructions(bed_type)
 
-        assert "OKIN receiver/control box" in instructions
-        assert "receiver pairing button" in instructions
+        assert "Power-cycle the OKIN control box" in instructions
+        assert "under-bed lamp button" in instructions
+        assert "Pair/Learn button only syncs the RF remote" in instructions
 
     async def test_okin_rf_eco_bt_requires_pairing(self) -> None:
         """RF ECO BT should request BLE pairing before authenticated OKIN writes."""
         assert requires_pairing(BED_TYPE_OKIN_RF_ECO_BT)
 
-    async def test_okin_cst_supports_position_feedback(self) -> None:
-        """CST should keep position sliders available after runtime correction."""
-        assert BED_TYPE_OKIN_CST in BEDS_WITH_POSITION_FEEDBACK
+    async def test_okin_cst_uses_fixed_three_motor_layout_without_position_feedback(
+        self,
+    ) -> None:
+        """The MFirm profile has three motors but no decoded position state."""
+        assert _default_motor_count(BED_TYPE_OKIN_CST) == 3
+        assert _is_valid_motor_count(BED_TYPE_OKIN_CST, "auto", 3)
+        assert not _is_valid_motor_count(BED_TYPE_OKIN_CST, "auto", 2)
+        assert not _is_valid_motor_count(BED_TYPE_OKIN_CST, "auto", 4)
+        assert BED_TYPE_OKIN_CST not in BEDS_WITH_POSITION_FEEDBACK
+        assert BED_TYPE_OKIN_CST in BEDS_WITHOUT_ANGLE_FEEDBACK
 
 
 class TestPairingPersistence:
@@ -1635,7 +1645,7 @@ class TestBluetoothDiscoveryFlow:
             result["flow_id"],
             user_input={
                 CONF_NAME: "My CST Bed",
-                CONF_MOTOR_COUNT: 2,
+                CONF_MOTOR_COUNT: 3,
                 CONF_HAS_MASSAGE: False,
                 CONF_DISABLE_ANGLE_SENSING: True,
                 CONF_PREFERRED_ADAPTER: "auto",
@@ -2384,7 +2394,7 @@ class TestOptionsFlow:
                 CONF_ADDRESS: "AA:BB:CC:DD:EE:96",
                 CONF_NAME: "Okin CST Bed",
                 CONF_BED_TYPE: BED_TYPE_OKIN_CST,
-                CONF_MOTOR_COUNT: 4,
+                CONF_MOTOR_COUNT: 3,
                 CONF_BLE_BOND_ESTABLISHED: True,
                 CONF_BLE_BOND_MARKER_UNRELIABLE: True,
                 CONF_BACK_MAX_ANGLE: 68.0,
@@ -2409,7 +2419,7 @@ class TestOptionsFlow:
             initial["flow_id"],
             user_input={
                 CONF_BED_TYPE: BED_TYPE_OCTO,
-                CONF_MOTOR_COUNT: 4,
+                CONF_MOTOR_COUNT: 3,
             },
         )
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -56,8 +56,6 @@ from custom_components.adjustable_bed.const import (
     NORDIC_DFU_SERVICE_UUID,
     OKIMAT_SERVICE_UUID,
     OKIMAT_WRITE_CHAR_UUID,
-    OKIN_FOOT_MAX_ANGLE,
-    OKIN_HEAD_MAX_ANGLE,
     OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
     OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID,
     RICHMAT_REMOTE_AUTO,
@@ -809,50 +807,6 @@ class TestCoordinatorConnection:
         assert mock_read_positions.await_count == 2
         assert controller.prepare_for_position_read.await_count == 2
         mock_sleep.assert_awaited_once()
-
-    async def test_cst_initial_position_axes_ignore_unreported_extra_motors(
-        self,
-        hass: HomeAssistant,
-        mock_config_entry_data: dict,
-    ) -> None:
-        """CST startup hydration should not wait for head/feet axes."""
-        mock_config_entry_data[CONF_BED_TYPE] = BED_TYPE_OKIN_CST
-        mock_config_entry_data[CONF_MOTOR_COUNT] = 4
-        coordinator = AdjustableBedCoordinator(
-            hass,
-            MockConfigEntry(
-                domain=DOMAIN,
-                title=TEST_NAME,
-                data=mock_config_entry_data,
-                unique_id=TEST_ADDRESS,
-                entry_id="cst_expected_axes",
-            ),
-        )
-
-        assert coordinator._expected_initial_position_axes() == {"back", "legs"}
-
-    async def test_cst_max_angles_use_reported_position_ranges(
-        self,
-        hass: HomeAssistant,
-        mock_config_entry_data: dict,
-    ) -> None:
-        """CST seek limits should match the angles reported by notifications."""
-        mock_config_entry_data[CONF_BED_TYPE] = BED_TYPE_OKIN_CST
-        coordinator = AdjustableBedCoordinator(
-            hass,
-            MockConfigEntry(
-                domain=DOMAIN,
-                title=TEST_NAME,
-                data=mock_config_entry_data,
-                unique_id=TEST_ADDRESS,
-                entry_id="cst_max_angles",
-            ),
-        )
-
-        assert coordinator.get_max_angle("back") == OKIN_HEAD_MAX_ANGLE
-        assert coordinator.get_max_angle("head") == OKIN_HEAD_MAX_ANGLE
-        assert coordinator.get_max_angle("legs") == OKIN_FOOT_MAX_ANGLE
-        assert coordinator.get_max_angle("feet") == OKIN_FOOT_MAX_ANGLE
 
     async def test_passive_position_reconciliation_reads_positions_when_idle(
         self,
@@ -3549,12 +3503,12 @@ class TestRuntimeBedTypeCorrection:
         assert coordinator.bed_type == BED_TYPE_OKIN_CST
         assert coordinator.entry.data[CONF_BED_TYPE] == BED_TYPE_OKIN_CST
 
-    async def test_correction_to_cst_preserves_enabled_angle_sensing(
+    async def test_correction_to_cst_disables_enabled_angle_sensing(
         self,
         hass: HomeAssistant,
         mock_config_entry_data: dict,
     ):
-        """CST corrections should keep position sensors and position controls enabled."""
+        """CST corrections should disable unsupported position feedback."""
         coordinator = self._make_coordinator(
             hass,
             mock_config_entry_data,
@@ -3565,15 +3519,15 @@ class TestRuntimeBedTypeCorrection:
         coordinator._apply_runtime_bed_type_correction(BED_TYPE_OKIN_CST)
 
         assert coordinator.bed_type == BED_TYPE_OKIN_CST
-        assert coordinator.disable_angle_sensing is False
-        assert coordinator.entry.data[CONF_DISABLE_ANGLE_SENSING] is False
+        assert coordinator.disable_angle_sensing is True
+        assert coordinator.entry.data[CONF_DISABLE_ANGLE_SENSING] is True
 
-    async def test_correction_to_cst_enables_defaulted_angle_sensing(
+    async def test_correction_to_cst_keeps_defaulted_angle_sensing_disabled(
         self,
         hass: HomeAssistant,
         mock_config_entry_data: dict,
     ):
-        """Legacy entries missing the angle key should gain CST position features."""
+        """Legacy entries missing the angle key should retain the disabled default."""
         legacy_data = dict(mock_config_entry_data)
         legacy_data.pop(CONF_DISABLE_ANGLE_SENSING, None)
         coordinator = self._make_coordinator(
@@ -3588,15 +3542,15 @@ class TestRuntimeBedTypeCorrection:
         coordinator._apply_runtime_bed_type_correction(BED_TYPE_OKIN_CST)
 
         assert coordinator.bed_type == BED_TYPE_OKIN_CST
-        assert coordinator.disable_angle_sensing is False
-        assert coordinator.entry.data[CONF_DISABLE_ANGLE_SENSING] is False
+        assert coordinator.disable_angle_sensing is True
+        assert CONF_DISABLE_ANGLE_SENSING not in coordinator.entry.data
 
-    async def test_correction_to_cst_enables_stored_no_feedback_default_angle_sensing(
+    async def test_correction_to_cst_preserves_stored_no_feedback_default(
         self,
         hass: HomeAssistant,
         mock_config_entry_data: dict,
     ):
-        """Saved no-feedback defaults should not suppress corrected CST position features."""
+        """Saved no-feedback defaults should remain disabled after correction."""
         coordinator = self._make_coordinator(
             hass,
             mock_config_entry_data,
@@ -3609,15 +3563,15 @@ class TestRuntimeBedTypeCorrection:
         coordinator._apply_runtime_bed_type_correction(BED_TYPE_OKIN_CST)
 
         assert coordinator.bed_type == BED_TYPE_OKIN_CST
-        assert coordinator.disable_angle_sensing is False
-        assert coordinator.entry.data[CONF_DISABLE_ANGLE_SENSING] is False
+        assert coordinator.disable_angle_sensing is True
+        assert coordinator.entry.data[CONF_DISABLE_ANGLE_SENSING] is True
 
-    async def test_correction_to_cst_repairs_same_type_stored_default_angle_sensing(
+    async def test_correction_to_cst_same_type_keeps_angle_sensing_disabled(
         self,
         hass: HomeAssistant,
         mock_config_entry_data: dict,
     ):
-        """Saved CST entries with the old no-feedback default should be repaired."""
+        """Saved CST entries should keep unsupported angle sensing disabled."""
         coordinator = self._make_coordinator(
             hass,
             mock_config_entry_data,
@@ -3629,10 +3583,10 @@ class TestRuntimeBedTypeCorrection:
 
         changed = coordinator._apply_runtime_bed_type_correction(BED_TYPE_OKIN_CST)
 
-        assert changed is True
+        assert changed is False
         assert coordinator.bed_type == BED_TYPE_OKIN_CST
-        assert coordinator.disable_angle_sensing is False
-        assert coordinator.entry.data[CONF_DISABLE_ANGLE_SENSING] is False
+        assert coordinator.disable_angle_sensing is True
+        assert coordinator.entry.data[CONF_DISABLE_ANGLE_SENSING] is True
 
     async def test_correction_to_cst_preserves_explicit_disabled_angle_sensing(
         self,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -45,8 +45,6 @@ from custom_components.adjustable_bed.const import (
     LEGGETT_GEN2_WRITE_CHAR_UUID,
     MALOUF_LAYOUT_HILO,
     OCTO_VARIANT_STANDARD,
-    OKIN_FOOT_MAX_ANGLE,
-    OKIN_HEAD_MAX_ANGLE,
     SLEEP_NUMBER_VARIANT_LEFT,
 )
 
@@ -113,6 +111,51 @@ class TestCoverEntities:
 
         assert registry.async_get_entity_id("cover", DOMAIN, "AA:BB:CC:DD:EE:01_head") is None
         assert registry.async_get_entity_id("cover", DOMAIN, "AA:BB:CC:DD:EE:01_feet") is None
+
+    async def test_okin_cst_uses_fixed_three_motor_layout_and_removes_duplicates(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """CST exposes head/feet/lumbar even when an old entry stored four motors."""
+        address = "AA:BB:CC:DD:EE:38"
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Okin CST Bed",
+            data={
+                CONF_ADDRESS: address,
+                CONF_NAME: "Okin CST Bed",
+                CONF_BED_TYPE: BED_TYPE_OKIN_CST,
+                CONF_MOTOR_COUNT: 4,
+                CONF_HAS_MASSAGE: True,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=address,
+            entry_id="okin_cst_cover_entry",
+        )
+        entry.add_to_hass(hass)
+
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        for key in ("back", "legs", "tilt"):
+            registry.async_get_or_create(
+                "cover",
+                DOMAIN,
+                f"{address}_{key}",
+                config_entry=entry,
+                suggested_object_id=f"okin_cst_{key}",
+            )
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        for key in ("head", "feet", "lumbar"):
+            assert registry.async_get_entity_id("cover", DOMAIN, f"{address}_{key}") is not None
+        for key in ("back", "legs", "tilt"):
+            assert registry.async_get_entity_id("cover", DOMAIN, f"{address}_{key}") is None
 
     async def test_okin_rf_eco_bt_exposes_only_stair_cover_and_stop(
         self,
@@ -617,13 +660,13 @@ class TestNumberEntities:
             is None
         )
 
-    async def test_okin_cst_number_entities_only_include_back_and_legs_position(
+    async def test_okin_cst_creates_no_position_number_entities(
         self,
         hass: HomeAssistant,
         mock_coordinator_connected,
         enable_custom_integrations,
     ):
-        """CST should expose only the axes reported by its position payload."""
+        """CST notifications do not encode motor positions."""
         entry = MockConfigEntry(
             domain=DOMAIN,
             title="OKIN CST Numbers",
@@ -631,7 +674,7 @@ class TestNumberEntities:
                 CONF_ADDRESS: "AA:BB:CC:DD:EE:28",
                 CONF_NAME: "OKIN CST Numbers",
                 CONF_BED_TYPE: BED_TYPE_OKIN_CST,
-                CONF_MOTOR_COUNT: 4,
+                CONF_MOTOR_COUNT: 3,
                 CONF_HAS_MASSAGE: False,
                 CONF_DISABLE_ANGLE_SENSING: False,
                 CONF_PREFERRED_ADAPTER: "auto",
@@ -647,31 +690,11 @@ class TestNumberEntities:
         from homeassistant.helpers import entity_registry as er
 
         registry = er.async_get(hass)
-        coordinator = hass.data[DOMAIN][entry.entry_id]
-        back_entity_id = registry.async_get_entity_id(
-            "number", DOMAIN, "AA:BB:CC:DD:EE:28_back_position"
-        )
-        legs_entity_id = registry.async_get_entity_id(
-            "number", DOMAIN, "AA:BB:CC:DD:EE:28_legs_position"
-        )
-        assert back_entity_id is not None
-        assert legs_entity_id is not None
-        back_state = hass.states.get(back_entity_id)
-        legs_state = hass.states.get(legs_entity_id)
-        assert back_state is not None
-        assert legs_state is not None
-        assert back_state.attributes["max"] == pytest.approx(coordinator.get_max_angle("back"))
-        assert legs_state.attributes["max"] == pytest.approx(coordinator.get_max_angle("legs"))
-        assert back_state.attributes["max"] == pytest.approx(OKIN_HEAD_MAX_ANGLE)
-        assert legs_state.attributes["max"] == pytest.approx(OKIN_FOOT_MAX_ANGLE)
-        assert (
-            registry.async_get_entity_id("number", DOMAIN, "AA:BB:CC:DD:EE:28_head_position")
-            is None
-        )
-        assert (
-            registry.async_get_entity_id("number", DOMAIN, "AA:BB:CC:DD:EE:28_feet_position")
-            is None
-        )
+        for axis in ("back", "legs", "head", "feet"):
+            assert (
+                registry.async_get_entity_id("number", DOMAIN, f"AA:BB:CC:DD:EE:28_{axis}_position")
+                is None
+            )
 
 
 class TestSleepNumberEntities:
@@ -2668,13 +2691,13 @@ class TestSensorEntities:
         # With 2 motors, should have back_angle and legs_angle sensors
         assert len(sensor_states) == 2
 
-    async def test_okin_cst_angle_sensors_only_include_back_and_legs(
+    async def test_okin_cst_creates_no_angle_sensors(
         self,
         hass: HomeAssistant,
         mock_coordinator_connected,
         enable_custom_integrations,
     ):
-        """CST should only create angle sensors for axes reported by notifications."""
+        """CST notifications have no decoded degree-angle fields."""
         entry = MockConfigEntry(
             domain=DOMAIN,
             title="OKIN CST Sensor Bed",
@@ -2682,7 +2705,7 @@ class TestSensorEntities:
                 CONF_ADDRESS: "AA:BB:CC:DD:EE:29",
                 CONF_NAME: "OKIN CST Sensor Bed",
                 CONF_BED_TYPE: BED_TYPE_OKIN_CST,
-                CONF_MOTOR_COUNT: 4,
+                CONF_MOTOR_COUNT: 3,
                 CONF_HAS_MASSAGE: False,
                 CONF_DISABLE_ANGLE_SENSING: False,
                 CONF_PREFERRED_ADAPTER: "auto",
@@ -2698,20 +2721,11 @@ class TestSensorEntities:
         from homeassistant.helpers import entity_registry as er
 
         registry = er.async_get(hass)
-        assert (
-            registry.async_get_entity_id("sensor", DOMAIN, "AA:BB:CC:DD:EE:29_back_angle")
-            is not None
-        )
-        assert (
-            registry.async_get_entity_id("sensor", DOMAIN, "AA:BB:CC:DD:EE:29_legs_angle")
-            is not None
-        )
-        assert (
-            registry.async_get_entity_id("sensor", DOMAIN, "AA:BB:CC:DD:EE:29_head_angle") is None
-        )
-        assert (
-            registry.async_get_entity_id("sensor", DOMAIN, "AA:BB:CC:DD:EE:29_feet_angle") is None
-        )
+        for axis in ("back", "legs", "head", "feet"):
+            assert (
+                registry.async_get_entity_id("sensor", DOMAIN, f"AA:BB:CC:DD:EE:29_{axis}_angle")
+                is None
+            )
 
     async def test_sleep_number_mcr_creates_no_angle_sensors_even_when_enabled(
         self,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -57,7 +57,6 @@ from custom_components.adjustable_bed.const import (
     KEESON_VARIANT_KSBT,
     MALOUF_LAYOUT_HILO,
     OCTO_VARIANT_STANDARD,
-    OKIN_HEAD_MAX_ANGLE,
 )
 
 
@@ -1570,13 +1569,13 @@ class TestServices:
                 blocking=True,
             )
 
-    async def test_set_position_service_accepts_okin_cst_back_and_legs(
+    async def test_set_position_service_rejects_okin_cst_without_position_feedback(
         self,
         hass: HomeAssistant,
         mock_coordinator_connected,
         enable_custom_integrations,
     ):
-        """CST set_position should accept only axes reported by position feedback."""
+        """CST should reject position seeking because it reports no motor positions."""
         entry = MockConfigEntry(
             domain=DOMAIN,
             title="OKIN CST Service Bed",
@@ -1584,7 +1583,7 @@ class TestServices:
                 CONF_ADDRESS: "AA:BB:CC:DD:EE:35",
                 CONF_NAME: "OKIN CST Service Bed",
                 CONF_BED_TYPE: BED_TYPE_OKIN_CST,
-                CONF_MOTOR_COUNT: 4,
+                CONF_MOTOR_COUNT: 3,
                 CONF_HAS_MASSAGE: False,
                 CONF_DISABLE_ANGLE_SENSING: False,
                 CONF_PREFERRED_ADAPTER: "auto",
@@ -1609,134 +1608,12 @@ class TestServices:
         assert len(devices) == 1
         device_id = devices[0].id
 
-        coordinator = hass.data[DOMAIN][entry.entry_id]
-        coordinator.async_seek_position = AsyncMock()
-
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SET_POSITION,
-            {
-                "device_id": [device_id],
-                "motor": "back",
-                "position": 50,
-            },
-            blocking=True,
-        )
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SET_POSITION,
-            {
-                "device_id": [device_id],
-                "motor": "legs",
-                "position": 40,
-            },
-            blocking=True,
-        )
-
-        assert [
-            call.kwargs["position_key"] for call in coordinator.async_seek_position.await_args_list
-        ] == ["back", "legs"]
-
-    async def test_set_position_service_rejects_okin_cst_head_and_feet(
-        self,
-        hass: HomeAssistant,
-        mock_coordinator_connected,
-        enable_custom_integrations,
-    ):
-        """CST set_position should reject axes without position data."""
         import pytest
         from homeassistant.exceptions import ServiceValidationError
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            title="OKIN CST Invalid Service Bed",
-            data={
-                CONF_ADDRESS: "AA:BB:CC:DD:EE:36",
-                CONF_NAME: "OKIN CST Invalid Service Bed",
-                CONF_BED_TYPE: BED_TYPE_OKIN_CST,
-                CONF_MOTOR_COUNT: 4,
-                CONF_HAS_MASSAGE: False,
-                CONF_DISABLE_ANGLE_SENSING: False,
-                CONF_PREFERRED_ADAPTER: "auto",
-            },
-            unique_id="AA:BB:CC:DD:EE:36",
-            entry_id="okin_cst_invalid_service_entry",
-        )
-        entry.add_to_hass(hass)
-
-        with patch(
-            "custom_components.adjustable_bed.coordinator."
-            "AdjustableBedCoordinator.async_read_initial_positions",
-            new=AsyncMock(),
-        ):
-            await hass.config_entries.async_setup(entry.entry_id)
-            await hass.async_block_till_done()
-
-        from homeassistant.helpers import device_registry as dr
-
-        device_registry = dr.async_get(hass)
-        devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
-        assert len(devices) == 1
-        device_id = devices[0].id
-
-        for motor in ("head", "feet"):
-            with pytest.raises(ServiceValidationError, match="Valid motors: back, legs"):
-                await hass.services.async_call(
-                    DOMAIN,
-                    SERVICE_SET_POSITION,
-                    {
-                        "device_id": [device_id],
-                        "motor": motor,
-                        "position": 20,
-                    },
-                    blocking=True,
-                )
-
-    async def test_set_position_service_rejects_okin_cst_back_above_reported_range(
-        self,
-        hass: HomeAssistant,
-        mock_coordinator_connected,
-        enable_custom_integrations,
-    ):
-        """CST back targets above reported feedback range should be rejected."""
-        import pytest
-        from homeassistant.exceptions import ServiceValidationError
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            title="OKIN CST Range Service Bed",
-            data={
-                CONF_ADDRESS: "AA:BB:CC:DD:EE:37",
-                CONF_NAME: "OKIN CST Range Service Bed",
-                CONF_BED_TYPE: BED_TYPE_OKIN_CST,
-                CONF_MOTOR_COUNT: 4,
-                CONF_HAS_MASSAGE: False,
-                CONF_DISABLE_ANGLE_SENSING: False,
-                CONF_PREFERRED_ADAPTER: "auto",
-            },
-            unique_id="AA:BB:CC:DD:EE:37",
-            entry_id="okin_cst_range_service_entry",
-        )
-        entry.add_to_hass(hass)
-
-        with patch(
-            "custom_components.adjustable_bed.coordinator."
-            "AdjustableBedCoordinator.async_read_initial_positions",
-            new=AsyncMock(),
-        ):
-            await hass.config_entries.async_setup(entry.entry_id)
-            await hass.async_block_till_done()
-
-        from homeassistant.helpers import device_registry as dr
-
-        device_registry = dr.async_get(hass)
-        devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
-        assert len(devices) == 1
-        device_id = devices[0].id
 
         with pytest.raises(
             ServiceValidationError,
-            match=rf"Valid range: 0-{OKIN_HEAD_MAX_ANGLE}°",
+            match="does not support position feedback",
         ):
             await hass.services.async_call(
                 DOMAIN,
@@ -1744,7 +1621,7 @@ class TestServices:
                 {
                     "device_id": [device_id],
                     "motor": "back",
-                    "position": OKIN_HEAD_MAX_ANGLE + 1,
+                    "position": 50,
                 },
                 blocking=True,
             )

--- a/tests/test_okin_cst.py
+++ b/tests/test_okin_cst.py
@@ -26,6 +26,7 @@ from custom_components.adjustable_bed.const import (
     CONF_MOTOR_COUNT,
     CONF_PREFERRED_ADAPTER,
     DOMAIN,
+    OKIMAT_NOTIFY_CHAR_UUID,
     OKIMAT_WRITE_CHAR_UUID,
 )
 from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
@@ -434,3 +435,29 @@ class TestOkinCstCommands:
 
         assert _payloads(mock_bleak_client) == [build_cst_command()] * 2
         assert mock_sleep.await_args_list == [call(0.1), call(0.1)]
+
+    async def test_notifications_are_forwarded_raw_without_position_updates(
+        self,
+        okin_cst_controller: OkinCstController,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """Diagnostics should receive CST notifications without invented positions."""
+        raw_callback = MagicMock()
+        position_callback = MagicMock()
+        okin_cst_controller.set_raw_notify_callback(raw_callback)
+        mock_bleak_client.start_notify.reset_mock()
+
+        await okin_cst_controller.start_notify(position_callback)
+
+        mock_bleak_client.start_notify.assert_awaited_once()
+        notify_uuid, handler = mock_bleak_client.start_notify.await_args.args
+        assert notify_uuid == OKIMAT_NOTIFY_CHAR_UUID
+
+        payload = bytearray.fromhex("0c02000000000000000001000000")
+        handler(MagicMock(), payload)
+
+        raw_callback.assert_called_once_with(OKIMAT_NOTIFY_CHAR_UUID, bytes(payload))
+        position_callback.assert_not_called()
+
+        await okin_cst_controller.stop_notify()
+        mock_bleak_client.stop_notify.assert_awaited_once_with(OKIMAT_NOTIFY_CHAR_UUID)

--- a/tests/test_okin_cst.py
+++ b/tests/test_okin_cst.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
@@ -13,6 +13,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.adjustable_bed.beds.okin_cst import (
     _BUTTON_PRESS_REPEAT_COUNT,
     _PRESET_REPEAT_COUNT,
+    CstMotorCommands,
     CstRemoteCommands,
     OkinCstController,
 )
@@ -37,7 +38,7 @@ def mock_okin_cst_config_entry_data() -> dict:
         CONF_ADDRESS: "AA:BB:CC:DD:EE:FF",
         CONF_NAME: "Okin CST Test Bed",
         CONF_BED_TYPE: BED_TYPE_OKIN_CST,
-        CONF_MOTOR_COUNT: 4,
+        CONF_MOTOR_COUNT: 3,
         CONF_HAS_MASSAGE: True,
         CONF_DISABLE_ANGLE_SENSING: True,
         CONF_PREFERRED_ADAPTER: "auto",
@@ -82,9 +83,9 @@ def _payloads(mock_client: MagicMock) -> list[bytes]:
 
 def _assert_writes_use_cst_characteristic(mock_client: MagicMock) -> None:
     """Assert every write targets the CST write characteristic."""
-    for call in mock_client.write_gatt_char.call_args_list:
-        assert call.args[0] == OKIMAT_WRITE_CHAR_UUID
-        assert call.kwargs["response"] is True
+    for recorded_call in mock_client.write_gatt_char.call_args_list:
+        assert recorded_call.args[0] == OKIMAT_WRITE_CHAR_UUID
+        assert recorded_call.kwargs["response"] is True
 
 
 def _assert_button_press_sequence(payloads: list[bytes], command: bytes) -> None:
@@ -116,13 +117,29 @@ class TestOkinCstCapabilities:
         assert okin_cst_controller.supports_discrete_light_control is True
         assert okin_cst_controller.supports_massage is True
         assert okin_cst_controller.supports_massage_off_control is True
+        assert okin_cst_controller.supports_massage_toggle_control is False
         assert okin_cst_controller.supports_massage_intensity_step_control is True
+        assert okin_cst_controller.supports_head_massage_intensity_step_control is False
+        assert okin_cst_controller.supports_foot_massage_intensity_step_control is False
+        assert okin_cst_controller.supports_position_feedback is False
+        assert [spec.key for spec in okin_cst_controller.motor_control_specs] == [
+            "head",
+            "feet",
+            "lumbar",
+        ]
+        assert okin_cst_controller.stale_motor_entity_keys == frozenset({"back", "legs", "tilt"})
 
-    def test_remote_command_values_match_cst_protocol_constants(self) -> None:
-        """Massage toggle and stop are distinct CSTProtocol constants."""
-        assert CstRemoteCommands.MASSAGE_TOGGLE == 0x04000000
+    def test_command_values_match_reachable_cst_protocol(self) -> None:
+        """Only command values reachable from the shipped app are declared."""
+        assert CstMotorCommands.HEAD_UP == 0x00000001
+        assert CstMotorCommands.HEAD_DOWN == 0x00000002
+        assert CstMotorCommands.FOOT_UP == 0x00000004
+        assert CstMotorCommands.FOOT_DOWN == 0x00000008
+        assert CstMotorCommands.LUMBAR_UP == 0x00000010
+        assert CstMotorCommands.LUMBAR_DOWN == 0x00000020
         assert CstRemoteCommands.MASSAGE_OFF == 0x02000000
-        assert CstRemoteCommands.MASSAGE_TOGGLE != CstRemoteCommands.MASSAGE_OFF
+        assert CstRemoteCommands.MASSAGE_INTENSITY == 0x00000C00
+        assert CstRemoteCommands.MASSAGE_INTENSITY_MINUS == 0x01800000
 
 
 class TestOkinCstCommands:
@@ -132,13 +149,13 @@ class TestOkinCstCommands:
         "custom_components.adjustable_bed.beds.okin_cst.asyncio.sleep",
         new_callable=AsyncMock,
     )
-    async def test_flat_preset_uses_primary_field_and_long_hold(
+    async def test_flat_preset_uses_primary_field_and_app_one_shot_cadence(
         self,
         _mock_sleep: AsyncMock,
         okin_cst_controller: OkinCstController,
         mock_bleak_client: MagicMock,
     ) -> None:
-        """Flat uses the primary field and repeats long enough to complete recall."""
+        """Flat uses the primary field and the app's fixed 500 ms voice cadence."""
         mock_bleak_client.write_gatt_char.reset_mock()
 
         await okin_cst_controller.preset_flat()
@@ -305,14 +322,9 @@ class TestOkinCstCommands:
     @pytest.mark.parametrize(
         ("method_name", "command_value"),
         [
-            ("massage_toggle", CstRemoteCommands.MASSAGE_TOGGLE),
             ("massage_off", CstRemoteCommands.MASSAGE_OFF),
             ("massage_intensity_up", CstRemoteCommands.MASSAGE_INTENSITY),
             ("massage_intensity_down", CstRemoteCommands.MASSAGE_INTENSITY_MINUS),
-            ("massage_head_up", CstRemoteCommands.MASSAGE_HEAD),
-            ("massage_head_down", CstRemoteCommands.MASSAGE_HEAD_MINUS),
-            ("massage_foot_up", CstRemoteCommands.MASSAGE_FEET),
-            ("massage_foot_down", CstRemoteCommands.MASSAGE_FEET_MINUS),
         ],
     )
     @patch(
@@ -367,3 +379,58 @@ class TestOkinCstCommands:
             second_press,
             build_cst_command(control_value=CstRemoteCommands.MASSAGE_WAVE_2),
         )
+
+    @pytest.mark.parametrize(
+        ("method_name", "command_value"),
+        [
+            ("move_back_up", CstMotorCommands.HEAD_UP),
+            ("move_back_down", CstMotorCommands.HEAD_DOWN),
+            ("move_legs_up", CstMotorCommands.FOOT_UP),
+            ("move_legs_down", CstMotorCommands.FOOT_DOWN),
+            ("move_lumbar_up", CstMotorCommands.LUMBAR_UP),
+            ("move_lumbar_down", CstMotorCommands.LUMBAR_DOWN),
+        ],
+    )
+    @patch(
+        "custom_components.adjustable_bed.beds.okin_cst.asyncio.sleep",
+        new_callable=AsyncMock,
+    )
+    async def test_motor_actions_use_exact_primary_field_bits(
+        self,
+        _mock_sleep: AsyncMock,
+        okin_cst_controller: OkinCstController,
+        mock_bleak_client: MagicMock,
+        method_name: str,
+        command_value: int,
+    ) -> None:
+        """Head, foot, and lumbar use the app's reachable motor bits."""
+        mock_bleak_client.write_gatt_char.reset_mock()
+        method: Callable[[], Awaitable[None]] = getattr(okin_cst_controller, method_name)
+
+        await method()
+
+        expected = build_cst_command(motor_value=command_value)
+        assert _payloads(mock_bleak_client) == [
+            expected,
+        ] * okin_cst_controller._coordinator.motor_pulse_count + [
+            build_cst_command(),
+            build_cst_command(),
+        ]
+
+    @patch(
+        "custom_components.adjustable_bed.beds.okin_cst.asyncio.sleep",
+        new_callable=AsyncMock,
+    )
+    async def test_stop_sequence_waits_before_both_release_frames(
+        self,
+        mock_sleep: AsyncMock,
+        okin_cst_controller: OkinCstController,
+        mock_bleak_client: MagicMock,
+    ) -> None:
+        """The app sends zero releases at +100 ms and +200 ms."""
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        await okin_cst_controller.stop_all()
+
+        assert _payloads(mock_bleak_client) == [build_cst_command()] * 2
+        assert mock_sleep.await_args_list == [call(0.1), call(0.1)]


### PR DESCRIPTION
MFirm 900-O users reported broken lumbar, light, and Flat controls. The CST profile used incorrect lumbar bits, an excessively long preset cadence, and unsupported motor and position assumptions.

This aligns the controller with the frozen MFirm 900-O 1.1.2 clean-room analysis: exact Head, Feet, and Lumbar controls, the app command cadence and STOP cleanup, reachable light and massage actions, and removal of unsupported position entities.

Validation:
- `uv run pytest` (2,758 passed)
- `uvx ruff@0.15.16 check custom_components tests`
- `uvx pyright@1.1.410 custom_components tests`
- clean local CodeRabbit preflight

Ref #501

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OKIN CST beds now use a fixed three-motor layout: head, feet, and lumbar.
  * Added updated lumbar controls, massage wave modes, and under-bed light controls.

* **Changes**
  * Position and angle feedback are no longer available for OKIN CST beds.
  * Position-based controls are unavailable without feedback.
  * Configuration is restricted to three motors.
  * Removed unsupported tilt, memory, and head/feet massage controls.

* **Bug Fixes**
  * Improved stop-command timing for more reliable motor release.
  * Cleaned up stale entities from previous configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->