### PR TITLE
fix: record scheduler outcomes in diagnostics

### DIFF
--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -155,6 +155,7 @@ class DiagnosticReport:
     connection_attempt_details: list[dict[str, Any]]
     command_trace: list[dict[str, Any]]
     errors: list[str]
+    command_timing: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert report to dictionary for JSON serialization."""
@@ -173,6 +174,7 @@ class DiagnosticReport:
             "connection_history": self.connection_history,
             "connection_attempt_details": self.connection_attempt_details,
             "command_trace": self.command_trace,
+            "command_timing": self.command_timing,
             "errors": self.errors,
         }
 
@@ -331,6 +333,7 @@ class BLEDiagnosticRunner:
             connection_attempt_details = self.coordinator.connection_attempt_details
 
         command_trace = self.coordinator.command_trace if self.coordinator else []
+        command_timing = self.coordinator.command_timing if self.coordinator else {}
 
         return DiagnosticReport(
             metadata={
@@ -361,6 +364,7 @@ class BLEDiagnosticRunner:
             connection_attempt_details=connection_attempt_details,
             command_trace=command_trace,
             errors=self._errors,
+            command_timing=command_timing,
         )
 
     async def _async_execute_diagnostic_query[T](

--- a/custom_components/adjustable_bed/command_scheduler.py
+++ b/custom_components/adjustable_bed/command_scheduler.py
@@ -200,7 +200,9 @@ class DeviceCommandScheduler:
         self._lock = asyncio.Lock()
         self._queue: deque[CommandHandle] = deque()
         self._active: CommandHandle | None = None
-        self._active_stops: dict[str, CommandHandle] = {}
+        self._active_stops: dict[
+            str, tuple[CommandHandle, asyncio.Task[None]]
+        ] = {}
         self._recent_records: deque[CommandRecord] = deque(
             maxlen=MAX_RECENT_COMMAND_RECORDS
         )
@@ -232,7 +234,7 @@ class DeviceCommandScheduler:
     @property
     def diagnostics(self) -> dict[str, object]:
         """Return a bounded snapshot suitable for integration diagnostics."""
-        active_handles = [*self._active_stops.values()]
+        active_handles = [handle for handle, _task in self._active_stops.values()]
         if self._active is not None:
             active_handles.append(self._active)
         active = active_handles[0] if active_handles else None
@@ -319,8 +321,8 @@ class DeviceCommandScheduler:
         resources: Collection[str] = ALL_COMMAND_RESOURCES,
         *,
         group_id: str | None = None,
-    ) -> CommandHandle:
-        """Invalidate matching work and synchronously admit a safety STOP."""
+    ) -> asyncio.Task[None]:
+        """Invalidate matching work and synchronously start a safety STOP."""
         if self._closed:
             raise RuntimeError(f"Command scheduler for {self._name} is shut down")
         normalized_resources = command_resources(*resources)
@@ -336,10 +338,14 @@ class DeviceCommandScheduler:
             prepared=False,
             admitted_stop_epoch=stop_epoch,
         )
-        self._active_stops[handle.intent.intent_id] = handle
-        return handle
+        task = asyncio.create_task(
+            self._execute_admitted_stop(handle),
+            name=f"adjustable_bed_stop_{self._name}",
+        )
+        self._active_stops[handle.intent.intent_id] = (handle, task)
+        return task
 
-    async def execute_admitted_stop(self, handle: CommandHandle) -> None:
+    async def _execute_admitted_stop(self, handle: CommandHandle) -> None:
         """Execute a synchronously admitted STOP outside the ordinary queue."""
         self._mark_started(handle)
         token: Token[CommandContext | None] = _CURRENT_COMMAND_CONTEXT.set(handle.context)
@@ -492,6 +498,18 @@ class DeviceCommandScheduler:
             worker.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await worker
+
+        # STOP is admitted outside the ordinary worker so it can preempt an
+        # active command. It is still scheduler-owned and must settle before
+        # coordinator teardown disconnects the BLE link.
+        stop_tasks = tuple(task for _handle, task in self._active_stops.values())
+        if stop_tasks:
+            stop_drain = asyncio.gather(*stop_tasks, return_exceptions=True)
+            try:
+                await asyncio.shield(stop_drain)
+            except asyncio.CancelledError:
+                await stop_drain
+                raise
 
     def _replace_conflicts_locked(self, incoming: CommandHandle) -> bool:
         """Cancel conflicts and report whether the active handle was replaced."""

--- a/custom_components/adjustable_bed/command_scheduler.py
+++ b/custom_components/adjustable_bed/command_scheduler.py
@@ -16,11 +16,13 @@ from collections import deque
 from collections.abc import Awaitable, Callable, Collection
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Final
+from typing import Any, Final
 from uuid import uuid4
 
 ALL_COMMAND_RESOURCES: Final = frozenset({"*"})
+MAX_RECENT_COMMAND_RECORDS: Final = 20
 
 
 class CommandKind(StrEnum):
@@ -29,13 +31,7 @@ class CommandKind(StrEnum):
     COMMAND = "command"
     SEEK = "seek"
     GROUP = "group"
-
-
-class IntentLifetime(StrEnum):
-    """How long an admitted command remains valid."""
-
-    ONE_SHOT = "one_shot"
-    HELD = "held"
+    STOP = "stop"
 
 
 class CommandState(StrEnum):
@@ -44,7 +40,6 @@ class CommandState(StrEnum):
     QUEUED = "queued"
     PREPARED = "prepared"
     ACTIVE = "active"
-    CLEANING = "cleaning"
     COMPLETED = "completed"
     CANCELLED = "cancelled"
     FAILED = "failed"
@@ -59,6 +54,7 @@ class CommandOutcome(StrEnum):
     CALLER_CANCELLED = "caller_cancelled"
     GROUP_ABORTED = "group_aborted"
     SHUTDOWN = "shutdown"
+    TIMEOUT = "timeout"
     FAILED = "failed"
 
 
@@ -74,11 +70,11 @@ class CommandContext:
     cancel_event: asyncio.Event
     admitted_stop_epoch: int
     intent_id: str
+    kind: CommandKind
     group_id: str | None
     resources: frozenset[str]
     pulse_count: int | None = None
     pulse_delay_ms: int | None = None
-    hold_owner: str | None = None
     cancel_reason: CommandOutcome | None = None
     active: bool = True
     defer_disconnect: bool = False
@@ -94,14 +90,49 @@ class CommandIntent:
     operation: CommandOperation
     resources: frozenset[str] = ALL_COMMAND_RESOURCES
     kind: CommandKind = CommandKind.COMMAND
-    lifetime: IntentLifetime = IntentLifetime.ONE_SHOT
     replacement_key: str | None = None
     cancel_running: bool = True
     group_id: str | None = None
     pulse_count: int | None = None
     pulse_delay_ms: int | None = None
-    hold_owner: str | None = None
     intent_id: str = field(default_factory=lambda: uuid4().hex)
+
+
+@dataclass(frozen=True, slots=True)
+class CommandRecord:
+    """Immutable terminal snapshot of one admitted command."""
+
+    intent_id: str
+    kind: CommandKind
+    group_id: str | None
+    resources: tuple[str, ...]
+    scheduler_strategy: str
+    stop_epoch: int
+    invalidated_stop_epoch: int | None
+    admitted_at: datetime
+    started_at: datetime | None
+    finished_at: datetime
+    outcome: CommandOutcome
+    queue_wait_seconds: float
+    active_duration_seconds: float | None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the shared JSON shape used by diagnostics and support bundles."""
+        return {
+            "intent_id": self.intent_id,
+            "kind": self.kind.value,
+            "group_id": self.group_id,
+            "resources": list(self.resources),
+            "scheduler_strategy": self.scheduler_strategy,
+            "stop_epoch": self.stop_epoch,
+            "invalidated_stop_epoch": self.invalidated_stop_epoch,
+            "admitted_at": self.admitted_at.isoformat(),
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "finished_at": self.finished_at.isoformat(),
+            "outcome": self.outcome.value,
+            "queue_wait_seconds": self.queue_wait_seconds,
+            "active_duration_seconds": self.active_duration_seconds,
+        }
 
 
 @dataclass(slots=True)
