### PR TITLE
fix: Restore Keeson massage control compatibility

### DIFF
--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -1116,6 +1116,11 @@ class BedController(ABC):
         return type(self).massage_mode_step is not BedController.massage_mode_step
 
     @property
+    def massage_mode_step_is_timer(self) -> bool:
+        """Return True when the shared mode-step action advances a timer."""
+        return False
+
+    @property
     def supports_massage_wave_direction_control(self) -> bool:
         """Return True if the controller exposes next/previous wave controls."""
         return False

--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -772,6 +772,11 @@ class KeesonController(BedController):
         return self._variant == KEESON_VARIANT_SINO
 
     @property
+    def massage_mode_step_is_timer(self) -> bool:
+        """Return True when the shared action sends the Keeson timer-step command."""
+        return self._variant != KEESON_VARIANT_SINO
+
+    @property
     def supports_massage_wave_direction_control(self) -> bool:
         """Return True for the hardware-confirmed BaseI4/I5 wave controls."""
         return self._variant == KEESON_VARIANT_BASE

--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -772,11 +772,6 @@ class KeesonController(BedController):
         return self._variant == KEESON_VARIANT_SINO
 
     @property
-    def supports_massage_mode_step_control(self) -> bool:
-        """Hide the ambiguous mode-step control when base wave controls exist."""
-        return self._variant != KEESON_VARIANT_BASE
-
-    @property
     def supports_massage_wave_direction_control(self) -> bool:
         """Return True for the hardware-confirmed BaseI4/I5 wave controls."""
         return self._variant == KEESON_VARIANT_BASE
@@ -1781,10 +1776,8 @@ class KeesonController(BedController):
             await self._write_single_shot(self._build_command(KeesonCommands.MASSAGE_FOOT_DOWN))
 
     async def massage_mode_step(self) -> None:
-        """Step through massage wave patterns."""
-        if self._variant == KEESON_VARIANT_BASE:
-            await self.massage_wave_next()
-        elif self._variant == KEESON_VARIANT_SINO:
+        """Step the profile-specific massage timer or mode."""
+        if self._variant == KEESON_VARIANT_SINO:
             self._wave_massage = (self._wave_massage % 10) + 1
             await self.write_command(
                 self._build_command(SinoCommands.MASSAGE_HEAD_WAVE_BASE + self._wave_massage),

--- a/custom_components/adjustable_bed/button.py
+++ b/custom_components/adjustable_bed/button.py
@@ -26,6 +26,12 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+_MASSAGE_INTENSITY_BUTTON_KEY_MIGRATIONS = (
+    ("massage_intensity_1", "massage_intensity_level_1"),
+    ("massage_intensity_2", "massage_intensity_level_2"),
+    ("massage_intensity_3", "massage_intensity_level_3"),
+)
+
 
 @dataclass(frozen=True, kw_only=True)
 class AdjustableBedButtonEntityDescription(ButtonEntityDescription):
@@ -387,8 +393,8 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         required_capability="supports_massage_wave_direction_control",
     ),
     AdjustableBedButtonEntityDescription(
-        key="massage_intensity_1",
-        translation_key="massage_intensity_1",
+        key="massage_intensity_level_1",
+        translation_key="massage_intensity_level_1",
         icon="mdi:numeric-1-circle",
         requires_massage=True,
         cancel_movement=True,
@@ -396,8 +402,8 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         required_capability="supports_massage_intensity_preset_control",
     ),
     AdjustableBedButtonEntityDescription(
-        key="massage_intensity_2",
-        translation_key="massage_intensity_2",
+        key="massage_intensity_level_2",
+        translation_key="massage_intensity_level_2",
         icon="mdi:numeric-2-circle",
         requires_massage=True,
         cancel_movement=True,
@@ -405,8 +411,8 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         required_capability="supports_massage_intensity_preset_control",
     ),
     AdjustableBedButtonEntityDescription(
-        key="massage_intensity_3",
-        translation_key="massage_intensity_3",
+        key="massage_intensity_level_3",
+        translation_key="massage_intensity_level_3",
         icon="mdi:numeric-3-circle",
         requires_massage=True,
         cancel_movement=True,
@@ -569,6 +575,7 @@ async def async_setup_entry(
         has_massage = True
 
     if controller is not None:
+        _async_migrate_massage_intensity_button_unique_ids(hass, coordinator)
         _async_remove_stale_button_entities(hass, coordinator, controller, has_massage)
 
     entities = []
@@ -578,6 +585,29 @@ async def async_setup_entry(
         entities.append(AdjustableBedButton(coordinator, description))
 
     async_add_entities(entities)
+
+
+def _async_migrate_massage_intensity_button_unique_ids(
+    hass: HomeAssistant,
+    coordinator: AdjustableBedCoordinator,
+) -> None:
+    """Restore established intensity IDs while preserving 3.6 entity IDs."""
+    registry = er.async_get(hass)
+    for old_key, new_key in _MASSAGE_INTENSITY_BUTTON_KEY_MIGRATIONS:
+        old_entity_id = registry.async_get_entity_id(
+            "button",
+            DOMAIN,
+            f"{coordinator.address}_{old_key}",
+        )
+        if old_entity_id is None:
+            continue
+
+        new_unique_id = f"{coordinator.address}_{new_key}"
+        if registry.async_get_entity_id("button", DOMAIN, new_unique_id) is not None:
+            registry.async_remove(old_entity_id)
+            continue
+
+        registry.async_update_entity(old_entity_id, new_unique_id=new_unique_id)
 
 
 def _should_add_button(

--- a/custom_components/adjustable_bed/button.py
+++ b/custom_components/adjustable_bed/button.py
@@ -715,7 +715,14 @@ class AdjustableBedButton(AdjustableBedEntity, ButtonEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.address}_{description.key}"
-        self._attr_translation_key = description.translation_key
+        controller = coordinator.controller
+        self._attr_translation_key = (
+            "massage_timer_step"
+            if description.key == "massage_mode_step"
+            and controller is not None
+            and controller.massage_mode_step_is_timer
+            else description.translation_key
+        )
 
         # Beds that name their memory slots (Octo CAP_MEMINFO reports e.g.
         # Zero-G or Anti-Snore) are far more useful with that name than with

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -466,14 +466,14 @@
       "massage_wave_previous": {
         "name": "Massage: Wave Previous"
       },
-      "massage_intensity_1": {
-        "name": "Massage: Intensity 1"
+      "massage_intensity_level_1": {
+        "name": "Massage: Intensity Level 1"
       },
-      "massage_intensity_2": {
-        "name": "Massage: Intensity 2"
+      "massage_intensity_level_2": {
+        "name": "Massage: Intensity Level 2"
       },
-      "massage_intensity_3": {
-        "name": "Massage: Intensity 3"
+      "massage_intensity_level_3": {
+        "name": "Massage: Intensity Level 3"
       },
       "massage_circulation_full_body": {
         "name": "Massage: Full Body Loop"

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -460,6 +460,9 @@
       "massage_mode_step": {
         "name": "Massage: Mode"
       },
+      "massage_timer_step": {
+        "name": "Massage: Timer"
+      },
       "massage_wave_next": {
         "name": "Massage: Wave Next"
       },

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -468,14 +468,14 @@
       "massage_wave_previous": {
         "name": "Massage: Wave Previous"
       },
-      "massage_intensity_1": {
-        "name": "Massage: Intensity 1"
+      "massage_intensity_level_1": {
+        "name": "Massage: Intensity Level 1"
       },
-      "massage_intensity_2": {
-        "name": "Massage: Intensity 2"
+      "massage_intensity_level_2": {
+        "name": "Massage: Intensity Level 2"
       },
-      "massage_intensity_3": {
-        "name": "Massage: Intensity 3"
+      "massage_intensity_level_3": {
+        "name": "Massage: Intensity Level 3"
       },
       "massage_circulation_full_body": {
         "name": "Massage: Full Body Loop"

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -462,6 +462,9 @@
       "massage_mode_step": {
         "name": "Massage: Mode"
       },
+      "massage_timer_step": {
+        "name": "Massage: Timer"
+      },
       "massage_wave_next": {
         "name": "Massage: Wave Next"
       },

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -77,9 +77,13 @@ Brands using Keeson/Ergomotion actuators:
 
 The GlideAway ComfortBase Odessa hardware report in
 [issue #508](https://github.com/kristofferR/ha-adjustable-bed/issues/508)
-confirms these additional BaseI4/I5 massage actions. Their meanings are
-variant-specific and must not be applied to the KSBT, Sino, Purple, or
-Ergomotion profiles.
+confirms these additional BaseI4/I5 massage actions. A 3.6.0 follow-up confirmed
+the wave controls, while its logs showed that the dashboard's established
+`massage_intensity_level_*` entity IDs no longer existed, so those button
+presses never reached BLE. The entity IDs are retained for compatibility.
+Their meanings are variant-specific and must not be applied to the KSBT, Sino,
+Purple, or Ergomotion profiles. The existing `0x00000200` timer-step action is
+separate from wave selection.
 
 | Action | Value |
 |--------|-------|

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -83,7 +83,8 @@ the wave controls, while its logs showed that the dashboard's established
 presses never reached BLE. The entity IDs are retained for compatibility.
 Their meanings are variant-specific and must not be applied to the KSBT, Sino,
 Purple, or Ergomotion profiles. The existing `0x00000200` timer-step action is
-separate from wave selection.
+separate from wave selection and is displayed as **Massage: Timer** while
+retaining its established entity identity.
 
 | Action | Value |
 |--------|-------|

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1447,24 +1447,108 @@ class TestButtonEntities:
         )
         entry.add_to_hass(hass)
 
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        old_level_1 = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_intensity_1",
+            config_entry=entry,
+            suggested_object_id="keeson_base_massage_bed_massage_intensity_1",
+        )
+        old_level_2 = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_intensity_2",
+            config_entry=entry,
+            suggested_object_id="keeson_base_massage_bed_massage_intensity_2",
+        )
+        established_level_2 = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_intensity_level_2",
+            config_entry=entry,
+            suggested_object_id="keeson_base_massage_bed_massage_intensity_level_2",
+        )
+
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
+
+        for key in (
+            "massage_mode_step",
+            "massage_wave_next",
+            "massage_wave_previous",
+            "massage_intensity_level_1",
+            "massage_intensity_level_2",
+            "massage_intensity_level_3",
+        ):
+            assert registry.async_get_entity_id("button", DOMAIN, f"{address}_{key}") is not None
+
+        # 3.6 briefly shipped different unique IDs. Migrate them without
+        # changing an existing entity ID, and prefer an established pre-3.6
+        # entity when both forms are present.
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_level_1"
+        ) == str(old_level_1.entity_id)
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_level_2"
+        ) == str(established_level_2.entity_id)
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_1"
+        ) is None
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_2"
+        ) is None
+        assert registry.async_get(str(old_level_2.entity_id)) is None
+
+    async def test_intensity_id_migration_removes_unsupported_stale_button(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """Migrated 3.6 intensity entities should not linger on other variants."""
+        address = "AA:BB:CC:DD:EE:51"
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Keeson KSBT Bed",
+            data={
+                CONF_ADDRESS: address,
+                CONF_NAME: "Keeson KSBT Bed",
+                CONF_BED_TYPE: BED_TYPE_KEESON,
+                CONF_PROTOCOL_VARIANT: "ksbt",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: True,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=address,
+            entry_id="keeson_ksbt_stale_intensity_entry",
+        )
+        entry.add_to_hass(hass)
 
         from homeassistant.helpers import entity_registry as er
 
         registry = er.async_get(hass)
-        for key in (
-            "massage_wave_next",
-            "massage_wave_previous",
-            "massage_intensity_1",
-            "massage_intensity_2",
-            "massage_intensity_3",
-        ):
-            assert registry.async_get_entity_id("button", DOMAIN, f"{address}_{key}") is not None
-
-        assert (
-            registry.async_get_entity_id("button", DOMAIN, f"{address}_massage_mode_step") is None
+        stale = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_intensity_1",
+            config_entry=entry,
+            suggested_object_id="keeson_ksbt_bed_massage_intensity_1",
         )
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert registry.async_get(str(stale.entity_id)) is None
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_1"
+        ) is None
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_level_1"
+        ) is None
 
     async def test_kaidi_entities_expose_book_leisure_direct_position_and_filtered_massage(
         self,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1450,6 +1450,13 @@ class TestButtonEntities:
         from homeassistant.helpers import entity_registry as er
 
         registry = er.async_get(hass)
+        established_timer = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_mode_step",
+            config_entry=entry,
+            suggested_object_id="keeson_base_massage_bed_massage_mode",
+        )
         old_level_1 = registry.async_get_or_create(
             "button",
             DOMAIN,
@@ -1484,6 +1491,14 @@ class TestButtonEntities:
             "massage_intensity_level_3",
         ):
             assert registry.async_get_entity_id("button", DOMAIN, f"{address}_{key}") is not None
+
+        timer_entity_id = registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_mode_step"
+        )
+        assert timer_entity_id == str(established_timer.entity_id)
+        timer_state = hass.states.get(timer_entity_id)
+        assert timer_state is not None
+        assert timer_state.name.endswith("Massage: Timer")
 
         # 3.6 briefly shipped different unique IDs. Migrate them without
         # changing an existing entity ID, and prefer an established pre-3.6

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -765,6 +765,7 @@ class TestKeesonMassage:
         assert controller.supports_massage_wave_direction_control is supported
         assert controller.supports_massage_intensity_preset_control is supported
         assert controller.supports_massage_mode_step_control is True
+        assert controller.massage_mode_step_is_timer is (variant != "sino")
 
     async def test_base_intensity_rejects_unknown_level(
         self,

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -685,6 +685,26 @@ class TestKeesonMassage:
             response=True,
         )
 
+    async def test_base_mode_step_remains_timer_step(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Base mode entity should retain its pre-3.6 timer-step behavior."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.massage_mode_step()
+
+        mock_bleak_client.write_gatt_char.assert_awaited_once_with(
+            KEESON_BASE_WRITE_CHAR_UUID,
+            bytes.fromhex("e5fe160002000004"),
+            response=True,
+        )
+
     @pytest.mark.parametrize(
         ("level", "expected_payload"),
         [
@@ -731,20 +751,20 @@ class TestKeesonMassage:
             ("purple", False),
         ],
     )
-    def test_direct_massage_controls_are_base_only(
+    def test_wave_direction_controls_are_base_only(
         self,
         hass: HomeAssistant,
         mock_keeson_config_entry,
         variant: str,
         supported: bool,
     ):
-        """Variant-specific Base meanings must not leak into other profiles."""
+        """Variant-specific Base wave meanings must not leak into other profiles."""
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         controller = KeesonController(coordinator, variant=variant)
 
         assert controller.supports_massage_wave_direction_control is supported
         assert controller.supports_massage_intensity_preset_control is supported
-        assert controller.supports_massage_mode_step_control is not supported
+        assert controller.supports_massage_mode_step_control is True
 
     async def test_base_intensity_rejects_unknown_level(
         self,


### PR DESCRIPTION
3.6 changed the direct intensity button identities and removed the existing massage timer button. Existing dashboards therefore called unavailable entities, so the confirmed intensity commands never reached BLE.

Restore the established intensity identities with a migration for 3.6 registry entries, and restore the timer-step entity as a separate action from wave navigation.

Ref #508