### PR TITLE
fix: apply Prodigy CE protocol variants and settings

### DIFF
--- a/custom_components/adjustable_bed/beds/base.py
+++ b/custom_components/adjustable_bed/beds/base.py
@@ -1241,6 +1241,16 @@ class BedController(ABC):
         return False
 
     @property
+    def supports_control_mode_configuration(self) -> bool:
+        """Return True if the bed can switch between press-control modes."""
+        return (
+            type(self).set_control_mode_press_and_hold
+            is not BedController.set_control_mode_press_and_hold
+            and type(self).set_control_mode_press_and_release
+            is not BedController.set_control_mode_press_and_release
+        )
+
+    @property
     def has_discrete_motor_control(self) -> bool:
         """Return True if bed uses discrete (button-press) motor control.
 
@@ -1711,6 +1721,14 @@ class BedController(ABC):
             NotImplementedError: If the bed doesn't support this preset
         """
         raise NotImplementedError("Yoga preset not supported on this bed")
+
+    async def set_control_mode_press_and_hold(self) -> None:
+        """Require controls to remain pressed while their action runs."""
+        raise NotImplementedError("Control mode configuration not supported on this bed")
+
+    async def set_control_mode_press_and_release(self) -> None:
+        """Allow controls to continue their action after they are released."""
+        raise NotImplementedError("Control mode configuration not supported on this bed")
 
     # Feature methods (may not be available on all beds)
 

--- a/custom_components/adjustable_bed/beds/leggett_okin.py
+++ b/custom_components/adjustable_bed/beds/leggett_okin.py
@@ -7,7 +7,7 @@ This controller handles Leggett & Platt beds using the Okin binary protocol.
 Protocol details:
     Service UUID: 62741523-52f9-8864-b1ab-3b3a8d65950b (shared with Okimat/Nectar)
     Write characteristic: 62741525-52f9-8864-b1ab-3b3a8d65950b
-    Command format: 6-byte binary [0x04, 0x02, <4-byte-command-big-endian>]
+    Command format: runtime-selected 6-byte R1 or checksummed 8-byte R0 frame
     Motor timing: held keycodes stream every 100ms, released with four zero frames
     Position feedback: Not supported
     Pairing: Required before first use; handled by coordinator
@@ -23,12 +23,21 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+from collections.abc import Callable
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from bleak.exc import BleakError
 
-from ..const import LEGGETT_OKIN_CHAR_UUID, LEGGETT_OKIN_PULSE_DEFAULTS
+from ..const import (
+    LEGGETT_OKIN_CHAR_UUID,
+    LEGGETT_OKIN_NOTIFY_CHAR_UUID,
+    LEGGETT_OKIN_PULSE_DEFAULTS,
+    LEGGETT_OKIN_REVISION_SELECTOR_CHAR_UUID,
+    LEGGETT_OKIN_SERVICE_UUID,
+    OKIN_SMART_REMOTE_CSS_NOTIFY_CHAR_UUID,
+    OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID,
+)
 from .base import BedController, MotorControlSpec
 from .okin_protocol import build_okin_command
 
@@ -51,7 +60,6 @@ class LeggettOkinCommands:
     # Presets. FLAT is a held button rather than a one-shot recall; the memory
     # slots and SNORE are one-shot recalls the control box completes on its own.
     PRESET_FLAT = 0x8000000
-    PRESET_ZERO_G = 0x1000  # Deliberate alias of memory 1
     PRESET_MEMORY_1 = 0x1000
     PRESET_MEMORY_2 = 0x2000
     PRESET_MEMORY_3 = 0x4000  # Ships pre-assigned as the snore position
@@ -82,6 +90,10 @@ class LeggettOkinCommands:
     # Lights
     TOGGLE_LIGHTS = 0x20000
 
+    # Persistent handset-control mode settings
+    CONTROL_MODE_PRESS_AND_HOLD = 0x08010000
+    CONTROL_MODE_PRESS_AND_RELEASE = 0x01800000
+
 
 # The app streams a held keycode until release, then emits exactly four
 # keycode-0 frames (OutputThread.runNormal, MaxZeroCount = 3). There is no
@@ -109,6 +121,61 @@ MEMORY_PROGRAM_FRAME_DELAY_MS = 100
 # usability choice, not a protocol constant.
 FLAT_HOLD_S = 30.0
 
