### PR TITLE
refactor: extract protocol-aware position seeking from the coordinator

### DIFF
--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -29,6 +29,7 @@ from ..const import (
     POSITION_TOLERANCE,
 )
 from ..diagnostic_payloads import format_payload
+from ..position_seek import PositionSeekPolicy
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -409,6 +410,18 @@ class BedController(ABC):
     def position_seek_chain_min_remaining_distance(self) -> float:
         """Return the minimum remaining error that still allows burst chaining."""
         return POSITION_TOLERANCE
+
+    @property
+    def position_seek_policy(self) -> PositionSeekPolicy:
+        """Return the protocol movement policy for feedback-driven seeking.
+
+        The default policy delegates to the tuning properties above, so
+        existing per-controller overrides keep working unchanged. Controller
+        families with protocol evidence for smarter seek behavior (coast
+        compensation, endpoint completion, reversal transitions) override this
+        to return a policy subclass.
+        """
+        return PositionSeekPolicy(self)
 
     @property
     def passive_position_reconciliation_interval(self) -> float | None:

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -2501,6 +2501,9 @@ def get_motor_pulse_defaults(
     ):
         return OCTO_STAR2_PULSE_DEFAULTS
 
+    if bed_type is None:
+        return (DEFAULT_MOTOR_PULSE_COUNT, DEFAULT_MOTOR_PULSE_DELAY_MS)
+
     return BED_MOTOR_PULSE_DEFAULTS.get(
         bed_type,
         (DEFAULT_MOTOR_PULSE_COUNT, DEFAULT_MOTOR_PULSE_DELAY_MS),

--- a/custom_components/adjustable_bed/coordinator.py
+++ b/custom_components/adjustable_bed/coordinator.py
@@ -159,8 +159,6 @@ from .const import (
     OFFLINE_CAPABILITY_SAFE_BED_TYPES,
     OKIMAT_SERVICE_UUID,
     POSITION_MODE_ACCURACY,
-    POSITION_OVERSHOOT_TOLERANCE,
-    POSITION_SEEK_TIMEOUT,
     REVERIE_BACK_MAX_ANGLE,
     RICHMAT_REMOTE_AUTO,
     RUNTIME_BOND_KEYS,
@@ -190,6 +188,14 @@ from .detection import (
 )
 from .diagnostic_payloads import new_connection_attempt_details
 from .pairing import inheritable_child_fields, octo_snapshot_from_descriptor
+from .position_seek import (
+    PositionSeekRunner,
+    SeekMotion,
+    SeekOutcome,
+    SeekResult,
+    SeekSample,
+    SeekTimeoutError,
+)
 from .unsupported import (
     create_pairing_required_issue,
     delete_pairing_required_issue,
@@ -508,6 +514,12 @@ class AdjustableBedCoordinator:
         self._last_protocol_operation_end: datetime | None = None
         self._active_operation_name: str | None = None
         self._last_notify_received: datetime | None = None
+
+        # Per-axis seek state: typed terminal outcomes for diagnostics and the
+        # last commanded motion so a replacement seek's policy can distinguish
+        # same-direction from opposite-direction transitions.
+        self._seek_outcomes: dict[str, dict[str, Any]] = {}
+        self._last_seek_motion: dict[str, SeekMotion] = {}
 
         # Adapter selection details for diagnostics (issue #168)
         self._actual_adapter: str | None = None
@@ -1772,6 +1784,10 @@ class AdjustableBedCoordinator:
             "last_notify_received": self._last_notify_received.isoformat()
             if self._last_notify_received
             else None,
+            "position_seeks": {
+                position_key: dict(record)
+                for position_key, record in self._seek_outcomes.items()
+            },
             "scheduler": self._command_scheduler.diagnostics,
         }
 
@@ -5260,6 +5276,24 @@ class AdjustableBedCoordinator:
             cancel_running=True,
         )
 
+    def _record_seek_result(self, result: SeekResult) -> None:
+        """Retain the typed terminal outcome of one seek for diagnostics."""
+        context = current_command_context()
+        self._seek_outcomes[result.position_key] = {
+            "outcome": result.outcome.value,
+            "target": result.target,
+            "final_angle": result.final_angle,
+            "duration_seconds": round(result.duration, 3),
+            "intent_id": context.intent_id if context is not None else None,
+            "finished_at": datetime.now(UTC).isoformat(),
+        }
+        if result.final_direction is not None:
+            self._last_seek_motion[result.position_key] = SeekMotion(
+                moving_up=result.final_direction,
+                outcome=result.outcome,
+                finished_monotonic=time.monotonic(),
+            )
+
     async def _async_seek_position_serial(
         self,
         position_key: str,
@@ -5270,12 +5304,10 @@ class AdjustableBedCoordinator:
     ) -> None:
         """Seek to a target position using feedback loop control.
 
-        This method moves the motor toward the target position by polling the
-        current position and adjusting direction as needed. It handles:
-        - Immediate return if already at target position
-        - Timeout protection (60s max)
-        - Stall detection (motor not moving)
-        - Cancellation via the cancel_command event
+        Owns the connection lifecycle around one seek: locking, connecting,
+        initial position acquisition, and the direct-position shortcut. The
+        feedback loop itself runs in `PositionSeekRunner` under the
+        controller-supplied `PositionSeekPolicy`.
 
         Args:
             position_key: Key in position_data (e.g., "back", "legs")
@@ -5342,25 +5374,34 @@ class AdjustableBedCoordinator:
                             f"Cannot seek {position_key}: no position data available"
                         )
 
-                position_tolerance = controller.position_seek_tolerance
-                position_check_interval = controller.position_seek_check_interval
-                position_stall_count = controller.position_seek_stall_count
-                position_stall_threshold = controller.position_seek_stall_threshold
-                chain_seek_steps = controller.chains_position_seek_steps_while_moving
-                position_seek_chain_min_remaining_distance = (
-                    controller.position_seek_chain_min_remaining_distance
-                )
+                policy = controller.position_seek_policy
 
-                # Check if already at target (within tolerance)
-                if (
-                    current_angle is not None
-                    and abs(current_angle - target_angle) <= position_tolerance
+                # Check if already at target (per the policy's completion band)
+                if current_angle is not None and policy.accepts_position(
+                    SeekSample(
+                        position_key=position_key,
+                        target=target_angle,
+                        current=current_angle,
+                        previous=None,
+                        moving_up=target_angle > current_angle,
+                        elapsed=0.0,
+                    )
                 ):
                     _LOGGER.debug(
                         "Position %s already at target: %.1f (target: %.1f)",
                         position_key,
                         current_angle,
                         target_angle,
+                    )
+                    self._record_seek_result(
+                        SeekResult(
+                            position_key=position_key,
+                            target=target_angle,
+                            outcome=SeekOutcome.ALREADY_AT_TARGET,
+                            final_angle=current_angle,
+                            final_direction=None,
+                            duration=0.0,
+                        )
                     )
                     return  # finally block handles disconnect
 
@@ -5391,6 +5432,16 @@ class AdjustableBedCoordinator:
                     )
                     await controller.set_motor_position(position_key, native_position)
                     self._handle_position_update(position_key, target_angle)
+                    self._record_seek_result(
+                        SeekResult(
+                            position_key=position_key,
+                            target=target_angle,
+                            outcome=SeekOutcome.DIRECT_SET,
+                            final_angle=target_angle,
+                            final_direction=None,
+                            duration=0.0,
+                        )
+                    )
                     return  # finally block handles disconnect timer
 
                 # Only direct-position controllers may reach this point without a
@@ -5400,9 +5451,6 @@ class AdjustableBedCoordinator:
                         f"Cannot seek {position_key}: no position data available"
                     )
 
-                # Determine initial direction
-                moving_up = target_angle > current_angle
-                reverse_on_overshoot = controller.reverses_position_seek_on_overshoot
                 use_custom_seek_steps = controller.uses_custom_position_seek_steps
 
                 async def issue_seek_step(direction_up: bool, remaining_distance: float) -> None:
@@ -5419,184 +5467,26 @@ class AdjustableBedCoordinator:
                     else:
                         await move_down_fn(controller)
 
-                # Start movement in try-finally to guarantee stop is sent
+                async def read_position() -> float | None:
+                    await self._async_read_positions()
+                    return self._position_data.get(position_key)
+
+                runner = PositionSeekRunner(
+                    position_key=position_key,
+                    target_angle=target_angle,
+                    policy=policy,
+                    cancel_event=cancel_event,
+                    read_position=read_position,
+                    issue_step=issue_seek_step,
+                    stop=lambda: move_stop_fn(controller),
+                    previous_motion=self._last_seek_motion.get(position_key),
+                )
                 try:
-                    await issue_seek_step(
-                        moving_up,
-                        abs(target_angle - cast(float, current_angle)),
-                    )
-
-                    # Tracking variables
-                    start_time = time.monotonic()
-                    stall_count = 0
-                    last_angle = current_angle
-
-                    # Position seeking loop
-                    while True:
-                        # Check for timeout
-                        if time.monotonic() - start_time > POSITION_SEEK_TIMEOUT:
-                            _LOGGER.warning(
-                                "Position seek timeout for %s after %.0fs",
-                                position_key,
-                                POSITION_SEEK_TIMEOUT,
-                            )
-                            raise TimeoutError(
-                                f"Position seek timed out for {position_key} "
-                                f"after {POSITION_SEEK_TIMEOUT:.0f}s"
-                            )
-
-                        # Check for cancellation
-                        if cancel_event.is_set():
-                            _LOGGER.debug("Position seek cancelled for %s", position_key)
-                            break
-
-                        # Wait and poll position
-                        await asyncio.sleep(position_check_interval)
-
-                        # Read current position
-                        await self._async_read_positions()
-
-                        # Get updated position
-                        current_angle = self._position_data.get(position_key)
-                        if current_angle is None:
-                            _LOGGER.warning(
-                                "Lost position data for %s during seek",
-                                position_key,
-                            )
-                            break
-
-                        _LOGGER.debug(
-                            "Position seek %s: current=%.1f, target=%.1f",
-                            position_key,
-                            current_angle,
-                            target_angle,
-                        )
-
-                        # Check if at target
-                        if abs(current_angle - target_angle) <= position_tolerance:
-                            _LOGGER.info(
-                                "Position %s reached target: %.1f (target: %.1f)",
-                                position_key,
-                                current_angle,
-                                target_angle,
-                            )
-                            break
-
-                        # Pulse-driven controllers can only evaluate the result of a
-                        # whole move burst, so once they cross the target they should
-                        # stop rather than hunt by reversing direction.
-                        if not reverse_on_overshoot and (
-                            (moving_up and current_angle >= target_angle)
-                            or (not moving_up and current_angle <= target_angle)
-                        ):
-                            _LOGGER.info(
-                                "Position %s crossed target in single-direction seek: %.1f (target: %.1f)",
-                                position_key,
-                                current_angle,
-                                target_angle,
-                            )
-                            break
-
-                        # Check for overshoot (passed the target). The ticket-local
-                        # cancellation event stays clear during an ordinary seek and
-                        # is set only by replacement, STOP, caller cancellation, or
-                        # shutdown, so a reversal cannot erase a newer safety action.
-                        # Use larger overshoot tolerance to prevent oscillation
-                        if reverse_on_overshoot and (
-                            moving_up
-                            and current_angle > target_angle + POSITION_OVERSHOOT_TOLERANCE
-                        ):
-                            _LOGGER.debug(
-                                "Position %s overshot target (up), reversing", position_key
-                            )
-                            # Only send explicit stop for controllers that don't auto-stop
-                            # (Linak auto-stops and explicit STOP can cause reverse blips)
-                            if not controller.auto_stops_on_idle:
-                                await move_stop_fn(controller)
-                                await asyncio.sleep(0.3)  # Ensure stop completes before reversal
-                            # Check if a new stop was requested while we were stopping
-                            if cancel_event.is_set():
-                                _LOGGER.debug(
-                                    "New stop request during overshoot - aborting reversal"
-                                )
-                                break
-                            await issue_seek_step(False, abs(target_angle - current_angle))
-                            moving_up = False
-                        elif reverse_on_overshoot and (
-                            not moving_up
-                            and current_angle < target_angle - POSITION_OVERSHOOT_TOLERANCE
-                        ):
-                            _LOGGER.debug(
-                                "Position %s overshot target (down), reversing", position_key
-                            )
-                            # Only send explicit stop for controllers that don't auto-stop
-                            # (Linak auto-stops and explicit STOP can cause reverse blips)
-                            if not controller.auto_stops_on_idle:
-                                await move_stop_fn(controller)
-                                await asyncio.sleep(0.3)  # Ensure stop completes before reversal
-                            # Check if a new stop was requested while we were stopping
-                            if cancel_event.is_set():
-                                _LOGGER.debug(
-                                    "New stop request during overshoot - aborting reversal"
-                                )
-                                break
-                            await issue_seek_step(True, abs(target_angle - current_angle))
-                            moving_up = True
-
-                        remaining_distance = abs(target_angle - current_angle)
-                        movement = abs(current_angle - last_angle)
-                        if (
-                            chain_seek_steps
-                            and movement >= position_stall_threshold
-                            and remaining_distance >= position_seek_chain_min_remaining_distance
-                        ):
-                            _LOGGER.debug(
-                                "Position %s still moving at %.1f with %.1f remaining, chaining seek step",
-                                position_key,
-                                current_angle,
-                                remaining_distance,
-                            )
-                            await issue_seek_step(
-                                moving_up,
-                                remaining_distance,
-                            )
-                            stall_count = 0
-                            last_angle = current_angle
-                            continue
-
-                        # Stall detection - re-issue movement if motor stopped prematurely
-                        if movement < position_stall_threshold:
-                            stall_count += 1
-                            if stall_count >= position_stall_count:
-                                # Motor appears stalled - re-issue movement command
-                                # This handles pulse-based protocols where motors auto-stop
-                                _LOGGER.debug(
-                                    "Position %s stalled at %.1f, re-issuing movement command",
-                                    position_key,
-                                    current_angle,
-                                )
-                                await issue_seek_step(
-                                    moving_up,
-                                    abs(target_angle - current_angle),
-                                )
-                                stall_count = 0  # Reset stall count after re-issue
-                        else:
-                            stall_count = 0
-
-                        last_angle = current_angle
-                finally:
-                    # Stop the motor unless it auto-stops on idle
-                    # Some controllers (e.g., Linak) auto-stop and sending explicit
-                    # STOP can cause brief reverse movement.
-                    if not controller.auto_stops_on_idle:
-                        try:
-                            await move_stop_fn(controller)
-                        except Exception:
-                            _LOGGER.exception(
-                                "CRITICAL: Failed to stop motor %s - manual intervention may be required",
-                                position_key,
-                            )
-                            raise
+                    result = await runner.async_run(cast(float, current_angle))
+                except SeekTimeoutError as err:
+                    self._record_seek_result(err.result)
+                    raise
+                self._record_seek_result(result)
 
             finally:
                 if self._client is not None and self._client.is_connected:

--- a/custom_components/adjustable_bed/position_seek.py
+++ b/custom_components/adjustable_bed/position_seek.py
@@ -1,0 +1,492 @@
+"""Protocol-aware position seeking.
+
+`PositionSeekRunner` owns the generic seek lifecycle: sampling, cancellation,
+timeout, progress tracking, cleanup, and a typed terminal outcome.
+`PositionSeekPolicy` owns protocol-specific movement decisions and is supplied
+by the controller (see `BedController.position_seek_policy`). The default
+policy delegates every tuning value to the controller's existing seek
+properties and reproduces the coordinator's historical serialized seek
+behavior exactly. GATT writes and STOP/release semantics remain
+controller-owned; a policy may only change wire behavior when the protocol
+evidence supports it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Final
+
+from .const import POSITION_OVERSHOOT_TOLERANCE, POSITION_SEEK_TIMEOUT
+
+if TYPE_CHECKING:
+    from .beds.base import BedController
+
+_LOGGER = logging.getLogger(__name__)
+
+# Delay after an explicit STOP before reversing direction so the stop
+# completes before the opposite movement starts.
+SEEK_REVERSAL_SETTLE_DELAY: Final = 0.3
+
+
+class SeekOutcome(StrEnum):
+    """Typed terminal result of one position seek."""
+
+    ALREADY_AT_TARGET = "already_at_target"
+    DIRECT_SET = "direct_set"
+    REACHED_TARGET = "reached_target"
+    CROSSED_TARGET = "crossed_target"
+    ENDPOINT_REACHED = "endpoint_reached"
+    CANCELLED = "cancelled"
+    POSITION_LOST = "position_lost"
+    TIMEOUT = "timeout"
+
+
+class SeekTransitionKind(StrEnum):
+    """How a starting seek relates to the previous motion on the same axis."""
+
+    INITIAL = "initial"
+    SAME_DIRECTION = "same_direction"
+    OPPOSITE_DIRECTION = "opposite_direction"
+
+
+@dataclass(frozen=True, slots=True)
+class SeekMotion:
+    """Last commanded motion on one axis, kept for transition decisions."""
+
+    moving_up: bool
+    outcome: SeekOutcome
+    finished_monotonic: float
+
+
+@dataclass(frozen=True, slots=True)
+class SeekTransition:
+    """Context handed to the policy before a seek issues its first step."""
+
+    kind: SeekTransitionKind
+    previous: SeekMotion | None
+
+
+@dataclass(frozen=True, slots=True)
+class SeekSample:
+    """One feedback observation evaluated by the policy."""
+
+    position_key: str
+    target: float
+    current: float
+    previous: float | None
+    moving_up: bool
+    elapsed: float
+    stalled_checks: int = 0
+
+    @property
+    def remaining(self) -> float:
+        """Return the unsigned distance still to travel."""
+        return abs(self.target - self.current)
+
+
+@dataclass(frozen=True, slots=True)
+class SeekResult:
+    """Typed terminal outcome of one seek run."""
+
+    position_key: str
+    target: float
+    outcome: SeekOutcome
+    final_angle: float | None
+    final_direction: bool | None
+    duration: float
+
+
+class SeekTimeoutError(TimeoutError):
+    """Seek timeout carrying its typed terminal result."""
+
+    def __init__(self, message: str, result: SeekResult) -> None:
+        super().__init__(message)
+        self.result = result
+
+
+class PositionSeekPolicy:
+    """Protocol movement policy for feedback-driven seeking.
+
+    Tuning values delegate to the controller's existing seek properties, so
+    per-controller overrides keep working unchanged. Controller families with
+    protocol evidence for smarter behavior (coast compensation, endpoint
+    completion, reversal transitions) override the hooks below.
+    """
+
+    def __init__(self, controller: BedController) -> None:
+        self._controller = controller
+
+    @property
+    def tolerance(self) -> float:
+        """Return the acceptable error band for target completion."""
+        return self._controller.position_seek_tolerance
+
+    @property
+    def check_interval(self) -> float:
+        """Return the interval between feedback polls."""
+        return self._controller.position_seek_check_interval
+
+    @property
+    def stall_count(self) -> int:
+        """Return how many stagnant reads confirm a stall."""
+        return self._controller.position_seek_stall_count
+
+    @property
+    def stall_threshold(self) -> float:
+        """Return the minimum delta that still counts as movement."""
+        return self._controller.position_seek_stall_threshold
+
+    @property
+    def chains_steps_while_moving(self) -> bool:
+        """Return True to reissue bursts before movement fully stalls."""
+        return self._controller.chains_position_seek_steps_while_moving
+
+    @property
+    def chain_min_remaining_distance(self) -> float:
+        """Return the minimum remaining error that still allows chaining."""
+        return self._controller.position_seek_chain_min_remaining_distance
+
+    @property
+    def reverses_on_overshoot(self) -> bool:
+        """Return True if overshoot should be corrected by reversing."""
+        return self._controller.reverses_position_seek_on_overshoot
+
+    @property
+    def overshoot_tolerance(self) -> float:
+        """Return how far past the target still avoids a reversal."""
+        return POSITION_OVERSHOOT_TOLERANCE
+
+    @property
+    def timeout(self) -> float:
+        """Return the maximum wall time for one seek."""
+        return POSITION_SEEK_TIMEOUT
+
+    @property
+    def sends_explicit_stop(self) -> bool:
+        """Return True if this protocol needs explicit STOP writes.
+
+        Auto-stopping motors (e.g. Linak) skip explicit STOP because it can
+        cause brief reverse movement.
+        """
+        return not self._controller.auto_stops_on_idle
+
+    def accepts_position(self, sample: SeekSample) -> bool:
+        """Return True when the sampled position completes the seek.
+
+        Coast-compensating policies may accept earlier based on recent
+        movement; the default is a plain tolerance band.
+        """
+        return sample.remaining <= self.tolerance
+
+    def completes_on_crossing(self, sample: SeekSample) -> bool:
+        """Return True when crossing the target should end the seek.
+
+        Pulse-driven controllers evaluate whole bursts and must not hunt by
+        reversing, so any crossing completes the seek for them.
+        """
+        if self.reverses_on_overshoot:
+            return False
+        return (sample.moving_up and sample.current >= sample.target) or (
+            not sample.moving_up and sample.current <= sample.target
+        )
+
+    def wants_reversal(self, sample: SeekSample) -> bool:
+        """Return True when overshoot should trigger a direction reversal."""
+        if not self.reverses_on_overshoot:
+            return False
+        if sample.moving_up:
+            return sample.current > sample.target + self.overshoot_tolerance
+        return sample.current < sample.target - self.overshoot_tolerance
+
+    def stall_completes_near_endpoint(self, sample: SeekSample) -> bool:
+        """Return True when a confirmed stall should count as completion.
+
+        Endpoint-aware policies can accept a persistent stall near a physical
+        travel limit instead of retrying until timeout. The default never
+        promotes a stall to success.
+        """
+        del sample
+        return False
+
+    async def async_on_seek_start(
+        self,
+        transition: SeekTransition,
+        stop: Callable[[], Awaitable[None]],
+    ) -> None:
+        """Prepare the axis before the first movement step.
+
+        Policies with evidence for a safe settle/release sequence between
+        opposite-direction seeks can implement it here. The default issues
+        nothing on the wire.
+        """
+        del transition, stop
+
+    async def async_prepare_reversal(
+        self,
+        stop: Callable[[], Awaitable[None]],
+    ) -> None:
+        """Transition the axis before reversing direction after overshoot."""
+        # Only send explicit stop for controllers that don't auto-stop
+        # (Linak auto-stops and explicit STOP can cause reverse blips)
+        if self.sends_explicit_stop:
+            await stop()
+            await asyncio.sleep(SEEK_REVERSAL_SETTLE_DELAY)
+
+
+class PositionSeekRunner:
+    """Run one feedback-driven seek and return a typed terminal outcome."""
+
+    def __init__(
+        self,
+        *,
+        position_key: str,
+        target_angle: float,
+        policy: PositionSeekPolicy,
+        cancel_event: asyncio.Event,
+        read_position: Callable[[], Awaitable[float | None]],
+        issue_step: Callable[[bool, float], Awaitable[None]],
+        stop: Callable[[], Awaitable[None]],
+        previous_motion: SeekMotion | None = None,
+    ) -> None:
+        self._position_key = position_key
+        self._target = target_angle
+        self._policy = policy
+        self._cancel_event = cancel_event
+        self._read_position = read_position
+        self._issue_step = issue_step
+        self._stop = stop
+        self._previous_motion = previous_motion
+
+    def _transition(self, moving_up: bool) -> SeekTransition:
+        previous = self._previous_motion
+        if previous is None:
+            kind = SeekTransitionKind.INITIAL
+        elif previous.moving_up == moving_up:
+            kind = SeekTransitionKind.SAME_DIRECTION
+        else:
+            kind = SeekTransitionKind.OPPOSITE_DIRECTION
+        return SeekTransition(kind=kind, previous=previous)
+
+    async def async_run(self, initial_angle: float) -> SeekResult:
+        """Seek toward the target and return the typed terminal outcome.
+
+        Raises `SeekTimeoutError` (a `TimeoutError`) on feedback timeout after
+        motor cleanup, matching the historical seek contract.
+        """
+        position_key = self._position_key
+        target_angle = self._target
+        policy = self._policy
+        cancel_event = self._cancel_event
+        start_time = time.monotonic()
+
+        def result(
+            outcome: SeekOutcome,
+            final_angle: float | None,
+            final_direction: bool | None,
+        ) -> SeekResult:
+            return SeekResult(
+                position_key=position_key,
+                target=target_angle,
+                outcome=outcome,
+                final_angle=final_angle,
+                final_direction=final_direction,
+                duration=time.monotonic() - start_time,
+            )
+
+        initial_sample = SeekSample(
+            position_key=position_key,
+            target=target_angle,
+            current=initial_angle,
+            previous=None,
+            moving_up=target_angle > initial_angle,
+            elapsed=0.0,
+        )
+        if policy.accepts_position(initial_sample):
+            _LOGGER.debug(
+                "Position %s already at target: %.1f (target: %.1f)",
+                position_key,
+                initial_angle,
+                target_angle,
+            )
+            return result(SeekOutcome.ALREADY_AT_TARGET, initial_angle, None)
+
+        moving_up = target_angle > initial_angle
+        current_angle: float | None = initial_angle
+        timeout = policy.timeout
+
+        # Nothing has been commanded yet, so a pending cancellation ends the
+        # seek without any wire traffic, including the cleanup STOP.
+        if cancel_event.is_set():
+            _LOGGER.debug("Position seek cancelled before first step for %s", position_key)
+            return result(SeekOutcome.CANCELLED, initial_angle, None)
+
+        # Start movement in try-finally to guarantee stop is sent
+        try:
+            await policy.async_on_seek_start(self._transition(moving_up), self._stop)
+            await self._issue_step(moving_up, abs(target_angle - initial_angle))
+
+            # Tracking variables
+            stall_count = 0
+            last_angle: float = initial_angle
+
+            # Position seeking loop
+            while True:
+                elapsed = time.monotonic() - start_time
+
+                # Check for timeout
+                if elapsed > timeout:
+                    _LOGGER.warning(
+                        "Position seek timeout for %s after %.0fs",
+                        position_key,
+                        timeout,
+                    )
+                    raise SeekTimeoutError(
+                        f"Position seek timed out for {position_key} after {timeout:.0f}s",
+                        result(SeekOutcome.TIMEOUT, current_angle, moving_up),
+                    )
+
+                # Check for cancellation
+                if cancel_event.is_set():
+                    _LOGGER.debug("Position seek cancelled for %s", position_key)
+                    return result(SeekOutcome.CANCELLED, current_angle, moving_up)
+
+                # Wait and poll position
+                await asyncio.sleep(policy.check_interval)
+
+                # Read current position
+                current_angle = await self._read_position()
+                if current_angle is None:
+                    _LOGGER.warning(
+                        "Lost position data for %s during seek",
+                        position_key,
+                    )
+                    return result(SeekOutcome.POSITION_LOST, None, moving_up)
+
+                _LOGGER.debug(
+                    "Position seek %s: current=%.1f, target=%.1f",
+                    position_key,
+                    current_angle,
+                    target_angle,
+                )
+
+                sample = SeekSample(
+                    position_key=position_key,
+                    target=target_angle,
+                    current=current_angle,
+                    previous=last_angle,
+                    moving_up=moving_up,
+                    elapsed=time.monotonic() - start_time,
+                    stalled_checks=stall_count,
+                )
+
+                # Check if at target
+                if policy.accepts_position(sample):
+                    _LOGGER.info(
+                        "Position %s reached target: %.1f (target: %.1f)",
+                        position_key,
+                        current_angle,
+                        target_angle,
+                    )
+                    return result(SeekOutcome.REACHED_TARGET, current_angle, moving_up)
+
+                # Pulse-driven controllers can only evaluate the result of a
+                # whole move burst, so once they cross the target they should
+                # stop rather than hunt by reversing direction.
+                if policy.completes_on_crossing(sample):
+                    _LOGGER.info(
+                        "Position %s crossed target in single-direction seek: %.1f (target: %.1f)",
+                        position_key,
+                        current_angle,
+                        target_angle,
+                    )
+                    return result(SeekOutcome.CROSSED_TARGET, current_angle, moving_up)
+
+                # Check for overshoot (passed the target). The ticket-local
+                # cancellation event stays clear during an ordinary seek and
+                # is set only by replacement, STOP, caller cancellation, or
+                # shutdown, so a reversal cannot erase a newer safety action.
+                # Use larger overshoot tolerance to prevent oscillation
+                if policy.wants_reversal(sample):
+                    _LOGGER.debug(
+                        "Position %s overshot target (%s), reversing",
+                        position_key,
+                        "up" if moving_up else "down",
+                    )
+                    await policy.async_prepare_reversal(self._stop)
+                    # Check if a new stop was requested while we were stopping
+                    if cancel_event.is_set():
+                        _LOGGER.debug("New stop request during overshoot - aborting reversal")
+                        return result(SeekOutcome.CANCELLED, current_angle, moving_up)
+                    moving_up = not moving_up
+                    await self._issue_step(moving_up, abs(target_angle - current_angle))
+
+                remaining_distance = abs(target_angle - current_angle)
+                movement = abs(current_angle - last_angle)
+                if (
+                    policy.chains_steps_while_moving
+                    and movement >= policy.stall_threshold
+                    and remaining_distance >= policy.chain_min_remaining_distance
+                ):
+                    _LOGGER.debug(
+                        "Position %s still moving at %.1f with %.1f remaining, chaining seek step",
+                        position_key,
+                        current_angle,
+                        remaining_distance,
+                    )
+                    await self._issue_step(moving_up, remaining_distance)
+                    stall_count = 0
+                    last_angle = current_angle
+                    continue
+
+                # Stall detection - re-issue movement if motor stopped prematurely
+                if movement < policy.stall_threshold:
+                    stall_count += 1
+                    if stall_count >= policy.stall_count:
+                        stalled_sample = SeekSample(
+                            position_key=position_key,
+                            target=target_angle,
+                            current=current_angle,
+                            previous=last_angle,
+                            moving_up=moving_up,
+                            elapsed=time.monotonic() - start_time,
+                            stalled_checks=stall_count,
+                        )
+                        if policy.stall_completes_near_endpoint(stalled_sample):
+                            _LOGGER.info(
+                                "Position %s stalled at %.1f near endpoint, accepting (target: %.1f)",
+                                position_key,
+                                current_angle,
+                                target_angle,
+                            )
+                            return result(SeekOutcome.ENDPOINT_REACHED, current_angle, moving_up)
+                        # Motor appears stalled - re-issue movement command
+                        # This handles pulse-based protocols where motors auto-stop
+                        _LOGGER.debug(
+                            "Position %s stalled at %.1f, re-issuing movement command",
+                            position_key,
+                            current_angle,
+                        )
+                        await self._issue_step(moving_up, abs(target_angle - current_angle))
+                        stall_count = 0  # Reset stall count after re-issue
+                else:
+                    stall_count = 0
+
+                last_angle = current_angle
+        finally:
+            # Stop the motor unless it auto-stops on idle
+            # Some controllers (e.g., Linak) auto-stop and sending explicit
+            # STOP can cause brief reverse movement.
+            if policy.sends_explicit_stop:
+                try:
+                    await self._stop()
+                except Exception:
+                    _LOGGER.exception(
+                        "CRITICAL: Failed to stop motor %s - manual intervention may be required",
+                        position_key,
+                    )
+                    raise

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,7 @@ def make_controller_mock(**overrides: object) -> MagicMock:
     Pass keyword overrides for the capabilities a given test actually cares about.
     """
     from custom_components.adjustable_bed.beds.base import BedController
+    from custom_components.adjustable_bed.position_seek import PositionSeekPolicy
 
     controller = MagicMock()
     for name, member in vars(BedController).items():
@@ -87,7 +88,12 @@ def make_controller_mock(**overrides: object) -> MagicMock:
             default = member.fget(controller)
         except Exception:  # noqa: BLE001 - property needs real state; leave it a Mock
             continue
-        if isinstance(default, bool | int | float | str | tuple | list | dict | None):
+        # The default seek policy delegates to the mock's seeded tuning
+        # attributes lazily, so per-test overrides still flow through it.
+        if isinstance(
+            default,
+            bool | int | float | str | tuple | list | dict | None | PositionSeekPolicy,
+        ):
             setattr(controller, name, default)
     for name, value in overrides.items():
         setattr(controller, name, value)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1525,7 +1525,7 @@ class TestCoordinatorPositionSeek:
                 new=AsyncMock(side_effect=_read_positions),
             ),
             patch(
-                "custom_components.adjustable_bed.coordinator.asyncio.sleep",
+                "custom_components.adjustable_bed.position_seek.asyncio.sleep",
                 new=AsyncMock(),
             ),
         ):
@@ -1575,7 +1575,7 @@ class TestCoordinatorPositionSeek:
                 new=AsyncMock(side_effect=_read_positions),
             ),
             patch(
-                "custom_components.adjustable_bed.coordinator.asyncio.sleep",
+                "custom_components.adjustable_bed.position_seek.asyncio.sleep",
                 new=AsyncMock(),
             ),
         ):
@@ -1626,7 +1626,7 @@ class TestCoordinatorPositionSeek:
                 new=read_positions,
             ),
             patch(
-                "custom_components.adjustable_bed.coordinator.asyncio.sleep",
+                "custom_components.adjustable_bed.position_seek.asyncio.sleep",
                 new=AsyncMock(),
             ),
         ):
@@ -1680,7 +1680,7 @@ class TestCoordinatorPositionSeek:
                 new=AsyncMock(side_effect=_read_positions),
             ),
             patch(
-                "custom_components.adjustable_bed.coordinator.asyncio.sleep",
+                "custom_components.adjustable_bed.position_seek.asyncio.sleep",
                 new=AsyncMock(),
             ),
         ):
@@ -1738,7 +1738,7 @@ class TestCoordinatorPositionSeek:
                 new=AsyncMock(side_effect=_read_positions),
             ),
             patch(
-                "custom_components.adjustable_bed.coordinator.asyncio.sleep",
+                "custom_components.adjustable_bed.position_seek.asyncio.sleep",
                 new=AsyncMock(),
             ),
         ):
@@ -1781,7 +1781,7 @@ class TestCoordinatorPositionSeek:
 
         with (
             patch(
-                "custom_components.adjustable_bed.coordinator.POSITION_SEEK_TIMEOUT",
+                "custom_components.adjustable_bed.position_seek.POSITION_SEEK_TIMEOUT",
                 0,
             ),
             pytest.raises(TimeoutError, match="Position seek timed out"),

--- a/tests/test_position_seek.py
+++ b/tests/test_position_seek.py
@@ -1,0 +1,382 @@
+"""Deterministic tests for the protocol-aware position seek runner and policy."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.adjustable_bed.position_seek import (
+    SEEK_REVERSAL_SETTLE_DELAY,
+    PositionSeekPolicy,
+    PositionSeekRunner,
+    SeekMotion,
+    SeekOutcome,
+    SeekSample,
+    SeekTimeoutError,
+    SeekTransition,
+    SeekTransitionKind,
+)
+
+from .conftest import make_controller_mock
+
+
+def make_policy(**controller_overrides: object) -> PositionSeekPolicy:
+    """Return the default policy bound to a contract-faithful controller mock."""
+    return PositionSeekPolicy(make_controller_mock(**controller_overrides))
+
+
+def make_runner(
+    *,
+    policy: PositionSeekPolicy,
+    target: float,
+    readings: list[float | None],
+    cancel_event: asyncio.Event | None = None,
+    previous_motion: SeekMotion | None = None,
+    stop: AsyncMock | None = None,
+    read_side_effect=None,
+) -> tuple[PositionSeekRunner, AsyncMock, AsyncMock]:
+    """Build a runner fed by a synthetic feedback sequence.
+
+    The readings list is consumed one value per poll; the final value repeats
+    once exhausted so long seeks settle deterministically.
+    """
+    sequence = list(readings)
+
+    async def read_position() -> float | None:
+        if read_side_effect is not None:
+            await read_side_effect()
+        if len(sequence) > 1:
+            return sequence.pop(0)
+        return sequence[0]
+
+    issue_step = AsyncMock()
+    stop = stop if stop is not None else AsyncMock()
+    runner = PositionSeekRunner(
+        position_key="back",
+        target_angle=target,
+        policy=policy,
+        cancel_event=cancel_event or asyncio.Event(),
+        read_position=read_position,
+        issue_step=issue_step,
+        stop=stop,
+        previous_motion=previous_motion,
+    )
+    return runner, issue_step, stop
+
+
+def _no_sleep():
+    return patch(
+        "custom_components.adjustable_bed.position_seek.asyncio.sleep",
+        new=AsyncMock(),
+    )
+
+
+class TestSeekProgress:
+    """Ordinary progress toward the target."""
+
+    async def test_progress_reaches_target(self) -> None:
+        policy = make_policy()
+        runner, issue_step, stop = make_runner(policy=policy, target=20.0, readings=[10.0, 19.0])
+
+        with _no_sleep():
+            result = await runner.async_run(0.0)
+
+        assert result.outcome is SeekOutcome.REACHED_TARGET
+        assert result.final_angle == 19.0
+        assert result.final_direction is True
+        issue_step.assert_awaited_once_with(True, 20.0)
+        # Default controllers do not auto-stop, so cleanup sends one STOP.
+        stop.assert_awaited_once_with()
+
+    async def test_initial_sample_already_at_target(self) -> None:
+        policy = make_policy()
+        runner, issue_step, stop = make_runner(policy=policy, target=20.0, readings=[20.0])
+
+        result = await runner.async_run(19.0)
+
+        assert result.outcome is SeekOutcome.ALREADY_AT_TARGET
+        assert result.final_direction is None
+        issue_step.assert_not_awaited()
+        stop.assert_not_awaited()
+
+    async def test_auto_stop_controller_skips_cleanup_stop(self) -> None:
+        policy = make_policy(auto_stops_on_idle=True)
+        runner, issue_step, stop = make_runner(policy=policy, target=20.0, readings=[19.0])
+
+        with _no_sleep():
+            result = await runner.async_run(0.0)
+
+        assert result.outcome is SeekOutcome.REACHED_TARGET
+        stop.assert_not_awaited()
+
+    async def test_crossing_completes_single_direction_seek(self) -> None:
+        policy = make_policy(
+            reverses_position_seek_on_overshoot=False,
+            auto_stops_on_idle=True,
+        )
+        runner, issue_step, stop = make_runner(policy=policy, target=20.0, readings=[27.0])
+
+        with _no_sleep():
+            result = await runner.async_run(0.0)
+
+        assert result.outcome is SeekOutcome.CROSSED_TARGET
+        issue_step.assert_awaited_once_with(True, 20.0)
+        stop.assert_not_awaited()
+
+
+class TestSeekOvershoot:
+    """Overshoot reversal for controllers that correct mid-flight."""
+
+    async def test_overshoot_reverses_with_explicit_stop(self) -> None:
+        policy = make_policy(position_seek_tolerance=1.0)
+        runner, issue_step, stop = make_runner(policy=policy, target=20.0, readings=[27.0, 20.5])
+
+        with _no_sleep() as sleep:
+            result = await runner.async_run(0.0)
+
+        assert result.outcome is SeekOutcome.REACHED_TARGET
+        assert issue_step.await_args_list[0].args == (True, 20.0)
+        assert issue_step.await_args_list[1].args == (False, 7.0)
+        assert result.final_direction is False
+        # One STOP before the reversal, one on cleanup.
+        assert stop.await_count == 2
+        sleep.assert_any_await(SEEK_REVERSAL_SETTLE_DELAY)
+
+    async def test_overshoot_on_auto_stop_controller_skips_stop(self) -> None:
+        policy = make_policy(position_seek_tolerance=1.0, auto_stops_on_idle=True)
+        runner, issue_step, stop = make_runner(policy=policy, target=20.0, readings=[27.0, 20.5])
+
+        with _no_sleep():
+            result = await runner.async_run(0.0)
+
+        assert result.outcome is SeekOutcome.REACHED_TARGET
+        assert issue_step.await_args_list[1].args == (False, 7.0)
+        stop.assert_not_awaited()
+
+    async def test_stop_request_during_reversal_aborts_new_direction(self) -> None:
+        cancel_event = asyncio.Event()
+        policy = make_policy(position_seek_tolerance=1.0)
+        stop = AsyncMock(side_effect=lambda: cancel_event.set())
+        runner, issue_step, stop = make_runner(
+            policy=policy,
+            target=20.0,
+            readings=[27.0],
+            cancel_event=cancel_event,
+            stop=stop,
+        )
+
+        with _no_sleep():
+            result = await runner.async_run(0.0)
+
+        assert result.outcome is SeekOutcome.CANCELLED
+        # Only the initial step went out; the reversal was aborted.
+        issue_step.assert_awaited_once_with(True, 20.0)
+
+
+class TestSeekStall:
+    """Stall detection, reissue, and endpoint completion."""
+
+    async def test_stall_reissues_movement(self) -> None:
+        policy = make_policy()
+        runner, issue_step, stop = make_runner(
+            policy=policy,
+            target=20.0,
+            readings=[10.0, 10.1, 10.2, 10.5, 19.0],
+        )
+
+        with _no_sleep():
+            result = await runner.async_run(0.0)
+
+        assert result.outcome is SeekOutcome.REACHED_TARGET
+        # Initial burst plus one reissue after three stagnant reads.
+        assert issue_step.await_count == 2
+        assert issue_step.await_args_list[1].args == (True, 9.5)
+
+    async def test_endpoint_policy_completes_persistent_stall(self) -> None:
+        class EndpointPolicy(PositionSeekPolicy):
+            def stall_completes_near_endpoint(self, sample: SeekSample) -> bool:
+                return sample.target == 0.0 and sample.current <= 2.0
+
+        policy = EndpointPolicy(
+            make_controller_mock(position_seek_tolerance=0.75, auto_stops_on_idle=True)
+        )
+        runner, issue_step, stop = make_runner(policy=policy, target=0.0, readings=[1.0])
+
+        with _no_sleep():
+            result = await runner.async_run(40.0)
+
+        assert result.outcome is SeekOutcome.ENDPOINT_REACHED
+        assert result.final_angle == 1.0
+        # The endpoint path performs bounded writes: only the initial burst.
+        issue_step.assert_awaited_once_with(False, 40.0)
+
+    async def test_endpoint_policy_still_retries_mid_range_stall(self) -> None:
+        class EndpointPolicy(PositionSeekPolicy):
+            def stall_completes_near_endpoint(self, sample: SeekSample) -> bool:
+                return sample.target == 0.0 and sample.current <= 2.0
+
+        policy = EndpointPolicy(
+            make_controller_mock(position_seek_tolerance=0.75, auto_stops_on_idle=True)
+        )
+        runner, issue_step, stop = make_runner(
+            policy=policy, target=0.0, readings=[15.0, 15.0, 15.0, 15.0, 0.5]
+        )
+
+        with _no_sleep():
+            result = await runner.async_run(40.0)
+
+        assert result.outcome is SeekOutcome.REACHED_TARGET
+        # The mid-range stall was reissued rather than promoted to success.
+        assert issue_step.await_count == 2
+
+
+class TestSeekTermination:
+    """Timeout, cancellation, feedback loss, and cleanup failure."""
+
+    async def test_timeout_raises_typed_result_after_cleanup(self) -> None:
+        policy = make_policy()
+        runner, issue_step, stop = make_runner(policy=policy, target=20.0, readings=[10.0])
+
+        with (
+            patch(
+                "custom_components.adjustable_bed.position_seek.POSITION_SEEK_TIMEOUT",
+                0,
+            ),
+            pytest.raises(TimeoutError, match="Position seek timed out") as err,
+        ):
+            await runner.async_run(0.0)
+
+        assert isinstance(err.value, SeekTimeoutError)
+        assert err.value.result.outcome is SeekOutcome.TIMEOUT
+        stop.assert_awaited_once_with()
+
+    async def test_cancel_before_first_step_issues_nothing(self) -> None:
+        cancel_event = asyncio.Event()
+        cancel_event.set()
+        policy = make_policy()
+        runner, issue_step, stop = make_runner(
+            policy=policy, target=20.0, readings=[10.0], cancel_event=cancel_event
+        )
+
+        result = await runner.async_run(0.0)
+
+        assert result.outcome is SeekOutcome.CANCELLED
+        issue_step.assert_not_awaited()
+        # Nothing was commanded, so no cleanup STOP goes on the wire either.
+        stop.assert_not_awaited()
+
+    async def test_stop_mid_seek_cancels(self) -> None:
+        cancel_event = asyncio.Event()
+        policy = make_policy()
+
+        async def set_cancel() -> None:
+            cancel_event.set()
+
+        runner, issue_step, stop = make_runner(
+            policy=policy,
+            target=20.0,
+            readings=[10.0],
+            cancel_event=cancel_event,
+            read_side_effect=set_cancel,
+        )
+
+        with _no_sleep():
+            result = await runner.async_run(0.0)
+
+        assert result.outcome is SeekOutcome.CANCELLED
+        issue_step.assert_awaited_once_with(True, 20.0)
+        stop.assert_awaited_once_with()
+
+    async def test_lost_feedback_ends_seek(self) -> None:
+        policy = make_policy()
+        runner, issue_step, stop = make_runner(policy=policy, target=20.0, readings=[10.0, None])
+
+        with _no_sleep():
+            result = await runner.async_run(0.0)
+
+        assert result.outcome is SeekOutcome.POSITION_LOST
+        assert result.final_angle is None
+        stop.assert_awaited_once_with()
+
+    async def test_disconnect_during_read_still_stops_motor(self) -> None:
+        policy = make_policy()
+
+        async def boom() -> None:
+            raise RuntimeError("disconnected")
+
+        runner, issue_step, stop = make_runner(
+            policy=policy,
+            target=20.0,
+            readings=[10.0],
+            read_side_effect=boom,
+        )
+
+        with _no_sleep(), pytest.raises(RuntimeError, match="disconnected"):
+            await runner.async_run(0.0)
+
+        stop.assert_awaited_once_with()
+
+    async def test_cleanup_stop_failure_propagates(self, caplog: pytest.LogCaptureFixture) -> None:
+        policy = make_policy()
+        stop = AsyncMock(side_effect=RuntimeError("stop write failed"))
+        runner, issue_step, stop = make_runner(
+            policy=policy, target=20.0, readings=[19.0], stop=stop
+        )
+
+        with _no_sleep(), pytest.raises(RuntimeError, match="stop write failed"):
+            await runner.async_run(0.0)
+
+        assert "CRITICAL: Failed to stop motor back" in caplog.text
+
+
+class TestSeekTransitions:
+    """Transition context handed to the policy at seek start."""
+
+    @staticmethod
+    def _capture_policy(**controller_overrides: object):
+        transitions: list[SeekTransition] = []
+
+        class CapturePolicy(PositionSeekPolicy):
+            async def async_on_seek_start(self, transition, stop) -> None:
+                transitions.append(transition)
+
+        controller_overrides.setdefault("auto_stops_on_idle", True)
+        return CapturePolicy(make_controller_mock(**controller_overrides)), transitions
+
+    async def test_first_seek_is_initial(self) -> None:
+        policy, transitions = self._capture_policy()
+        runner, _issue_step, _stop = make_runner(policy=policy, target=20.0, readings=[19.0])
+
+        with _no_sleep():
+            await runner.async_run(0.0)
+
+        assert [t.kind for t in transitions] == [SeekTransitionKind.INITIAL]
+        assert transitions[0].previous is None
+
+    async def test_replacement_distinguishes_direction(self) -> None:
+        previous = SeekMotion(
+            moving_up=True,
+            outcome=SeekOutcome.CANCELLED,
+            finished_monotonic=0.0,
+        )
+        policy, transitions = self._capture_policy()
+
+        runner, _issue_step, _stop = make_runner(
+            policy=policy, target=20.0, readings=[19.0], previous_motion=previous
+        )
+        with _no_sleep():
+            await runner.async_run(0.0)
+
+        runner, _issue_step, _stop = make_runner(
+            policy=policy, target=5.0, readings=[5.5], previous_motion=previous
+        )
+        with _no_sleep():
+            await runner.async_run(40.0)
+
+        assert [t.kind for t in transitions] == [
+            SeekTransitionKind.SAME_DIRECTION,
+            SeekTransitionKind.OPPOSITE_DIRECTION,
+        ]
+        assert transitions[1].previous is previous


