### PR TITLE
Expose BOX25 lumbar position as a percentage slider

### DIFF
--- a/custom_components/adjustable_bed/beds/sleepys_box25.py
+++ b/custom_components/adjustable_bed/beds/sleepys_box25.py
@@ -255,10 +255,11 @@ class SleepysBox25Controller(BedController):
 
     @property
     def position_number_specs(self) -> tuple[PositionNumberSpec, ...]:
-        """Expose head/feet as percentage sliders; BOX25 reports percent, not angles."""
+        """Expose head/feet/lumbar as percentage sliders; BOX25 reports percent, not angles."""
         return (
             build_position_number_spec("head", max_value=100.0, unit=POSITION_UNIT_PERCENT),
             build_position_number_spec("feet", max_value=100.0, unit=POSITION_UNIT_PERCENT),
+            build_position_number_spec("lumbar", max_value=100.0, unit=POSITION_UNIT_PERCENT),
         )
 
     @property

--- a/custom_components/adjustable_bed/services.py
+++ b/custom_components/adjustable_bed/services.py
@@ -327,7 +327,7 @@ async def handle_set_position(call: ServiceCall) -> None:
 
         # Define motor configurations.
         # For Keeson/Ergomotion: only head and feet are valid, they map to back/legs keys.
-        # For BOX25: only head and feet are valid, using direct percentage positions.
+        # For BOX25: head, feet, and lumbar are valid, using direct percentage positions.
         # For Kaidi: direct position writes expose back/legs percentage targets.
         # For standard beds: based on motor_count (2=back/legs, 3=+head, 4=+feet).
         uses_percentage_positions = bed_type in (
@@ -374,7 +374,7 @@ async def handle_set_position(call: ServiceCall) -> None:
                 },
             }
         elif bed_type == BED_TYPE_SLEEPYS_BOX25:
-            valid_motors = {"head", "feet"}
+            valid_motors = {"head", "feet", "lumbar"}
             motor_configs = {
                 "head": {
                     "position_key": "head",
@@ -388,6 +388,13 @@ async def handle_set_position(call: ServiceCall) -> None:
                     "move_up_fn": lambda ctrl: ctrl.move_feet_up(),
                     "move_down_fn": lambda ctrl: ctrl.move_feet_down(),
                     "move_stop_fn": lambda ctrl: ctrl.move_feet_stop(),
+                    "max_value": 100.0,
+                },
+                "lumbar": {
+                    "position_key": "lumbar",
+                    "move_up_fn": lambda ctrl: ctrl.move_lumbar_up(),
+                    "move_down_fn": lambda ctrl: ctrl.move_lumbar_down(),
+                    "move_stop_fn": lambda ctrl: ctrl.move_lumbar_stop(),
                     "max_value": 100.0,
                 },
             }
@@ -894,7 +901,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
         schema=vol.Schema(
             {
                 vol.Required(CONF_DEVICE_ID): cv.ensure_list,
-                vol.Required(ATTR_MOTOR): vol.In(["back", "legs", "head", "feet"]),
+                vol.Required(ATTR_MOTOR): vol.In(["back", "legs", "head", "feet", "lumbar"]),
                 # No max cap here - per-motor validation handles bed-specific limits
                 vol.Required(ATTR_POSITION): vol.All(vol.Coerce(float), vol.Range(min=0)),
             }

--- a/custom_components/adjustable_bed/services.yaml
+++ b/custom_components/adjustable_bed/services.yaml
@@ -78,6 +78,8 @@ set_position:
               value: head
             - label: Feet
               value: feet
+            - label: Lumbar
+              value: lumbar
     position:
       name: Position
       description: Target position (0-68° for back/head, 0-45° for legs/feet, 0-100% for Keeson/Ergomotion/BOX25 Star).

--- a/custom_components/adjustable_bed/strings.json
+++ b/custom_components/adjustable_bed/strings.json
@@ -823,7 +823,7 @@
         },
         "motor": {
           "name": "Motor",
-          "description": "The motor to move (back, legs, head, or feet)."
+          "description": "The motor to move (back, legs, head, feet, or lumbar)."
         },
         "position": {
           "name": "Position",

--- a/custom_components/adjustable_bed/translations/en.json
+++ b/custom_components/adjustable_bed/translations/en.json
@@ -825,7 +825,7 @@
         },
         "motor": {
           "name": "Motor",
-          "description": "The motor to move (back, legs, head, or feet)."
+          "description": "The motor to move (back, legs, head, feet, or lumbar)."
         },
         "position": {
           "name": "Position",

--- a/docs/beds/sleepys.md
+++ b/docs/beds/sleepys.md
@@ -160,7 +160,7 @@ A5 5A 00 00 00 40 02
 
 **Integration motor surface:** `head`, `feet`, `lumbar`, `tilt`
 
-**Integration direct-position surface:** `head`, `feet`, and `lumbar` sliders; `head` and `feet` are also exposed through the `set_position` service (lumbar is not yet wired into that service). Neck tilt does not currently have a protocol-backed position zone.
+**Integration direct-position surface:** `head`, `feet`, and `lumbar`, exposed both as number sliders and through the `set_position` service. Neck tilt does not currently have a protocol-backed position zone.
 
 The Sleepy's app first classifies `Star25...` as BOX25, reads manufacturer name
 characteristic `2A29`, then promotes it to `BOX25_STAR` only when the decoded

--- a/docs/beds/sleepys.md
+++ b/docs/beds/sleepys.md
@@ -160,7 +160,7 @@ A5 5A 00 00 00 40 02
 
 **Integration motor surface:** `head`, `feet`, `lumbar`, `tilt`
 
-**Integration direct-position surface:** `head` and `feet` sliders/services. The protocol also reports lumbar position and accepts direct lumbar position commands, but neck tilt does not currently have a protocol-backed position zone.
+**Integration direct-position surface:** `head`, `feet`, and `lumbar` sliders; `head` and `feet` are also exposed through the `set_position` service (lumbar is not yet wired into that service). Neck tilt does not currently have a protocol-backed position zone.
 
 The Sleepy's app first classifies `Star25...` as BOX25, reads manufacturer name
 characteristic `2A29`, then promotes it to `BOX25_STAR` only when the decoded

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -613,13 +613,13 @@ class TestNumberEntities:
             is None
         )
 