+# The settings dialog schedules 55 attempts at the normal cadence and then one
+# explicit zero frame. This is a distinct lifecycle from an ordinary held key,
+# whose release is four zero frames.
+CONTROL_MODE_FRAME_COUNT = 55
+CONTROL_MODE_FRAME_DELAY_MS = 100
+
+
+def _build_revision_0_command(command_value: int) -> bytes:
+    """Build the APK's revision-0 E5 FE 16 command frame."""
+    keycode = build_okin_command(command_value)[2:]
+    frame = b"\xe5\xfe\x16" + keycode
+    return frame + bytes(((~sum(frame)) & 0xFF,))
+
+
+def parse_leggett_okin_feedback(data: bytes) -> tuple[int, int] | None:
+    """Reconstruct the Prodigy CE LED/status pair from a notification."""
+    if len(data) < 4:
+        return None
+
+    size = data[0] & 0x0F
+    if len(data) < size + 3:
+        return None
+
+    led_mask = 0
+    for index in range(min(max(size - 2, 0), 4)):
+        led_mask = (led_mask << 8) | data[index + 2]
+
+    status = data[6] if size > 5 else -1
+    if status >= 0x80:
+        status -= 0x100
+
+    def read_unsigned(offset: int, count: int) -> int:
+        value = 0
+        for index in range(count):
+            value = (value << 8) | data[offset + index]
+        return value
+
+    opcode = data[2]
+    if opcode == 6:
+        led_mask |= read_unsigned(3, size)
+    elif opcode in (7, 9):
+        led_mask &= ~read_unsigned(3, size)
+    elif opcode == 8 and size != 6:
+        led_mask ^= read_unsigned(3, size)
+    elif opcode == 11:
+        half = size >> 1
+        offset = 3 + (size & 1)
+        led_mask = (
+            read_unsigned(offset + half, half)
+            & read_unsigned(offset, half)
+            & ~0x200
+        ) | (led_mask & 0x200)
+
+    return led_mask & 0xFFFFFFFF, status
+
 
 class MotorDirection(Enum):
     """Direction for motor movement."""
@@ -134,7 +201,15 @@ class LeggettOkinController(BedController):
         """Initialize the Leggett & Platt Okin controller."""
         super().__init__(coordinator)
         self._motor_state: dict[str, MotorDirection] = {}
-        _LOGGER.debug("LeggettOkinController initialized")
+        self._protocol_revision = self._detect_protocol_revision()
+        self._notification_led_mask: int | None = None
+        self._notification_status: int | None = None
+        self._notify_started: set[str] = set()
+        self._settings_initialized = False
+        _LOGGER.debug(
+            "LeggettOkinController initialized (protocol revision: %s)",
+            self._protocol_revision if self._protocol_revision is not None else "unknown",
+        )
 
     @property
     def control_characteristic_uuid(self) -> str:
@@ -142,10 +217,6 @@ class LeggettOkinController(BedController):
         return LEGGETT_OKIN_CHAR_UUID
 
     # Capability properties
-    @property
-    def supports_preset_zero_g(self) -> bool:
-        return True
-
     @property
     def supports_preset_anti_snore(self) -> bool:
         """Return True - 0x4000 is bound to the app's dedicated snore button."""
@@ -175,6 +246,37 @@ class LeggettOkinController(BedController):
     def supports_memory_programming(self) -> bool:
         """Return True - slots are programmed by the two-stage store hold."""
         return True
+
+    @property
+    def memory_slot_names(self) -> tuple[str | None, ...]:
+        """Return the three editable favorites and fixed Snore entry."""
+        return ("Favorite 1", "Favorite 2", "Snore", "Favorite 3")
+
+    def is_memory_slot_programmable(self, memory_num: int) -> bool:
+        """Return False for the APK's fixed Snore entry in slot 3."""
+        return memory_num in (1, 2, 4)
+
+    @property
+    def requires_notification_channel(self) -> bool:
+        """Subscribe to the app's status channels even without position sensing."""
+        return True
+
+    @property
+    def protocol_diagnostics(self) -> dict[str, Any]:
+        """Report resolved framing and the APK-parsed opaque status mask."""
+        led_mask = self._notification_led_mask
+        return {
+            "protocol_revision": self._protocol_revision,
+            "revision_selector_present": (
+                self._protocol_revision == 1 if self._protocol_revision is not None else None
+            ),
+            "notification_led_mask": f"0x{led_mask:08x}" if led_mask is not None else None,
+            "notification_status": self._notification_status,
+            "alarm_armed": bool(led_mask & 0x4000) if led_mask is not None else None,
+            "sleep_timer_armed": bool(led_mask & 0x8000) if led_mask is not None else None,
+            "notification_characteristics": sorted(self._notify_started),
+            "settings_initialized": self._settings_initialized,
+        }
 
     @property
     def has_pillow_support(self) -> bool:
@@ -225,15 +327,58 @@ class LeggettOkinController(BedController):
         """Remove duplicate aliases and the former tilt label."""
         return frozenset({"back", "legs", "tilt"})
 
+    def _available_characteristic_uuids(self) -> frozenset[str] | None:
+        """Return discovered characteristic UUIDs, or None before discovery."""
+        client = self.client
+        services = getattr(client, "services", None) if client is not None else None
+        if services is None:
+            return None
+
+        try:
+            return frozenset(
+                str(characteristic.uuid).lower()
+                for service in services
+                for characteristic in getattr(service, "characteristics", ())
+            )
+        except TypeError:
+            return None
+
+    def _detect_protocol_revision(self) -> int | None:
+        """Select R1 only when the APK's selector characteristic is present."""
+        client = self.client
+        services = getattr(client, "services", None) if client is not None else None
+        if services is None:
+            return None
+
+        try:
+            service = next(
+                (
+                    service
+                    for service in services
+                    if str(getattr(service, "uuid", "")).lower()
+                    == LEGGETT_OKIN_SERVICE_UUID.lower()
+                ),
+                None,
+            )
+        except TypeError:
+            return None
+        if service is None:
+            return None
+
+        characteristic_uuids = {
+            str(characteristic.uuid).lower()
+            for characteristic in getattr(service, "characteristics", ())
+        }
+        if LEGGETT_OKIN_CHAR_UUID.lower() not in characteristic_uuids:
+            return None
+        return int(LEGGETT_OKIN_REVISION_SELECTOR_CHAR_UUID.lower() in characteristic_uuids)
+
     def _build_command(self, command_value: int) -> bytes:
-        """Build Okin binary command by delegating to build_okin_command.
-
-        Args:
-            command_value: 32-bit command value (0 to 0xFFFFFFFF)
-
-        Returns:
-            6-byte command: [0x04, 0x02, <4-byte-command-big-endian>]
-        """
+        """Build the runtime-selected revision-0 or revision-1 command."""
+        if self._protocol_revision is None:
+            self._protocol_revision = self._detect_protocol_revision()
+        if self._protocol_revision == 0:
+            return _build_revision_0_command(command_value)
         return build_okin_command(command_value)
 
     async def write_command(
@@ -253,6 +398,91 @@ class LeggettOkinController(BedController):
             response=False,
             wall_clock_pacing=True,
         )
+
+    async def start_notify(
+        self, callback: Callable[[str, float], None] | None = None
+    ) -> None:
+        """Subscribe to the status channels recovered from Prodigy CE."""
+        self._notify_callback = callback
+        client = self.client
+        if client is None or not client.is_connected:
+            _LOGGER.warning("Cannot start Leggett Okin notifications: not connected")
+            return
+
+        characteristic_uuids = self._available_characteristic_uuids() or frozenset()
+        candidates = (
+            LEGGETT_OKIN_NOTIFY_CHAR_UUID,
+            OKIN_SMART_REMOTE_CSS_NOTIFY_CHAR_UUID,
+        )
+        settings_started_now = False
+        for characteristic_uuid in candidates:
+            normalized_uuid = characteristic_uuid.lower()
+            if (
+                normalized_uuid not in characteristic_uuids
+                or normalized_uuid in self._notify_started
+            ):
+                continue
+            try:
+                async with self._ble_lock:
+                    await client.start_notify(characteristic_uuid, self._handle_notification)
+                self._notify_started.add(normalized_uuid)
+                settings_started_now |= (
+                    normalized_uuid == OKIN_SMART_REMOTE_CSS_NOTIFY_CHAR_UUID.lower()
+                )
+            except BleakError as err:
+                _LOGGER.debug(
+                    "Could not start Leggett Okin notifications on %s: %s",
+                    characteristic_uuid,
+                    err,
+                )
+
+        if (
+            (settings_started_now or OKIN_SMART_REMOTE_CSS_NOTIFY_CHAR_UUID.lower() in self._notify_started)
+            and not self._settings_initialized
+            and OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID.lower() in characteristic_uuids
+        ):
+            try:
+                await self._write_gatt_with_retry(
+                    OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID,
+                    b"\x01\x02",
+                    response=True,
+                    log_errors=False,
+                )
+                self._settings_initialized = True
+            except (BleakError, ConnectionError) as err:
+                _LOGGER.debug("Could not initialize Leggett Okin settings: %s", err)
+
+    def _handle_notification(self, sender: object, data: bytearray) -> None:
+        """Forward raw data and retain the APK's opaque LED/status result."""
+        characteristic_uuid = str(getattr(sender, "uuid", sender)).lower()
+        payload = bytes(data)
+        self.forward_raw_notification(characteristic_uuid, payload)
+        parsed = parse_leggett_okin_feedback(payload)
+        if parsed is None:
+            return
+        self._notification_led_mask, self._notification_status = parsed
+
+    async def stop_notify(self) -> None:
+        """Stop every active Prodigy CE status subscription."""
+        self._notify_callback = None
+        client = self.client
+        if client is None or not client.is_connected:
+            self._notify_started.clear()
+            self._settings_initialized = False
+            return
+
+        for characteristic_uuid in tuple(self._notify_started):
+            try:
+                async with self._ble_lock:
+                    await client.stop_notify(characteristic_uuid)
+            except BleakError as err:
+                _LOGGER.debug(
+                    "Could not stop Leggett Okin notifications on %s: %s",
+                    characteristic_uuid,
+                    err,
+                )
+        self._notify_started.clear()
+        self._settings_initialized = False
 
     def motor_pulse_settings(self) -> tuple[int, int]:
         """Keep movement streams at the proven CU170 cadence."""
@@ -307,12 +537,18 @@ class LeggettOkinController(BedController):
             # mask the original error.
             await self._send_release_frames("motor movement", raise_on_error=completed)
 
