### PR TITLE
Merge v3 improvements into v4

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -434,7 +434,7 @@ def _async_ensure_paired_device_registry(
     """
     registry = dr.async_get(hass)
     parent_info = coordinator.device_info
-    registry.async_get_or_create(
+    parent = registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers=parent_info.get("identifiers"),
         name=parent_info.get("name"),
@@ -444,14 +444,25 @@ def _async_ensure_paired_device_registry(
     parent_identifier = (DOMAIN, coordinator.pair_id)
     for child in coordinator.children.values():
         child_info = child.device_info
-        registry.async_get_or_create(
-            config_entry_id=entry.entry_id,
-            identifiers=child_info.get("identifiers"),
-            name=child_info.get("name"),
-            manufacturer=child_info.get("manufacturer"),
-            model=child_info.get("model"),
-            via_device=parent_identifier,
-        )
+        if hasattr(registry, "async_get_device_by_identifier"):
+            registry.async_get_or_create(
+                config_entry_id=entry.entry_id,
+                identifiers=child_info.get("identifiers"),
+                name=child_info.get("name"),
+                manufacturer=child_info.get("manufacturer"),
+                model=child_info.get("model"),
+                via_device_id=parent.id,
+            )
+        else:
+            # Home Assistant before 2026.8 identifies a parent by identifier.
+            registry.async_get_or_create(
+                config_entry_id=entry.entry_id,
+                identifiers=child_info.get("identifiers"),
+                name=child_info.get("name"),
+                manufacturer=child_info.get("manufacturer"),
+                model=child_info.get("model"),
+                via_device=parent_identifier,
+            )
 
 
 def _device_for_entry_and_identifier(
@@ -803,10 +814,18 @@ async def async_unpair_entry(hass: HomeAssistant, entry: ConfigEntry) -> list[Co
 
     ent_reg = er.async_get(hass)
     dev_reg = dr.async_get(hass)
-    parent = dev_reg.async_get_device(identifiers={(DOMAIN, entry.data[CONF_PAIR_ID])})
+    parent = _device_for_entry_and_identifier(
+        dev_reg,
+        entry.entry_id,
+        (DOMAIN, entry.data[CONF_PAIR_ID]),
+    )
     child_devices: dict[str, dr.DeviceEntry] = {}
     for single, address in singles:
-        device = dev_reg.async_get_device(identifiers={(DOMAIN, address)})
+        device = _device_for_entry_and_identifier(
+            dev_reg,
+            entry.entry_id,
+            (DOMAIN, address),
+        )
         if device is not None:
             child_devices[single.entry_id] = device
 
@@ -885,7 +904,7 @@ async def async_unpair_entry(hass: HomeAssistant, entry: ConfigEntry) -> list[Co
                 continue
             current = dev_reg.async_get(device.id)
             if (
-                current is not None
+                isinstance(current, dr.DeviceEntry)
                 and single.entry_id in current.config_entries
                 and hass.config_entries.async_get_entry(single.entry_id) is not None
             ):

--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -1182,6 +1182,11 @@ class BedController(ABC):
         return type(self).massage_mode_step is not BedController.massage_mode_step
 
     @property
+    def massage_mode_step_is_timer(self) -> bool:
+        """Return True when the shared mode-step action advances a timer."""
+        return False
+
+    @property
     def supports_massage_wave_direction_control(self) -> bool:
         """Return True if the controller exposes next/previous wave controls."""
         return False

--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -1116,6 +1116,11 @@ class BedController(ABC):
         return type(self).massage_mode_step is not BedController.massage_mode_step
 
     @property
+    def massage_mode_step_is_timer(self) -> bool:
+        """Return True when the shared mode-step action advances a timer."""
+        return False
+
+    @property
     def supports_massage_wave_direction_control(self) -> bool:
         """Return True if the controller exposes next/previous wave controls."""
         return False

--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -772,6 +772,11 @@ class KeesonController(BedController):
         return self._variant == KEESON_VARIANT_SINO
 
     @property
+    def massage_mode_step_is_timer(self) -> bool:
+        """Return True when the shared action sends the Keeson timer-step command."""
+        return self._variant != KEESON_VARIANT_SINO
+
+    @property
     def supports_massage_wave_direction_control(self) -> bool:
         """Return True for the hardware-confirmed BaseI4/I5 wave controls."""
         return self._variant == KEESON_VARIANT_BASE

--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -772,9 +772,9 @@ class KeesonController(BedController):
         return self._variant == KEESON_VARIANT_SINO
 
     @property
-    def supports_massage_mode_step_control(self) -> bool:
-        """Hide the ambiguous mode-step control when base wave controls exist."""
-        return self._variant != KEESON_VARIANT_BASE
+    def massage_mode_step_is_timer(self) -> bool:
+        """Return True when the shared action sends the Keeson timer-step command."""
+        return self._variant != KEESON_VARIANT_SINO
 
     @property
     def supports_massage_wave_direction_control(self) -> bool:
@@ -1781,10 +1781,8 @@ class KeesonController(BedController):
             await self._write_single_shot(self._build_command(KeesonCommands.MASSAGE_FOOT_DOWN))
 
     async def massage_mode_step(self) -> None:
-        """Step through massage wave patterns."""
-        if self._variant == KEESON_VARIANT_BASE:
-            await self.massage_wave_next()
-        elif self._variant == KEESON_VARIANT_SINO:
+        """Step the profile-specific massage timer or mode."""
+        if self._variant == KEESON_VARIANT_SINO:
             self._wave_massage = (self._wave_massage % 10) + 1
             await self.write_command(
                 self._build_command(SinoCommands.MASSAGE_HEAD_WAVE_BASE + self._wave_massage),

--- a/custom_components/adjustable_bed/beds/keeson.py
+++ b/custom_components/adjustable_bed/beds/keeson.py
@@ -772,11 +772,6 @@ class KeesonController(BedController):
         return self._variant == KEESON_VARIANT_SINO
 
     @property
-    def supports_massage_mode_step_control(self) -> bool:
-        """Hide the ambiguous mode-step control when base wave controls exist."""
-        return self._variant != KEESON_VARIANT_BASE
-
-    @property
     def supports_massage_wave_direction_control(self) -> bool:
         """Return True for the hardware-confirmed BaseI4/I5 wave controls."""
         return self._variant == KEESON_VARIANT_BASE
@@ -1781,10 +1776,8 @@ class KeesonController(BedController):
             await self._write_single_shot(self._build_command(KeesonCommands.MASSAGE_FOOT_DOWN))
 
     async def massage_mode_step(self) -> None:
-        """Step through massage wave patterns."""
-        if self._variant == KEESON_VARIANT_BASE:
-            await self.massage_wave_next()
-        elif self._variant == KEESON_VARIANT_SINO:
+        """Step the profile-specific massage timer or mode."""
+        if self._variant == KEESON_VARIANT_SINO:
             self._wave_massage = (self._wave_massage % 10) + 1
             await self.write_command(
                 self._build_command(SinoCommands.MASSAGE_HEAD_WAVE_BASE + self._wave_massage),

--- a/custom_components/adjustable_bed/button.py
+++ b/custom_components/adjustable_bed/button.py
@@ -26,6 +26,12 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+_MASSAGE_INTENSITY_BUTTON_KEY_MIGRATIONS = (
+    ("massage_intensity_1", "massage_intensity_level_1"),
+    ("massage_intensity_2", "massage_intensity_level_2"),
+    ("massage_intensity_3", "massage_intensity_level_3"),
+)
+
 
 @dataclass(frozen=True, kw_only=True)
 class AdjustableBedButtonEntityDescription(ButtonEntityDescription):
@@ -387,8 +393,8 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         required_capability="supports_massage_wave_direction_control",
     ),
     AdjustableBedButtonEntityDescription(
-        key="massage_intensity_1",
-        translation_key="massage_intensity_1",
+        key="massage_intensity_level_1",
+        translation_key="massage_intensity_level_1",
         icon="mdi:numeric-1-circle",
         requires_massage=True,
         cancel_movement=True,
@@ -396,8 +402,8 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         required_capability="supports_massage_intensity_preset_control",
     ),
     AdjustableBedButtonEntityDescription(
-        key="massage_intensity_2",
-        translation_key="massage_intensity_2",
+        key="massage_intensity_level_2",
+        translation_key="massage_intensity_level_2",
         icon="mdi:numeric-2-circle",
         requires_massage=True,
         cancel_movement=True,
@@ -405,8 +411,8 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         required_capability="supports_massage_intensity_preset_control",
     ),
     AdjustableBedButtonEntityDescription(
-        key="massage_intensity_3",
-        translation_key="massage_intensity_3",
+        key="massage_intensity_level_3",
+        translation_key="massage_intensity_level_3",
         icon="mdi:numeric-3-circle",
         requires_massage=True,
         cancel_movement=True,
@@ -569,6 +575,7 @@ async def async_setup_entry(
         has_massage = True
 
     if controller is not None:
+        _async_migrate_massage_intensity_button_unique_ids(hass, coordinator)
         _async_remove_stale_button_entities(hass, coordinator, controller, has_massage)
 
     entities = []
@@ -578,6 +585,29 @@ async def async_setup_entry(
         entities.append(AdjustableBedButton(coordinator, description))
 
     async_add_entities(entities)
+
+
+def _async_migrate_massage_intensity_button_unique_ids(
+    hass: HomeAssistant,
+    coordinator: AdjustableBedCoordinator,
+) -> None:
+    """Restore established intensity IDs while preserving 3.6 entity IDs."""
+    registry = er.async_get(hass)
+    for old_key, new_key in _MASSAGE_INTENSITY_BUTTON_KEY_MIGRATIONS:
+        old_entity_id = registry.async_get_entity_id(
+            "button",
+            DOMAIN,
+            f"{coordinator.address}_{old_key}",
+        )
+        if old_entity_id is None:
+            continue
+
+        new_unique_id = f"{coordinator.address}_{new_key}"
+        if registry.async_get_entity_id("button", DOMAIN, new_unique_id) is not None:
+            registry.async_remove(old_entity_id)
+            continue
+
+        registry.async_update_entity(old_entity_id, new_unique_id=new_unique_id)
 
 
 def _should_add_button(

--- a/custom_components/adjustable_bed/button.py
+++ b/custom_components/adjustable_bed/button.py
@@ -26,6 +26,12 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+_MASSAGE_INTENSITY_BUTTON_KEY_MIGRATIONS = (
+    ("massage_intensity_1", "massage_intensity_level_1"),
+    ("massage_intensity_2", "massage_intensity_level_2"),
+    ("massage_intensity_3", "massage_intensity_level_3"),
+)
+
 
 @dataclass(frozen=True, kw_only=True)
 class AdjustableBedButtonEntityDescription(ButtonEntityDescription):
@@ -387,8 +393,8 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         required_capability="supports_massage_wave_direction_control",
     ),
     AdjustableBedButtonEntityDescription(
-        key="massage_intensity_1",
-        translation_key="massage_intensity_1",
+        key="massage_intensity_level_1",
+        translation_key="massage_intensity_level_1",
         icon="mdi:numeric-1-circle",
         requires_massage=True,
         cancel_movement=True,
@@ -396,8 +402,8 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         required_capability="supports_massage_intensity_preset_control",
     ),
     AdjustableBedButtonEntityDescription(
-        key="massage_intensity_2",
-        translation_key="massage_intensity_2",
+        key="massage_intensity_level_2",
+        translation_key="massage_intensity_level_2",
         icon="mdi:numeric-2-circle",
         requires_massage=True,
         cancel_movement=True,
@@ -405,8 +411,8 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         required_capability="supports_massage_intensity_preset_control",
     ),
     AdjustableBedButtonEntityDescription(
-        key="massage_intensity_3",
-        translation_key="massage_intensity_3",
+        key="massage_intensity_level_3",
+        translation_key="massage_intensity_level_3",
         icon="mdi:numeric-3-circle",
         requires_massage=True,
         cancel_movement=True,
@@ -569,6 +575,7 @@ async def async_setup_entry(
         has_massage = True
 
     if controller is not None:
+        _async_migrate_massage_intensity_button_unique_ids(hass, coordinator)
         _async_remove_stale_button_entities(hass, coordinator, controller, has_massage)
 
     entities = []
@@ -578,6 +585,29 @@ async def async_setup_entry(
         entities.append(AdjustableBedButton(coordinator, description))
 
     async_add_entities(entities)
+
+
+def _async_migrate_massage_intensity_button_unique_ids(
+    hass: HomeAssistant,
+    coordinator: AdjustableBedCoordinator,
+) -> None:
+    """Restore established intensity IDs while preserving 3.6 entity IDs."""
+    registry = er.async_get(hass)
+    for old_key, new_key in _MASSAGE_INTENSITY_BUTTON_KEY_MIGRATIONS:
+        old_entity_id = registry.async_get_entity_id(
+            "button",
+            DOMAIN,
+            f"{coordinator.address}_{old_key}",
+        )
+        if old_entity_id is None:
+            continue
+
+        new_unique_id = f"{coordinator.address}_{new_key}"
+        if registry.async_get_entity_id("button", DOMAIN, new_unique_id) is not None:
+            registry.async_remove(old_entity_id)
+            continue
+
+        registry.async_update_entity(old_entity_id, new_unique_id=new_unique_id)
 
 
 def _should_add_button(
@@ -685,7 +715,14 @@ class AdjustableBedButton(AdjustableBedEntity, ButtonEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.address}_{description.key}"
-        self._attr_translation_key = description.translation_key
+        controller = coordinator.controller
+        self._attr_translation_key = (
+            "massage_timer_step"
+            if description.key == "massage_mode_step"
+            and controller is not None
+            and controller.massage_mode_step_is_timer
+            else description.translation_key
+        )
 
         # Beds that name their memory slots (Octo CAP_MEMINFO reports e.g.
         # Zero-G or Anti-Snore) are far more useful with that name than with

--- a/custom_components/adjustable_bed/button.py
+++ b/custom_components/adjustable_bed/button.py
@@ -715,7 +715,14 @@ class AdjustableBedButton(AdjustableBedEntity, ButtonEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.address}_{description.key}"
-        self._attr_translation_key = description.translation_key
+        controller = coordinator.controller
+        self._attr_translation_key = (
+            "massage_timer_step"
+            if description.key == "massage_mode_step"
+            and controller is not None
+            and controller.massage_mode_step_is_timer
+            else description.translation_key
+        )
 
         # Beds that name their memory slots (Octo CAP_MEMINFO reports e.g.
         # Zero-G or Anti-Snore) are far more useful with that name than with

--- a/custom_components/adjustable_bed/button.py
+++ b/custom_components/adjustable_bed/button.py
@@ -591,6 +591,9 @@ async def async_setup_entry(
     if isinstance(coordinator, PairedBedCoordinator):
         entities: list[ButtonEntity] = []
         children = list(coordinator.children.values())
+        _async_migrate_massage_intensity_button_unique_ids(
+            hass, coordinator, key_suffix="_both"
+        )
         for side, child in coordinator.children.items():
             entities.extend(
                 _button_entities_for(
@@ -723,20 +726,23 @@ def _combined_motor_buttons_for(
 
 def _async_migrate_massage_intensity_button_unique_ids(
     hass: HomeAssistant,
-    coordinator: AdjustableBedCoordinator,
+    coordinator: AdjustableBedCoordinator | PairedBedCoordinator,
+    *,
+    key_suffix: str = "",
 ) -> None:
     """Restore established intensity IDs while preserving 3.6 entity IDs."""
     registry = er.async_get(hass)
     for old_key, new_key in _MASSAGE_INTENSITY_BUTTON_KEY_MIGRATIONS:
+        old_unique_id = coordinator.entity_unique_id(f"{old_key}{key_suffix}")
         old_entity_id = registry.async_get_entity_id(
             "button",
             DOMAIN,
-            f"{coordinator.address}_{old_key}",
+            old_unique_id,
         )
         if old_entity_id is None:
             continue
 
-        new_unique_id = f"{coordinator.address}_{new_key}"
+        new_unique_id = coordinator.entity_unique_id(f"{new_key}{key_suffix}")
         if registry.async_get_entity_id("button", DOMAIN, new_unique_id) is not None:
             registry.async_remove(old_entity_id)
             continue

--- a/custom_components/adjustable_bed/button.py
+++ b/custom_components/adjustable_bed/button.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
@@ -30,6 +30,12 @@ if TYPE_CHECKING:
     from .beds.base import BedController, MotorControlSpec
 
 _LOGGER = logging.getLogger(__name__)
+
+_MASSAGE_INTENSITY_BUTTON_KEY_MIGRATIONS = (
+    ("massage_intensity_1", "massage_intensity_level_1"),
+    ("massage_intensity_2", "massage_intensity_level_2"),
+    ("massage_intensity_3", "massage_intensity_level_3"),
+)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -392,8 +398,8 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         required_capability="supports_massage_wave_direction_control",
     ),
     AdjustableBedButtonEntityDescription(
-        key="massage_intensity_1",
-        translation_key="massage_intensity_1",
+        key="massage_intensity_level_1",
+        translation_key="massage_intensity_level_1",
         icon="mdi:numeric-1-circle",
         requires_massage=True,
         cancel_movement=True,
@@ -401,8 +407,8 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         required_capability="supports_massage_intensity_preset_control",
     ),
     AdjustableBedButtonEntityDescription(
-        key="massage_intensity_2",
-        translation_key="massage_intensity_2",
+        key="massage_intensity_level_2",
+        translation_key="massage_intensity_level_2",
         icon="mdi:numeric-2-circle",
         requires_massage=True,
         cancel_movement=True,
@@ -410,8 +416,8 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         required_capability="supports_massage_intensity_preset_control",
     ),
     AdjustableBedButtonEntityDescription(
-        key="massage_intensity_3",
-        translation_key="massage_intensity_3",
+        key="massage_intensity_level_3",
+        translation_key="massage_intensity_level_3",
         icon="mdi:numeric-3-circle",
         requires_massage=True,
         cancel_movement=True,
@@ -618,6 +624,7 @@ def _button_entities_for(
         has_massage = True
 
     if controller is not None:
+        _async_migrate_massage_intensity_button_unique_ids(hass, coordinator)
         _async_remove_stale_button_entities(hass, coordinator, controller, has_massage)
 
     entities: list[ButtonEntity] = []
@@ -714,6 +721,29 @@ def _combined_motor_buttons_for(
     return entities
 
 
+def _async_migrate_massage_intensity_button_unique_ids(
+    hass: HomeAssistant,
+    coordinator: AdjustableBedCoordinator,
+) -> None:
+    """Restore established intensity IDs while preserving 3.6 entity IDs."""
+    registry = er.async_get(hass)
+    for old_key, new_key in _MASSAGE_INTENSITY_BUTTON_KEY_MIGRATIONS:
+        old_entity_id = registry.async_get_entity_id(
+            "button",
+            DOMAIN,
+            f"{coordinator.address}_{old_key}",
+        )
+        if old_entity_id is None:
+            continue
+
+        new_unique_id = f"{coordinator.address}_{new_key}"
+        if registry.async_get_entity_id("button", DOMAIN, new_unique_id) is not None:
+            registry.async_remove(old_entity_id)
+            continue
+
+        registry.async_update_entity(old_entity_id, new_unique_id=new_unique_id)
+
+
 def _should_add_button(
     description: AdjustableBedButtonEntityDescription,
     controller: BedController | None,
@@ -762,6 +792,24 @@ def _should_add_button(
             return False
 
     return True
+
+
+def _button_translation_key(
+    description: AdjustableBedButtonEntityDescription,
+    controllers: Iterable[BedController | None],
+) -> str:
+    """Return the action label shared by every participating controller."""
+    resolved_controllers = tuple(controllers)
+    if (
+        description.key == "massage_mode_step"
+        and resolved_controllers
+        and all(
+            controller is not None and controller.massage_mode_step_is_timer
+            for controller in resolved_controllers
+        )
+    ):
+        return "massage_timer_step"
+    return description.translation_key or description.key
 
 
 def _async_remove_stale_button_entities(
@@ -819,9 +867,11 @@ class AdjustableBedButton(AdjustableBedEntity, ButtonEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = coordinator.entity_unique_id(description.key)
-        self._attr_translation_key = coordinator.entity_translation_key(
-            description.translation_key or description.key
+        translation_key = _button_translation_key(
+            description,
+            (coordinator.capability_controller,),
         )
+        self._attr_translation_key = coordinator.entity_translation_key(translation_key)
 
         # Beds that name their memory slots (Octo CAP_MEMINFO reports e.g.
         # Zero-G or Anti-Snore) are far more useful with that name than with
@@ -941,10 +991,17 @@ class PairedBedCombinedButton(ButtonEntity):
         """Initialize the combined button."""
         self._coordinator = coordinator
         self.entity_description = description
+        base_translation_key = _button_translation_key(
+            description,
+            (
+                child.capability_controller
+                for child in coordinator.children.values()
+            ),
+        )
         self._attr_translation_key = (
-            f"{description.translation_key}_both"
+            f"{base_translation_key}_both"
             if isinstance(coordinator, SingleAddressPairedCoordinator)
-            else description.translation_key
+            else base_translation_key
         )
         self._attr_unique_id = _paired_entity_unique_id(
             coordinator, f"{description.key}_both"

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -684,20 +684,23 @@
       "massage_mode_step": {
         "name": "Massage: Mode"
       },
+      "massage_timer_step": {
+        "name": "Massage: Timer"
+      },
       "massage_wave_next": {
         "name": "Massage: Wave Next"
       },
       "massage_wave_previous": {
         "name": "Massage: Wave Previous"
       },
-      "massage_intensity_1": {
-        "name": "Massage: Intensity 1"
+      "massage_intensity_level_1": {
+        "name": "Massage: Intensity Level 1"
       },
-      "massage_intensity_2": {
-        "name": "Massage: Intensity 2"
+      "massage_intensity_level_2": {
+        "name": "Massage: Intensity Level 2"
       },
-      "massage_intensity_3": {
-        "name": "Massage: Intensity 3"
+      "massage_intensity_level_3": {
+        "name": "Massage: Intensity Level 3"
       },
       "massage_circulation_full_body": {
         "name": "Massage: Full Body Loop"
@@ -1070,6 +1073,15 @@
       },
       "massage_mode_step_both": {
         "name": "Both sides: Massage: Mode"
+      },
+      "massage_timer_step_left": {
+        "name": "Left: Massage: Timer"
+      },
+      "massage_timer_step_right": {
+        "name": "Right: Massage: Timer"
+      },
+      "massage_timer_step_both": {
+        "name": "Both sides: Massage: Timer"
       },
       "massage_circulation_full_body_left": {
         "name": "Left: Massage: Full Body Loop"

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -460,20 +460,23 @@
       "massage_mode_step": {
         "name": "Massage: Mode"
       },
+      "massage_timer_step": {
+        "name": "Massage: Timer"
+      },
       "massage_wave_next": {
         "name": "Massage: Wave Next"
       },
       "massage_wave_previous": {
         "name": "Massage: Wave Previous"
       },
-      "massage_intensity_1": {
-        "name": "Massage: Intensity 1"
+      "massage_intensity_level_1": {
+        "name": "Massage: Intensity Level 1"
       },
-      "massage_intensity_2": {
-        "name": "Massage: Intensity 2"
+      "massage_intensity_level_2": {
+        "name": "Massage: Intensity Level 2"
       },
-      "massage_intensity_3": {
-        "name": "Massage: Intensity 3"
+      "massage_intensity_level_3": {
+        "name": "Massage: Intensity Level 3"
       },
       "massage_circulation_full_body": {
         "name": "Massage: Full Body Loop"

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -466,14 +466,14 @@
       "massage_wave_previous": {
         "name": "Massage: Wave Previous"
       },
-      "massage_intensity_1": {
-        "name": "Massage: Intensity 1"
+      "massage_intensity_level_1": {
+        "name": "Massage: Intensity Level 1"
       },
-      "massage_intensity_2": {
-        "name": "Massage: Intensity 2"
+      "massage_intensity_level_2": {
+        "name": "Massage: Intensity Level 2"
       },
-      "massage_intensity_3": {
-        "name": "Massage: Intensity 3"
+      "massage_intensity_level_3": {
+        "name": "Massage: Intensity Level 3"
       },
       "massage_circulation_full_body": {
         "name": "Massage: Full Body Loop"

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -460,6 +460,9 @@
       "massage_mode_step": {
         "name": "Massage: Mode"
       },
+      "massage_timer_step": {
+        "name": "Massage: Timer"
+      },
       "massage_wave_next": {
         "name": "Massage: Wave Next"
       },

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -462,20 +462,23 @@
       "massage_mode_step": {
         "name": "Massage: Mode"
       },
+      "massage_timer_step": {
+        "name": "Massage: Timer"
+      },
       "massage_wave_next": {
         "name": "Massage: Wave Next"
       },
       "massage_wave_previous": {
         "name": "Massage: Wave Previous"
       },
-      "massage_intensity_1": {
-        "name": "Massage: Intensity 1"
+      "massage_intensity_level_1": {
+        "name": "Massage: Intensity Level 1"
       },
-      "massage_intensity_2": {
-        "name": "Massage: Intensity 2"
+      "massage_intensity_level_2": {
+        "name": "Massage: Intensity Level 2"
       },
-      "massage_intensity_3": {
-        "name": "Massage: Intensity 3"
+      "massage_intensity_level_3": {
+        "name": "Massage: Intensity Level 3"
       },
       "massage_circulation_full_body": {
         "name": "Massage: Full Body Loop"

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -468,14 +468,14 @@
       "massage_wave_previous": {
         "name": "Massage: Wave Previous"
       },
-      "massage_intensity_1": {
-        "name": "Massage: Intensity 1"
+      "massage_intensity_level_1": {
+        "name": "Massage: Intensity Level 1"
       },
-      "massage_intensity_2": {
-        "name": "Massage: Intensity 2"
+      "massage_intensity_level_2": {
+        "name": "Massage: Intensity Level 2"
       },
-      "massage_intensity_3": {
-        "name": "Massage: Intensity 3"
+      "massage_intensity_level_3": {
+        "name": "Massage: Intensity Level 3"
       },
       "massage_circulation_full_body": {
         "name": "Massage: Full Body Loop"

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -684,20 +684,23 @@
       "massage_mode_step": {
         "name": "Massage: Mode"
       },
+      "massage_timer_step": {
+        "name": "Massage: Timer"
+      },
       "massage_wave_next": {
         "name": "Massage: Wave Next"
       },
       "massage_wave_previous": {
         "name": "Massage: Wave Previous"
       },
-      "massage_intensity_1": {
-        "name": "Massage: Intensity 1"
+      "massage_intensity_level_1": {
+        "name": "Massage: Intensity Level 1"
       },
-      "massage_intensity_2": {
-        "name": "Massage: Intensity 2"
+      "massage_intensity_level_2": {
+        "name": "Massage: Intensity Level 2"
       },
-      "massage_intensity_3": {
-        "name": "Massage: Intensity 3"
+      "massage_intensity_level_3": {
+        "name": "Massage: Intensity Level 3"
       },
       "massage_circulation_full_body": {
         "name": "Massage: Full Body Loop"
@@ -1070,6 +1073,15 @@
       },
       "massage_mode_step_both": {
         "name": "Both sides: Massage: Mode"
+      },
+      "massage_timer_step_left": {
+        "name": "Left: Massage: Timer"
+      },
+      "massage_timer_step_right": {
+        "name": "Right: Massage: Timer"
+      },
+      "massage_timer_step_both": {
+        "name": "Both sides: Massage: Timer"
       },
       "massage_circulation_full_body_left": {
         "name": "Left: Massage: Full Body Loop"

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -462,6 +462,9 @@
       "massage_mode_step": {
         "name": "Massage: Mode"
       },
+      "massage_timer_step": {
+        "name": "Massage: Timer"
+      },
       "massage_wave_next": {
         "name": "Massage: Wave Next"
       },

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -77,9 +77,14 @@ Brands using Keeson/Ergomotion actuators:
 
 The GlideAway ComfortBase Odessa hardware report in
 [issue #508](https://github.com/kristofferR/ha-adjustable-bed/issues/508)
-confirms these additional BaseI4/I5 massage actions. Their meanings are
-variant-specific and must not be applied to the KSBT, Sino, Purple, or
-Ergomotion profiles.
+confirms these additional BaseI4/I5 massage actions. A 3.6.0 follow-up confirmed
+the wave controls, while its logs showed that the dashboard's established
+`massage_intensity_level_*` entity IDs no longer existed, so those button
+presses never reached BLE. The entity IDs are retained for compatibility.
+Their meanings are variant-specific and must not be applied to the KSBT, Sino,
+Purple, or Ergomotion profiles. The existing `0x00000200` timer-step action is
+separate from wave selection and is displayed as **Massage: Timer** while
+retaining its established entity identity.
 
 | Action | Value |
 |--------|-------|

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -77,9 +77,13 @@ Brands using Keeson/Ergomotion actuators:
 
 The GlideAway ComfortBase Odessa hardware report in
 [issue #508](https://github.com/kristofferR/ha-adjustable-bed/issues/508)
-confirms these additional BaseI4/I5 massage actions. Their meanings are
-variant-specific and must not be applied to the KSBT, Sino, Purple, or
-Ergomotion profiles.
+confirms these additional BaseI4/I5 massage actions. A 3.6.0 follow-up confirmed
+the wave controls, while its logs showed that the dashboard's established
+`massage_intensity_level_*` entity IDs no longer existed, so those button
+presses never reached BLE. The entity IDs are retained for compatibility.
+Their meanings are variant-specific and must not be applied to the KSBT, Sino,
+Purple, or Ergomotion profiles. The existing `0x00000200` timer-step action is
+separate from wave selection.
 
 | Action | Value |
 |--------|-------|

--- a/docs/beds/keeson.md
+++ b/docs/beds/keeson.md
@@ -83,7 +83,8 @@ the wave controls, while its logs showed that the dashboard's established
 presses never reached BLE. The entity IDs are retained for compatibility.
 Their meanings are variant-specific and must not be applied to the KSBT, Sino,
 Purple, or Ergomotion profiles. The existing `0x00000200` timer-step action is
-separate from wave selection.
+separate from wave selection and is displayed as **Massage: Timer** while
+retaining its established entity identity.
 
 | Action | Value |
 |--------|-------|

--- a/docs/reanalysis/2026-08-27-phase4b-odd-clusters/HANDOFF.md
+++ b/docs/reanalysis/2026-08-27-phase4b-odd-clusters/HANDOFF.md
@@ -1,0 +1,80 @@
+# Phase 4B odd-cluster handoff (2026-08-28)
+
+This is the repository accounting note for the interrupted odd-cluster Phase 4B run. It records
+the completed cluster-007 result for later issue #436/#443 bookkeeping. Raw artifacts,
+decompilation output, reports, audit history, and reproducer logs remain machine-local under the
+ignored `disassembly/output/phase4-early/` tree.
+
+## Run accounting
+
+Assigned clusters: `007`, `009`, `011`, `013`, `015`, `017`, `019`, `021`, `023`, and `025`.
+
+Cluster 007 is **COMPLETE**. Work stopped before cluster 009, so clusters 009 through 025 were not
+started by this run. No integration source or historical protocol documentation was inspected or
+modified.
+
+## Cluster 007 packages
+
+| Role | Package | Version | Artifact-set SHA-256 | Final route | Report manifest SHA-256 | Audit result |
+|---|---|---:|---|---|---|---|
+| Representative | `com.malouf.bedbase` | 2.4.3 (54) | `d9b242a8dda6772f62c5b8f21fe13b462af2533b82a16d67ee7a4a841e6ff894` | FULL | `746d913ad256afd0deffe42e989a96c4e2f4c7aa941add5343a65f2236f9e5de` | ACCEPT, round 003 |
+| Sibling | `com.lucid.bedbase` | 1.3.3 (16) | `88162f4b6adc2cf0d0d5ee4252fe4de3e6564db1881e42ed0a34db3ba58ad148` | FULL, promoted from planned DELTA | `8d21996769e6d209345dc38ac84bb178b9fe70293305f22a39227dfe9f3a880c` | ACCEPT, round 007 |
+
+The cluster input audit passed every artifact member, identity, signer, ABI, canonical prompt,
+schema, and tooling check.
+
+## Report counts
+
+| Package | Inventory | Candidates | Commands | Protocol split | Vectors | Gates | Package audits |
+|---|---:|---:|---:|---|---:|---:|---:|
+| `com.malouf.bedbase` | 23 | 19 | 69 | 30 + 39 | 27 | 17/17 PASS | 3 |
+| `com.lucid.bedbase` | 32 | 133 | 174 | 112 + 62 | 19 | 17/17 PASS | 7 |
+
+The representative audit rejected rounds 001 and 002 before accepting round 003. The sibling
+audit rejected rounds 001 through 006 before accepting round 007. All rejected revisions and audit
+history are preserved machine-locally.
+
+## Reconciliation
+
+The accepted reconciliation covers all 11 frozen delta-checklist areas:
+
+| Result | Areas |
+|---|---|
+| SAME | GATT roles; packet construction; framing/authentication; notification parsing; application stack/native payloads |
+| DIFFERENT | delivery; manifest/discovery; BLE callsites; reachable command/STOP/timing routes; resources/variants; capability routing |
+| INCOMPLETE | none |
+
+Both reports contain the same 68 normalized controller terminal families with no terminal-only
+delta. The packages nevertheless differ in six semantic checklist areas, including reachable scan,
+preset, model, and capability routes. The frozen promotion rule therefore requires a FULL sibling
+route rather than DELTA.
+
+Reconciliation accounting:
+
+- 11/11 areas reconciled: 5 SAME, 6 DIFFERENT, 0 incomplete;
+- 2 unique members: 2 FULL, 0 DELTA, 0 missing, 0 duplicate, 0 unaccounted;
+- 20 exact source anchors;
+- 140 source-bound mutation cases, all 140 rejected;
+- deterministic Markdown, JSON, search-log, and validation-log agreement; and
+- reconciliation audits 001 through 004 REJECT, round 005 ACCEPT.
+
+The final reconciliation `REPORT.SHA256` has SHA-256
+`fd9492a0f0a17ba454247ad9532c5e5f309cbc1090c20a5c9519e8bc8c820239`. Its accepted round-005
+audit has SHA-256 `94c824326a6c8391065c15e48aa5e5c59401b6b89dec784c53bf84fd6e12769c`.
+Both package reports, the reconciliation report, audit histories, and the final machine-local
+handoff are read-only and their manifests verify after freeze.
+
+## Deferred external validation
+
+Artifact analysis has no remaining blocker. Physical-device acceptance, actuator semantics,
+multi-service ordering, and runtime notification values remain deferred external validation. They
+do not make either report or the cluster reconciliation partial.
+
+## Tracker-ready accounting
+
+- Cluster 007: COMPLETE.
+- `com.malouf.bedbase` 2.4.3: FULL, COMPLETE, independently accepted and frozen.
+- `com.lucid.bedbase` 1.3.3: promoted from DELTA to FULL, COMPLETE, independently accepted and
+  frozen.
+- Cluster total: 2 FULL, 0 DELTA, 0 blocked, 0 missing, 0 duplicate, 0 unaccounted.
+- Assigned clusters 009 through 025: not started by this interrupted run.

--- a/docs/reanalysis/2026-08-27-phase4b-odd-clusters/HANDOFF.md
+++ b/docs/reanalysis/2026-08-27-phase4b-odd-clusters/HANDOFF.md
@@ -78,3 +78,10 @@ do not make either report or the cluster reconciliation partial.
   frozen.
 - Cluster total: 2 FULL, 0 DELTA, 0 blocked, 0 missing, 0 duplicate, 0 unaccounted.
 - Assigned clusters 009 through 025: not started by this interrupted run.
+- Origin: the scheduled Phase 4B bulk run tracked by issues #436 and #443, with the durable
+  repository handoff carried by PR #528.
+- Registry: issue #443 records both exact cluster-007 package entries as `ACCEPTED / COUNTED`;
+  issue #436 lists both under completed scheduled-bulk reports and deducts them from its remaining
+  queue accounting.
+- Bulk disposition: these are scheduled-bulk completions, not early analyses. They therefore do
+  not belong in issue #447's `ACCEPTED / EXCLUDE FROM BULK` registry.

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1447,24 +1447,108 @@ class TestButtonEntities:
         )
         entry.add_to_hass(hass)
 
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        old_level_1 = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_intensity_1",
+            config_entry=entry,
+            suggested_object_id="keeson_base_massage_bed_massage_intensity_1",
+        )
+        old_level_2 = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_intensity_2",
+            config_entry=entry,
+            suggested_object_id="keeson_base_massage_bed_massage_intensity_2",
+        )
+        established_level_2 = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_intensity_level_2",
+            config_entry=entry,
+            suggested_object_id="keeson_base_massage_bed_massage_intensity_level_2",
+        )
+
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
+
+        for key in (
+            "massage_mode_step",
+            "massage_wave_next",
+            "massage_wave_previous",
+            "massage_intensity_level_1",
+            "massage_intensity_level_2",
+            "massage_intensity_level_3",
+        ):
+            assert registry.async_get_entity_id("button", DOMAIN, f"{address}_{key}") is not None
+
+        # 3.6 briefly shipped different unique IDs. Migrate them without
+        # changing an existing entity ID, and prefer an established pre-3.6
+        # entity when both forms are present.
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_level_1"
+        ) == str(old_level_1.entity_id)
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_level_2"
+        ) == str(established_level_2.entity_id)
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_1"
+        ) is None
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_2"
+        ) is None
+        assert registry.async_get(str(old_level_2.entity_id)) is None
+
+    async def test_intensity_id_migration_removes_unsupported_stale_button(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """Migrated 3.6 intensity entities should not linger on other variants."""
+        address = "AA:BB:CC:DD:EE:51"
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Keeson KSBT Bed",
+            data={
+                CONF_ADDRESS: address,
+                CONF_NAME: "Keeson KSBT Bed",
+                CONF_BED_TYPE: BED_TYPE_KEESON,
+                CONF_PROTOCOL_VARIANT: "ksbt",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: True,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=address,
+            entry_id="keeson_ksbt_stale_intensity_entry",
+        )
+        entry.add_to_hass(hass)
 
         from homeassistant.helpers import entity_registry as er
 
         registry = er.async_get(hass)
-        for key in (
-            "massage_wave_next",
-            "massage_wave_previous",
-            "massage_intensity_1",
-            "massage_intensity_2",
-            "massage_intensity_3",
-        ):
-            assert registry.async_get_entity_id("button", DOMAIN, f"{address}_{key}") is not None
-
-        assert (
-            registry.async_get_entity_id("button", DOMAIN, f"{address}_massage_mode_step") is None
+        stale = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_intensity_1",
+            config_entry=entry,
+            suggested_object_id="keeson_ksbt_bed_massage_intensity_1",
         )
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert registry.async_get(str(stale.entity_id)) is None
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_1"
+        ) is None
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_level_1"
+        ) is None
 
     async def test_kaidi_entities_expose_book_leisure_direct_position_and_filtered_massage(
         self,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -11,9 +11,13 @@ from homeassistant.const import CONF_ADDRESS, CONF_NAME, STATE_OFF, STATE_ON, ST
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.adjustable_bed.beds.base import BedController
 from custom_components.adjustable_bed.beds.leggett_gen2 import LeggettGen2Commands
 from custom_components.adjustable_bed.beds.richmat import RichmatCommands
-from custom_components.adjustable_bed.button import BUTTON_DESCRIPTIONS
+from custom_components.adjustable_bed.button import (
+    BUTTON_DESCRIPTIONS,
+    _button_translation_key,
+)
 from custom_components.adjustable_bed.const import (
     BED_TYPE_BEDTECH,
     BED_TYPE_KAIDI,
@@ -1368,6 +1372,33 @@ class TestButtonEntities:
         assert len(massage_buttons) > 0
         assert all(desc.cancel_movement for desc in massage_buttons)
 
+    def test_massage_timer_label_requires_every_controller_to_report_timer(self):
+        """Combined mode actions are timers only when every side agrees."""
+        description = next(
+            description
+            for description in BUTTON_DESCRIPTIONS
+            if description.key == "massage_mode_step"
+        )
+        timer_controller = MagicMock(spec=BedController)
+        timer_controller.massage_mode_step_is_timer = True
+        mode_controller = MagicMock(spec=BedController)
+        mode_controller.massage_mode_step_is_timer = False
+
+        assert (
+            _button_translation_key(
+                description,
+                (timer_controller, timer_controller),
+            )
+            == "massage_timer_step"
+        )
+        assert (
+            _button_translation_key(
+                description,
+                (timer_controller, mode_controller),
+            )
+            == "massage_mode_step"
+        )
+
     async def test_button_entities_created(
         self,
         hass: HomeAssistant,
@@ -1447,24 +1478,123 @@ class TestButtonEntities:
         )
         entry.add_to_hass(hass)
 
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        established_timer = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_mode_step",
+            config_entry=entry,
+            suggested_object_id="keeson_base_massage_bed_massage_mode",
+        )
+        old_level_1 = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_intensity_1",
+            config_entry=entry,
+            suggested_object_id="keeson_base_massage_bed_massage_intensity_1",
+        )
+        old_level_2 = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_intensity_2",
+            config_entry=entry,
+            suggested_object_id="keeson_base_massage_bed_massage_intensity_2",
+        )
+        established_level_2 = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_intensity_level_2",
+            config_entry=entry,
+            suggested_object_id="keeson_base_massage_bed_massage_intensity_level_2",
+        )
+
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
+
+        for key in (
+            "massage_mode_step",
+            "massage_wave_next",
+            "massage_wave_previous",
+            "massage_intensity_level_1",
+            "massage_intensity_level_2",
+            "massage_intensity_level_3",
+        ):
+            assert registry.async_get_entity_id("button", DOMAIN, f"{address}_{key}") is not None
+
+        timer_entity_id = registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_mode_step"
+        )
+        assert timer_entity_id == str(established_timer.entity_id)
+        timer_state = hass.states.get(timer_entity_id)
+        assert timer_state is not None
+        assert timer_state.name.endswith("Massage: Timer")
+
+        # 3.6 briefly shipped different unique IDs. Migrate them without
+        # changing an existing entity ID, and prefer an established pre-3.6
+        # entity when both forms are present.
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_level_1"
+        ) == str(old_level_1.entity_id)
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_level_2"
+        ) == str(established_level_2.entity_id)
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_1"
+        ) is None
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_2"
+        ) is None
+        assert registry.async_get(str(old_level_2.entity_id)) is None
+
+    async def test_intensity_id_migration_removes_unsupported_stale_button(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """Migrated 3.6 intensity entities should not linger on other variants."""
+        address = "AA:BB:CC:DD:EE:51"
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Keeson KSBT Bed",
+            data={
+                CONF_ADDRESS: address,
+                CONF_NAME: "Keeson KSBT Bed",
+                CONF_BED_TYPE: BED_TYPE_KEESON,
+                CONF_PROTOCOL_VARIANT: "ksbt",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: True,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=address,
+            entry_id="keeson_ksbt_stale_intensity_entry",
+        )
+        entry.add_to_hass(hass)
 
         from homeassistant.helpers import entity_registry as er
 
         registry = er.async_get(hass)
-        for key in (
-            "massage_wave_next",
-            "massage_wave_previous",
-            "massage_intensity_1",
-            "massage_intensity_2",
-            "massage_intensity_3",
-        ):
-            assert registry.async_get_entity_id("button", DOMAIN, f"{address}_{key}") is not None
-
-        assert (
-            registry.async_get_entity_id("button", DOMAIN, f"{address}_massage_mode_step") is None
+        stale = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_intensity_1",
+            config_entry=entry,
+            suggested_object_id="keeson_ksbt_bed_massage_intensity_1",
         )
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert registry.async_get(str(stale.entity_id)) is None
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_1"
+        ) is None
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_level_1"
+        ) is None
 
     async def test_kaidi_entities_expose_book_leisure_direct_position_and_filtered_massage(
         self,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1447,24 +1447,123 @@ class TestButtonEntities:
         )
         entry.add_to_hass(hass)
 
+        from homeassistant.helpers import entity_registry as er
+
+        registry = er.async_get(hass)
+        established_timer = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_mode_step",
+            config_entry=entry,
+            suggested_object_id="keeson_base_massage_bed_massage_mode",
+        )
+        old_level_1 = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_intensity_1",
+            config_entry=entry,
+            suggested_object_id="keeson_base_massage_bed_massage_intensity_1",
+        )
+        old_level_2 = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_intensity_2",
+            config_entry=entry,
+            suggested_object_id="keeson_base_massage_bed_massage_intensity_2",
+        )
+        established_level_2 = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_intensity_level_2",
+            config_entry=entry,
+            suggested_object_id="keeson_base_massage_bed_massage_intensity_level_2",
+        )
+
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
+
+        for key in (
+            "massage_mode_step",
+            "massage_wave_next",
+            "massage_wave_previous",
+            "massage_intensity_level_1",
+            "massage_intensity_level_2",
+            "massage_intensity_level_3",
+        ):
+            assert registry.async_get_entity_id("button", DOMAIN, f"{address}_{key}") is not None
+
+        timer_entity_id = registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_mode_step"
+        )
+        assert timer_entity_id == str(established_timer.entity_id)
+        timer_state = hass.states.get(timer_entity_id)
+        assert timer_state is not None
+        assert timer_state.name.endswith("Massage: Timer")
+
+        # 3.6 briefly shipped different unique IDs. Migrate them without
+        # changing an existing entity ID, and prefer an established pre-3.6
+        # entity when both forms are present.
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_level_1"
+        ) == str(old_level_1.entity_id)
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_level_2"
+        ) == str(established_level_2.entity_id)
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_1"
+        ) is None
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_2"
+        ) is None
+        assert registry.async_get(str(old_level_2.entity_id)) is None
+
+    async def test_intensity_id_migration_removes_unsupported_stale_button(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ):
+        """Migrated 3.6 intensity entities should not linger on other variants."""
+        address = "AA:BB:CC:DD:EE:51"
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Keeson KSBT Bed",
+            data={
+                CONF_ADDRESS: address,
+                CONF_NAME: "Keeson KSBT Bed",
+                CONF_BED_TYPE: BED_TYPE_KEESON,
+                CONF_PROTOCOL_VARIANT: "ksbt",
+                CONF_MOTOR_COUNT: 2,
+                CONF_HAS_MASSAGE: True,
+                CONF_DISABLE_ANGLE_SENSING: True,
+                CONF_PREFERRED_ADAPTER: "auto",
+            },
+            unique_id=address,
+            entry_id="keeson_ksbt_stale_intensity_entry",
+        )
+        entry.add_to_hass(hass)
 
         from homeassistant.helpers import entity_registry as er
 
         registry = er.async_get(hass)
-        for key in (
-            "massage_wave_next",
-            "massage_wave_previous",
-            "massage_intensity_1",
-            "massage_intensity_2",
-            "massage_intensity_3",
-        ):
-            assert registry.async_get_entity_id("button", DOMAIN, f"{address}_{key}") is not None
-
-        assert (
-            registry.async_get_entity_id("button", DOMAIN, f"{address}_massage_mode_step") is None
+        stale = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_intensity_1",
+            config_entry=entry,
+            suggested_object_id="keeson_ksbt_bed_massage_intensity_1",
         )
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert registry.async_get(str(stale.entity_id)) is None
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_1"
+        ) is None
+        assert registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_intensity_level_1"
+        ) is None
 
     async def test_kaidi_entities_expose_book_leisure_direct_position_and_filtered_massage(
         self,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1450,6 +1450,13 @@ class TestButtonEntities:
         from homeassistant.helpers import entity_registry as er
 
         registry = er.async_get(hass)
+        established_timer = registry.async_get_or_create(
+            "button",
+            DOMAIN,
+            f"{address}_massage_mode_step",
+            config_entry=entry,
+            suggested_object_id="keeson_base_massage_bed_massage_mode",
+        )
         old_level_1 = registry.async_get_or_create(
             "button",
             DOMAIN,
@@ -1484,6 +1491,14 @@ class TestButtonEntities:
             "massage_intensity_level_3",
         ):
             assert registry.async_get_entity_id("button", DOMAIN, f"{address}_{key}") is not None
+
+        timer_entity_id = registry.async_get_entity_id(
+            "button", DOMAIN, f"{address}_massage_mode_step"
+        )
+        assert timer_entity_id == str(established_timer.entity_id)
+        timer_state = hass.states.get(timer_entity_id)
+        assert timer_state is not None
+        assert timer_state.name.endswith("Massage: Timer")
 
         # 3.6 briefly shipped different unique IDs. Migrate them without
         # changing an existing entity ID, and prefer an established pre-3.6

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -765,6 +765,7 @@ class TestKeesonMassage:
         assert controller.supports_massage_wave_direction_control is supported
         assert controller.supports_massage_intensity_preset_control is supported
         assert controller.supports_massage_mode_step_control is True
+        assert controller.massage_mode_step_is_timer is (variant != "sino")
 
     async def test_base_intensity_rejects_unknown_level(
         self,

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -685,6 +685,26 @@ class TestKeesonMassage:
             response=True,
         )
 
+    async def test_base_mode_step_remains_timer_step(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Base mode entity should retain its pre-3.6 timer-step behavior."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.massage_mode_step()
+
+        mock_bleak_client.write_gatt_char.assert_awaited_once_with(
+            KEESON_BASE_WRITE_CHAR_UUID,
+            bytes.fromhex("e5fe160002000004"),
+            response=True,
+        )
+
     @pytest.mark.parametrize(
         ("level", "expected_payload"),
         [
@@ -731,20 +751,20 @@ class TestKeesonMassage:
             ("purple", False),
         ],
     )
-    def test_direct_massage_controls_are_base_only(
+    def test_wave_direction_controls_are_base_only(
         self,
         hass: HomeAssistant,
         mock_keeson_config_entry,
         variant: str,
         supported: bool,
     ):
-        """Variant-specific Base meanings must not leak into other profiles."""
+        """Variant-specific Base wave meanings must not leak into other profiles."""
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         controller = KeesonController(coordinator, variant=variant)
 
         assert controller.supports_massage_wave_direction_control is supported
         assert controller.supports_massage_intensity_preset_control is supported
-        assert controller.supports_massage_mode_step_control is not supported
+        assert controller.supports_massage_mode_step_control is True
 
     async def test_base_intensity_rejects_unknown_level(
         self,

--- a/tests/test_keeson.py
+++ b/tests/test_keeson.py
@@ -685,6 +685,26 @@ class TestKeesonMassage:
             response=True,
         )
 
+    async def test_base_mode_step_remains_timer_step(
+        self,
+        hass: HomeAssistant,
+        mock_keeson_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Base mode entity should retain its pre-3.6 timer-step behavior."""
+        coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
+        await coordinator.async_connect()
+        mock_bleak_client.write_gatt_char.reset_mock()
+
+        await coordinator.controller.massage_mode_step()
+
+        mock_bleak_client.write_gatt_char.assert_awaited_once_with(
+            KEESON_BASE_WRITE_CHAR_UUID,
+            bytes.fromhex("e5fe160002000004"),
+            response=True,
+        )
+
     @pytest.mark.parametrize(
         ("level", "expected_payload"),
         [
@@ -731,20 +751,21 @@ class TestKeesonMassage:
             ("purple", False),
         ],
     )
-    def test_direct_massage_controls_are_base_only(
+    def test_wave_direction_controls_are_base_only(
         self,
         hass: HomeAssistant,
         mock_keeson_config_entry,
         variant: str,
         supported: bool,
     ):
-        """Variant-specific Base meanings must not leak into other profiles."""
+        """Variant-specific Base wave meanings must not leak into other profiles."""
         coordinator = AdjustableBedCoordinator(hass, mock_keeson_config_entry)
         controller = KeesonController(coordinator, variant=variant)
 
         assert controller.supports_massage_wave_direction_control is supported
         assert controller.supports_massage_intensity_preset_control is supported
-        assert controller.supports_massage_mode_step_control is not supported
+        assert controller.supports_massage_mode_step_control is True
+        assert controller.massage_mode_step_is_timer is (variant != "sino")
 
     async def test_base_intensity_rejects_unknown_level(
         self,

--- a/tests/test_paired_setup.py
+++ b/tests/test_paired_setup.py
@@ -20,6 +20,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.adjustable_bed import (
     _async_release_absorbed_singles,
     _build_paired_children,
+    _device_for_entry_and_identifier,
     _make_child_persist_cb,
     _maybe_create_pairing_issue_for,
     _shared_child_fields,
@@ -219,8 +220,8 @@ class TestPairedSetup:
         assert any(row.unique_id.endswith("_right") for row in rows)
         assert any(row.unique_id.endswith("_both") for row in rows)
 
-        device = dr.async_get(hass).async_get_device(
-            identifiers={(DOMAIN, LEFT_ADDR)}
+        device = _device_for_entry_and_identifier(
+            dr.async_get(hass), entry.entry_id, (DOMAIN, LEFT_ADDR)
         )
         assert device is not None
         mock_bleak_client.write_gatt_char.reset_mock()
@@ -582,7 +583,9 @@ class TestPairedSetup:
         row = ent_reg.async_get(row_id)
         assert row is not None
         assert row.config_entry_id == entry.entry_id
-        device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, LEFT_ADDR)})
+        device = _device_for_entry_and_identifier(
+            dr.async_get(hass), entry.entry_id, (DOMAIN, LEFT_ADDR)
+        )
         assert device is not None
         assert device.config_entry_id == entry.entry_id
 
@@ -598,11 +601,17 @@ class TestPairedSetup:
         await hass.async_block_till_done()
 
         registry = dr.async_get(hass)
-        parent = registry.async_get_device(identifiers={(DOMAIN, PAIR_ID)})
+        parent = _device_for_entry_and_identifier(
+            registry, entry.entry_id, (DOMAIN, PAIR_ID)
+        )
         assert parent is not None
 
-        left = registry.async_get_device(identifiers={(DOMAIN, LEFT_ADDR)})
-        right = registry.async_get_device(identifiers={(DOMAIN, RIGHT_ADDR)})
+        left = _device_for_entry_and_identifier(
+            registry, entry.entry_id, (DOMAIN, LEFT_ADDR)
+        )
+        right = _device_for_entry_and_identifier(
+            registry, entry.entry_id, (DOMAIN, RIGHT_ADDR)
+        )
         assert left is not None and right is not None
         assert left.via_device_id == parent.id
         assert right.via_device_id == parent.id
@@ -1613,7 +1622,9 @@ class TestPairBedsConversion:
         assert before_row.config_entry_id == left.entry_id
 
         # Customize the left side's device too.
-        left_device = dev_reg.async_get_device(identifiers={(DOMAIN, LEFT_ADDR)})
+        left_device = _device_for_entry_and_identifier(
+            dev_reg, left.entry_id, (DOMAIN, LEFT_ADDR)
+        )
         assert left_device is not None
         left_device_id = left_device.id
         dev_reg.async_update_device(left_device_id, name_by_user="Left headboard")
@@ -1658,9 +1669,15 @@ class TestPairBedsConversion:
 
         # The device survived in place (same id), keeps its user name, and now
         # nests under the synthetic parent.
-        parent = dev_reg.async_get_device(identifiers={(DOMAIN, pair.data[CONF_PAIR_ID])})
+        parent = _device_for_entry_and_identifier(
+            dev_reg,
+            pair.entry_id,
+            (DOMAIN, pair.data[CONF_PAIR_ID]),
+        )
         assert parent is not None
-        left_after = dev_reg.async_get_device(identifiers={(DOMAIN, LEFT_ADDR)})
+        left_after = _device_for_entry_and_identifier(
+            dev_reg, pair.entry_id, (DOMAIN, LEFT_ADDR)
+        )
         assert left_after is not None
         assert left_after.id == left_device_id  # same device, not recreated
         assert left_after.config_entry_id == pair.entry_id
@@ -1693,7 +1710,9 @@ class TestPairBedsConversion:
         assert final_row.name == "Kris head angle"
         assert len([e for e in ent_reg.entities.values() if e.unique_id == cover_uid]) == 1
 
-        final_device = dev_reg.async_get_device(identifiers={(DOMAIN, LEFT_ADDR)})
+        final_device = _device_for_entry_and_identifier(
+            dev_reg, left.entry_id, (DOMAIN, LEFT_ADDR)
+        )
         assert final_device is not None
         assert final_device.id == left_device_id
         assert final_device.config_entry_id == left.entry_id
@@ -2057,7 +2076,9 @@ class TestSideServiceRouting:
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        parent = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, PAIR_ID)})
+        parent = _device_for_entry_and_identifier(
+            dr.async_get(hass), entry.entry_id, (DOMAIN, PAIR_ID)
+        )
         assert parent is not None
         for side in ("both", SIDE_LEFT, SIDE_RIGHT):
             await hass.services.async_call(
@@ -2118,7 +2139,9 @@ class TestSideServiceRouting:
         _async_ensure_paired_device_registry(hass, entry, coordinator)
         await async_register_services(hass)
 
-        parent = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, PAIR_ID)})
+        parent = _device_for_entry_and_identifier(
+            dr.async_get(hass), entry.entry_id, (DOMAIN, PAIR_ID)
+        )
         assert parent is not None
         await hass.services.async_call(
             DOMAIN,
@@ -2198,7 +2221,9 @@ class TestSideServiceRouting:
         _async_ensure_paired_device_registry(hass, entry, coordinator)
         await async_register_services(hass)
 
-        parent = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, PAIR_ID)})
+        parent = _device_for_entry_and_identifier(
+            dr.async_get(hass), entry.entry_id, (DOMAIN, PAIR_ID)
+        )
         assert parent is not None
         with pytest.raises(ServiceValidationError):
             await hass.services.async_call(
@@ -2222,7 +2247,9 @@ class TestSideServiceRouting:
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        parent = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, PAIR_ID)})
+        parent = _device_for_entry_and_identifier(
+            dr.async_get(hass), entry.entry_id, (DOMAIN, PAIR_ID)
+        )
         assert parent is not None
 
         # This fixture disables angle sensing, so set_position still rejects the
