### PR TITLE
Declare percentage position units

### DIFF
--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -1079,6 +1079,11 @@ class BedController(ABC):
         return False
 
     @property
+    def reports_percentage_position(self) -> bool:
+        """Return whether reported motor positions use a 0-100 percentage scale."""
+        return False
+
+    @property
     def requires_notification_channel(self) -> bool:
         """Return True if commands depend on BLE notifications for responses/auth.
 

--- a/custom_components/adjustable_bed/beds/jensen.py
+++ b/custom_components/adjustable_bed/beds/jensen.py
@@ -20,7 +20,12 @@ from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.exc import BleakError
 
 from ..const import JENSEN_CHAR_UUID, JENSEN_SERVICE_UUID
-from .base import BedController
+from .base import (
+    POSITION_UNIT_PERCENT,
+    BedController,
+    PositionNumberSpec,
+    build_position_number_spec,
+)
 
 if TYPE_CHECKING:
     from ..coordinator import AdjustableBedCoordinator
@@ -273,6 +278,19 @@ class JensenController(BedController):
     def supports_position_feedback(self) -> bool:
         """Return True - Jensen beds report position via notifications."""
         return True
+
+    @property
+    def reports_percentage_position(self) -> bool:
+        """Return True because Jensen normalizes reported positions to percentages."""
+        return True
+
+    @property
+    def position_number_specs(self) -> tuple[PositionNumberSpec, ...]:
+        """Expose back and legs as percentage sliders."""
+        return (
+            build_position_number_spec("back", max_value=100.0, unit=POSITION_UNIT_PERCENT),
+            build_position_number_spec("legs", max_value=100.0, unit=POSITION_UNIT_PERCENT),
+        )
 
     @property
     def massage_intensity_zones(self) -> list[str]:

--- a/custom_components/adjustable_bed/beds/sleep_number.py
+++ b/custom_components/adjustable_bed/beds/sleep_number.py
@@ -300,6 +300,11 @@ class SleepNumberController(BedController):
         return True
 
     @property
+    def reports_percentage_position(self) -> bool:
+        """Return True because foundation positions use percentages."""
+        return True
+
+    @property
     def supports_direct_position_control(self) -> bool:
         """Sleep Number supports 0-100 target positions per actuator."""
         return True

--- a/custom_components/adjustable_bed/beds/sleepstar.py
+++ b/custom_components/adjustable_bed/beds/sleepstar.py
@@ -325,6 +325,11 @@ class SleepStarController(BedController):
         return True
 
     @property
+    def reports_percentage_position(self) -> bool:
+        """Return True because SLEEPSTAR positions use percentages."""
+        return True
+
+    @property
     def supports_direct_position_control(self) -> bool:
         """Return True for the five app-addressable position zones."""
         return True

--- a/custom_components/adjustable_bed/beds/sleepys_box25.py
+++ b/custom_components/adjustable_bed/beds/sleepys_box25.py
@@ -250,6 +250,11 @@ class SleepysBox25Controller(BedController):
         return True
 
     @property
+    def reports_percentage_position(self) -> bool:
+        """Return True because BOX25 reports percentage positions."""
+        return True
+
+    @property
     def supports_direct_position_control(self) -> bool:
         return True
 

--- a/tests/test_controller_contract.py
+++ b/tests/test_controller_contract.py
@@ -13,8 +13,11 @@ from typing import Any
 import pytest
 
 from custom_components.adjustable_bed import const, controller_factory
-from custom_components.adjustable_bed.beds.base import BedController
-from custom_components.adjustable_bed.beds.keeson import KeesonController
+from custom_components.adjustable_bed.beds.base import (
+    POSITION_UNIT_DEGREES,
+    POSITION_UNIT_PERCENT,
+    BedController,
+)
 from custom_components.adjustable_bed.const import (
     BED_TYPE_COOLBASE,
     BED_TYPE_KEESON,
@@ -52,6 +55,7 @@ SHARED_CAPABILITY_FLAGS: tuple[str, ...] = (
     "supports_light_color_control",
     "supports_light_cycle",
     "supports_position_feedback",
+    "reports_percentage_position",
     "supports_massage",
     "supports_motor_control",
     "supports_stop_all",
@@ -99,6 +103,10 @@ class _FactoryCoordinator(SimpleNamespace):
     async def async_execute_controller_command(self, *args: Any, **kwargs: Any) -> None:
         """Stub command executor used by keepalive-capable controllers."""
         return None
+
+    def get_max_angle(self, position_key: str) -> float:
+        """Return the integration's default calibration for a position axis."""
+        return 45.0 if position_key in {"legs", "feet"} else 68.0
 
 
 def _protocol_variant_for_bed_type(bed_type: str) -> str | None:
@@ -240,24 +248,35 @@ async def test_factory_resolves_every_supported_bed_type(bed_type: str) -> None:
 
 
 @pytest.mark.parametrize("bed_type", SUPPORTED_BED_TYPES)
-async def test_keeson_protocol_bed_types_are_listed_as_percentage_beds(
+async def test_percentage_position_contract_matches_bed_type_metadata(
     bed_type: str,
 ) -> None:
-    """Every bed type running KeesonController must be a known percentage bed.
-
-    sensor.py consults BEDS_WITH_PERCENTAGE_POSITIONS by bed type rather than asking
-    the controller, so a Keeson-protocol bed type missing from the set gets degree
-    angle sensors. Only the ergomotion variant reports positions at all, so for the
-    others those sensors would sit at "unknown" forever. BED_TYPE_OKIN_FFE was absent
-    this way despite running KeesonController like Keeson and Serta.
-    """
+    """Controller declarations must agree with offline-safe bed-type metadata."""
     controller = await _create_controller_for_bed_type(bed_type)
-    if not isinstance(controller, KeesonController):
-        return
-    assert bed_type in const.BEDS_WITH_PERCENTAGE_POSITIONS, (
-        f"{bed_type} runs KeesonController but is not in BEDS_WITH_PERCENTAGE_POSITIONS, "
-        "so angle sensing would create degree angle sensors for it"
+    assert controller.reports_percentage_position is (
+        bed_type in const.BEDS_WITH_PERCENTAGE_POSITIONS
+    ), (
+        f"{bed_type} reports_percentage_position disagrees with "
+        "BEDS_WITH_PERCENTAGE_POSITIONS"
     )
+
+
+@pytest.mark.parametrize("bed_type", SUPPORTED_BED_TYPES)
+async def test_position_slider_units_match_reported_position_units(bed_type: str) -> None:
+    """Position sliders must use the controller's declared feedback unit."""
+    controller = await _create_controller_for_bed_type(bed_type)
+    if not controller.supports_position_feedback:
+        return
+
+    expected_unit = (
+        POSITION_UNIT_PERCENT
+        if controller.reports_percentage_position
+        else POSITION_UNIT_DEGREES
+    )
+    specs = controller.position_number_specs
+
+    assert specs, f"{bed_type} reports positions but exposes no position sliders"
+    assert {spec.native_unit_of_measurement for spec in specs} == {expected_unit}
 
 
 @pytest.mark.parametrize("bed_type", sorted(_SIMPLE_CONTROLLERS))


### PR DESCRIPTION
## Problem

`reports_percentage_position` existed only on Keeson and was not part of the base controller contract. Offline behavior still depends on `BEDS_WITH_PERCENTAGE_POSITIONS`, so the two authorities could silently drift.

## Solution

- Declare the capability on `BedController` and override it for every percentage-position controller.
- Keep `BEDS_WITH_PERCENTAGE_POSITIONS` as the offline-safe runtime authority.
- Enforce agreement between each resolved controller and its bed-type metadata.
- Enforce that feedback-capable slider units match the declared unit.
- Correct Jensen slider metadata to percentages, matching its existing normalized 0-100 feedback and target behavior.

No BLE commands, parsing, timing, or STOP behavior changed.

## Validation

- `uv run pytest` (3,467 passed)
- `uvx ruff@0.15.16 check custom_components tests`
- `uvx pyright@1.1.411 custom_components tests`
- `crq preflight --type uncommitted` (clean, zero findings)

Ref #477

<!-- crq:skip-autoreview -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for beds that report motor positions as percentages.
  * Jensen bed controls now display back and leg positions as 0–100% sliders.
  * Position controls automatically use the correct unit based on each bed’s reported feedback.

* **Bug Fixes**
  * Improved position feedback handling across supported bed types for more accurate controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->