### PR TITLE
fix: recheck cancellation after the seek-start policy hook

### DIFF
--- a/custom_components/adjustable_bed/position_seek.py
+++ b/custom_components/adjustable_bed/position_seek.py
@@ -328,6 +328,14 @@ class PositionSeekRunner:
         # Start movement in try-finally to guarantee stop is sent
         try:
             await policy.async_on_seek_start(self._transition(moving_up), self._stop)
+            # A STOP or replacement can arrive while the policy runs its start
+            # transition; never begin motion after a newer safety request.
+            if cancel_event.is_set():
+                _LOGGER.debug(
+                    "Position seek cancelled during start transition for %s",
+                    position_key,
+                )
+                return result(SeekOutcome.CANCELLED, initial_angle, None)
             await self._issue_step(moving_up, abs(target_angle - initial_angle))
 
             # Tracking variables

--- a/tests/test_position_seek.py
+++ b/tests/test_position_seek.py
@@ -267,6 +267,27 @@ class TestSeekTermination:
         # Nothing was commanded, so no cleanup STOP goes on the wire either.
         stop.assert_not_awaited()
 
+    async def test_cancel_during_start_transition_never_starts_motion(self) -> None:
+        cancel_event = asyncio.Event()
+
+        class SettlingPolicy(PositionSeekPolicy):
+            async def async_on_seek_start(self, transition, stop) -> None:
+                # A STOP/replacement lands while the policy settles the axis.
+                cancel_event.set()
+
+        policy = SettlingPolicy(make_controller_mock())
+        runner, issue_step, stop = make_runner(
+            policy=policy, target=20.0, readings=[10.0], cancel_event=cancel_event
+        )
+
+        result = await runner.async_run(0.0)
+
+        assert result.outcome is SeekOutcome.CANCELLED
+        issue_step.assert_not_awaited()
+        # The hook may have touched the wire, so cleanup still sends STOP for
+        # explicit-stop protocols.
+        stop.assert_awaited_once_with()
+
     async def test_stop_mid_seek_cancels(self) -> None:
         cancel_event = asyncio.Event()
         policy = make_policy()


### PR DESCRIPTION
## Problem

Codex's required review on #532 landed about 90 seconds before the merge and its P1 finding went unaddressed: `PositionSeekRunner.async_run` checks the cancel ticket before `async_on_seek_start()` but not after it. The default hook never suspends, so no current controller can hit this, but the hook exists precisely so a future policy (#518) can run an awaitable settle/release transition. A STOP or replacement arriving during that await would be followed by the runner issuing the first movement step, starting motion after a newer safety request.

## Solution

Recheck `cancel_event` after the start hook, mirroring the existing recheck after `async_prepare_reversal()`, and return a `CANCELLED` outcome before any movement step. The cleanup STOP in the `finally` block still runs for explicit-stop protocols since the hook may have written on the wire. Behavior with the default policy is unchanged.

New deterministic test: a policy whose start transition observes a STOP ends the seek with no movement step and one cleanup STOP.

Ref #522, #518. Addresses https://github.com/kristofferR/ha-adjustable-bed/pull/532#pullrequestreview-5054405966.