-    async def _send_release_frames(self, context: str, *, raise_on_error: bool = False) -> None:
+    async def _send_release_frames(
+        self,
+        context: str,
+        *,
+        raise_on_error: bool = False,
+        repeat_count: int = RELEASE_FRAME_COUNT,
+    ) -> None:
         """Send the release burst that ends a held keycode.
 
-        The app emits exactly four keycode-0 frames when a button is released,
-        so mirror that rather than a single frame. The burst gets a fresh cancel
-        event so a stop request cannot suppress the release itself.
+        Ordinary button release emits exactly four keycode-0 frames. Callers
+        with a protocol-specific lifecycle can select another proven count. The
+        release gets a fresh cancel event so a stop request cannot suppress it.
 
         ``raise_on_error`` is for callers where the burst *is* the operation, so
         a failure must reach the user. Cleanup callers leave it False: they are
@@ -321,7 +557,7 @@ class LeggettOkinController(BedController):
         release = asyncio.ensure_future(
             self.write_command(
                 self._build_command(0),
-                repeat_count=RELEASE_FRAME_COUNT,
+                repeat_count=repeat_count,
                 repeat_delay_ms=RELEASE_FRAME_DELAY_MS,
                 cancel_event=asyncio.Event(),
             )
@@ -472,6 +708,10 @@ class LeggettOkinController(BedController):
         ~2s. Both stages are ordinary held keycodes, so each ends with the
         normal release burst.
         """
+        if not self.is_memory_slot_programmable(memory_num):
+            _LOGGER.warning("Memory slot %d is fixed and cannot be programmed", memory_num)
+            return
+
         command = self._MEMORY_SLOTS.get(memory_num)
         if command is None:
             _LOGGER.warning("Invalid memory slot for programming: %d", memory_num)
@@ -503,13 +743,40 @@ class LeggettOkinController(BedController):
             repeat_delay_ms=MEMORY_PROGRAM_FRAME_DELAY_MS,
         )
 
-    async def preset_zero_g(self) -> None:
-        """Go to zero gravity position (memory slot 1 on this protocol)."""
-        await self._recall(LeggettOkinCommands.PRESET_ZERO_G)
-
     async def preset_anti_snore(self) -> None:
         """Go to anti-snore position (memory slot 3 on this protocol)."""
         await self._recall(LeggettOkinCommands.PRESET_ANTI_SNORE)
