### PR TITLE
fix: support RF ECO BT bed receivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The names below refer to motor/actuator manufacturers. Your bed might use one of
 | ✅ [Solace](docs/beds/solace.md) | Solace, Sealy, Woosa Sleep, QMS |
 | ✅ [Leggett & Platt](docs/beds/leggett-platt.md) | Leggett & Platt, Prodigy Comfort Elite / Prodigy CE |
 | ✅ [Reverie](docs/beds/reverie.md) | Reverie |
-| ✅ [Okimat/Okin](docs/beds/okimat.md) | Lucid (including some Smartbed/L600 bases), CVB, Smartbed |
+| ✅ [Okimat/Okin](docs/beds/okimat.md) | Lucid (including some Smartbed/L600 bases), CVB, Smartbed, RF ECO BT 88802 bed receivers |
 | ✅ [Okin 64-Bit](docs/beds/okin-64bit.md) | NORA_CON / NORACON Mattress Firm controllers |
 | ✅ [Jiecang](docs/beds/jiecang.md) | Glideaway, Dream Motion, LOGICDATA |
 | ✅ [Kaidi](docs/beds/kaidi.md) | Rize Remedy III / newer Mouselet-based Rize beds, Floyd Home, ISleep |

--- a/custom_components/adjustable_bed/ble_diagnostics.py
+++ b/custom_components/adjustable_bed/ble_diagnostics.py
@@ -30,6 +30,7 @@ from .const import (
     BED_TYPE_OKIN_CST,
     BED_TYPE_OKIN_RF_ECO_BT,
     CONF_PREFERRED_ADAPTER,
+    CONF_PROTOCOL_VARIANT,
     DEVICE_INFO_CHARS,
     DEVICE_INFO_SERVICE_UUID,
     DOMAIN,
@@ -960,6 +961,11 @@ class BLEDiagnosticRunner:
             configured_bed_type = (
                 self.coordinator.bed_type if self.coordinator is not None else None
             )
+            configured_protocol_variant = (
+                self.coordinator.entry.data.get(CONF_PROTOCOL_VARIANT)
+                if self.coordinator is not None
+                else None
+            )
             refinement_seed = gatt_detection.bed_type
             if (
                 gatt_detection.bed_type
@@ -975,12 +981,14 @@ class BLEDiagnosticRunner:
                 bed_type_without_model = refine_okin_shared_uuid_protocol_from_gatt(
                     refinement_seed,
                     gatt_services,
+                    protocol_variant=configured_protocol_variant,
                     device_name=observed_device_name or getattr(service_info, "name", None),
                     _log_correction=False,
                 )
             bed_type = refine_okin_shared_uuid_protocol_from_gatt(
                 refinement_seed,
                 gatt_services,
+                protocol_variant=configured_protocol_variant,
                 ble_model=model_number,
                 device_name=observed_device_name or getattr(service_info, "name", None),
             )

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -2242,6 +2242,7 @@ def get_motor_pulse_defaults(
     detection_signals: list[str] | None = None,
 ) -> tuple[int, int]:
     """Return motor pulse defaults for a bed type and protocol variant."""
+    default = (DEFAULT_MOTOR_PULSE_COUNT, DEFAULT_MOTOR_PULSE_DELAY_MS)
     if bed_type == BED_TYPE_OCTO and (
         protocol_variant == OCTO_VARIANT_STAR2
         or (
@@ -2252,7 +2253,6 @@ def get_motor_pulse_defaults(
     ):
         return OCTO_STAR2_PULSE_DEFAULTS
 
-    return BED_MOTOR_PULSE_DEFAULTS.get(
-        bed_type,
-        (DEFAULT_MOTOR_PULSE_COUNT, DEFAULT_MOTOR_PULSE_DELAY_MS),
-    )
+    if bed_type is None:
+        return default
+    return BED_MOTOR_PULSE_DEFAULTS.get(bed_type, default)

--- a/custom_components/adjustable_bed/detection.py
+++ b/custom_components/adjustable_bed/detection.py
@@ -132,6 +132,7 @@ from .const import (
     OKIMAT_NAME_PATTERNS,
     OKIMAT_NOTIFY_CHAR_UUID,
     OKIMAT_SERVICE_UUID,
+    OKIMAT_VARIANTS,
     OKIMAT_WRITE_CHAR_UUID,
     OKIN_FFE_NAME_PATTERNS,
     OKIN_GENERIC_NAME_PATTERNS,
@@ -165,6 +166,7 @@ from .const import (
     SVANE_NAME_PATTERNS,
     TIMOTION_AHF_NAME_PATTERNS,
     TIMOTION_AHF_SERVICE_UUID,
+    VARIANT_AUTO,
     VIBRADORM_NAME_PATTERNS,
     VIBRADORM_SECONDARY_SERVICE_UUID,
     VIBRADORM_SERVICE_UUID,
@@ -749,6 +751,30 @@ def refine_okin_shared_uuid_protocol_from_gatt(
                     ble_model,
                 )
             return BED_TYPE_OKIN_RF_ECO_BT
+        if (
+            gatt_detection.bed_type
+            in {
+                BED_TYPE_OKIN_CST,
+                BED_TYPE_OKIN_RF_ECO_BT,
+            }
+            and bed_type in {BED_TYPE_OKIMAT, BED_TYPE_OKIN_UUID}
+            and protocol_variant in OKIMAT_VARIANTS
+            and protocol_variant != VARIANT_AUTO
+        ):
+            # RF ECO BT is a receiver family, not a topology: the two-motor
+            # installation in #344 reports that generic model while using the
+            # standard Okin UUID transport selected by its 82620 handset code.
+            # A validated explicit remote is stronger evidence than shared GATT.
+            if _log_correction:
+                _LOGGER.info(
+                    "Keeping %s profile for explicitly configured Okin remote %s "
+                    "despite shared OKIN GATT detection %s and model %r",
+                    bed_type,
+                    protocol_variant,
+                    gatt_detection.bed_type,
+                    ble_model,
+                )
+            return bed_type
         if gatt_detection.bed_type in {
             BED_TYPE_OKIN_CST,
             BED_TYPE_OKIN_RF_ECO_BT,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -226,6 +226,10 @@ These variants apply to newer Sleep Number Fuzion bases (`Smart bed *`). Older B
 ### Okimat Variants
 
 Okimat beds use different remote codes that determine available features and command values.
+RF ECO BT receivers used with adjustable beds also belong on this profile. Select
+the code printed on the handset rather than the single-actuator RF ECO BT stair
+profile. For example, RF-TOPLINE `82620` exposes Back, Legs, Flat, and the
+receiver's under-bed light toggle.
 
 | Variant | Remote Model | Motors |
 |---------|--------------|--------|

--- a/docs/beds/okimat.md
+++ b/docs/beds/okimat.md
@@ -71,8 +71,11 @@ Detection priority:
 3. Device name contains "okimat", "okin rf", or "okin ble" → Okimat/Okin UUID
 4. Connected GATT has OKIN UUID + CSS → Okin CST or OKIN Smart Remote / RF
    ECO BT. Nordic DFU is only an initial CST hint. Device Information model
-   `MEGAMAT MBZ` identifies RF ECO BT, while an `OKIMAT` model identifies a full
-   bed. Otherwise an already configured CST or RF ECO BT profile is preserved.
+   `MEGAMAT MBZ` identifies the confirmed staircase, while an `OKIMAT` model
+   identifies a full bed. The generic model `RF eco BT` is also used by full
+   beds, so an explicitly selected valid handset code preserves the Okin UUID
+   profile. Otherwise an already configured CST or RF ECO BT profile is
+   preserved.
 5. Device name is `OKIN-Receiver` / `OKIN - Receiver` → prompt for Okin-family protocol
 6. Fallback → Okimat (with warning)
 

--- a/docs/beds/okin-rf-eco-bt.md
+++ b/docs/beds/okin-rf-eco-bt.md
@@ -1,6 +1,6 @@
 # OKIN Smart Remote / RF ECO BT Single Actuator
 
-**Status:** Supported, needs reporter validation
+**Status:** Supported
 
 This profile is for the Elda BTH / RF ECO BT / MEGAMAT setup from
 [issue #344](https://github.com/kristofferR/ha-adjustable-bed/issues/344). It is
@@ -28,6 +28,11 @@ emergency lowering.
 
 Use manual setup and choose **OKIN Smart Remote / RF ECO BT single actuator**.
 
+Choose this profile only for a single moving actuator. RF ECO BT is also used
+as the receiver for adjustable beds. For a bed, choose **Okin UUID (Okimat,
+Lucid, requires pairing)**, set the motor count, and select the code printed on
+the handset under **Protocol variant**.
+
 The reported device advertises as `OKIN-050226` with no service UUIDs, so the
 integration cannot safely auto-detect it from advertisements alone. Diagnostics
 can identify it after connecting when this GATT signature is present:
@@ -43,13 +48,19 @@ bed controller using [Okin CST](okin-cst.md). That service is not a safe
 discriminator: the integration preserves an already configured RF ECO BT or
 CST profile when these GATT signals disagree with it.
 
-Full OKIMAT beds expose the **same** OKIN write + CSS GATT signature as this
-stair profile (see [issue #406](https://github.com/kristofferR/ha-adjustable-bed/issues/406),
-an OKIMAT 4 IPS/M Lattoflex bed). The GATT signature alone is therefore not
-enough to choose this single-actuator profile. The auto-refinement only
-downgrades to RF ECO BT when the connected Device Information **model** is not a
-multi-motor OKIMAT bed: the ELDA stair reports `MEGAMAT MBZ`, whereas a real bed
-reports e.g. `OKIMAT 4 IPS/M` and keeps its multi-motor profile.
+Full OKIMAT beds and RF ECO BT bed receivers expose the **same** OKIN write +
+CSS GATT signature as this stair profile. The GATT signature alone is therefore
+not enough to choose a topology. Confirmed Device Information models include:
+
+- `MEGAMAT MBZ`: the single-actuator ELDA staircase from issue #344
+- `OKIMAT 4 IPS/M`: the multi-motor Lattoflex bed from issue #406
+- `RF eco BT`: a two-motor bed receiver using RF-TOPLINE handset `82620`, also
+  reported in issue #344
+
+The exact `MEGAMAT MBZ` model remains the stronger staircase signal. For other
+shared-GATT receivers, selecting a valid handset code explicitly under the
+Okin UUID profile is stronger evidence than the generic receiver identity and
+keeps the multi-motor controller active.
 
 Generic `OKIN-*` devices remain ambiguous because multiple unrelated OKIN
 protocols use that naming pattern.
@@ -84,7 +95,8 @@ motion is safe, visible, and supervised.
 
 ## Follow-up
 
-If M2 is not the correct actuator channel for a specific installation, a future
-follow-up may need the reporter's OKIN Smart Remote ID or QR contents to map the
-actual channel. Do not add M3, reversed, DOT, or RF-gateway variants without
-new evidence.
+If M2 is not the correct actuator channel for a single-actuator installation, a
+future follow-up may need the reporter's OKIN Smart Remote ID or QR contents to
+map the actual channel. Do not add M3, reversed, DOT, or RF-gateway variants to
+the stair profile without new evidence. Adjustable beds belong on the Okin UUID
+profile with their printed handset code.

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1545,6 +1545,52 @@ class TestOkinUUIDDisambiguation:
             == BED_TYPE_OKIN_RF_ECO_BT
         )
 
+    @pytest.mark.parametrize(
+        ("bed_type", "protocol_variant", "ble_model", "expected_bed_type"),
+        [
+            (BED_TYPE_OKIN_UUID, "82620", "RF eco BT", BED_TYPE_OKIN_UUID),
+            (BED_TYPE_OKIMAT, "82620", "RF eco BT", BED_TYPE_OKIMAT),
+            (BED_TYPE_OKIN_UUID, "auto", "RF eco BT", BED_TYPE_OKIN_CST),
+            (BED_TYPE_OKIN_UUID, "82620", "MEGAMAT MBZ", BED_TYPE_OKIN_RF_ECO_BT),
+        ],
+    )
+    def test_shared_okin_gatt_refinement_respects_explicit_bed_remote(
+        self,
+        bed_type: str,
+        protocol_variant: str,
+        ble_model: str,
+        expected_bed_type: str,
+    ):
+        """A selected bed remote beats generic RF ECO identity, but not the stair model."""
+        gatt_services = [
+            SimpleNamespace(
+                uuid=OKIMAT_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIMAT_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=OKIN_SMART_REMOTE_CSS_SERVICE_UUID,
+                characteristics=[
+                    SimpleNamespace(uuid=OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID),
+                ],
+            ),
+            SimpleNamespace(
+                uuid=NORDIC_DFU_SERVICE_UUID,
+                characteristics=[],
+            ),
+        ]
+
+        assert (
+            refine_okin_shared_uuid_protocol_from_gatt(
+                bed_type,
+                gatt_services,
+                protocol_variant=protocol_variant,
+                ble_model=ble_model,
+            )
+            == expected_bed_type
+        )
+
     def test_shared_okin_gatt_refinement_downgrades_non_okimat_model_to_rf_eco_bt(self):
         """The ELDA stair (#344, ``MEGAMAT MBZ``) keeps the RF ECO BT downgrade."""
         gatt_services = [

--- a/tests/test_okin_uuid.py
+++ b/tests/test_okin_uuid.py
@@ -984,8 +984,8 @@ class TestOkinUuidMotorLayout:
     @pytest.mark.parametrize(
         ("variant", "motor_count", "expected_keys"),
         [
-            # Standard 2-motor remote.
-            ("82417", 2, ["back", "legs"]),
+            # RF-TOPLINE 82620 from the two-motor RF ECO BT bed in issue #344.
+            ("82620", 2, ["back", "legs"]),
             # 4-motor remote exposes all axes when configured for 4 motors...
             ("93332", 4, ["back", "legs", "head", "feet"]),
             # ...and is still capped by the configured motor count.
@@ -1034,7 +1034,7 @@ class TestOkinUuidMotorLayout:
         mock_bleak_client: MagicMock,
     ):
         """On 2-motor remotes without a head motor, head stays a back synonym."""
-        coordinator = self._controller(hass, "82417")
+        coordinator = self._controller(hass, "82620")
         await coordinator.async_connect()
 
         await coordinator.controller.move_head_up()
@@ -1080,7 +1080,7 @@ class TestOkinUuidMotorLayout:
         mock_coordinator_connected,
     ):
         """Remotes with a UBL key keep the light toggle."""
-        coordinator = self._controller(hass, "82417")
+        coordinator = self._controller(hass, "82620")
         await coordinator.async_connect()
 
         assert coordinator.controller.supports_lights is True

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -568,6 +568,7 @@ class TestBleDiagnosticsRunner:
         assert model_detection["ambiguous_types"] == []
 
         coordinator.entry.data = {CONF_PROTOCOL_VARIANT: "82620"}
+        coordinator.observed_ble_device_name = "Jasper"
         rf_eco_bed_detection = runner._build_detection_section(
             SimpleNamespace(name="Jasper"),
             gatt_services,

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -30,6 +30,7 @@ from custom_components.adjustable_bed.const import (
     CONF_HAS_MASSAGE,
     CONF_MOTOR_COUNT,
     CONF_PREFERRED_ADAPTER,
+    CONF_PROTOCOL_VARIANT,
     DEVICE_INFO_CHARS,
     DOMAIN,
     LINAK_CONTROL_SERVICE_UUID,
@@ -512,6 +513,7 @@ class TestBleDiagnosticsRunner:
         coordinator = MagicMock()
         coordinator.bed_type = BED_TYPE_OKIN_RF_ECO_BT
         coordinator.observed_ble_device_name = "OKIN-050226"
+        coordinator.entry.data = {CONF_PROTOCOL_VARIANT: "auto"}
         gatt_services = [
             ServiceInfo(
                 uuid=OKIMAT_SERVICE_UUID,
@@ -564,6 +566,18 @@ class TestBleDiagnosticsRunner:
         assert "configured_profile:shared_okin_uuid" not in model_detection["signals"]
         assert model_detection["confidence"] == 0.95
         assert model_detection["ambiguous_types"] == []
+
+        coordinator.entry.data = {CONF_PROTOCOL_VARIANT: "82620"}
+        rf_eco_bed_detection = runner._build_detection_section(
+            SimpleNamespace(name="Jasper"),
+            gatt_services,
+            {"model_number": "RF eco BT"},
+        )
+
+        assert rf_eco_bed_detection["bed_type"] == BED_TYPE_OKIN_UUID
+        assert "configured_profile:shared_okin_uuid" in rf_eco_bed_detection["signals"]
+        assert "device_info:model_number" not in rf_eco_bed_detection["signals"]
+        assert rf_eco_bed_detection["confidence"] == 0.8
 
     async def test_run_diagnostics_reconnects_after_mid_enumeration_disconnect(
         self,


### PR DESCRIPTION
RF ECO BT is a receiver family used by both single-actuator staircases and adjustable beds. Shared GATT refinement currently replaces a manually selected Okin UUID profile even when the user selects the known `82620` bed handset, hiding the second motor and light.

Preserve an explicitly selected valid Okin UUID handset unless Device Information identifies the confirmed `MEGAMAT MBZ` staircase. Support-bundle detection now uses the saved variant too, and the setup documentation explains which profile to choose.

Ref #344

## Validation

- `uv run pytest` (2,775 passed)
- `uv run pytest -n 0 tests/test_detection.py tests/test_okin_uuid.py tests/test_support_bundle.py` (371 passed)
- `uvx ruff@0.15.16 check custom_components tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved adjustable-bed detection for RF ECO BT receivers and configured handset variants.
  - Explicit handset selections now take precedence over ambiguous Bluetooth device identities.
  - Diagnostic results consistently reflect the configured protocol variant.

- **Documentation**
  - Expanded setup guidance for RF ECO BT receivers, full beds, stair installations, and handset codes.
  - Added RF-TOPLINE 82620 and RF ECO BT 88802 examples.

- **Bug Fixes**
  - Prevented valid configured profiles from being incorrectly replaced during device detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->