@@ -114,9 +145,13 @@ class CommandHandle:
     prepared: bool
     state: CommandState = CommandState.QUEUED
     outcome: CommandOutcome | None = None
-    admitted_at: float = field(default_factory=time.monotonic)
-    started_at: float | None = None
-    finished_at: float | None = None
+    admitted_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    admitted_monotonic: float = field(default_factory=time.monotonic)
+    started_at: datetime | None = None
+    started_monotonic: float | None = None
+    finished_at: datetime | None = None
+    finished_monotonic: float | None = None
+    invalidated_stop_epoch: int | None = None
     ready: asyncio.Event = field(default_factory=asyncio.Event)
     commit: asyncio.Event = field(default_factory=asyncio.Event)
 
@@ -165,6 +200,10 @@ class DeviceCommandScheduler:
         self._lock = asyncio.Lock()
         self._queue: deque[CommandHandle] = deque()
         self._active: CommandHandle | None = None
+        self._active_stops: dict[str, CommandHandle] = {}
+        self._recent_records: deque[CommandRecord] = deque(
+            maxlen=MAX_RECENT_COMMAND_RECORDS
+        )
         self._worker: asyncio.Task[None] | None = None
         self._stop_epoch = 0
         self._stop_barrier = asyncio.Event()
@@ -186,20 +225,57 @@ class DeviceCommandScheduler:
         return self._stop_epoch
 
     @property
+    def recent_records(self) -> tuple[CommandRecord, ...]:
+        """Return the bounded immutable terminal history."""
+        return tuple(self._recent_records)
+
+    @property
     def diagnostics(self) -> dict[str, object]:
         """Return a bounded snapshot suitable for integration diagnostics."""
-        active = self._active
+        active_handles = [*self._active_stops.values()]
+        if self._active is not None:
+            active_handles.append(self._active)
+        active = active_handles[0] if active_handles else None
         return {
             "strategy": self.strategy_name,
             "stop_epoch": self._stop_epoch,
             "queue_depth": len(self._queue),
             "active_intent_id": active.intent.intent_id if active else None,
+            "active_kind": active.intent.kind.value if active else None,
             "active_group_id": active.intent.group_id if active else None,
             "active_resources": sorted(active.intent.resources) if active else [],
             "active_state": active.state if active else None,
             "active_age_seconds": (
-                round(time.monotonic() - active.started_at, 3)
-                if active is not None and active.started_at is not None
+                round(time.monotonic() - active.started_monotonic, 3)
+                if active is not None and active.started_monotonic is not None
+                else None
+            ),
+            "active_intents": [
+                self._active_diagnostics(handle) for handle in active_handles
+            ],
+            "recent_records": [record.as_dict() for record in self._recent_records],
+        }
+
+    def _active_diagnostics(self, handle: CommandHandle) -> dict[str, object]:
+        now = time.monotonic()
+        return {
+            "intent_id": handle.intent.intent_id,
+            "kind": handle.intent.kind.value,
+            "group_id": handle.intent.group_id,
+            "resources": sorted(handle.intent.resources),
+            "scheduler_strategy": self.strategy_name,
+            "stop_epoch": handle.context.admitted_stop_epoch,
+            "state": handle.state.value,
+            "admitted_at": handle.admitted_at.isoformat(),
+            "started_at": (
+                handle.started_at.isoformat() if handle.started_at is not None else None
+            ),
+            "queue_wait_seconds": round(
+                (handle.started_monotonic or now) - handle.admitted_monotonic, 3
+            ),
+            "active_duration_seconds": (
+                round(now - handle.started_monotonic, 3)
+                if handle.started_monotonic is not None
                 else None
             ),
         }
@@ -215,26 +291,7 @@ class DeviceCommandScheduler:
 
     async def enqueue(self, intent: CommandIntent, *, prepared: bool = False) -> CommandHandle:
         """Admit an intent and return its handle without waiting for execution."""
-        loop = asyncio.get_running_loop()
-        context = CommandContext(
-            scheduler_token=self._token,
-            cancel_event=asyncio.Event(),
-            admitted_stop_epoch=self._stop_epoch,
-            intent_id=intent.intent_id,
-            group_id=intent.group_id,
-            resources=intent.resources,
-            pulse_count=intent.pulse_count,
-            pulse_delay_ms=intent.pulse_delay_ms,
-            hold_owner=intent.hold_owner,
-        )
-        handle = CommandHandle(
-            intent=intent,
-            context=context,
-            future=loop.create_future(),
-            prepared=prepared,
-        )
-        if not prepared:
-            handle.commit.set()
+        handle = self._new_handle(intent, prepared=prepared)
 
         async with self._lock:
             if self._closed:
@@ -254,6 +311,94 @@ class DeviceCommandScheduler:
                 self._worker = asyncio.create_task(
                     self._run(), name=f"adjustable_bed_commands_{self._name}"
                 )