+
+    async def _set_control_mode(self, command: int, context: str) -> None:
+        """Send one of the APK's persistent handset-control mode commands."""
+        completed = False
+        try:
+            await self.write_command(
+                self._build_command(command),
+                repeat_count=CONTROL_MODE_FRAME_COUNT,
+                repeat_delay_ms=CONTROL_MODE_FRAME_DELAY_MS,
+            )
+            completed = True
+        finally:
+            await self._send_release_frames(
+                context,
+                raise_on_error=completed,
+                repeat_count=1,
+            )
+
+    async def set_control_mode_press_and_hold(self) -> None:
+        """Require a control to remain held while its action runs."""
+        await self._set_control_mode(
+            LeggettOkinCommands.CONTROL_MODE_PRESS_AND_HOLD,
+            "press-and-hold control mode",
+        )
+
+    async def set_control_mode_press_and_release(self) -> None:
+        """Allow an action to continue after its control is released."""
+        await self._set_control_mode(
+            LeggettOkinCommands.CONTROL_MODE_PRESS_AND_RELEASE,
+            "press-and-release control mode",
+        )
 
     async def _tap_keycode(self, command: int, context: str) -> None:
         """Send a keycode as a short press, then release it.

--- a/custom_components/adjustable_bed/beds/leggett_okin.py
+++ b/custom_components/adjustable_bed/beds/leggett_okin.py
@@ -566,9 +566,9 @@ class LeggettOkinController(BedController):
         """Toggle massage / step through modes."""
         await self._tap_keycode(LeggettOkinCommands.MASSAGE_STEP, "massage_toggle")
 
-    async def massage_wave_step(self) -> None:
+    async def massage_mode_step(self) -> None:
         """Step through massage wave patterns."""
-        await self._tap_keycode(LeggettOkinCommands.MASSAGE_WAVE_STEP, "massage_wave_step")
+        await self._tap_keycode(LeggettOkinCommands.MASSAGE_WAVE_STEP, "massage_mode_step")
 
     # Pillow motor control. Keep the tilt methods as compatibility aliases for
     # service calls or stale entities created by older releases.

--- a/custom_components/adjustable_bed/button.py
+++ b/custom_components/adjustable_bed/button.py
@@ -254,6 +254,24 @@ BUTTON_DESCRIPTIONS: tuple[AdjustableBedButtonEntityDescription, ...] = (
         memory_slot=6,
         is_program_button=True,
     ),
+    AdjustableBedButtonEntityDescription(
+        key="control_mode_press_and_hold",
+        translation_key="control_mode_press_and_hold",
+        icon="mdi:gesture-tap-hold",
+        entity_category=EntityCategory.CONFIG,
+        press_fn=lambda ctrl: ctrl.set_control_mode_press_and_hold(),
+        cancel_movement=True,
+        required_capability="supports_control_mode_configuration",
+    ),
+    AdjustableBedButtonEntityDescription(
+        key="control_mode_press_and_release",
+        translation_key="control_mode_press_and_release",
+        icon="mdi:gesture-tap",
+        entity_category=EntityCategory.CONFIG,
+        press_fn=lambda ctrl: ctrl.set_control_mode_press_and_release(),
+        cancel_movement=True,
+        required_capability="supports_control_mode_configuration",
+    ),
     # Stop button
     AdjustableBedButtonEntityDescription(
         key="stop",

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -659,6 +659,8 @@ LEGGETT_GEN2_MANUFACTURER_PREFIXES: Final = (b"XP", b"CP")
 # Okin variant (requires pairing)
 LEGGETT_OKIN_SERVICE_UUID: Final = "62741523-52f9-8864-b1ab-3b3a8d65950b"
 LEGGETT_OKIN_CHAR_UUID: Final = "62741525-52f9-8864-b1ab-3b3a8d65950b"
+LEGGETT_OKIN_NOTIFY_CHAR_UUID: Final = "62741625-52f9-8864-b1ab-3b3a8d65950b"
+LEGGETT_OKIN_REVISION_SELECTOR_CHAR_UUID: Final = "00001721-0000-1000-8000-00805f9b34fb"
 
 # Leggett & Platt Richmat variant (WiLinke protocol, discrete massage commands)
 # Uses same service/char as Richmat WiLinke but with L&P-specific features

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -651,6 +651,12 @@
       "program_memory_6": {
         "name": "Save to Memory 6"
       },
+      "control_mode_press_and_hold": {
+        "name": "Use Press-and-Hold Controls"
+      },
+      "control_mode_press_and_release": {
+        "name": "Use Press-and-Release Controls"
+      },
       "massage_all_off": {
         "name": "Massage: Off"
       },

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -651,6 +651,12 @@
       "program_memory_6": {
         "name": "Save to Memory 6"
       },
+      "control_mode_press_and_hold": {
+        "name": "Use Press-and-Hold Controls"
+      },
+      "control_mode_press_and_release": {
+        "name": "Use Press-and-Release Controls"
+      },
       "massage_all_off": {
         "name": "Massage: Off"
       },

--- a/docs/beds/leggett-okin.md
+++ b/docs/beds/leggett-okin.md
@@ -87,7 +87,8 @@ reprogram a slot with whatever position the bed happened to be in.
 | Under-bed light toggle | `0x00020000` |
 
 Massage power is a **toggle** with no discrete off, so the integration exposes
-no massage-off button.
+no massage-off button. The wave keycode is exposed as the massage mode-step
+button.
 
 There is no massage timer. `0x00000200` appears in the app as a constant
 (`FBP_KEYCODE_M5_IN`, a fifth actuator channel) but is never bound to a control
@@ -133,23 +134,26 @@ buzz once. Within 5 seconds, touch the Favorite Position being edited."
 ## Notifications
 
 The notify characteristic acknowledges accepted writes and also emits status
-updates for physical-remote actions. The vendor app parses it into two live
-indicators - sleep timer (`0x8000`) and alarm (`0x4000`) - and no parsed value
-ever influences a later command.
+updates for physical-remote actions. The vendor app reconstructs a generic
+LED/status bitmask from operations 6, 7, 8, 9, and 11, but only assigns UI
+meaning to sleep timer (`0x8000`) and alarm (`0x4000`). No parsed value ever
+influences a later command.
 
 There is **no position, angle, percentage, motor-state or error feedback of any
-kind** in either app. Under-bed light state is *not* among the bits either app
-reads. CU170 hardware testing confirms that a light-state bit is present, but
-the exact byte and mask still need a paired before/after notification capture.
-Until then the integration keeps the light as a blind toggle rather than
-guessing the bit.
+kind** in either app. CU170 hardware testing confirms that the opaque bitmask
+contains light state, but the app never labels that bit and the available
+captures do not include a paired light-off/light-on notification. The exact
+mask and polarity therefore still require that capture. Until then the
+integration keeps the light as a blind toggle rather than guessing.
 
 ## Provenance
 
-Command values, framing, timing and release semantics come from a clean-room
-analysis of `com.leggett.prodigy4` 1.2.0 (versionCode 18, artifact SHA-256
-`f32978d8…`), traced from layout binding to the GATT write boundary. Two
-independent analyst runs agreed on every value recorded here.
+Command values, framing, timing, notification parsing and release semantics
+come from the accepted Phase 4 clean-room analysis of `com.leggett.prodigy4`
+1.2.0 (versionCode 18, artifact SHA-256 `45922c518c9e8070…`), traced from layout
+binding to the GATT boundary and independently audited. The report is COMPLETE;
+the missing light-bit meaning is explicitly deferred physical validation, not
+an unresolved APK-analysis path.
 
 Unverified against hardware, and worth a capture if you have the equipment:
 which frame revision real units use, whether preset recall truly ends without a

--- a/docs/beds/leggett-okin.md
+++ b/docs/beds/leggett-okin.md
@@ -31,9 +31,10 @@ The app picks its framing once per connection, purely on whether characteristic
 The revision-0 checksum is `~sum(bytes[0..6])` truncated to 8 bits, giving the
 invariant that all eight bytes sum to `0xFF`.
 
-**The integration currently only emits the 6-byte revision-1 frame.** A
-revision-0 control box would silently ignore every command. This is a known gap,
-not a proven-absent case.
+The integration applies this same characteristic check after service discovery
+and records the selected revision in protocol diagnostics. If service discovery
+is unavailable it preserves the established revision-1 default rather than
+guessing that a connected device is revision 0.
 
 ## Keycodes
 
@@ -60,15 +61,17 @@ buttons, so multiple simultaneous actions are one frame with several bits set.
 
 | Action | Keycode | Kind |
 |---|---|---|
-| Memory 1 / Zero-G | `0x00001000` | recall |
-| Memory 2 | `0x00002000` | recall |
-| Memory 3 / Anti-snore | `0x00004000` | recall |
-| Memory 4 | `0x00008000` | recall |
+| Favorite 1 | `0x00001000` | editable recall |
+| Favorite 2 | `0x00002000` | editable recall |
+| Snore | `0x00004000` | fixed recall |
+| Favorite 3 | `0x00008000` | editable recall |
 | Flat | `0x08000000` | **held button**, not a recall |
 | Memory store (arm) | `0x00010000` | **not a recall** |
 
-Zero-G and anti-snore are genuine aliases: the vendor apps ship those positions
-pre-assigned to slots 1 and 3, and send the same keycode.
+Prodigy CE initializes Favorite 1, Favorite 2 and Favorite 3 as editable entries.
+It initializes the third wire slot as the fixed Snore entry. The integration
+therefore exposes no separate Zero-G action, and never offers or accepts a save
+operation for the Snore slot.
 
 `0x00010000` arms the box to overwrite a slot. It must never appear in the
 recall ladder. Earlier releases of this integration used a ladder shifted one
@@ -146,6 +149,26 @@ captures do not include a paired light-off/light-on notification. The exact
 mask and polarity therefore still require that capture. Until then the
 integration keeps the light as a blind toggle rather than guessing.
 
+The integration subscribes to the main status characteristic and, when present,
+the optional Smart Remote CSS status characteristic. It runs the app's exact
+operations 6/7/8/9/11 parser and records the resulting opaque LED mask, signed
+status byte, and the two app-labelled alarm/sleep bits in protocol diagnostics.
+It does not promote an unlabeled bit to a Home Assistant entity.
+
+## Control mode
+
+Prodigy CE exposes two persistent control-box settings:
+
+| Mode | Keycode | Lifecycle |
+|---|---|---|
+| Press-and-hold | `0x08010000` | 55 attempts at 100 ms, then one zero frame |
+| Press-and-release | `0x01800000` | 55 attempts at 100 ms, then one zero frame |
+
+Home Assistant exposes these as configuration buttons rather than a select,
+because neither notification channel reports the currently active mode. On
+boxes with the optional Smart Remote CSS service, notification setup also sends
+the app's raw `01 02` initialization write.
+
 ## Provenance
 
 Command values, framing, timing, notification parsing and release semantics
@@ -157,5 +180,6 @@ an unresolved APK-analysis path.
 
 Unverified against hardware, and worth a capture if you have the equipment:
 which frame revision real units use, whether preset recall truly ends without a
-terminator, and whether the `0x08010000` chord resets memory to factory
-defaults as the vendor guide states.
+terminator, whether changing control mode also resets editable favorites on all
+firmware, and which opaque notification-mask bit and polarity represent the
+under-bed light.

--- a/tests/test_controller_contract.py
+++ b/tests/test_controller_contract.py
@@ -61,6 +61,7 @@ SHARED_CAPABILITY_FLAGS: tuple[str, ...] = (
     "supports_motor_control",
     "supports_stop_all",
     "supports_fan_control",
+    "supports_control_mode_configuration",
 )
 
 
@@ -635,6 +636,10 @@ async def test_declared_capabilities_map_to_implemented_methods(bed_type: str) -
         for method_name in ("fan_left_cycle", "fan_right_cycle", "fan_sync_cycle"):
             assert _is_overridden(controller, method_name)
         assert controller.fan_level_max > 0
+
+    if controller.supports_control_mode_configuration:
+        assert _is_overridden(controller, "set_control_mode_press_and_hold")
+        assert _is_overridden(controller, "set_control_mode_press_and_release")
 
 
 async def test_base_move_with_stop_always_sends_stop_on_error() -> None:

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from bleak.exc import BleakError
@@ -17,7 +19,9 @@ from custom_components.adjustable_bed.beds.leggett_gen2 import (
 from custom_components.adjustable_bed.beds.leggett_okin import (
     LeggettOkinCommands,
     LeggettOkinController,
+    parse_leggett_okin_feedback,
 )
+from custom_components.adjustable_bed.button import BUTTON_DESCRIPTIONS, _should_add_button
 from custom_components.adjustable_bed.const import (
     BED_TYPE_LEGGETT_GEN2,
     BED_TYPE_LEGGETT_PLATT,
@@ -30,10 +34,16 @@ from custom_components.adjustable_bed.const import (
     CONF_PROTOCOL_VARIANT,
     DOMAIN,
     LEGGETT_GEN2_WRITE_CHAR_UUID,
+    LEGGETT_OKIN_CHAR_UUID,
+    LEGGETT_OKIN_NOTIFY_CHAR_UUID,
     LEGGETT_OKIN_PULSE_DEFAULTS,
+    LEGGETT_OKIN_REVISION_SELECTOR_CHAR_UUID,
+    LEGGETT_OKIN_SERVICE_UUID,
     LEGGETT_VARIANT_GEN2,
     LEGGETT_VARIANT_MLRM,
     LEGGETT_VARIANT_OKIN,
+    OKIN_SMART_REMOTE_CSS_NOTIFY_CHAR_UUID,
+    OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID,
     VARIANT_AUTO,
     connection_gated_by_bond,
     requires_pairing,
@@ -130,6 +140,47 @@ class TestLeggettOkinController:
         # Command 0x1 in big-endian
         assert command[2:] == bytes([0x00, 0x00, 0x00, 0x01])
 
+    @staticmethod
+    def _controller_with_characteristics(*uuids: str) -> LeggettOkinController:
+        coordinator = MagicMock()
+        coordinator.client = SimpleNamespace(
+            is_connected=True,
+            services=[
+                SimpleNamespace(
+                    uuid=LEGGETT_OKIN_SERVICE_UUID,
+                    characteristics=[SimpleNamespace(uuid=uuid) for uuid in uuids]
+                )
+            ],
+        )
+        coordinator.cancel_command = asyncio.Event()
+        coordinator.address = "AA:BB:CC:DD:EE:FF"
+        return LeggettOkinController(coordinator)
+
+    def test_revision_zero_framing_selected_when_selector_is_absent(self):
+        """The write characteristic without 1721 selects the checksummed R0 frame."""
+        controller = self._controller_with_characteristics(LEGGETT_OKIN_CHAR_UUID)
+
+        assert controller._build_command(LeggettOkinCommands.MOTOR_HEAD_UP) == bytes.fromhex(
+            "e5fe160000000105"
+        )
+        assert controller._build_command(0) == bytes.fromhex("e5fe160000000006")
+        assert controller._build_command(
+            LeggettOkinCommands.CONTROL_MODE_PRESS_AND_HOLD
+        ) == bytes.fromhex("e5fe1608010000fd")
+        assert controller.protocol_diagnostics["protocol_revision"] == 0
+
+    def test_revision_one_framing_selected_when_selector_is_present(self):
+        """Characteristic 1721 selects the established six-byte R1 frame."""
+        controller = self._controller_with_characteristics(
+            LEGGETT_OKIN_CHAR_UUID,
+            LEGGETT_OKIN_REVISION_SELECTOR_CHAR_UUID,
+        )
+
+        assert controller._build_command(LeggettOkinCommands.MOTOR_HEAD_UP) == bytes.fromhex(
+            "040200000001"
+        )
+        assert controller.protocol_diagnostics["protocol_revision"] == 1
+
     async def test_massage_off_is_not_advertised(self):
         """Massage power is a toggle, so no massage-off button should be offered.
 