@@ -2271,7 +2298,9 @@ class TestSideServiceRouting:
         await hass.async_block_till_done()
         coordinator = hass.data[DOMAIN][entry.entry_id]
         coordinator.async_run_child_operation = AsyncMock()
-        parent = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, PAIR_ID)})
+        parent = _device_for_entry_and_identifier(
+            dr.async_get(hass), entry.entry_id, (DOMAIN, PAIR_ID)
+        )
         assert parent is not None
 
         await hass.services.async_call(
@@ -2299,7 +2328,9 @@ class TestSideServiceRouting:
         coordinator = hass.data[DOMAIN][entry.entry_id]
         coordinator.children[SIDE_RIGHT]._controller = SimpleNamespace(motor_control_specs=())
         coordinator.async_run_child_operation = AsyncMock()
-        parent = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, PAIR_ID)})
+        parent = _device_for_entry_and_identifier(
+            dr.async_get(hass), entry.entry_id, (DOMAIN, PAIR_ID)
+        )
         assert parent is not None
 
         with pytest.raises(ServiceValidationError, match="Motor 'back' is not valid"):

--- a/tests/test_paired_setup.py
+++ b/tests/test_paired_setup.py
@@ -28,6 +28,7 @@ from custom_components.adjustable_bed import (
 )
 from custom_components.adjustable_bed.const import (
     BED_TYPE_KAIDI,
+    BED_TYPE_KEESON,
     BED_TYPE_LEGGETT_GEN2,
     BED_TYPE_LEGGETT_OKIN,
     BED_TYPE_LEGGETT_PLATT,
@@ -38,6 +39,7 @@ from custom_components.adjustable_bed.const import (
     BED_TYPE_SBI,
     CONF_BED_TYPE,
     CONF_DISABLE_ANGLE_SENSING,
+    CONF_HAS_MASSAGE,
     CONF_KAIDI_RESOLVED_VARIANT,
     CONF_MOTOR_COUNT,
     CONF_PAIR_CHILDREN,
@@ -649,6 +651,62 @@ class TestPairedSetup:
         # per-motor "both sides" up/down motion buttons instead.
         for key in ("back_up", "back_down", "legs_up", "legs_down"):
             assert f"{PAIR_ID}_{key}_both" in both_uids
+
+    async def test_paired_entry_migrates_combined_massage_intensity_ids(
+        self,
+        hass: HomeAssistant,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ) -> None:
+        """Briefly shipped combined intensity IDs keep their entity IDs."""
+        data = _paired_entry_data()
+        data[CONF_BED_TYPE] = BED_TYPE_KEESON
+        for child in data[CONF_PAIR_CHILDREN]:
+            child.update(
+                {
+                    CONF_BED_TYPE: BED_TYPE_KEESON,
+                    CONF_PROTOCOL_VARIANT: "base",
+                    CONF_HAS_MASSAGE: True,
+                }
+            )
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Paired Keeson Bed",
+            data=data,
+            unique_id=PAIR_ID,
+            entry_id="paired_keeson_migration_entry",
+            version=4,
+        )
+        entry.add_to_hass(hass)
+
+        registry = er.async_get(hass)
+        legacy_entries = {
+            level: registry.async_get_or_create(
+                "button",
+                DOMAIN,
+                f"{PAIR_ID}_massage_intensity_{level}_both",
+                config_entry=entry,
+                suggested_object_id=f"paired_keeson_massage_intensity_{level}",
+            )
+            for level in range(1, 4)
+        }
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        for level, legacy_entry in legacy_entries.items():
+            new_unique_id = f"{PAIR_ID}_massage_intensity_level_{level}_both"
+            assert registry.async_get_entity_id("button", DOMAIN, new_unique_id) == str(
+                legacy_entry.entity_id
+            )
+            assert (
+                registry.async_get_entity_id(
+                    "button",
+                    DOMAIN,
+                    f"{PAIR_ID}_massage_intensity_{level}_both",
+                )
+                is None
+            )
 
     async def test_diagnostics_for_paired_entry_does_not_crash(
         self,


### PR DESCRIPTION
## Problem

The v3 branch gained a Keeson massage compatibility follow-up and a Phase 4B handoff after its latest shared commit with v4. A fresh v4 environment also exposed deprecated Home Assistant device-registry calls that now fail the paired setup tests.

## Solution

- Merge the current v3 history into `release/4.0`.
- Preserve established Keeson intensity entity IDs and keep timer stepping separate from wave selection.
- Integrate the restored controls with v4 paired-button identities and combined capability handling.
- Use config-entry-scoped device lookups and the current parent-device API, with the older identifier form retained for pre-2026.8 Home Assistant.
- Carry the Phase 4B cluster 007 handoff into v4.

No new protocol behavior was inferred. The Keeson behavior is the implementation already reviewed and merged in v3.

## Validation

- `uv run pytest` (3,470 passed)
- `uvx ruff@0.15.16 check custom_components tests`
- `uvx pyright@1.1.411 custom_components tests`
- `crq preflight --type uncommitted` (valid combined-label finding addressed; unreachable Keeson single-address translation suggestion declined)

Ref #508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Massage: Timer** control for supported bed models and paired-bed configurations.
  * Improved massage mode behavior across Keeson variants, including clearer timer and wave controls.

* **Improvements**
  * Renamed massage intensity controls to **Massage: Intensity Level 1–3**.
  * Existing intensity entities are migrated automatically to preserve compatibility.

* **Bug Fixes**
  * Improved paired-bed device setup and removal across Home Assistant versions.
  * Corrected stale massage controls that could remain visible on unsupported variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->