+        return handle
+
+    def admit_stop(
+        self,
+        operation: CommandOperation,
+        resources: Collection[str] = ALL_COMMAND_RESOURCES,
+        *,
+        group_id: str | None = None,
+    ) -> CommandHandle:
+        """Invalidate matching work and synchronously admit a safety STOP."""
+        if self._closed:
+            raise RuntimeError(f"Command scheduler for {self._name} is shut down")
+        normalized_resources = command_resources(*resources)
+        stop_epoch = self.request_stop(normalized_resources)
+        handle = self._new_handle(
+            CommandIntent(
+                operation,
+                resources=normalized_resources,
+                kind=CommandKind.STOP,
+                cancel_running=False,
+                group_id=group_id,
+            ),
+            prepared=False,
+            admitted_stop_epoch=stop_epoch,
+        )
+        self._active_stops[handle.intent.intent_id] = handle
+        return handle
+
+    async def execute_admitted_stop(self, handle: CommandHandle) -> None:
+        """Execute a synchronously admitted STOP outside the ordinary queue."""
+        self._mark_started(handle)
+        token: Token[CommandContext | None] = _CURRENT_COMMAND_CONTEXT.set(handle.context)
+        try:
+            await handle.intent.operation(handle.context)
+        except asyncio.CancelledError:
+            outcome = (
+                CommandOutcome.SHUTDOWN
+                if self._closed
+                else CommandOutcome.CALLER_CANCELLED
+            )
+            self._finish(handle, outcome)
+            raise
+        except TimeoutError as err:
+            self._finish(handle, CommandOutcome.TIMEOUT, error=err)
+            handle.future.exception()
+            raise
+        except Exception as err:
+            self._finish(handle, CommandOutcome.FAILED, error=err)
+            handle.future.exception()
+            raise
+        else:
+            self._finish(handle, CommandOutcome.COMPLETED)
+        finally:
+            _CURRENT_COMMAND_CONTEXT.reset(token)
+            self._active_stops.pop(handle.intent.intent_id, None)
+            self.finish_stop(handle.context.admitted_stop_epoch)
+
+    def _new_handle(
+        self,
+        intent: CommandIntent,
+        *,
+        prepared: bool,
+        admitted_stop_epoch: int | None = None,
+    ) -> CommandHandle:
+        loop = asyncio.get_running_loop()
+        context = CommandContext(
+            scheduler_token=self._token,
+            cancel_event=asyncio.Event(),
+            admitted_stop_epoch=(
+                self._stop_epoch
+                if admitted_stop_epoch is None
+                else admitted_stop_epoch
+            ),
+            intent_id=intent.intent_id,
+            kind=intent.kind,
+            group_id=intent.group_id,
+            resources=intent.resources,
+            pulse_count=intent.pulse_count,
+            pulse_delay_ms=intent.pulse_delay_ms,
+        )
+        handle = CommandHandle(
+            intent=intent,
+            context=context,
+            future=loop.create_future(),
+            prepared=prepared,
+        )
+        if not prepared:
+            handle.commit.set()
         return handle
 
     async def wait_ready(self, handle: CommandHandle) -> None:
@@ -306,13 +451,25 @@ class DeviceCommandScheduler:
         outcome: CommandOutcome = CommandOutcome.REPLACED,
     ) -> None:
         """Synchronously invalidate matching active and queued commands."""
-        self._cancel_matching(resources, outcome=outcome)
+        self._cancel_matching(
+            resources,
+            outcome=outcome,
+            invalidated_stop_epoch=(
+                self._stop_epoch
+                if outcome in {CommandOutcome.STOPPED, CommandOutcome.SHUTDOWN}
+                else None
+            ),
+        )
 
     def request_stop(self, resources: Collection[str] = ALL_COMMAND_RESOURCES) -> int:
         """Invalidate matching work and advance the monotonic STOP epoch."""
         self._stop_barrier.clear()
         self._stop_epoch += 1
-        self._cancel_matching(resources, outcome=CommandOutcome.STOPPED)
+        self._cancel_matching(
+            resources,
+            outcome=CommandOutcome.STOPPED,
+            invalidated_stop_epoch=self._stop_epoch,
+        )
         return self._stop_epoch
 
     def finish_stop(self, stop_epoch: int) -> None:
@@ -325,7 +482,11 @@ class DeviceCommandScheduler:
         self._closed = True
         self._stop_barrier.set()
         self._stop_epoch += 1
-        self._cancel_matching(ALL_COMMAND_RESOURCES, outcome=CommandOutcome.SHUTDOWN)
+        self._cancel_matching(
+            ALL_COMMAND_RESOURCES,
+            outcome=CommandOutcome.SHUTDOWN,
+            invalidated_stop_epoch=self._stop_epoch,
+        )
         worker = self._worker
         if worker is not None and not worker.done():
             worker.cancel()
@@ -365,18 +526,24 @@ class DeviceCommandScheduler:
         resources: Collection[str],
         *,
         outcome: CommandOutcome,
+        invalidated_stop_epoch: int | None = None,
     ) -> None:
         active = self._active
         if active is not None and _resources_overlap(active.intent.resources, resources):
             active.context.cancel_reason = outcome
             active.context.cancel_event.set()
+            active.invalidated_stop_epoch = invalidated_stop_epoch
         for queued in tuple(self._queue):
             if not _resources_overlap(queued.intent.resources, resources):
                 continue
             self._queue.remove(queued)
             queued.context.cancel_reason = outcome
             queued.context.cancel_event.set()
-            self._finish_locked(queued, outcome)
+            self._finish_locked(
+                queued,
+                outcome,
+                invalidated_stop_epoch=invalidated_stop_epoch,
+            )
 
     async def _run(self) -> None:
         try:
@@ -433,8 +600,7 @@ class DeviceCommandScheduler:
                             self._active = None
                     continue
 
-                handle.state = CommandState.ACTIVE
-                handle.started_at = time.monotonic()
+                self._mark_started(handle)
                 token: Token[CommandContext | None] = _CURRENT_COMMAND_CONTEXT.set(handle.context)
                 try:
                     await handle.intent.operation(handle.context)
@@ -460,14 +626,10 @@ class DeviceCommandScheduler:
                     # scheduler worker task itself was externally cancelled.
                     if worker_cancelled:
                         raise
+                except TimeoutError as err:
+                    self._finish(handle, CommandOutcome.TIMEOUT, error=err)
                 except Exception as err:
-                    handle.state = CommandState.FAILED
-                    handle.outcome = CommandOutcome.FAILED
-                    handle.finished_at = time.monotonic()
-                    handle.context.active = False
-                    handle.ready.set()
-                    if not handle.future.done():
-                        handle.future.set_exception(err)
+                    self._finish(handle, CommandOutcome.FAILED, error=err)
                 else:
                     outcome = CommandOutcome.COMPLETED
                     if handle.context.cancel_event.is_set():
@@ -504,19 +666,81 @@ class DeviceCommandScheduler:
                     task.cancel()
             await asyncio.gather(commit_task, cancel_task, return_exceptions=True)
 
-    def _finish(self, handle: CommandHandle, outcome: CommandOutcome) -> None:
-        self._finish_locked(handle, outcome)
+    def _finish(
+        self,
+        handle: CommandHandle,
+        outcome: CommandOutcome,
+        *,
+        error: BaseException | None = None,
+        invalidated_stop_epoch: int | None = None,
+    ) -> None:
+        self._finish_locked(
+            handle,
+            outcome,
+            error=error,
+            invalidated_stop_epoch=invalidated_stop_epoch,
+        )
 
-    @staticmethod
-    def _finish_locked(handle: CommandHandle, outcome: CommandOutcome) -> None:
+    def _mark_started(self, handle: CommandHandle) -> None:
+        handle.state = CommandState.ACTIVE
+        handle.started_at = datetime.now(UTC)
+        handle.started_monotonic = time.monotonic()
+
+    def _finish_locked(
+        self,
+        handle: CommandHandle,
+        outcome: CommandOutcome,
+        *,
+        error: BaseException | None = None,
+        invalidated_stop_epoch: int | None = None,
+    ) -> None:
+        if handle.finished_at is not None:
+            return
+        if invalidated_stop_epoch is not None:
+            handle.invalidated_stop_epoch = invalidated_stop_epoch
+        finished_at = datetime.now(UTC)
+        finished_monotonic = time.monotonic()
         handle.context.active = False
         handle.outcome = outcome