@@ -140,6 +191,39 @@ class TestLeggettOkinController:
         controller = LeggettOkinController(MagicMock())
 
         assert controller.supports_massage_off_control is False
+
+    async def test_favorites_match_the_prodigy_ce_model(self):
+        """Only Favorite 1/2/3 are editable; the third wire slot is fixed Snore."""
+        controller = LeggettOkinController(MagicMock())
+        controller.write_command = AsyncMock()
+
+        assert controller.supports_preset_zero_g is False
+        assert controller.memory_slot_names == (
+            "Favorite 1",
+            "Favorite 2",
+            "Snore",
+            "Favorite 3",
+        )
+        assert [controller.is_memory_slot_programmable(slot) for slot in range(1, 5)] == [
+            True,
+            True,
+            False,
+            True,
+        ]
+
+        await controller.program_memory(3)
+
+        controller.write_command.assert_not_awaited()
+
+        descriptions = {description.key: description for description in BUTTON_DESCRIPTIONS}
+        assert not _should_add_button(descriptions["preset_zero_g"], controller, True)
+        assert not _should_add_button(descriptions["program_memory_3"], controller, True)
+        assert _should_add_button(
+            descriptions["control_mode_press_and_hold"], controller, True
+        )
+        assert _should_add_button(
+            descriptions["control_mode_press_and_release"], controller, True
+        )
 
     async def test_massage_wave_mode_is_advertised_and_sends_release(self):
         """Expose the proven wave keycode through the shared mode-step entity."""