-    async def test_box25_number_entities_only_include_head_and_feet_position(
+    async def test_box25_number_entities_include_head_feet_and_lumbar_position(
         self,
         hass: HomeAssistant,
         mock_coordinator_connected,
         enable_custom_integrations,
     ):
-        """BOX25 should only create head_position and feet_position number entities."""
+        """BOX25 should create head/feet/lumbar position sliders, but not back/legs."""
         entry = MockConfigEntry(
             domain=DOMAIN,
             title="Sleepy's BOX25 Numbers",
@@ -649,6 +649,10 @@ class TestNumberEntities:
         )
         assert (
             registry.async_get_entity_id("number", DOMAIN, "AA:BB:CC:DD:EE:27_feet_position")
+            is not None
+        )
+        assert (
+            registry.async_get_entity_id("number", DOMAIN, "AA:BB:CC:DD:EE:27_lumbar_position")
             is not None
         )
         assert (

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1453,13 +1453,13 @@ class TestServices:
                 blocking=True,
             )
 
-    async def test_set_position_service_accepts_box25_head_and_feet(
+    async def test_set_position_service_accepts_box25_head_feet_and_lumbar(
         self,
         hass: HomeAssistant,
         mock_coordinator_connected,
         enable_custom_integrations,
     ):
-        """BOX25 set_position should accept head and feet only."""
+        """BOX25 set_position should accept head, feet, and lumbar."""
         entry = MockConfigEntry(
             domain=DOMAIN,
             title="Sleepy's BOX25 Service Bed",
@@ -1515,8 +1515,18 @@ class TestServices:
             },
             blocking=True,
         )
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_POSITION,
+            {
+                "device_id": [device_id],
+                "motor": "lumbar",
+                "position": 30,
+            },
+            blocking=True,
+        )
 
-        assert coordinator.async_seek_position.await_count == 2
+        assert coordinator.async_seek_position.await_count == 3
 
     async def test_set_position_service_rejects_box25_back_and_legs(
         self,
@@ -1558,7 +1568,7 @@ class TestServices:
         assert len(devices) == 1
         device_id = devices[0].id
 
-        with pytest.raises(ServiceValidationError, match="Valid motors: feet, head"):
+        with pytest.raises(ServiceValidationError, match="Valid motors: feet, head, lumbar"):
             await hass.services.async_call(
                 DOMAIN,
                 SERVICE_SET_POSITION,


### PR DESCRIPTION
The BOX25 Star protocol already reports lumbar position and accepts direct lumbar position commands — it's used by the existing lumbar up/down/stop cover controls — but there was no way to set it directly to an exact percentage, the way head/feet already work.

This adds a `lumbar` percentage number entity (0–100%) alongside the existing head/feet sliders, and wires `lumbar` into the `set_position` service's per-bed-type motor table and schema so scripts/automations can set it the same way.

Both paths reuse the existing `move_lumbar_up`/`move_lumbar_down`/`move_lumbar_stop` + live position-feedback seek mechanism already shipped for head/feet — no new protocol code.

Tested end-to-end against a real Sleepy's Elite BOX25 Star unit: called `set_position` with `motor: lumbar, position: 40`, confirmed `number.master_adjustable_bed_lumbar_position` and the lumbar cover's `current_position` both updated to 40, and confirmed the physical lumbar section moved and stopped at that position.

Full test suite passes (2799 passed, 2 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a lumbar position slider for Sleepy’s BOX25 beds.
  - Added lumbar support to the position-setting service, with percentage-based positioning.

- **Documentation**
  - Updated BOX25 documentation and service descriptions to include lumbar positioning.

- **Tests**
  - Added coverage confirming the lumbar slider and service functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->