-        handle.finished_at = time.monotonic()
+        handle.finished_at = finished_at
+        handle.finished_monotonic = finished_monotonic
         handle.state = (
             CommandState.COMPLETED
             if outcome is CommandOutcome.COMPLETED
-            else CommandState.CANCELLED
+            else (
+                CommandState.FAILED
+                if outcome in {CommandOutcome.FAILED, CommandOutcome.TIMEOUT}
+                else CommandState.CANCELLED
+            )
         )
         handle.ready.set()
+        started_monotonic = handle.started_monotonic
+        queue_finished_monotonic = started_monotonic or finished_monotonic
+        self._recent_records.append(
+            CommandRecord(
+                intent_id=handle.intent.intent_id,
+                kind=handle.intent.kind,
+                group_id=handle.intent.group_id,
+                resources=tuple(sorted(handle.intent.resources)),
+                scheduler_strategy=self.strategy_name,
+                stop_epoch=handle.context.admitted_stop_epoch,
+                invalidated_stop_epoch=handle.invalidated_stop_epoch,
+                admitted_at=handle.admitted_at,
+                started_at=handle.started_at,
+                finished_at=finished_at,
+                outcome=outcome,
+                queue_wait_seconds=round(
+                    queue_finished_monotonic - handle.admitted_monotonic, 3
+                ),
+                active_duration_seconds=(
+                    round(finished_monotonic - started_monotonic, 3)
+                    if started_monotonic is not None
+                    else None
+                ),
+            )
+        )
         if not handle.future.done():
-            handle.future.set_result(None)
+            if error is not None:
+                handle.future.set_exception(error)
+            else:
+                handle.future.set_result(None)

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -13,6 +13,7 @@ from collections import deque
 from collections.abc import AsyncIterator, Awaitable, Callable, Collection, Coroutine, Mapping
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, TypeVar, cast
+from uuid import uuid4
 
 from bleak import BleakClient
 from bleak.backends.device import BLEDevice
@@ -502,9 +503,9 @@ class AdjustableBedCoordinator:
             None  # "idle_timeout", "intentional", "unexpected"
         )
 
-        # Command timing tracking for diagnostics (issue #168)
-        self._last_command_start: datetime | None = None
-        self._last_command_end: datetime | None = None
+        # Protocol-operation timing remains separate from scheduler intent timing.
+        self._last_protocol_operation_start: datetime | None = None
+        self._last_protocol_operation_end: datetime | None = None
         self._active_operation_name: str | None = None
         self._last_notify_received: datetime | None = None
 
@@ -1756,12 +1757,18 @@ class AdjustableBedCoordinator:
     def command_timing(self) -> dict[str, Any]:
         """Return command timing for diagnostics."""
         return {
-            "last_command_start": self._last_command_start.isoformat()
-            if self._last_command_start
-            else None,
-            "last_command_end": self._last_command_end.isoformat()
-            if self._last_command_end
-            else None,
+            "protocol_operation_timing": {
+                "last_started_at": (
+                    self._last_protocol_operation_start.isoformat()
+                    if self._last_protocol_operation_start
+                    else None
+                ),
+                "last_finished_at": (
+                    self._last_protocol_operation_end.isoformat()
+                    if self._last_protocol_operation_end
+                    else None
+                ),
+            },
             "last_notify_received": self._last_notify_received.isoformat()
             if self._last_notify_received
             else None,
@@ -1985,6 +1992,7 @@ class AdjustableBedCoordinator:
                 "command_origin": command_origin,
                 "operation_name": self._active_operation_name,
                 "intent_id": context.intent_id if context is not None else None,
+                "kind": context.kind.value if context is not None else None,
                 "group_id": context.group_id if context is not None else None,
                 "resources": sorted(context.resources) if context is not None else [],
                 "scheduler_strategy": self._command_scheduler.strategy_name,
@@ -4213,8 +4221,16 @@ class AdjustableBedCoordinator:
         # The epoch check prevents a queued command from starting after STOP.
         self._cancel_counter += 1
         self._cancel_command.set()
-        stop_epoch = self._command_scheduler.request_stop(ALL_COMMAND_RESOURCES)
-        stop_task = asyncio.create_task(self._async_send_stop_command())
+
+        async def stop_operation(_context: CommandContext) -> None:
+            await self._async_send_stop_command()
+
+        stop_handle = self._command_scheduler.admit_stop(
+            stop_operation, ALL_COMMAND_RESOURCES
+        )
+        stop_task = asyncio.create_task(
+            self._command_scheduler.execute_admitted_stop(stop_handle)
+        )
 
         try:
             await asyncio.shield(stop_task)
@@ -4226,10 +4242,6 @@ class AdjustableBedCoordinator:
             except Exception:
                 _LOGGER.exception("STOP failed after its caller was cancelled")
             raise
-        finally:
-            # A caller cancellation must never leave the scheduler barrier closed.
-            # Overlapping STOP calls use their epochs so only the newest one releases it.
-            self._command_scheduler.finish_stop(stop_epoch)
 
     async def _async_send_stop_command(self) -> None:
         """Send STOP while owning the legacy wire and connection lifecycle lane."""
@@ -4451,7 +4463,7 @@ class AdjustableBedCoordinator:
                         raise asyncio.CancelledError
                     return None
                 self._active_operation_name = operation_name
-                self._last_command_start = datetime.now(UTC)
+                self._last_protocol_operation_start = datetime.now(UTC)
 
                 poll_stop: asyncio.Event | None = None
                 poll_task: asyncio.Task[None] | None = None
@@ -4477,7 +4489,7 @@ class AdjustableBedCoordinator:
                     else:
                         result = await operation_task
                 finally:
-                    self._last_command_end = datetime.now(UTC)
+                    self._last_protocol_operation_end = datetime.now(UTC)
                     self._active_operation_name = None
                     if poll_stop is not None:
                         poll_stop.set()
@@ -4546,6 +4558,7 @@ class AdjustableBedCoordinator:
         pulse_count: int | None = None,
         pulse_delay_ms: int | None = None,
         group_id: str | None = None,
+        kind: CommandKind = CommandKind.COMMAND,
     ) -> None:
         """Execute an opaque controller command through the device scheduler."""
 
@@ -4565,7 +4578,7 @@ class AdjustableBedCoordinator:
             operation,
             resource=resource,
             resources=resources,
-            kind=CommandKind.COMMAND,
+            kind=kind,
             cancel_running=cancel_running,
             pulse_count=pulse_count,
             pulse_delay_ms=pulse_delay_ms,
@@ -4740,7 +4753,7 @@ class AdjustableBedCoordinator:
             resources=command_resources(*resources),
             kind=CommandKind.GROUP,
             cancel_running=cancel_running,
-            group_id=group_id,
+            group_id=group_id or uuid4().hex,
         )
         await self._command_scheduler.execute(intent)
 
@@ -5430,7 +5443,10 @@ class AdjustableBedCoordinator:
                                 position_key,
                                 POSITION_SEEK_TIMEOUT,
                             )