@@ -260,9 +344,94 @@ class TestLeggettOkinController:
             LeggettOkinCommands.PRESET_MEMORY_2,
             LeggettOkinCommands.PRESET_MEMORY_3,
             LeggettOkinCommands.PRESET_MEMORY_4,
-            LeggettOkinCommands.PRESET_ZERO_G,
             LeggettOkinCommands.PRESET_ANTI_SNORE,
         }
+
+    @pytest.mark.parametrize(
+        ("method_name", "command_hex"),
+        [
+            ("set_control_mode_press_and_hold", "040208010000"),
+            ("set_control_mode_press_and_release", "040201800000"),
+        ],
+    )
+    async def test_control_modes_use_the_exact_special_command_lifecycle(
+        self, method_name: str, command_hex: str
+    ):
+        """Each persistent mode is 55 attempts followed by one explicit zero."""
+        controller = LeggettOkinController(MagicMock())
+        controller.write_command = AsyncMock()
+
+        assert controller.supports_control_mode_configuration is True
+        await getattr(controller, method_name)()
+
+        command_write, release_write = controller.write_command.await_args_list
+        assert command_write.args == (bytes.fromhex(command_hex),)
+        assert command_write.kwargs == {
+            "repeat_count": 55,
+            "repeat_delay_ms": 100,
+        }
+        assert release_write.args == (bytes.fromhex("040200000000"),)
+        assert release_write.kwargs["repeat_count"] == 1
+        assert release_write.kwargs["cancel_event"].is_set() is False
+
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            ("010203", None),
+            ("06000600000000", None),
+            ("0200061234", (4660, -1)),
+            ("04000712340000", (1810, -1)),
+            ("04000812340000", (305399826, -1)),
+            ("060008123456fe0000", (135410774, -2)),
+            ("04000912340000", (2322, -1)),
+            ("04000bffff0f0f", (3855, -1)),
+            ("040055aa000000", (21930, -1)),
+            ("060055aa0000fe0000", (1437204480, -2)),
+        ],
+    )
+    def test_feedback_parser_matches_frozen_apk_vectors(
+        self, payload: str, expected: tuple[int, int] | None
+    ):
+        """Keep all ten accepted clean-room parser vectors exact."""
+        assert parse_leggett_okin_feedback(bytes.fromhex(payload)) == expected
+
+    async def test_status_channels_are_subscribed_and_settings_initialized(self):
+        """Start both APK channels and perform the optional raw 01 02 setup write."""
+        controller = self._controller_with_characteristics(
+            LEGGETT_OKIN_CHAR_UUID,
+            LEGGETT_OKIN_REVISION_SELECTOR_CHAR_UUID,
+            LEGGETT_OKIN_NOTIFY_CHAR_UUID,
+            OKIN_SMART_REMOTE_CSS_NOTIFY_CHAR_UUID,
+            OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID,
+        )
+        client = controller.client
+        assert client is not None
+        client.start_notify = AsyncMock()
+        client.stop_notify = AsyncMock()
+        client.write_gatt_char = AsyncMock()
+
+        await controller.start_notify()
+
+        assert client.start_notify.await_args_list == [
+            call(LEGGETT_OKIN_NOTIFY_CHAR_UUID, controller._handle_notification),
+            call(OKIN_SMART_REMOTE_CSS_NOTIFY_CHAR_UUID, controller._handle_notification),
+        ]
+        client.write_gatt_char.assert_awaited_once_with(
+            OKIN_SMART_REMOTE_CSS_WRITE_CHAR_UUID,
+            b"\x01\x02",
+            response=True,
+        )
+        assert controller.protocol_diagnostics["settings_initialized"] is True
+
+        controller._handle_notification(
+            SimpleNamespace(uuid=LEGGETT_OKIN_NOTIFY_CHAR_UUID),
+            bytearray.fromhex("040055aa000000"),
+        )
+        assert controller.protocol_diagnostics["notification_led_mask"] == "0x000055aa"
+        assert controller.protocol_diagnostics["notification_status"] == -1
+
+        await controller.stop_notify()
+        assert client.stop_notify.await_count == 2
 
     async def test_program_memory_is_a_two_stage_hold(self):
         """Programming arms with the store keycode, releases, then holds the slot."""

