### PR TITLE
fix: preserve configured OKIN stair profile

### DIFF
--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -27,6 +27,8 @@ from .adapter import (
 from .address_lock import async_get_connect_lock
 from .const import (
     ADAPTER_AUTO,
+    BED_TYPE_OKIN_CST,
+    BED_TYPE_OKIN_RF_ECO_BT,
     CONF_PREFERRED_ADAPTER,
     DEVICE_INFO_CHARS,
     DEVICE_INFO_SERVICE_UUID,
@@ -34,6 +36,7 @@ from .const import (
     SUPPORTED_BED_TYPES,
 )
 from .detection import (
+    OKIN_SHARED_UUID_GATT_REFINABLE_TYPES,
     detect_bed_type_detailed,
     detect_bed_type_from_gatt_services,
     refine_okin_shared_uuid_protocol_from_gatt,
@@ -954,8 +957,21 @@ class BLEDiagnosticRunner:
         )
         if gatt_detection.bed_type is not None:
             model_number = (device_information or {}).get("model_number")
+            configured_bed_type = (
+                self.coordinator.bed_type if self.coordinator is not None else None
+            )
+            refinement_seed = gatt_detection.bed_type
+            if (
+                gatt_detection.bed_type
+                in {BED_TYPE_OKIN_CST, BED_TYPE_OKIN_RF_ECO_BT}
+                and configured_bed_type in OKIN_SHARED_UUID_GATT_REFINABLE_TYPES
+            ):
+                # CSS plus Nordic DFU cannot distinguish CST from RF ECO BT.
+                # Seed the same configured profile that runtime refinement uses
+                # so a support bundle does not contradict the active controller.
+                refinement_seed = configured_bed_type
             bed_type = refine_okin_shared_uuid_protocol_from_gatt(
-                gatt_detection.bed_type,
+                refinement_seed,
                 gatt_services,
                 ble_model=model_number,
                 device_name=observed_device_name or getattr(service_info, "name", None),
@@ -964,9 +980,12 @@ class BLEDiagnosticRunner:
             confidence = gatt_detection.confidence
             ambiguous_types = list(gatt_detection.ambiguous_types or [])
             if bed_type != gatt_detection.bed_type:
-                signals.append("device_info:model_number")
-                confidence = max(confidence, 0.95)
-                ambiguous_types = []
+                if bed_type == refinement_seed and refinement_seed != gatt_detection.bed_type:
+                    signals.append("configured_profile:shared_okin_uuid")
+                else:
+                    signals.append("device_info:model_number")
+                    confidence = max(confidence, 0.95)
+                    ambiguous_types = []
             return {
                 "bed_type": bed_type,
                 "confidence": confidence,

--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -33,7 +33,11 @@ from .const import (
     DOMAIN,
     SUPPORTED_BED_TYPES,
 )
-from .detection import detect_bed_type_detailed, detect_bed_type_from_gatt_services
+from .detection import (
+    detect_bed_type_detailed,
+    detect_bed_type_from_gatt_services,
+    refine_okin_shared_uuid_protocol_from_gatt,
+)
 from .diagnostic_payloads import (
     format_mapping_payloads,
     format_payload,
@@ -281,6 +285,7 @@ class BLEDiagnosticRunner:
         detection = self._build_detection_section(
             best_snapshot[0] if best_snapshot else None,
             services_info,
+            device_information,
         )
 
         adapter_details: dict[str, Any] = self.coordinator.adapter_details if self.coordinator else {}
@@ -933,6 +938,7 @@ class BLEDiagnosticRunner:
         self,
         service_info: Any | None,
         gatt_services: list[ServiceInfo] | None = None,
+        device_information: dict[str, str | None] | None = None,
     ) -> dict[str, Any]:
         """Build a detection reasoning section."""
         connected_device = self._extract_backend_device()
@@ -947,14 +953,28 @@ class BLEDiagnosticRunner:
             observed_device_name or getattr(service_info, "name", None),
         )
         if gatt_detection.bed_type is not None:
+            model_number = (device_information or {}).get("model_number")
+            bed_type = refine_okin_shared_uuid_protocol_from_gatt(
+                gatt_detection.bed_type,
+                gatt_services,
+                ble_model=model_number,
+                device_name=observed_device_name or getattr(service_info, "name", None),
+            )
+            signals = list(gatt_detection.signals)
+            confidence = gatt_detection.confidence
+            ambiguous_types = list(gatt_detection.ambiguous_types or [])
+            if bed_type != gatt_detection.bed_type:
+                signals.append("device_info:model_number")
+                confidence = max(confidence, 0.95)
+                ambiguous_types = []
             return {
-                "bed_type": gatt_detection.bed_type,
-                "confidence": gatt_detection.confidence,
-                "signals": list(gatt_detection.signals),
-                "ambiguous_types": list(gatt_detection.ambiguous_types or []),
+                "bed_type": bed_type,
+                "confidence": confidence,
+                "signals": signals,
+                "ambiguous_types": ambiguous_types,
                 "requires_characteristic_check": gatt_detection.requires_characteristic_check,
                 "detected_remote": gatt_detection.detected_remote,
-                "supported_match": gatt_detection.bed_type in SUPPORTED_BED_TYPES,
+                "supported_match": bed_type in SUPPORTED_BED_TYPES,
                 "manufacturer_id": gatt_detection.manufacturer_id,
             }
 

--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -970,6 +970,14 @@ class BLEDiagnosticRunner:
                 # Seed the same configured profile that runtime refinement uses
                 # so a support bundle does not contradict the active controller.
                 refinement_seed = configured_bed_type
+            bed_type_without_model = None
+            if model_number:
+                bed_type_without_model = refine_okin_shared_uuid_protocol_from_gatt(
+                    refinement_seed,
+                    gatt_services,
+                    device_name=observed_device_name or getattr(service_info, "name", None),
+                    _log_correction=False,
+                )
             bed_type = refine_okin_shared_uuid_protocol_from_gatt(
                 refinement_seed,
                 gatt_services,
@@ -980,12 +988,12 @@ class BLEDiagnosticRunner:
             confidence = gatt_detection.confidence
             ambiguous_types = list(gatt_detection.ambiguous_types or [])
             if bed_type != gatt_detection.bed_type:
-                if bed_type == refinement_seed and refinement_seed != gatt_detection.bed_type:
-                    signals.append("configured_profile:shared_okin_uuid")
-                else:
+                if bed_type_without_model is not None and bed_type != bed_type_without_model:
                     signals.append("device_info:model_number")
                     confidence = max(confidence, 0.95)
                     ambiguous_types = []
+                elif bed_type == refinement_seed and refinement_seed != gatt_detection.bed_type:
+                    signals.append("configured_profile:shared_okin_uuid")
             return {
                 "bed_type": bed_type,
                 "confidence": confidence,

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -2047,13 +2047,14 @@ def bed_type_has_position_feedback(
         return True
     return bed_type == BED_TYPE_KEESON and protocol_variant == KEESON_VARIANT_ERGOMOTION
 
-# Bed types that may have angle sensing enabled but report NO degree-angle data.
-# Sleep Number MCR/BAM beds only report sleep-number values and bed presence over BLE
-# (no motor angle feedback at all), so degree angle sensors would sit at "unknown"
-# forever. These are skipped during angle-sensor creation regardless of the
-# disable_angle_sensing option, which also fixes existing installs whose stored config
-# still has angle sensing enabled (#322).
-BEDS_WITHOUT_ANGLE_FEEDBACK: Final = frozenset({BED_TYPE_SLEEP_NUMBER_MCR})
+# Bed types that report no degree-angle data. Sleep Number MCR/BAM only reports
+# sleep-number values and bed presence, while RF ECO BT controls a single stair
+# actuator without position feedback. Degree angle sensors would sit at "unknown"
+# forever, so these types skip angle-sensor creation and remove stale entities from
+# previously selected profiles (#322, #344).
+BEDS_WITHOUT_ANGLE_FEEDBACK: Final = frozenset(
+    {BED_TYPE_OKIN_RF_ECO_BT, BED_TYPE_SLEEP_NUMBER_MCR}
+)
 
 # Bed types that report positions as 0-100 percentages (not angle degrees)
 # These bed types return percentage values directly, so no angle-to-percent conversion is needed.

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -177,6 +177,9 @@ _INITIAL_POSITION_READ_TIMEOUT = 10.0
 _INITIAL_POSITION_READ_RETRY_DELAY = 3.0
 _INITIAL_POSITION_READ_MAX_ATTEMPTS = 6
 _PASSIVE_POSITION_RECONCILIATION_IDLE_MARGIN = 15.0
+# One reconnect gives a stale CST entry another chance to reveal the RF ECO BT
+# stair model without making genuine CST receivers pay DIS timeouts forever.
+_OKIN_CST_DEVICE_INFO_MAX_READ_ATTEMPTS = 2
 
 MAX_COMMAND_TRACE_ENTRIES = 100
 
@@ -335,6 +338,7 @@ class AdjustableBedCoordinator:
         self._ble_manufacturer: str | None = None
         self._ble_model: str | None = None
         self._device_info_read_done: bool = False
+        self._device_info_read_attempts: int = 0
         self._bond_probe_timed_out: bool = False
 
         # Track if pairing is supported by the Bluetooth adapter (None = unknown)
@@ -1439,6 +1443,7 @@ class AdjustableBedCoordinator:
         model: str | None,
     ) -> None:
         """Store Device Information and decide whether reconnects should retry it."""
+        self._device_info_read_attempts += 1
         self._ble_manufacturer = manufacturer
         self._ble_model = model
 
@@ -1458,9 +1463,22 @@ class AdjustableBedCoordinator:
             not self._bed_type_needs_ble_model() or model_useful
         )
 
-        self._device_info_read_done = has_useful_value and required_fields_present
+        read_succeeded = has_useful_value and required_fields_present
+        cst_retry_exhausted = (
+            self._bed_type == BED_TYPE_OKIN_CST
+            and self._device_info_read_attempts
+            >= _OKIN_CST_DEVICE_INFO_MAX_READ_ATTEMPTS
+        )
+        self._device_info_read_done = read_succeeded or cst_retry_exhausted
 
-        if not self._device_info_read_done:
+        if cst_retry_exhausted and not read_succeeded:
+            _LOGGER.debug(
+                "Device Information read for %s did not return the model after "
+                "%d attempts; caching the CST result for this coordinator session.",
+                self._address,
+                self._device_info_read_attempts,
+            )
+        elif not self._device_info_read_done:
             if has_useful_value and not required_fields_present:
                 _LOGGER.debug(
                     "Device Information read for %s is missing the model this "

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -71,6 +71,7 @@ from .const import (
     BED_TYPE_OKIN_FFE,
     BED_TYPE_OKIN_HANDLE,
     BED_TYPE_OKIN_NORDIC,
+    BED_TYPE_OKIN_RF_ECO_BT,
     BED_TYPE_OKIN_UUID,
     BED_TYPE_REVERIE,
     BED_TYPE_REVERIE_NIGHTSTAND,
@@ -177,9 +178,10 @@ _INITIAL_POSITION_READ_TIMEOUT = 10.0
 _INITIAL_POSITION_READ_RETRY_DELAY = 3.0
 _INITIAL_POSITION_READ_MAX_ATTEMPTS = 6
 _PASSIVE_POSITION_RECONCILIATION_IDLE_MARGIN = 15.0
-# One reconnect gives a stale CST entry another chance to reveal the RF ECO BT
-# stair model without making genuine CST receivers pay DIS timeouts forever.
-_OKIN_CST_DEVICE_INFO_MAX_READ_ATTEMPTS = 2
+# One reconnect gives a stale preserved OKIN profile another chance to reveal
+# the CST/RF ECO BT discriminator without making known receivers pay DIS
+# timeouts forever.
+_OKIN_PRESERVED_PROFILE_DEVICE_INFO_MAX_READ_ATTEMPTS = 2
 
 MAX_COMMAND_TRACE_ENTRIES = 100
 
@@ -1464,19 +1466,20 @@ class AdjustableBedCoordinator:
         )
 
         read_succeeded = has_useful_value and required_fields_present
-        cst_retry_exhausted = (
-            self._bed_type == BED_TYPE_OKIN_CST
+        profile_retry_exhausted = (
+            self._bed_type in {BED_TYPE_OKIN_CST, BED_TYPE_OKIN_RF_ECO_BT}
             and self._device_info_read_attempts
-            >= _OKIN_CST_DEVICE_INFO_MAX_READ_ATTEMPTS
+            >= _OKIN_PRESERVED_PROFILE_DEVICE_INFO_MAX_READ_ATTEMPTS
         )
-        self._device_info_read_done = read_succeeded or cst_retry_exhausted
+        self._device_info_read_done = read_succeeded or profile_retry_exhausted
 
-        if cst_retry_exhausted and not read_succeeded:
+        if profile_retry_exhausted and not read_succeeded:
             _LOGGER.debug(
                 "Device Information read for %s did not return the model after "
-                "%d attempts; caching the CST result for this coordinator session.",
+                "%d attempts; caching the %s profile for this coordinator session.",
                 self._address,
                 self._device_info_read_attempts,
+                self._bed_type,
             )
         elif not self._device_info_read_done:
             if has_useful_value and not required_fields_present:

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -1453,18 +1453,12 @@ class AdjustableBedCoordinator:
         # every reconnect. Require the model before we stop retrying; a genuinely
         # model-less bed re-reads cheaply (an absent characteristic errors fast,
         # only a transient timeout costs the read budget, which is what we want
-        # to retry). OKIN CST is exempted below via the negative cache.
+        # to retry).
         required_fields_present = (
             not self._bed_type_needs_ble_model() or model_useful
         )
 
-        # Certain OKIN CST receivers consistently never answer DIS reads. Their
-        # protocol is already explicit and does not depend on Device Information,
-        # so a negative session cache is safe and avoids 10s on every reconnect.
-        negative_cache_is_safe = self._bed_type == BED_TYPE_OKIN_CST
-        self._device_info_read_done = (
-            has_useful_value and required_fields_present
-        ) or negative_cache_is_safe
+        self._device_info_read_done = has_useful_value and required_fields_present
 
         if not self._device_info_read_done:
             if has_useful_value and not required_fields_present:

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -714,6 +714,8 @@ def refine_okin_shared_uuid_protocol_from_gatt(
     protocol_variant: str | None = None,
     ble_model: str | None = None,
     device_name: str | None = None,
+    *,
+    _log_correction: bool = True,
 ) -> str:
     """Correct shared OKIN UUID profiles once connected GATT services are known."""
     is_leggett_okin_variant = (
@@ -729,7 +731,7 @@ def refine_okin_shared_uuid_protocol_from_gatt(
         BED_TYPE_OKIN_RF_ECO_BT,
     }:
         if gatt_detection.bed_type == BED_TYPE_LEGGETT_OKIN:
-            if bed_type != BED_TYPE_LEGGETT_OKIN:
+            if bed_type != BED_TYPE_LEGGETT_OKIN and _log_correction:
                 _LOGGER.info(
                     "Refined shared OKIN protocol from %s to %s using LP Control "
                     "device identity and GATT signals: %s",
@@ -739,7 +741,7 @@ def refine_okin_shared_uuid_protocol_from_gatt(
                 )
             return BED_TYPE_LEGGETT_OKIN
         if _is_rf_eco_bt_stair_model(ble_model):
-            if bed_type != BED_TYPE_OKIN_RF_ECO_BT:
+            if bed_type != BED_TYPE_OKIN_RF_ECO_BT and _log_correction:
                 _LOGGER.info(
                     "Refined shared OKIN protocol from %s to %s using stair model %r",
                     bed_type,
@@ -757,22 +759,24 @@ def refine_okin_shared_uuid_protocol_from_gatt(
                 # Already on an OKIMAT-compatible controller; keep the saved label
                 # (BED_TYPE_OKIMAT/OKIN_UUID resolve to the same controller, and
                 # OKIN CST is its own deliberately preserved full-bed profile).
-                _LOGGER.debug(
-                    "Keeping %s profile for OKIMAT bed model %r despite shared OKIN GATT signals",
-                    bed_type,
-                    ble_model,
-                )
+                if _log_correction:
+                    _LOGGER.debug(
+                        "Keeping %s profile for OKIMAT bed model %r despite shared OKIN GATT signals",
+                        bed_type,
+                        ble_model,
+                    )
                 return bed_type
             # Any other shared-UUID guess — a persisted RF ECO BT stair entry, or
             # an incompatible profile such as Nectar / OKIN 7-byte / Leggett OKIN —
             # is the wrong controller for an OKIMAT bed. Promote it to the
             # multi-motor OKIN UUID profile so the bed recovers (issue #406).
-            _LOGGER.info(
-                "Promoted %s to %s for OKIMAT bed model %r despite shared OKIN GATT signals",
-                bed_type,
-                BED_TYPE_OKIN_UUID,
-                ble_model,
-            )
+            if _log_correction:
+                _LOGGER.info(
+                    "Promoted %s to %s for OKIMAT bed model %r despite shared OKIN GATT signals",
+                    bed_type,
+                    BED_TYPE_OKIN_UUID,
+                    ble_model,
+                )
             return BED_TYPE_OKIN_UUID
         if {bed_type, gatt_detection.bed_type} == {
             BED_TYPE_OKIN_CST,
@@ -781,7 +785,7 @@ def refine_okin_shared_uuid_protocol_from_gatt(
             # CSS and Nordic DFU overlap across these profiles. GATT can narrow
             # the family but cannot safely override the configured choice.
             return bed_type
-        if gatt_detection.bed_type != bed_type:
+        if gatt_detection.bed_type != bed_type and _log_correction:
             _LOGGER.info(
                 "Refined shared OKIN protocol from %s to %s using GATT signals: %s",
                 bed_type,

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -733,17 +733,18 @@ def refine_okin_shared_uuid_protocol_from_gatt(
                     ", ".join(gatt_detection.signals),
                 )
             return BED_TYPE_LEGGETT_OKIN
-        if gatt_detection.bed_type == BED_TYPE_OKIN_RF_ECO_BT and _is_okimat_bed_model(ble_model):
-            # Full OKIMAT beds share the RF ECO BT stair's CSS GATT signature, so
-            # the bare signature is not enough to pick the single-actuator stair
-            # profile. The Device Info model proves this is a multi-motor OKIMAT
-            # bed (issue #406).
+        if gatt_detection.bed_type in {
+            BED_TYPE_OKIN_CST,
+            BED_TYPE_OKIN_RF_ECO_BT,
+        } and _is_okimat_bed_model(ble_model):
+            # Full OKIMAT beds share the CSS GATT inventory used to infer both
+            # profiles, so the Device Info model is the stronger signal (#406).
             if bed_type in OKIMAT_COMPATIBLE_PROFILES:
                 # Already on an OKIMAT-compatible controller; keep the saved label
                 # (BED_TYPE_OKIMAT/OKIN_UUID resolve to the same controller, and
                 # OKIN CST is its own deliberately preserved full-bed profile).
                 _LOGGER.debug(
-                    "Keeping %s profile for OKIMAT bed model %r despite RF ECO BT GATT signature",
+                    "Keeping %s profile for OKIMAT bed model %r despite shared OKIN GATT signals",
                     bed_type,
                     ble_model,
                 )
@@ -753,13 +754,18 @@ def refine_okin_shared_uuid_protocol_from_gatt(
             # is the wrong controller for an OKIMAT bed. Promote it to the
             # multi-motor OKIN UUID profile so the bed recovers (issue #406).
             _LOGGER.info(
-                "Promoted %s to %s for OKIMAT bed model %r despite RF ECO BT GATT signature",
+                "Promoted %s to %s for OKIMAT bed model %r despite shared OKIN GATT signals",
                 bed_type,
                 BED_TYPE_OKIN_UUID,
                 ble_model,
             )
             return BED_TYPE_OKIN_UUID
-        if bed_type == BED_TYPE_OKIN_CST and gatt_detection.bed_type == BED_TYPE_OKIN_RF_ECO_BT:
+        if {bed_type, gatt_detection.bed_type} == {
+            BED_TYPE_OKIN_CST,
+            BED_TYPE_OKIN_RF_ECO_BT,
+        }:
+            # CSS and Nordic DFU overlap across these profiles. GATT can narrow
+            # the family but cannot safely override the configured choice.
             return bed_type
         if gatt_detection.bed_type != bed_type:
             _LOGGER.info(

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -703,6 +703,11 @@ def _is_okimat_bed_model(ble_model: str | None) -> bool:
     return "okimat" in (ble_model or "").strip().lower()
 
 
+def _is_rf_eco_bt_stair_model(ble_model: str | None) -> bool:
+    """Return True when Device Info identifies the known RF ECO BT stair."""
+    return (ble_model or "").strip().lower() == "megamat mbz"
+
+
 def refine_okin_shared_uuid_protocol_from_gatt(
     bed_type: str,
     gatt_services: Any,
@@ -733,6 +738,15 @@ def refine_okin_shared_uuid_protocol_from_gatt(
                     ", ".join(gatt_detection.signals),
                 )
             return BED_TYPE_LEGGETT_OKIN
+        if _is_rf_eco_bt_stair_model(ble_model):
+            if bed_type != BED_TYPE_OKIN_RF_ECO_BT:
+                _LOGGER.info(
+                    "Refined shared OKIN protocol from %s to %s using stair model %r",
+                    bed_type,
+                    BED_TYPE_OKIN_RF_ECO_BT,
+                    ble_model,
+                )
+            return BED_TYPE_OKIN_RF_ECO_BT
         if gatt_detection.bed_type in {
             BED_TYPE_OKIN_CST,
             BED_TYPE_OKIN_RF_ECO_BT,

--- a/custom_components/adjustable_bed/number.py
+++ b/custom_components/adjustable_bed/number.py
@@ -272,9 +272,9 @@ async def async_setup_entry(
 
     entities: list[NumberEntity] = []
 
-    # Beds with no angle/position feedback (e.g. Sleep Number MCR/BAM) were briefly
-    # in BEDS_WITH_POSITION_FEEDBACK and may have registered position number sliders;
-    # remove any so existing installs don't keep dead orphaned numbers (#322).
+    # Beds with no angle/position feedback may have registered position sliders
+    # under an earlier version or a previously selected profile. Remove any so
+    # existing installs do not keep dead orphaned numbers (#322, #344).
     if bed_type in BEDS_WITHOUT_ANGLE_FEEDBACK:
         _async_remove_stale_position_entities(hass, coordinator)
     elif bed_type == BED_TYPE_SLEEPSTAR:
@@ -437,10 +437,9 @@ def _async_remove_stale_position_entities(
 ) -> None:
     """Remove position number entities the integration no longer creates.
 
-    Beds in BEDS_WITHOUT_ANGLE_FEEDBACK (e.g. Sleep Number MCR/BAM) have no
-    position feedback, but were briefly in BEDS_WITH_POSITION_FEEDBACK and so
-    registered *_back_position/*_legs_position sliders that now linger as dead
-    orphaned numbers (#322).
+    Beds in BEDS_WITHOUT_ANGLE_FEEDBACK have no position feedback, but an earlier
+    version or profile may have registered *_back_position/*_legs_position sliders
+    that now linger as dead orphaned numbers (#322, #344).
     """
     registry = er.async_get(hass)
     for description in NUMBER_DESCRIPTIONS:

--- a/custom_components/adjustable_bed/sensor.py
+++ b/custom_components/adjustable_bed/sensor.py
@@ -141,10 +141,9 @@ async def async_setup_entry(
 
     entities: list[SensorEntity] = []
 
-    # Beds that never report degree angles (e.g. Sleep Number MCR/BAM) must not keep
-    # angle sensors. Remove any an earlier version registered (when angle sensing was
-    # enabled by default) so existing installs stop showing dead "unknown" entities
-    # after upgrading, regardless of the current disable_angle_sensing value (#322).
+    # Beds that never report degree angles must not keep angle sensors. Remove any
+    # registered by an earlier version or a previously selected profile so existing
+    # installs stop showing dead "unknown" entities after upgrading (#322, #344).
     if bed_type in BEDS_WITHOUT_ANGLE_FEEDBACK:
         _async_remove_stale_angle_entities(hass, coordinator)
 
@@ -154,8 +153,8 @@ async def async_setup_entry(
         # (Keeson/Ergomotion/Serta report 0-100% position, not degrees)
         if bed_type in BEDS_WITH_PERCENTAGE_POSITIONS:
             _LOGGER.debug("Skipping angle sensors for %s - reports percentage, not angle", bed_type)
-        # Skip beds that report no degree-angle data at all (e.g. Sleep Number MCR/BAM),
-        # which would otherwise create sensors stuck at "unknown" forever (#322).
+        # Skip beds that report no degree-angle data at all, which would otherwise
+        # create sensors stuck at "unknown" forever (#322, #344).
         elif bed_type in BEDS_WITHOUT_ANGLE_FEEDBACK:
             _LOGGER.debug("Skipping angle sensors for %s - no angle feedback", bed_type)
         else:
@@ -200,9 +199,9 @@ def _async_remove_stale_angle_entities(
 ) -> None:
     """Remove angle sensor entities the integration no longer creates.
 
-    Beds in BEDS_WITHOUT_ANGLE_FEEDBACK (e.g. Sleep Number MCR/BAM) report no
-    angles, but an earlier version registered back/legs/head/feet angle sensors
-    for them; those would otherwise linger as dead "unknown" entities (#322).
+    Beds in BEDS_WITHOUT_ANGLE_FEEDBACK report no angles, but an earlier version
+    or profile may have registered back/legs/head/feet angle sensors for them;
+    those would otherwise linger as dead "unknown" entities (#322, #344).
     """
     registry = er.async_get(hass)
     for description in SENSOR_DESCRIPTIONS:

--- a/docs/SUPPORTED_ACTUATORS.md
+++ b/docs/SUPPORTED_ACTUATORS.md
@@ -87,11 +87,13 @@ Several bed brands use Okin-based BLE controllers. While they share common roots
 3. Name contains "okimat", "okin rf", or "okin ble" → Okimat
 4. Name starts with `OKIN-` → prompt for Okin-family protocol (confirmed Nectar bases can advertise this way)
 5. Name is `OKIN-Receiver` / `OKIN - Receiver` → prompt for Okin-family protocol
-6. Connected GATT has `62741525-...` plus CSS `90311625-...` and Nordic DFU
-   `00001530-...` → Okin CST, unless the name begins `LP BED`, which identifies
-   LP Control's proven 6-byte Okin path
-7. Connected GATT has `62741525-...` plus CSS `90311625-...` without Nordic DFU → OKIN Smart Remote / RF ECO BT
-8. Fallback → Okimat (with warning logged)
+6. Connected GATT has `62741525-...` plus CSS `90311625-...` → Okin CST or
+   OKIN Smart Remote / RF ECO BT. Nordic DFU is an initial CST hint, not a safe
+   discriminator. Device Information model `MEGAMAT MBZ` identifies RF ECO BT,
+   an `OKIMAT` model identifies a full bed, and an already configured CST or RF
+   ECO BT profile is otherwise preserved. A name beginning `LP BED` identifies
+   LP Control's proven 6-byte Okin path.
+7. Fallback → Okimat (with warning logged)
 
 ---
 
@@ -139,7 +141,7 @@ These beds have their own dedicated integrations:
    - `Serta*` or `Motion Perfect*` → Serta
    - `Octo*` → Octo (Standard variant)
    - `iFlex*` → Mattress Firm 900
-   - `OKIN-*` with service `62741523-...` plus CSS service `90311623-...` and Nordic DFU `00001530-...` → [Okin CST](beds/okin-cst.md), including MFirm 900-O / Rize MF900-style bases
+   - `OKIN-*` with service `62741523-...` plus CSS service `90311623-...` → [Okin CST](beds/okin-cst.md) or [OKIN Smart Remote / RF ECO BT](beds/okin-rf-eco-bt.md); Nordic DFU alone does not distinguish them
    - `Malouf*`, `Structures*` → Malouf
    - `Smart bed *` → [Sleep Number](beds/sleep_number.md) (Climate 360 / FlexFit, Fuzion)
    - MAC-address-like name such as `64:DB:A0:07:DD:02` + service `ffffd1fd-...` → [Sleep Number](beds/sleep_number.md) (i8 / 360 FlexFit 2, BAM/MCR)
@@ -159,8 +161,7 @@ These beds have their own dedicated integrations:
 
 4. **Use the support bundle to find service UUIDs**: If unsure, use **Browse unsupported BLE devices** to find the MAC address, then run `adjustable_bed.generate_support_bundle` with `target_address`. The output includes service UUIDs:
    - Service `62741523-...` → Okin family (see [Okin Protocol Family](#okin-protocol-family))
-   - Service `62741523-...` plus CSS service `90311623-...`, write characteristic `90311625-...`, and Nordic DFU service `00001530-...` → [Okin CST](beds/okin-cst.md)
-   - Service `62741523-...` plus CSS service `90311623-...` and write characteristic `90311625-...` without Nordic DFU → [OKIN Smart Remote / RF ECO BT](beds/okin-rf-eco-bt.md)
+   - Service `62741523-...` plus CSS service `90311623-...` and write characteristic `90311625-...` → [Okin CST](beds/okin-cst.md) or [OKIN Smart Remote / RF ECO BT](beds/okin-rf-eco-bt.md); Nordic DFU is only an initial CST hint. Device Information model `MEGAMAT MBZ` identifies RF ECO BT, while an `OKIMAT` model identifies a full bed. Otherwise the integration preserves an already configured CST or RF ECO BT profile.
    - Service `45e25100-...` → Leggett & Platt Gen2
    - Service `0000aa5c-...` → Octo Star2 variant
    - Service `01000001-...` → Malouf/Lucid family (usually New OKIN; `OKIN-BLE` + `BTCB` uses Legacy OKIN)

--- a/docs/beds/nectar.md
+++ b/docs/beds/nectar.md
@@ -12,9 +12,11 @@
 
 Some newer Nectar Motion bases advertise only as `OKIN-XXXXXX` and use the
 [Okin CST](okin-cst.md) 14-byte protocol instead of this 7-byte protocol.
-If diagnostics show the `62741523-...` OKIN service, `90311623-...` CSS service,
-and Nordic DFU service `00001530-...`, choose **Okin CST / Nectar Motion** in
-manual setup.
+The `62741523-...` OKIN service, `90311623-...` CSS service, and Nordic DFU
+service `00001530-...` are not sufficient by themselves to identify CST because
+RF ECO BT stair actuators share that GATT inventory. Choose **Okin CST / Nectar
+Motion** only when the known base or app identity also corroborates CST. Device
+Information model `MEGAMAT MBZ` identifies RF ECO BT instead.
 
 ## Apps
 
@@ -86,8 +88,9 @@ Detected by device name containing: `nectar` (case-insensitive) AND Okin service
 Some Nectar bases advertise only as `OKIN-XXXXXX`. Those names are ambiguous
 with classic Okimat, 7-byte Nectar, and newer CST controllers, so setup prompts
 for the Okin-family protocol. Choose `Nectar` only for the 7-byte protocol.
-Choose `Okin CST / Nectar Motion` when diagnostics show the CSS service
-`90311623-...` plus Nordic DFU service `00001530-...`.
+Do not choose `Okin CST / Nectar Motion` from CSS plus Nordic DFU alone. Choose
+it only when a known Nectar Motion base or app identity corroborates CST; Device
+Information model `MEGAMAT MBZ` identifies RF ECO BT instead.
 
 Or manually configured with bed type: `nectar`
 

--- a/docs/beds/okimat.md
+++ b/docs/beds/okimat.md
@@ -69,7 +69,10 @@ Detection priority:
 1. Device name contains "nectar" → Nectar
 2. Device name contains "leggett", "l&p", or "adjustable base" → Leggett & Platt
 3. Device name contains "okimat", "okin rf", or "okin ble" → Okimat/Okin UUID
-4. Connected GATT has OKIN UUID + CSS + Nordic DFU → Okin CST
+4. Connected GATT has OKIN UUID + CSS → Okin CST or OKIN Smart Remote / RF
+   ECO BT. Nordic DFU is only an initial CST hint. Device Information model
+   `MEGAMAT MBZ` identifies RF ECO BT, while an `OKIMAT` model identifies a full
+   bed. Otherwise an already configured CST or RF ECO BT profile is preserved.
 5. Device name is `OKIN-Receiver` / `OKIN - Receiver` → prompt for Okin-family protocol
 6. Fallback → Okimat (with warning)
 

--- a/docs/beds/okin-cst.md
+++ b/docs/beds/okin-cst.md
@@ -15,14 +15,14 @@
 |--------|-------|
 | Service UUID | `62741523-52f9-8864-b1ab-3b3a8d65950b` (standard OKIN) |
 | Name patterns | Varies (shared UUID requires disambiguation; some report as `OKIN-XXXXXX`) |
-| Connected GATT hint | CSS `90311623-...` plus Nordic DFU `00001530-...`, unless a stronger device identity selects another shared-UUID protocol |
+| Connected GATT hint | CSS `90311623-...` plus Nordic DFU `00001530-...` is ambiguous and requires another identity signal |
 | BLE Pairing | Required |
 
 Manual selection may be needed since the service UUID is shared with other Okin protocols.
-Choose this profile for Nectar Motion style `OKIN-*` bases when diagnostics show
-both the CSS service and Nordic DFU service.
-This also applies to Mattress Firm 900-O / MFirm 900-O bases advertising as
-`OKIN-XXXXXX` with the same connected GATT signature.
+Do not choose CST solely because diagnostics show both the CSS and Nordic DFU
+services. That connected GATT signature is also exposed by RF ECO BT stair
+actuators. Device Information model `MEGAMAT MBZ` identifies RF ECO BT. Choose
+CST only when the known base or app identity corroborates the CST protocol.
 
 Do not select CST for `LP BED...` receivers. LP Control 2.9.0 identifies those
 as its Okin profile and sends 6-byte commands, even when the receiver also

--- a/docs/beds/okin-rf-eco-bt.md
+++ b/docs/beds/okin-rf-eco-bt.md
@@ -38,8 +38,10 @@ can identify it after connecting when this GATT signature is present:
 - CSS write characteristic `90311625-25fa-3346-12ef-3cfb7a2556ac`
 
 If the same device also exposes Nordic DFU service
-`00001530-1212-efde-1523-785feabcd123`, it may be a full bed controller using
-[Okin CST](okin-cst.md), not this single-actuator stair profile.
+`00001530-1212-efde-1523-785feabcd123`, it may be either this profile or a full
+bed controller using [Okin CST](okin-cst.md). That service is not a safe
+discriminator: the integration preserves an already configured RF ECO BT or
+CST profile when these GATT signals disagree with it.
 
 Full OKIMAT beds expose the **same** OKIN write + CSS GATT signature as this
 stair profile (see [issue #406](https://github.com/kristofferR/ha-adjustable-bed/issues/406),

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4152,6 +4152,7 @@ class TestDeviceInfoCache:
         [
             BED_TYPE_OKIMAT,
             BED_TYPE_OKIN_CST,
+            BED_TYPE_OKIN_RF_ECO_BT,
         ],
     )
     def test_missing_device_info_cache_policy(
@@ -4182,25 +4183,30 @@ class TestDeviceInfoCache:
 
         assert coordinator._device_info_read_done is False
 
-    def test_cst_missing_device_info_is_cached_after_bounded_retry(
+    @pytest.mark.parametrize(
+        "bed_type",
+        [BED_TYPE_OKIN_CST, BED_TYPE_OKIN_RF_ECO_BT],
+    )
+    def test_preserved_okin_profile_missing_device_info_is_cached_after_bounded_retry(
         self,
         hass: HomeAssistant,
+        bed_type: str,
     ):
-        """A genuine CST receiver should not pay DIS timeouts on every reconnect."""
+        """Preserved OKIN profiles should not pay DIS timeouts on every reconnect."""
         entry = MockConfigEntry(
             domain=DOMAIN,
             title=TEST_NAME,
             data={
                 CONF_ADDRESS: TEST_ADDRESS,
                 CONF_NAME: TEST_NAME,
-                CONF_BED_TYPE: BED_TYPE_OKIN_CST,
+                CONF_BED_TYPE: bed_type,
                 CONF_MOTOR_COUNT: 2,
                 CONF_HAS_MASSAGE: False,
                 CONF_DISABLE_ANGLE_SENSING: True,
                 CONF_PREFERRED_ADAPTER: "auto",
             },
             unique_id=TEST_ADDRESS,
-            entry_id="okin_cst_bounded_device_info_retry_test",
+            entry_id=f"{bed_type}_bounded_device_info_retry_test",
         )
         entry.add_to_hass(hass)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4182,6 +4182,37 @@ class TestDeviceInfoCache:
 
         assert coordinator._device_info_read_done is False
 
+    def test_cst_missing_device_info_is_cached_after_bounded_retry(
+        self,
+        hass: HomeAssistant,
+    ):
+        """A genuine CST receiver should not pay DIS timeouts on every reconnect."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=TEST_NAME,
+            data={
+                CONF_ADDRESS: TEST_ADDRESS,
+                CONF_NAME: TEST_NAME,
+                CONF_BED_TYPE: BED_TYPE_OKIN_CST,
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=TEST_ADDRESS,
+            entry_id="okin_cst_bounded_device_info_retry_test",
+        )
+        entry.add_to_hass(hass)
+
+        coordinator = AdjustableBedCoordinator(hass, entry)
+        coordinator._store_ble_device_info(None, None)
+        assert coordinator._device_info_read_done is False
+
+        coordinator._store_ble_device_info(None, None)
+
+        assert coordinator._device_info_read_attempts == 2
+        assert coordinator._device_info_read_done is True
+
     def test_useful_device_info_is_cached_for_refinable_bed(
         self,
         hass: HomeAssistant,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4148,19 +4148,18 @@ class TestDeviceInfoCache:
             assert coordinator._ble_model == "Model X"
 
     @pytest.mark.parametrize(
-        ("bed_type", "expected_read_done"),
+        "bed_type",
         [
-            (BED_TYPE_OKIMAT, False),
-            (BED_TYPE_OKIN_CST, True),
+            BED_TYPE_OKIMAT,
+            BED_TYPE_OKIN_CST,
         ],
     )
     def test_missing_device_info_cache_policy(
         self,
         hass: HomeAssistant,
         bed_type: str,
-        expected_read_done: bool,
     ):
-        """Only the known-unresponsive explicit protocol uses a negative cache."""
+        """Shared-UUID profiles retry when a missing model could correct routing."""
         entry = MockConfigEntry(
             domain=DOMAIN,
             title=TEST_NAME,
@@ -4181,7 +4180,7 @@ class TestDeviceInfoCache:
         coordinator = AdjustableBedCoordinator(hass, entry)
         coordinator._store_ble_device_info(None, None)
 
-        assert coordinator._device_info_read_done is expected_read_done
+        assert coordinator._device_info_read_done is False
 
     def test_useful_device_info_is_cached_for_refinable_bed(
         self,

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1378,9 +1378,10 @@ class TestOkinUUIDDisambiguation:
 
         Installations that connected with the old logic persisted the bed type as
         ``okin_rf_eco_bt``; on upgrade the OKIMAT model must promote them back to
-        a multi-motor profile instead of staying stuck on the stair profile (#406).
+        a multi-motor profile instead of staying stuck on the stair profile (#406),
+        whether or not the shared GATT inventory also includes Nordic DFU.
         """
-        gatt_services = [
+        base_gatt_services = [
             SimpleNamespace(
                 uuid=OKIMAT_SERVICE_UUID,
                 characteristics=[
@@ -1395,14 +1396,23 @@ class TestOkinUUIDDisambiguation:
             ),
         ]
 
-        assert (
-            refine_okin_shared_uuid_protocol_from_gatt(
-                BED_TYPE_OKIN_RF_ECO_BT,
-                gatt_services,
-                ble_model="OKIMAT 4 IPS/M",
+        for include_dfu in (False, True):
+            gatt_services = [
+                *base_gatt_services,
+                *(
+                    [SimpleNamespace(uuid=NORDIC_DFU_SERVICE_UUID, characteristics=[])]
+                    if include_dfu
+                    else []
+                ),
+            ]
+            assert (
+                refine_okin_shared_uuid_protocol_from_gatt(
+                    BED_TYPE_OKIN_RF_ECO_BT,
+                    gatt_services,
+                    ble_model="OKIMAT 4 IPS/M",
+                )
+                == BED_TYPE_OKIN_UUID
             )
-            == BED_TYPE_OKIN_UUID
-        )
 
     def test_shared_okin_gatt_refinement_promotes_incompatible_profile_for_okimat_model(self):
         """An incompatible shared-UUID guess is promoted when the model is OKIMAT.
@@ -1474,8 +1484,8 @@ class TestOkinUUIDDisambiguation:
             == BED_TYPE_OKIN_CST
         )
 
-    def test_shared_okin_gatt_refinement_keeps_persisted_rf_eco_bt_non_okimat(self):
-        """A genuine RF ECO BT stair (non-OKIMAT model) stays on its profile."""
+    def test_shared_okin_gatt_refinement_preserves_rf_eco_bt_with_dfu(self):
+        """The #344 stair keeps its configured profile despite CST-like GATT."""
         gatt_services = [
             SimpleNamespace(
                 uuid=OKIMAT_SERVICE_UUID,
@@ -1489,16 +1499,21 @@ class TestOkinUUIDDisambiguation:
                     SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
                 ],
             ),
+            SimpleNamespace(
+                uuid=NORDIC_DFU_SERVICE_UUID,
+                characteristics=[],
+            ),
         ]
 
-        assert (
-            refine_okin_shared_uuid_protocol_from_gatt(
-                BED_TYPE_OKIN_RF_ECO_BT,
-                gatt_services,
-                ble_model="MEGAMAT MBZ",
+        for ble_model in ("MEGAMAT MBZ", None):
+            assert (
+                refine_okin_shared_uuid_protocol_from_gatt(
+                    BED_TYPE_OKIN_RF_ECO_BT,
+                    gatt_services,
+                    ble_model=ble_model,
+                )
+                == BED_TYPE_OKIN_RF_ECO_BT
             )
-            == BED_TYPE_OKIN_RF_ECO_BT
-        )
 
     def test_shared_okin_gatt_refinement_downgrades_non_okimat_model_to_rf_eco_bt(self):
         """The ELDA stair (#344, ``MEGAMAT MBZ``) keeps the RF ECO BT downgrade."""

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1515,6 +1515,36 @@ class TestOkinUUIDDisambiguation:
                 == BED_TYPE_OKIN_RF_ECO_BT
             )
 
+    def test_shared_okin_gatt_refinement_recovers_persisted_cst_stair(self):
+        """The #344 stair model repairs an entry previously persisted as CST."""
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=NORDIC_DFU_SERVICE_UUID,
+                characteristics=[],
+            ),
+        ]
+
+        assert (
+            refine_okin_shared_uuid_protocol_from_gatt(
+                BED_TYPE_OKIN_CST,
+                gatt_services,
+                ble_model="MEGAMAT MBZ",
+            )
+            == BED_TYPE_OKIN_RF_ECO_BT
+        )
+
     def test_shared_okin_gatt_refinement_downgrades_non_okimat_model_to_rf_eco_bt(self):
         """The ELDA stair (#344, ``MEGAMAT MBZ``) keeps the RF ECO BT downgrade."""
         gatt_services = [

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2833,6 +2833,62 @@ class TestSensorEntities:
                 is None
             )
 
+    async def test_okin_rf_eco_bt_removes_pre_existing_cst_position_entities(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """A CST entry corrected to RF ECO BT must remove stale position entities."""
+        del mock_coordinator_connected, enable_custom_integrations
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="RF ECO BT Stair",
+            data={
+                CONF_ADDRESS: "AA:BB:CC:DD:EE:62",
+                CONF_NAME: "RF ECO BT Stair",
+                CONF_BED_TYPE: BED_TYPE_OKIN_RF_ECO_BT,
+                CONF_MOTOR_COUNT: 1,
+                CONF_HAS_MASSAGE: False,
+                CONF_DISABLE_ANGLE_SENSING: False,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id="AA:BB:CC:DD:EE:62",
+            entry_id="okin_rf_eco_bt_stale_position_entry",
+        )
+        entry.add_to_hass(hass)
+
+        # Simulate the back/legs entities registered while this entry used CST.
+        for axis in ("back", "legs"):
+            registry.async_get_or_create(
+                "sensor",
+                DOMAIN,
+                f"AA:BB:CC:DD:EE:62_{axis}_angle",
+                config_entry=entry,
+            )
+            registry.async_get_or_create(
+                "number",
+                DOMAIN,
+                f"AA:BB:CC:DD:EE:62_{axis}_position",
+                config_entry=entry,
+            )
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        for axis in ("back", "legs"):
+            assert (
+                registry.async_get_entity_id("sensor", DOMAIN, f"AA:BB:CC:DD:EE:62_{axis}_angle")
+                is None
+            )
+            assert (
+                registry.async_get_entity_id("number", DOMAIN, f"AA:BB:CC:DD:EE:62_{axis}_position")
+                is None
+            )
+
 
 class TestEntityAvailability:
     """Test entity availability."""

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -23,6 +23,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_LEGGETT_OKIN,
     BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_RF_ECO_BT,
+    BED_TYPE_OKIN_UUID,
     CONF_BED_TYPE,
     CONF_BLE_BOND_ESTABLISHED,
     CONF_DISABLE_ANGLE_SENSING,
@@ -550,6 +551,19 @@ class TestBleDiagnosticsRunner:
         assert "configured_profile:shared_okin_uuid" in detection["signals"]
         assert "device_info:model_number" not in detection["signals"]
         assert detection["confidence"] == 0.8
+
+        coordinator.bed_type = BED_TYPE_OKIN_UUID
+        model_detection = runner._build_detection_section(
+            SimpleNamespace(name="OKIN-050226"),
+            gatt_services,
+            {"model_number": "OKIMAT 4 IPS/M"},
+        )
+
+        assert model_detection["bed_type"] == BED_TYPE_OKIN_UUID
+        assert "device_info:model_number" in model_detection["signals"]
+        assert "configured_profile:shared_okin_uuid" not in model_detection["signals"]
+        assert model_detection["confidence"] == 0.95
+        assert model_detection["ambiguous_types"] == []
 
     async def test_run_diagnostics_reconnects_after_mid_enumeration_disconnect(
         self,

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -370,11 +370,12 @@ class TestBleDiagnosticsRunner:
         assert "gatt_char:okin_smart_remote_css_write" in report.detection["signals"]
 
     @pytest.mark.parametrize(
-        ("snapshot_name", "selected_device_name", "expected_bed_type"),
+        ("snapshot_name", "selected_device_name", "ble_model", "expected_bed_type"),
         [
-            ("OKIN-441954", "OKIN-441954", BED_TYPE_OKIN_CST),
-            ("LP BED CONTROL", "LP BED CONTROL", BED_TYPE_LEGGETT_OKIN),
-            (None, "LP BED CONTROL", BED_TYPE_LEGGETT_OKIN),
+            ("OKIN-441954", "OKIN-441954", None, BED_TYPE_OKIN_CST),
+            ("OKIN-050226", "OKIN-050226", "MEGAMAT MBZ", BED_TYPE_OKIN_RF_ECO_BT),
+            ("LP BED CONTROL", "LP BED CONTROL", None, BED_TYPE_LEGGETT_OKIN),
+            (None, "LP BED CONTROL", None, BED_TYPE_LEGGETT_OKIN),
         ],
     )
     async def test_run_diagnostics_disambiguates_okin_dual_stack_by_name(
@@ -383,6 +384,7 @@ class TestBleDiagnosticsRunner:
         enable_custom_integrations,
         snapshot_name: str | None,
         selected_device_name: str,
+        ble_model: str | None,
         expected_bed_type: str,
     ):
         """Diagnostics should combine the dual-stack signature with receiver identity."""
@@ -476,6 +478,13 @@ class TestBleDiagnosticsRunner:
                 "custom_components.adjustable_bed.ble_diagnostics.bluetooth.async_scanner_count",
                 return_value=1,
             ),
+            patch.object(
+                BLEDiagnosticRunner,
+                "_read_device_information",
+                new=AsyncMock(
+                    return_value={"model_number": ble_model} if ble_model is not None else {}
+                ),
+            ),
         ):
             report = await BLEDiagnosticRunner(
                 hass,
@@ -487,8 +496,10 @@ class TestBleDiagnosticsRunner:
         assert report.detection["supported_match"] is True
         if expected_bed_type == BED_TYPE_OKIN_CST:
             assert "gatt_service:nordic_dfu" in report.detection["signals"]
-        else:
+        elif expected_bed_type == BED_TYPE_LEGGETT_OKIN:
             assert "name:leggett_okin" in report.detection["signals"]
+        else:
+            assert "device_info:model_number" in report.detection["signals"]
 
     async def test_run_diagnostics_reconnects_after_mid_enumeration_disconnect(
         self,

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -14,7 +14,9 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.adjustable_bed.adapter import AdapterSelectionResult
 from custom_components.adjustable_bed.ble_diagnostics import (
     BLEDiagnosticRunner,
+    CharacteristicInfo,
     DiagnosticReport,
+    ServiceInfo,
 )
 from custom_components.adjustable_bed.const import (
     BED_TYPE_LEGGETT_GEN2,
@@ -500,6 +502,54 @@ class TestBleDiagnosticsRunner:
             assert "name:leggett_okin" in report.detection["signals"]
         else:
             assert "device_info:model_number" in report.detection["signals"]
+
+    def test_detection_preserves_configured_rf_eco_bt_without_device_info(
+        self,
+        hass: HomeAssistant,
+    ):
+        """An ambiguous support bundle should agree with its configured stair profile."""
+        coordinator = MagicMock()
+        coordinator.bed_type = BED_TYPE_OKIN_RF_ECO_BT
+        coordinator.observed_ble_device_name = "OKIN-050226"
+        gatt_services = [
+            ServiceInfo(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    CharacteristicInfo(
+                        uuid=OKIMAT_WRITE_CHAR_UUID,
+                        handle=19,
+                        properties=["write"],
+                    )
+                ],
+            ),
+            ServiceInfo(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    CharacteristicInfo(
+                        uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID,
+                        handle=42,
+                        properties=["write"],
+                    )
+                ],
+            ),
+            ServiceInfo(uuid=NORDIC_DFU_SERVICE_UUID),
+        ]
+        runner = BLEDiagnosticRunner(
+            hass,
+            "AA:BB:CC:DD:EE:55",
+            capture_duration=0,
+            coordinator=coordinator,
+        )
+
+        detection = runner._build_detection_section(
+            SimpleNamespace(name="OKIN-050226"),
+            gatt_services,
+        )
+
+        assert detection["bed_type"] == BED_TYPE_OKIN_RF_ECO_BT
+        assert "configured_profile:shared_okin_uuid" in detection["signals"]
+        assert "device_info:model_number" not in detection["signals"]
+        assert detection["confidence"] == 0.8
 
     async def test_run_diagnostics_reconnects_after_mid_enumeration_disconnect(
         self,


### PR DESCRIPTION
The RF ECO BT staircase from #344 exposes the same OKIN, CSS, and Nordic DFU inventory used to infer CST. Runtime GATT refinement therefore replaced its working single-actuator profile with the incompatible CST controller.

Preserve the configured CST or RF ECO BT choice when those ambiguous signals disagree. Device Information model detection still takes priority, so full OKIMAT beds affected by #406 continue to recover from a stale RF ECO BT profile. Regression coverage now includes the exact DFU-present staircase inventory and OKIMAT recovery with and without DFU.

Validation:
- 2,758 tests passed
- Ruff clean
- Pyright clean
- Local CodeRabbit preflight clean

Ref #344