-                            break
+                            raise TimeoutError(
+                                f"Position seek timed out for {position_key} "
+                                f"after {POSITION_SEEK_TIMEOUT:.0f}s"
+                            )
 
                         # Check for cancellation
                         if cancel_event.is_set():

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -4225,11 +4225,8 @@ class AdjustableBedCoordinator:
         async def stop_operation(_context: CommandContext) -> None:
             await self._async_send_stop_command()
 
-        stop_handle = self._command_scheduler.admit_stop(
+        stop_task = self._command_scheduler.admit_stop(
             stop_operation, ALL_COMMAND_RESOURCES
-        )
-        stop_task = asyncio.create_task(
-            self._command_scheduler.execute_admitted_stop(stop_handle)
         )
 
         try:
@@ -4252,11 +4249,11 @@ class AdjustableBedCoordinator:
             try:
                 if not await self.async_ensure_connected(reset_timer=False):
                     _LOGGER.error("Cannot send stop: not connected to bed")
-                    return
+                    raise ConnectionError("Not connected to bed")
 
                 if self._controller is None:
                     _LOGGER.error("Cannot send stop: no controller available")
-                    return
+                    raise RuntimeError("No controller available")
 
                 try:
                     await self._async_refresh_controller_auth()

--- a/custom_components/adjustable_bed/diagnostics.py
+++ b/custom_components/adjustable_bed/diagnostics.py
@@ -77,6 +77,7 @@ async def _async_paired_diagnostics(
                 else None
             ),
             "position_data": getattr(child, "position_data", None),
+            "command_timing": child.command_timing,
             "config": dict(child.entry.data),
         }
 

--- a/custom_components/adjustable_bed/paired_coordinator.py
+++ b/custom_components/adjustable_bed/paired_coordinator.py
@@ -29,6 +29,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 
 from .command_scheduler import (
     CommandHandle,
+    CommandKind,
     CommandOutcome,
     PreparedCommandInvalidated,
     command_resources,
@@ -1343,6 +1344,7 @@ class SingleAddressSideCoordinator:
             stop,
             cancel_running=False,
             resources=self._scoped_command_resources(),
+            kind=CommandKind.STOP,
         )
 
 