--- a/tests/test_leggett.py
+++ b/tests/test_leggett.py
@@ -141,6 +141,21 @@ class TestLeggettOkinController:
 
         assert controller.supports_massage_off_control is False
 
+    async def test_massage_wave_mode_is_advertised_and_sends_release(self):
+        """Expose the proven wave keycode through the shared mode-step entity."""
+        controller = LeggettOkinController(MagicMock())
+        controller.write_command = AsyncMock()
+
+        assert controller.supports_massage_mode_step_control is True
+
+        await controller.massage_mode_step()
+
+        wave, release = controller.write_command.await_args_list
+        assert wave.args == (bytes.fromhex("040210000000"),)
+        assert release.args == (bytes.fromhex("040200000000"),)
+        assert release.kwargs["repeat_count"] == 4
+        assert release.kwargs["cancel_event"].is_set() is False
+
     async def test_write_stream_is_unconfirmed_and_wall_clock_paced(self):
         """CU170 streams must not add a confirmed-write RTT to every gap."""
         controller = LeggettOkinController(MagicMock())


### PR DESCRIPTION
The Prodigy CE controller only emitted revision-1 frames, treated its fixed Snore favorite as writable, exposed an editable favorite as Zero-G, and ignored the recovered settings and notification flows.

Apply the APK-proven R0/R1 characteristic selector and checksum, correct the Favorite 1/Favorite 2/Snore/Favorite 3 model, add both persistent control-mode actions, subscribe and initialize the status channels, and retain the exact parsed LED/status mask in diagnostics without guessing the unknown light-state bit. This also keeps the massage wave-mode entity fix.

Tests: `uv run pytest -q` (3,538 passed)
Type check: `uvx pyright@1.1.411 custom_components tests`
Lint: `uvx ruff check custom_components tests`

Ref #368

<!-- crq:skip-autoreview -->