### PR DESCRIPTION
## Problem

The v4 scheduler made position seeking part of grouped and resource-scoped command execution, but the generic seek lifecycle and protocol-specific movement policy still lived together in `AdjustableBedCoordinator._async_seek_position_serial()` (353 lines). The fixes tracked by #517, #518, and #519 each need a different protocol-specific decision inside that loop, which would otherwise grow into a set of bed-type branches in the coordinator.

## Solution

New `position_seek` module with two focused concepts:

- **`PositionSeekRunner`** owns the generic seek lifecycle: sampling, cancellation, timeout, stall and chain tracking, overshoot reversal, guaranteed motor cleanup, and a typed `SeekOutcome` terminal result (`SeekTimeoutError`, a `TimeoutError` subclass carrying the typed result, preserves the historical timeout contract).
- **`PositionSeekPolicy`** is supplied by the controller via a new `BedController.position_seek_policy` property. The default policy delegates every tuning value lazily to the controller's existing seek properties (tolerance, check interval, stall thresholds, chaining, overshoot reversal, explicit-STOP), so existing controllers -- including Linak's overrides -- retain byte-identical command and cleanup traces with zero controller changes.

Policy hooks are in place for the planned protocol work, each defaulting to the historical behavior:

- `stall_completes_near_endpoint()` lets a policy accept a persistent stall near a physical travel limit without widening normal tolerance (#519).
- `accepts_position()` receives movement samples so a policy can compensate for measured coast (#517).
- `async_on_seek_start()` receives a `SeekTransition` distinguishing initial, same-direction, and opposite-direction seeks; the coordinator tracks the last commanded motion per axis so a replacement seek's policy can react (#518).
- The typed per-axis terminal outcome is recorded into `command_timing` diagnostics under `position_seeks` (feeds #520).

The coordinator keeps what is genuinely its own: command lock, connection assurance, controller pinning and auth refresh, initial position acquisition, the direct-position shortcut, and disconnect-after-command handling.

GATT writes and STOP/release semantics remain controller-owned; the only intentional behavior delta is that a cancellation arriving before the first movement step now ends the seek with no wire traffic at all (previously the initial burst and cleanup STOP could still go out in that race).

## Testing

- New `tests/test_position_seek.py`: 18 deterministic runner/policy tests with synthetic feedback sequences covering progress, already-at-target, crossing, overshoot reversal (with and without explicit STOP), STOP during reversal, stall reissue, endpoint completion, mid-range stall non-promotion, timeout, cancellation, feedback loss, disconnect during read, cleanup-STOP failure, and transition kinds.
- Existing coordinator seek tests pass unchanged apart from patch targets moving to the new module.
- Full suite: 3504 passed. `ruff check` and `pyright` clean.

Ref #522. Prepares #517, #518, #519, #520.