--- a/custom_components/adjustable_bed/support_bundle.py
+++ b/custom_components/adjustable_bed/support_bundle.py
@@ -51,7 +51,7 @@ from .support_report import (
 
 _LOGGER = logging.getLogger(__name__)
 
-_REPORT_VERSION = "2.2"
+_REPORT_VERSION = "2.3"
 _MAX_NEARBY_BLUETOOTH_DEVICES = 30
 _BLUETOOTH_DOMAIN = "bluetooth"
 _ESPHOME_DOMAIN = "esphome"
@@ -83,7 +83,7 @@ async def generate_support_bundle(
     reproduction_command_trace = [
         trace
         for trace in pre_capture_command_trace
-        if trace.get("operation_name") == "command"
+        if trace.get("intent_id") is not None
     ]
 
     diagnostics_report = await BLEDiagnosticRunner(
@@ -163,6 +163,9 @@ async def generate_support_bundle(
         "position_data": position_data,
         "notifications": diagnostics_report.notifications,
         "notification_summary": diagnostics_report.notification_summary,
+        "command_timing": (
+            coordinator.command_timing if coordinator is not None else {}
+        ),
         "command_trace": diagnostics_report.command_trace if coordinator is not None else [],
         "recent_logs": recent_logs,
         "evidence": evidence,

--- a/custom_components/adjustable_bed/support_bundle.py
+++ b/custom_components/adjustable_bed/support_bundle.py
@@ -163,9 +163,7 @@ async def generate_support_bundle(
         "position_data": position_data,
         "notifications": diagnostics_report.notifications,
         "notification_summary": diagnostics_report.notification_summary,
-        "command_timing": (
-            coordinator.command_timing if coordinator is not None else {}
-        ),
+        "command_timing": diagnostics_report.command_timing,
         "command_trace": diagnostics_report.command_trace if coordinator is not None else [],
         "recent_logs": recent_logs,
         "evidence": evidence,

--- a/tests/test_command_scheduler.py
+++ b/tests/test_command_scheduler.py
@@ -8,7 +8,9 @@ import pytest
 
 from custom_components.adjustable_bed.command_scheduler import (
     ALL_COMMAND_RESOURCES,
+    MAX_RECENT_COMMAND_RECORDS,
     CommandIntent,
+    CommandKind,
     CommandOutcome,
     CommandState,
     DeviceCommandScheduler,
@@ -153,6 +155,10 @@ async def test_same_resource_replaces_only_after_active_cleanup() -> None:
     cleanup_release.set()
     await asyncio.gather(first_task, replacement_task)
     assert events == ["first:start", "first:cleanup", "first:done", "replacement"]
+    assert [record.outcome for record in scheduler.recent_records] == [
+        CommandOutcome.REPLACED,
+        CommandOutcome.COMPLETED,
+    ]
 
 
 async def test_ticket_cancelled_error_does_not_shutdown_replacement() -> None:
@@ -223,6 +229,10 @@ async def test_stop_epoch_invalidates_active_and_queued_work() -> None:
     assert active_handle.outcome is CommandOutcome.STOPPED
     assert queued_handle.outcome is CommandOutcome.STOPPED
     assert not queued_ran
+    assert {
+        (record.outcome, record.invalidated_stop_epoch)
+        for record in scheduler.recent_records
+    } == {(CommandOutcome.STOPPED, 1)}
 
 
 async def test_command_admitted_during_stop_waits_for_safety_lane() -> None:
@@ -336,6 +346,9 @@ async def test_caller_cancellation_drops_queued_one_shot() -> None:
     with pytest.raises(asyncio.CancelledError):
         await queued_task
 
+    assert scheduler.recent_records[-1].outcome is CommandOutcome.CALLER_CANCELLED
+    assert scheduler.recent_records[-1].started_at is None
+
     release_first.set()
     await first_task
     assert not queued_ran
@@ -383,3 +396,143 @@ async def test_context_copied_to_background_task_expires_with_command() -> None:
     await asyncio.sleep(0)
 
     assert background_context is None
+
+
+async def test_completed_record_contains_shared_diagnostic_metadata() -> None:
+    scheduler = DeviceCommandScheduler("record")
+
+    async def operation(_context) -> None:
+        await asyncio.sleep(0)
+
+    handle = await scheduler.enqueue(
+        CommandIntent(
+            operation,
+            resources=command_resources("motor:back", "motor:legs"),
+            kind=CommandKind.GROUP,
+            group_id="group-1",
+            intent_id="intent-1",
+        )
+    )
+    await handle.future
+
+    record = scheduler.recent_records[-1]
+    assert record.intent_id == "intent-1"
+    assert record.kind is CommandKind.GROUP
+    assert record.group_id == "group-1"
+    assert record.resources == ("motor:back", "motor:legs")
+    assert record.scheduler_strategy == "serial_opaque"
+    assert record.stop_epoch == 0
+    assert record.invalidated_stop_epoch is None
+    assert record.started_at is not None
+    assert record.admitted_at <= record.started_at <= record.finished_at
+    assert record.outcome is CommandOutcome.COMPLETED
+    assert record.queue_wait_seconds >= 0
+    assert record.active_duration_seconds is not None
+    assert record.active_duration_seconds >= 0
+    recent_diagnostics = scheduler.diagnostics["recent_records"]
+    assert isinstance(recent_diagnostics, list)
+    assert recent_diagnostics[-1] == record.as_dict()
+
+
+async def test_recent_record_history_is_bounded() -> None:
+    scheduler = DeviceCommandScheduler("bounded")
+
+    async def operation(_context) -> None:
+        return
+
+    for index in range(MAX_RECENT_COMMAND_RECORDS + 3):
+        await scheduler.execute(
+            CommandIntent(operation, intent_id=f"intent-{index}")
+        )
+
+    assert len(scheduler.recent_records) == MAX_RECENT_COMMAND_RECORDS
+    assert scheduler.recent_records[0].intent_id == "intent-3"
+
+
+async def test_admitted_stop_records_stop_intent_and_releases_barrier() -> None:
+    scheduler = DeviceCommandScheduler("stop-record")
+    seen_context = None
+
+    async def stop(context) -> None:
+        nonlocal seen_context
+        seen_context = current_command_context()
+        assert seen_context is context
+
+    handle = scheduler.admit_stop(
+        stop,
+        command_resources("motor:back"),
+        group_id="stop-group",
+    )
+    assert not scheduler._stop_barrier.is_set()
+
+    await scheduler.execute_admitted_stop(handle)
+
+    record = scheduler.recent_records[-1]
+    assert record.kind is CommandKind.STOP
+    assert record.group_id == "stop-group"
+    assert record.resources == ("motor:back",)
+    assert record.stop_epoch == 1
+    assert record.outcome is CommandOutcome.COMPLETED
+    assert scheduler._stop_barrier.is_set()
+    assert seen_context is not None
+
+
+@pytest.mark.parametrize(
+    ("error", "outcome"),
+    [
+        (TimeoutError("too slow"), CommandOutcome.TIMEOUT),
+        (RuntimeError("broken"), CommandOutcome.FAILED),
+    ],
+)
+async def test_operation_errors_have_typed_terminal_outcomes(
+    error: Exception,
+    outcome: CommandOutcome,
+) -> None:
+    scheduler = DeviceCommandScheduler("error")
+
+    async def operation(_context) -> None:
+        raise error
+
+    with pytest.raises(type(error), match=str(error)):
+        await scheduler.execute(CommandIntent(operation))
+
+    record = scheduler.recent_records[-1]
+    assert record.outcome is outcome
+    assert record.active_duration_seconds is not None
+
+
+async def test_prepared_group_abort_has_terminal_record() -> None:
+    scheduler = DeviceCommandScheduler("group-abort")
+
+    async def operation(_context) -> None:
+        pytest.fail("aborted prepared operation must not run")
+
+    handle = await scheduler.enqueue(
+        CommandIntent(operation, kind=CommandKind.GROUP, group_id="group-abort"),
+        prepared=True,
+    )
+    await scheduler.wait_ready(handle)
+    await scheduler.cancel(handle, CommandOutcome.GROUP_ABORTED)
+
+    record = scheduler.recent_records[-1]
+    assert record.outcome is CommandOutcome.GROUP_ABORTED
+    assert record.group_id == "group-abort"
+    assert record.started_at is None
+
+
+async def test_shutdown_records_active_intent_outcome() -> None:
+    scheduler = DeviceCommandScheduler("shutdown")
+    started = asyncio.Event()
+
+    async def operation(_context) -> None:
+        started.set()
+        await asyncio.Future()
+
+    task = asyncio.create_task(scheduler.execute(CommandIntent(operation)))
+    await started.wait()
+    await scheduler.async_shutdown()
+    await task
+
+    record = scheduler.recent_records[-1]
+    assert record.outcome is CommandOutcome.SHUTDOWN
+    assert record.invalidated_stop_epoch == 1

--- a/tests/test_command_scheduler.py
+++ b/tests/test_command_scheduler.py
@@ -458,14 +458,14 @@ async def test_admitted_stop_records_stop_intent_and_releases_barrier() -> None:
         seen_context = current_command_context()
         assert seen_context is context
 
-    handle = scheduler.admit_stop(
+    stop_task = scheduler.admit_stop(
         stop,
         command_resources("motor:back"),
         group_id="stop-group",
     )
     assert not scheduler._stop_barrier.is_set()
 
-    await scheduler.execute_admitted_stop(handle)
+    await stop_task
 
     record = scheduler.recent_records[-1]
     assert record.kind is CommandKind.STOP
@@ -475,6 +475,31 @@ async def test_admitted_stop_records_stop_intent_and_releases_barrier() -> None:
     assert record.outcome is CommandOutcome.COMPLETED
     assert scheduler._stop_barrier.is_set()
     assert seen_context is not None
+
+
+async def test_shutdown_drains_stop_admitted_before_its_task_starts() -> None:
+    scheduler = DeviceCommandScheduler("stop-shutdown")
+    stop_started = asyncio.Event()
+    release_stop = asyncio.Event()
+
+    async def stop(_context) -> None:
+        assert scheduler._closed
+        stop_started.set()
+        await release_stop.wait()
+
+    stop_task = scheduler.admit_stop(stop)
+
+    async def release_after_start() -> None:
+        await stop_started.wait()
+        assert not stop_task.done()
+        release_stop.set()
+
+    release_task = asyncio.create_task(release_after_start())
+    await scheduler.async_shutdown()
+    await release_task
+
+    assert stop_task.done()
+    assert scheduler.recent_records[-1].outcome is CommandOutcome.COMPLETED
 
 
 @pytest.mark.parametrize(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -5295,6 +5295,43 @@ class TestStopAfterCancel:
             await stop_task
         assert coordinator._command_scheduler._stop_barrier.is_set()
 
+    async def test_shutdown_waits_for_admitted_stop_before_disconnect(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+    ) -> None:
+        """Coordinator teardown must drain an accepted STOP before disconnecting."""
+        coordinator = AdjustableBedCoordinator(hass, mock_config_entry)
+        stop_started = asyncio.Event()
+        release_stop = asyncio.Event()
+
+        async def blocking_stop() -> None:
+            stop_started.set()
+            await release_stop.wait()
+
+        with (
+            patch.object(
+                coordinator,
+                "_async_send_stop_command",
+                new=AsyncMock(side_effect=blocking_stop),
+            ),
+            patch.object(
+                coordinator,
+                "async_disconnect",
+                new=AsyncMock(),
+            ) as mock_disconnect,
+        ):
+            stop_task = asyncio.create_task(coordinator.async_stop_command())
+            await stop_started.wait()
+            shutdown_task = asyncio.create_task(coordinator.async_shutdown())
+            await asyncio.sleep(0)
+
+            mock_disconnect.assert_not_awaited()
+            release_stop.set()
+            await asyncio.gather(stop_task, shutdown_task)
+
+        mock_disconnect.assert_awaited_once_with()
+
     async def test_stop_command_when_not_connected(
         self,
         hass: HomeAssistant,
@@ -5302,7 +5339,7 @@ class TestStopAfterCancel:
         mock_coordinator_connected,
         mock_bleak_client: MagicMock,
     ):
-        """Test stop_command handles not connected state gracefully."""
+        """An unsent STOP should fail instead of being recorded as completed."""
         coordinator = AdjustableBedCoordinator(hass, mock_config_entry)
         await coordinator.async_connect()
 
@@ -5310,8 +5347,19 @@ class TestStopAfterCancel:
         # This prevents async_ensure_connected from trying to reconnect
         coordinator._client = None
 
-        # Should not raise, just log error
-        await coordinator.async_stop_command()
+        with (
+            patch.object(
+                coordinator,
+                "async_ensure_connected",
+                new=AsyncMock(return_value=False),
+            ),
+            pytest.raises(ConnectionError, match="Not connected to bed"),
+        ):
+            await coordinator.async_stop_command()
+
+        record = coordinator._command_scheduler.recent_records[-1]
+        assert record.kind is CommandKind.STOP
+        assert record.outcome is CommandOutcome.FAILED
 
     async def test_execute_controller_command_cancels_running(
         self,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -17,7 +17,11 @@ from custom_components.adjustable_bed.bluetooth_transport import (
     ConnectionPath,
     TransportClass,
 )
-from custom_components.adjustable_bed.command_scheduler import current_command_context
+from custom_components.adjustable_bed.command_scheduler import (
+    CommandKind,
+    CommandOutcome,
+    current_command_context,
+)
 from custom_components.adjustable_bed.const import (
     BED_MOTOR_PULSE_DEFAULTS,
     BED_TYPE_BEDTECH,
@@ -1748,6 +1752,50 @@ class TestCoordinatorPositionSeek:
         move_up.assert_not_awaited()
         move_down.assert_not_awaited()
         move_stop.assert_not_awaited()
+
+    async def test_seek_timeout_records_outcome_after_motor_cleanup(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+    ) -> None:
+        """A feedback timeout should be terminal only after protocol cleanup."""
+        coordinator = AdjustableBedCoordinator(hass, mock_config_entry)
+        coordinator._client = MagicMock()
+        coordinator._client.is_connected = True
+        coordinator._position_data["legs"] = 0.0
+
+        controller = make_controller_mock()
+        controller.supports_direct_position_control = False
+        controller.reverses_position_seek_on_overshoot = False
+        controller.uses_custom_position_seek_steps = False
+        controller.auto_stops_on_idle = False
+        coordinator._controller = controller
+
+        move_up = AsyncMock()
+        move_down = AsyncMock()
+        move_stop = AsyncMock()
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.coordinator.POSITION_SEEK_TIMEOUT",
+                0,
+            ),
+            pytest.raises(TimeoutError, match="Position seek timed out"),
+        ):
+            await coordinator.async_seek_position(
+                "legs",
+                20.0,
+                lambda c: move_up(c),
+                lambda c: move_down(c),
+                lambda c: move_stop(c),
+            )
+
+        move_up.assert_awaited_once_with(controller)
+        move_down.assert_not_awaited()
+        move_stop.assert_awaited_once_with(controller)
+        record = coordinator._command_scheduler.recent_records[-1]
+        assert record.kind is CommandKind.SEEK
+        assert record.outcome is CommandOutcome.TIMEOUT
 
     async def test_connect_uses_persisted_bond_marker_to_skip_pairing(
         self,
@@ -5181,7 +5229,11 @@ class TestStopAfterCancel:
         del mock_bleak_client
         coordinator = AdjustableBedCoordinator(hass, mock_config_entry)
         await coordinator.async_connect()
-        coordinator._controller.stop_all = AsyncMock()
+
+        async def send_stop() -> None:
+            await coordinator._controller.write_command(b"\x00")
+
+        coordinator._controller.stop_all = AsyncMock(side_effect=send_stop)
 
         command_started = asyncio.Event()
 
@@ -5202,6 +5254,16 @@ class TestStopAfterCancel:
         await command_task
 
         coordinator._controller.stop_all.assert_awaited_once()
+        command_record, stop_record = coordinator._command_scheduler.recent_records[-2:]
+        assert command_record.outcome is CommandOutcome.STOPPED
+        assert command_record.kind is CommandKind.COMMAND
+        assert stop_record.outcome is CommandOutcome.COMPLETED
+        assert stop_record.kind is CommandKind.STOP
+        assert stop_record.stop_epoch == command_record.invalidated_stop_epoch
+        stop_trace = coordinator.command_trace[-1]
+        assert stop_trace["kind"] == "stop"
+        assert stop_trace["intent_id"] == stop_record.intent_id
+        assert stop_trace["stop_epoch"] == stop_record.stop_epoch
 
     async def test_stop_command_settles_after_caller_cancellation(
         self,
@@ -5426,6 +5488,10 @@ class TestStopAfterCancel:
         release_first.set()
         await asyncio.gather(group_task, other_task)
         assert events == ["group:first", "group:second", "other"]
+        group_record = coordinator._command_scheduler.recent_records[-2]
+        assert group_record.kind is CommandKind.GROUP
+        assert group_record.group_id is not None
+        assert group_record.resources == ("motor:back", "motor:legs")
 
     async def test_command_group_keeps_connection_until_final_member(
         self,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -217,6 +217,41 @@ class TestDiagnosticsOutput:
         assert controller_info["class"] == "LinakController"
         assert "characteristic_uuid" in controller_info
 
+    async def test_diagnostics_include_scheduler_terminal_records(
+        self,
+        hass: HomeAssistant,
+        mock_diagnostics_config_entry,
+        mock_coordinator_connected,  # noqa: ARG002
+        enable_custom_integrations,  # noqa: ARG002
+    ):
+        """Command diagnostics should come from scheduler admission."""
+        from custom_components.adjustable_bed.coordinator import AdjustableBedCoordinator
+
+        coordinator = AdjustableBedCoordinator(hass, mock_diagnostics_config_entry)
+        await coordinator.async_connect()
+
+        async def command(_controller) -> None:
+            return
+
+        await coordinator.async_execute_controller_command(
+            command,
+            resource="motor:back",
+        )
+        hass.data.setdefault(DOMAIN, {})
+        hass.data[DOMAIN][mock_diagnostics_config_entry.entry_id] = coordinator
+
+        result = await async_get_config_entry_diagnostics(
+            hass, mock_diagnostics_config_entry
+        )
+
+        timing = result["coordinator"]["command_timing"]
+        assert "last_command_start" not in timing
+        assert timing["protocol_operation_timing"]["last_started_at"]
+        record = timing["scheduler"]["recent_records"][-1]
+        assert record["kind"] == "command"
+        assert record["resources"] == ["motor:back"]
+        assert record["outcome"] == "completed"
+
     async def test_diagnostics_uses_non_connectable_advertisement_fallback(
         self,
         hass: HomeAssistant,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1362,6 +1362,10 @@ class TestServices:
         assert {tuple(item["resources"]) for item in coordinator.command_trace} == {
             ("motor:back",)
         }
+        timed_move_record = coordinator._command_scheduler.recent_records[-1]
+        assert timed_move_record.kind.value == "command"
+        assert timed_move_record.resources == ("motor:back",)
+        assert timed_move_record.outcome.value == "completed"
 
     async def test_timed_move_service_accepts_okin_rf_eco_bt_stair(
         self,
@@ -1602,6 +1606,14 @@ class TestServices:
         )
 
         assert coordinator.async_seek_position.await_count == 4
+        position_records = coordinator._command_scheduler.recent_records[-3:]
+        assert [record.kind.value for record in position_records] == [
+            "group",
+            "group",
+            "group",
+        ]
+        assert all(record.group_id is not None for record in position_records)
+        assert position_records[-1].resources == ("motor:feet", "motor:head")
 
         coordinator.async_seek_position.reset_mock()
         with pytest.raises(ServiceValidationError, match="out of range"):

--- a/tests/test_paired_coordinator.py
+++ b/tests/test_paired_coordinator.py
@@ -24,6 +24,7 @@ from custom_components.adjustable_bed.command_scheduler import (
     CommandContext,
     CommandHandle,
     CommandIntent,
+    CommandKind,
     CommandOutcome,
     DeviceCommandScheduler,
     command_resources,
@@ -201,6 +202,7 @@ class ScheduledRecordingChild(RecordingChild):
             CommandIntent(
                 scheduled,
                 resources=command_scope,
+                kind=CommandKind.GROUP,
                 replacement_key=(resource or "*") if resources is None else None,
                 cancel_running=cancel_running,
                 group_id=group_id,
@@ -629,6 +631,14 @@ class TestSideRouting:
 
         assert left.prepared_scopes == [frozenset(resources)]
         assert right.prepared_scopes == [frozenset(resources)]
+        left_record = left.scheduler.recent_records[-1]
+        right_record = right.scheduler.recent_records[-1]
+        assert left_record.kind is CommandKind.GROUP
+        assert right_record.kind is CommandKind.GROUP
+        assert left_record.group_id == right_record.group_id
+        assert left_record.group_id is not None
+        assert left_record.resources == ("motor:back", "motor:legs")
+        assert right_record.resources == ("motor:back", "motor:legs")
 
     async def test_linked_group_replacement_is_normal_cancellation(self):
         log: list[tuple[str, str]] = []

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -1262,7 +1262,7 @@ class TestSupportBundle:
             )
 
         assert report["target"]["mode"] == "target_address"
-        assert report["metadata"]["report_version"] == "2.2"
+        assert report["metadata"]["report_version"] == "2.3"
         assert report["integration"]["configured_device"] is False
         assert report["integration"]["kaidi_product_id"] is None
         assert report["integration"]["kaidi_sofa_acu_no"] is None
@@ -1412,7 +1412,7 @@ class TestSupportBundle:
             )
 
         pairing = report["pairing"]
-        assert report["metadata"]["report_version"] == "2.2"
+        assert report["metadata"]["report_version"] == "2.3"
         assert pairing["required"] is True
         assert pairing["connection_gated_by_bond"] is True
         assert pairing["persisted_bond_marker"] is True
@@ -1633,7 +1633,25 @@ class TestSupportBundle:
             await active_controller.write_command(b"\x03\x04")
 
         await coordinator.async_execute_controller_command(_user_command)
-        assert coordinator.command_trace[-1]["operation_name"] == "command"
+        scheduled_trace = coordinator.command_trace[-1]
+        terminal_record = coordinator._command_scheduler.recent_records[-1].as_dict()
+        assert scheduled_trace["operation_name"] == "command"
+        for key in (
+            "intent_id",
+            "kind",
+            "group_id",
+            "resources",
+            "scheduler_strategy",
+            "stop_epoch",
+        ):
+            assert scheduled_trace[key] == terminal_record[key]
+
+        command_timing = coordinator.command_timing
+        assert "last_command_start" not in command_timing
+        assert "last_command_end" not in command_timing
+        assert command_timing["protocol_operation_timing"]["last_started_at"]
+        assert command_timing["protocol_operation_timing"]["last_finished_at"]
+        assert command_timing["scheduler"]["recent_records"][-1] == terminal_record
 
 
 class TestSupportBundleLoggingWarning:

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -1147,6 +1147,60 @@ class TestBleDiagnosticsRunner:
 class TestSupportBundle:
     """Test support bundle orchestration."""
 
+    async def test_command_timing_uses_same_diagnostic_snapshot_as_trace(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        enable_custom_integrations,
+    ) -> None:
+        """Bundle timing and trace should come from one diagnostic snapshot."""
+        del enable_custom_integrations
+        captured_timing = {
+            "scheduler": {"recent_records": [{"intent_id": "captured"}]}
+        }
+        diagnostic_report = DiagnosticReport(
+            metadata={"version": "2.0"},
+            device={"address": mock_config_entry.data[CONF_ADDRESS]},
+            advertisement={},
+            advertisements_by_source=[],
+            detection={"bed_type": "linak", "supported_match": True},
+            gatt_services=[],
+            gatt_summary={"available": False, "service_count": 0},
+            device_information={},
+            notifications=[],
+            notification_summary={"total_notifications": 0},
+            adapter_details={},
+            connection_history={},
+            connection_attempt_details=[],
+            command_trace=[{"intent_id": "captured"}],
+            command_timing=captured_timing,
+            errors=[],
+        )
+        coordinator = AdjustableBedCoordinator(hass, mock_config_entry)
+
+        with (
+            patch.object(
+                BLEDiagnosticRunner,
+                "run_diagnostics",
+                new=AsyncMock(return_value=diagnostic_report),
+            ),
+            patch(
+                "custom_components.adjustable_bed.support_bundle.bluetooth.async_current_scanners",
+                return_value=[],
+            ),
+        ):
+            report = await generate_support_bundle(
+                hass,
+                address=mock_config_entry.data[CONF_ADDRESS],
+                capture_duration=0,
+                include_logs=False,
+                coordinator=coordinator,
+                entry=mock_config_entry,
+            )
+
+        assert report["command_timing"] == captured_timing
+        assert report["command_trace"] == diagnostic_report.command_trace
+
     async def test_nearby_device_inventory_ranks_deduplicates_and_caps(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
Scheduled position seeks and grouped commands were not represented accurately by the existing command timing diagnostics, and terminal outcomes disappeared after callers returned.

This adds bounded immutable scheduler records for intent timing and outcomes, carries shared scheduler metadata into command traces and support bundles, records STOP operations, and separates protocol-operation timing from whole-intent timing.

Validation:
- 3,480 tests passed
- Ruff
- Pyright
- Local review preflight, 0 findings

Ref #520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed command timing and recent command history to diagnostics and support bundles.
  * Diagnostics now include command outcomes, resources, groups, timestamps, and protocol-operation timing.
  * Added explicit timeout reporting for position-seeking operations.
  * Stop commands are handled more immediately and reliably.

* **Bug Fixes**
  * Improved cancellation, stop handling, timeout processing, and command completion tracking.
  * Support bundle command traces now provide more complete operation details.

* **Tests**
  * Expanded coverage for command history, diagnostics, grouped operations, cancellations, timeouts, and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->