### PR TITLE
feat: wire up Richmat combined head+feet motor command

### DIFF
--- a/custom_components/adjustable_bed/beds/richmat.py
+++ b/custom_components/adjustable_bed/beds/richmat.py
@@ -32,6 +32,7 @@ from ..const import (
     RICHMAT_WILINKE_W1_SERVICE_UUID,
     RichmatFeatures,
     get_richmat_features,
+    richmat_remote_has_combined_head_feet,
 )
 from .base import BedController, MotorControlSpec
 
@@ -323,17 +324,21 @@ class RichmatController(BedController):
 
     @property
     def _has_head_feet_support(self) -> bool:
-        """Return True when both head and feet motors are present.
+        """Return True when this remote drives head and feet as one step.
 
-        The combined command drives both actuators at once, so it only makes
-        sense when the remote profile exposes both of them. This stays a
-        Richmat-local predicate rather than a `BedController` capability flag:
-        no entity platform queries it, and the combined step is a protocol
-        detail of this remote family, not a shared motor axis.
+        Two conditions: the profile has both motors, and its official app
+        layout binds a button to the combined command pair. Only about a third
+        of the remote surfaces do, so the two motor flags alone would offer the
+        control on beds whose remote has no such button.
+
+        This stays a Richmat-local predicate rather than a `BedController`
+        capability flag: no entity platform queries it, and the combined step
+        is a protocol detail of this remote family, not a shared motor axis.
         """
         return bool(
             self._features & RichmatFeatures.MOTOR_HEAD
             and self._features & RichmatFeatures.MOTOR_FEET
+            and richmat_remote_has_combined_head_feet(self._remote_code)
         )
 
     @property

--- a/custom_components/adjustable_bed/beds/richmat.py
+++ b/custom_components/adjustable_bed/beds/richmat.py
@@ -322,6 +322,18 @@ class RichmatController(BedController):
         return bool(self._features & RichmatFeatures.MOTOR_PILLOW)
 
     @property
+    def has_head_feet_support(self) -> bool:
+        """Return True when both head and feet motors are present.
+
+        The combined command drives both actuators at once, so it only makes
+        sense when the remote profile exposes both of them.
+        """
+        return bool(
+            self._features & RichmatFeatures.MOTOR_HEAD
+            and self._features & RichmatFeatures.MOTOR_FEET
+        )
+
+    @property
     def motor_control_specs(self) -> tuple[MotorControlSpec, ...]:
         """Expose the native Richmat layout without back/legs alias duplicates."""
         specs = [
@@ -341,6 +353,21 @@ class RichmatController(BedController):
                 max_angle=45,
             ),
         ]
+
+        if self.has_head_feet_support:
+            # Richmat drives head and feet together as one hardware step
+            # (MOTOR_HEAD_FEET_UP/DOWN), which is what the combined button on
+            # the physical remote sends. This is not the same as opening the
+            # head and feet covers one after the other.
+            specs.append(
+                MotorControlSpec(
+                    key="head_feet",
+                    translation_key="head_feet",
+                    open_fn=lambda ctrl: ctrl.move_head_feet_up(),
+                    close_fn=lambda ctrl: ctrl.move_head_feet_down(),
+                    stop_fn=lambda ctrl: ctrl.move_head_feet_stop(),
+                )
+            )
 
         if self.has_pillow_support:
             specs.append(
@@ -683,6 +710,24 @@ class RichmatController(BedController):
 
     async def move_feet_stop(self) -> None:
         """Stop feet motor."""
+        await self.move_head_stop()
+
+    async def move_head_feet_up(self) -> None:
+        """Move head and feet up together.
+
+        Richmat exposes this as a single combined command, which is what the
+        physical remote sends. Driving the two motors one after the other is
+        not equivalent: each motor command ends with its own STOP frame, so a
+        second concurrent command would cut the first one short.
+        """
+        await self._move_with_stop(RichmatCommands.MOTOR_HEAD_FEET_UP)
+
+    async def move_head_feet_down(self) -> None:
+        """Move head and feet down together."""
+        await self._move_with_stop(RichmatCommands.MOTOR_HEAD_FEET_DOWN)
+
+    async def move_head_feet_stop(self) -> None:
+        """Stop the combined head and feet movement."""
         await self.move_head_stop()
 
     async def move_lumbar_up(self) -> None:

--- a/custom_components/adjustable_bed/beds/richmat.py
+++ b/custom_components/adjustable_bed/beds/richmat.py
@@ -326,10 +326,9 @@ class RichmatController(BedController):
     def _has_head_feet_support(self) -> bool:
         """Return True when this remote drives head and feet as one step.
 
-        Two conditions: the profile has both motors, and its official app
-        layout binds a button to the combined command pair. Only about a third
-        of the remote surfaces do, so the two motor flags alone would offer the
-        control on beds whose remote has no such button.
+        Two conditions: the profile has both motors, and the remote is one we
+        have confirmed sends the combined command. The motor flags alone are
+        not enough, since not every Richmat remote surface has this button.
 
         This stays a Richmat-local predicate rather than a `BedController`
         capability flag: no entity platform queries it, and the combined step

--- a/custom_components/adjustable_bed/beds/richmat.py
+++ b/custom_components/adjustable_bed/beds/richmat.py
@@ -327,9 +327,9 @@ class RichmatController(BedController):
 
         The combined command drives both actuators at once, so it only makes
         sense when the remote profile exposes both of them. This stays a
-        Richmat-local predicate rather than a shared capability flag: no other
-        platform queries it, and `BedController` builds combined steps from the
-        motor layout instead.
+        Richmat-local predicate rather than a `BedController` capability flag:
+        no entity platform queries it, and the combined step is a protocol
+        detail of this remote family, not a shared motor axis.
         """
         return bool(
             self._features & RichmatFeatures.MOTOR_HEAD

--- a/custom_components/adjustable_bed/beds/richmat.py
+++ b/custom_components/adjustable_bed/beds/richmat.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from bleak import BleakClient
 from bleak.exc import BleakError
@@ -366,9 +366,9 @@ class RichmatController(BedController):
                 MotorControlSpec(
                     key="head_feet",
                     translation_key="head_feet",
-                    open_fn=lambda ctrl: ctrl.move_head_feet_up(),
-                    close_fn=lambda ctrl: ctrl.move_head_feet_down(),
-                    stop_fn=lambda ctrl: ctrl.move_head_feet_stop(),
+                    open_fn=lambda ctrl: cast(RichmatController, ctrl).move_head_feet_up(),
+                    close_fn=lambda ctrl: cast(RichmatController, ctrl).move_head_feet_down(),
+                    stop_fn=lambda ctrl: cast(RichmatController, ctrl).move_head_feet_stop(),
                 )
             )
 

--- a/custom_components/adjustable_bed/beds/richmat.py
+++ b/custom_components/adjustable_bed/beds/richmat.py
@@ -322,11 +322,14 @@ class RichmatController(BedController):
         return bool(self._features & RichmatFeatures.MOTOR_PILLOW)
 
     @property
-    def has_head_feet_support(self) -> bool:
+    def _has_head_feet_support(self) -> bool:
         """Return True when both head and feet motors are present.
 
         The combined command drives both actuators at once, so it only makes
-        sense when the remote profile exposes both of them.
+        sense when the remote profile exposes both of them. This stays a
+        Richmat-local predicate rather than a shared capability flag: no other
+        platform queries it, and `BedController` builds combined steps from the
+        motor layout instead.
         """
         return bool(
             self._features & RichmatFeatures.MOTOR_HEAD
@@ -354,7 +357,7 @@ class RichmatController(BedController):
             ),
         ]
 
-        if self.has_head_feet_support:
+        if self._has_head_feet_support:
             # Richmat drives head and feet together as one hardware step
             # (MOTOR_HEAD_FEET_UP/DOWN), which is what the combined button on
             # the physical remote sends. This is not the same as opening the
@@ -396,8 +399,13 @@ class RichmatController(BedController):
 
     @property
     def stale_motor_entity_keys(self) -> frozenset[str]:
-        """Remove legacy generic motor aliases when Richmat layout changes."""
-        return frozenset({"back", "legs", "pillow", "lumbar"})
+        """Remove legacy generic motor aliases when Richmat layout changes.
+
+        `head_feet` is listed too: correcting a bed to a single-axis remote
+        profile drops the combined step, and without this the old cover lingers
+        in the registry as an unavailable ghost.
+        """
+        return frozenset({"back", "legs", "pillow", "lumbar", "head_feet"})
 
     @property
     def supports_lights(self) -> bool:

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -1204,6 +1204,12 @@ RICHMAT_WILINKE_STOP_COMPAT_REMOTE_CODES: Final[frozenset[str]] = frozenset(
     {"qrrm", "bt6500"}
 )
 
+# Richmat remotes confirmed to move head and feet as one combined step
+# (0x29/0x2A). Confirmed on two WLT / WLT825X_H35_S beds running the TWRM
+# profile (PR #552). Other remote surfaces are not assumed to have this
+# button, so add codes here as they are confirmed.
+RICHMAT_COMBINED_HEAD_FEET_REMOTE_CODES: Final[frozenset[str]] = frozenset({"twrm"})
+
 # Display names for remote selection
 RICHMAT_REMOTES: Final = {
     RICHMAT_REMOTE_AUTO: "Auto (all features enabled)",
@@ -1551,24 +1557,20 @@ def get_richmat_features(remote_code: str) -> RichmatFeatures:
 
 
 def richmat_remote_has_combined_head_feet(remote_code: str) -> bool:
-    """Return True when this remote surface has the combined head+feet button.
+    """Return True when this remote is known to drive head and feet as one step.
 
-    The combined command pair (0x29/0x2A) is not part of every Richmat remote:
-    only about a third of the official app layouts bind a button to it, so it
-    cannot be inferred from the head and feet motor flags. "auto" keeps the
-    same meaning it has for every other Richmat capability - unknown remote,
-    everything offered.
+    The combined command pair (0x29/0x2A) is not on every Richmat remote, and
+    the head and feet motor flags do not tell us whether a given surface has
+    it, so remotes are listed only once confirmed. "auto" keeps the meaning it
+    has for every other Richmat capability: unknown remote, everything offered.
 
     Args:
         remote_code: The remote code (e.g., "twrm", "qrrm"), case-insensitive.
     """
-    # Import here to avoid circular dependency
-    from .richmat_features import RICHMAT_COMBINED_HEAD_FEET_REMOTES
-
     code_lower = remote_code.lower() if remote_code else ""
     if code_lower in {"", RICHMAT_REMOTE_AUTO}:
         return True
-    return code_lower in RICHMAT_COMBINED_HEAD_FEET_REMOTES
+    return code_lower in RICHMAT_COMBINED_HEAD_FEET_REMOTE_CODES
 
 
 def get_richmat_motor_count(features: RichmatFeatures) -> int:

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -1550,6 +1550,27 @@ def get_richmat_features(remote_code: str) -> RichmatFeatures:
     return RICHMAT_REMOTE_FEATURES[RICHMAT_REMOTE_AUTO]
 
 
+def richmat_remote_has_combined_head_feet(remote_code: str) -> bool:
+    """Return True when this remote surface has the combined head+feet button.
+
+    The combined command pair (0x29/0x2A) is not part of every Richmat remote:
+    only about a third of the official app layouts bind a button to it, so it
+    cannot be inferred from the head and feet motor flags. "auto" keeps the
+    same meaning it has for every other Richmat capability - unknown remote,
+    everything offered.
+
+    Args:
+        remote_code: The remote code (e.g., "twrm", "qrrm"), case-insensitive.
+    """
+    # Import here to avoid circular dependency
+    from .richmat_features import RICHMAT_COMBINED_HEAD_FEET_REMOTES
+
+    code_lower = remote_code.lower() if remote_code else ""
+    if code_lower in {"", RICHMAT_REMOTE_AUTO}:
+        return True
+    return code_lower in RICHMAT_COMBINED_HEAD_FEET_REMOTES
+
+
 def get_richmat_motor_count(features: RichmatFeatures) -> int:
     """Get motor count from Richmat feature flags.
 

--- a/custom_components/adjustable_bed/const.py
+++ b/custom_components/adjustable_bed/const.py
@@ -1561,16 +1561,15 @@ def richmat_remote_has_combined_head_feet(remote_code: str) -> bool:
 
     The combined command pair (0x29/0x2A) is not on every Richmat remote, and
     the head and feet motor flags do not tell us whether a given surface has
-    it, so remotes are listed only once confirmed. "auto" keeps the meaning it
-    has for every other Richmat capability: unknown remote, everything offered.
+    it, so remotes are listed only once confirmed. Unlike other Richmat
+    capabilities, "auto" does not enable this one: it is the default whenever
+    detection cannot name the remote, so it would put the control on beds that
+    may not move both axes at all.
 
     Args:
         remote_code: The remote code (e.g., "twrm", "qrrm"), case-insensitive.
     """
-    code_lower = remote_code.lower() if remote_code else ""
-    if code_lower in {"", RICHMAT_REMOTE_AUTO}:
-        return True
-    return code_lower in RICHMAT_COMBINED_HEAD_FEET_REMOTE_CODES
+    return (remote_code or "").lower() in RICHMAT_COMBINED_HEAD_FEET_REMOTE_CODES
 
 
 def get_richmat_motor_count(features: RichmatFeatures) -> int:

--- a/custom_components/adjustable_bed/richmat_features.py
+++ b/custom_components/adjustable_bed/richmat_features.py
@@ -6910,3 +6910,35 @@ RICHMAT_REMOTE_FEATURES_GENERATED: Final[dict[str, RichmatFeatures]] = {
     ),
     "zzrm": _F.PRESET_FLAT | _F.MOTOR_HEAD | _F.MOTOR_FEET,
 }
+
+
+# Remote codes whose official app layout binds a button to the combined
+# motor1+motor2 command pair (0x29 up / 0x2A down). Extracted from the
+# res/layout/f<code>.xml button maps of 75 Richmat OEM apps: each button
+# references the command byte through a string resource, so a code is listed
+# here only when the majority of apps that ship its layout give it both
+# directions. Roughly a third of the remote surfaces have this button, so it
+# cannot be inferred from the head and feet motor flags alone.
+RICHMAT_COMBINED_HEAD_FEET_REMOTES: Final[frozenset[str]] = frozenset(
+    {
+        "6brm", "a2rm", "a3rm", "a3rn", "ajrn", "aqrn", "atrm", "aurm", "avrm", "awrm", "axrn",
+        "ayrm", "azrn", "b2rn", "b5rn", "b6rm", "b7rm", "b7rn", "b8rn", "bfrm", "bgrm", "bhrm",
+        "bnrm", "bqrm", "burm", "c2rn", "c5rm", "c9rn", "carn", "cbrm", "ccrn", "cerm", "ckrm",
+        "cmrn", "corm", "corn", "cyrm", "d2rm", "d5rm", "dfrm", "dhrm", "dirm", "dmrm", "durm",
+        "dvrm", "e0rm", "e3rm", "e5rm", "efrm", "enrm", "eqrm", "esrm", "etrm", "f3rm", "f5rm",
+        "farm", "fbrm", "firm", "frrm", "fvrm", "fyrm", "g2rm", "g3rm", "g5rm", "g8rm", "g9rm",
+        "gcrm", "germ", "ghrm", "gmrm", "gorm", "gsrm", "gxrm", "gyrm", "h5rm", "h8rm", "harm",
+        "herm", "hkrm", "hmrm", "hnrm", "hqrm", "htrm", "hvrm", "hzrm", "i2rm", "i3rm", "iarm",
+        "idrm", "iirm", "iprm", "iqrm", "irrm", "j5rm", "jbrm", "jmrm", "jrrm", "k6rm", "k7rm",
+        "khrm", "kmrm", "knrm", "kurm", "kxrm", "kyrm", "m4rm", "m8rm", "marm", "mmrm", "o2rm",
+        "o3rm", "o9rm", "oarm", "oprm", "oqrm", "oxrm", "p0rm", "p2rm", "p3rm", "p4rm", "p5rm",
+        "r2rm", "r5rm", "r6rm", "t4rm", "t8rm", "tarm", "tcrm", "tdrm", "thrm", "tlrm", "twrm",
+        "u0rm", "u1rm", "u4rm", "ucrm", "ufrm", "ujrm", "ukrm", "ulrm", "uprm", "utrm", "uvrm",
+        "uwrm", "uxrm", "uyrm", "uzrm", "v3rm", "v4rm", "vxrm", "vyrm", "w0rm", "w2rm", "w5rm",
+        "w6rm", "w7rm", "werm", "wkrm", "wrrm", "wsrm", "wtrm", "wurm", "wvrm", "wzrm", "x4rm",
+        "x5rm", "x7rm", "x8rm", "xerm", "xhrm", "xirm", "xjrm", "xkrm", "xnrm", "xorm", "xwrm",
+        "y3rm", "yhrm", "yjrm", "ywrm", "yyrm", "yzrm", "z1rm", "z2rm", "z4rm", "z5rm", "z7rm",
+        "z8rm", "zbrm", "zdrm", "zerm", "zr10", "zr20", "zr30", "zr51", "zr70", "zr80", "zra0",
+        "zra1", "zra2", "zurm", "zzrm"
+    }
+)

--- a/custom_components/adjustable_bed/richmat_features.py
+++ b/custom_components/adjustable_bed/richmat_features.py
@@ -6910,35 +6910,3 @@ RICHMAT_REMOTE_FEATURES_GENERATED: Final[dict[str, RichmatFeatures]] = {
     ),
     "zzrm": _F.PRESET_FLAT | _F.MOTOR_HEAD | _F.MOTOR_FEET,
 }
-
-
-# Remote codes whose official app layout binds a button to the combined
-# motor1+motor2 command pair (0x29 up / 0x2A down). Extracted from the
-# res/layout/f<code>.xml button maps of 75 Richmat OEM apps: each button
-# references the command byte through a string resource, so a code is listed
-# here only when the majority of apps that ship its layout give it both
-# directions. Roughly a third of the remote surfaces have this button, so it
-# cannot be inferred from the head and feet motor flags alone.
-RICHMAT_COMBINED_HEAD_FEET_REMOTES: Final[frozenset[str]] = frozenset(
-    {
-        "6brm", "a2rm", "a3rm", "a3rn", "ajrn", "aqrn", "atrm", "aurm", "avrm", "awrm", "axrn",
-        "ayrm", "azrn", "b2rn", "b5rn", "b6rm", "b7rm", "b7rn", "b8rn", "bfrm", "bgrm", "bhrm",
-        "bnrm", "bqrm", "burm", "c2rn", "c5rm", "c9rn", "carn", "cbrm", "ccrn", "cerm", "ckrm",
-        "cmrn", "corm", "corn", "cyrm", "d2rm", "d5rm", "dfrm", "dhrm", "dirm", "dmrm", "durm",
-        "dvrm", "e0rm", "e3rm", "e5rm", "efrm", "enrm", "eqrm", "esrm", "etrm", "f3rm", "f5rm",
-        "farm", "fbrm", "firm", "frrm", "fvrm", "fyrm", "g2rm", "g3rm", "g5rm", "g8rm", "g9rm",
-        "gcrm", "germ", "ghrm", "gmrm", "gorm", "gsrm", "gxrm", "gyrm", "h5rm", "h8rm", "harm",
-        "herm", "hkrm", "hmrm", "hnrm", "hqrm", "htrm", "hvrm", "hzrm", "i2rm", "i3rm", "iarm",
-        "idrm", "iirm", "iprm", "iqrm", "irrm", "j5rm", "jbrm", "jmrm", "jrrm", "k6rm", "k7rm",
-        "khrm", "kmrm", "knrm", "kurm", "kxrm", "kyrm", "m4rm", "m8rm", "marm", "mmrm", "o2rm",
-        "o3rm", "o9rm", "oarm", "oprm", "oqrm", "oxrm", "p0rm", "p2rm", "p3rm", "p4rm", "p5rm",
-        "r2rm", "r5rm", "r6rm", "t4rm", "t8rm", "tarm", "tcrm", "tdrm", "thrm", "tlrm", "twrm",
-        "u0rm", "u1rm", "u4rm", "ucrm", "ufrm", "ujrm", "ukrm", "ulrm", "uprm", "utrm", "uvrm",
-        "uwrm", "uxrm", "uyrm", "uzrm", "v3rm", "v4rm", "vxrm", "vyrm", "w0rm", "w2rm", "w5rm",
-        "w6rm", "w7rm", "werm", "wkrm", "wrrm", "wsrm", "wtrm", "wurm", "wvrm", "wzrm", "x4rm",
-        "x5rm", "x7rm", "x8rm", "xerm", "xhrm", "xirm", "xjrm", "xkrm", "xnrm", "xorm", "xwrm",
-        "y3rm", "yhrm", "yjrm", "ywrm", "yyrm", "yzrm", "z1rm", "z2rm", "z4rm", "z5rm", "z7rm",
-        "z8rm", "zbrm", "zdrm", "zerm", "zr10", "zr20", "zr30", "zr51", "zr70", "zr80", "zra0",
-        "zra1", "zra2", "zurm", "zzrm"
-    }
-)

--- a/docs/beds/richmat.md
+++ b/docs/beds/richmat.md
@@ -140,18 +140,25 @@ Motors 5-7 are only present on select models (e.g., some table/lift actuators).
 | Head Up + Feet Down | `0x21` | Inverse: head up while feet down |
 | Head Down + Feet Up | `0x22` | Inverse: head down while feet up |
 
-`0x29`/`0x2A` are exposed as the `head_feet` cover on remote profiles that
-have both the head and feet motor flags. Confirmed on hardware (#552): on two
-`twrm` beds (`WLT` / `WLT825X_H35_S`) the command raises head and feet at the
-same time, which two sequential cover commands cannot do because each Richmat
-motor command ends with its own STOP frame.
+`0x29`/`0x2A` are exposed as the `head_feet` cover, but only on remote profiles
+listed in `RICHMAT_COMBINED_HEAD_FEET_REMOTES`. The official apps name these
+bytes `com_motor1_2_up` / `com_motor1_2_down`, and the same string tables give
+`k_motor1_up` = `0x24` (head) and `k_motor2_up` = `0x26` (feet), so motor 1 + 2
+is head + feet. Each app ships one `res/layout/f<code>.xml` button map per
+remote code, and only about a third of them bind a button to this pair: 202 of
+the 726 remote surfaces across 75 Richmat OEM apps. The two motor flags alone
+therefore do not imply the combined step exists on a given remote.
+
+Confirmed on hardware (#552): on two `twrm` beds (`WLT` / `WLT825X_H35_S`) the
+command raises head and feet at the same time, which two sequential cover
+commands cannot do because each Richmat motor command ends with its own STOP
+frame. All 31 apps that ship a `twrm` layout give it the combined button, while
+`qrrm` and the BedTech `bt6500` surface have it in none of them.
 
 > [!NOTE]
 > The BedTech app calls the same byte pair `bothHeads` (see
-> [bedtech.md](bedtech.md)), which would mean two head actuators rather than
-> head plus feet. No dual-head Richmat bed has been tested, so on a flex-head
-> model this control may drive both head sections instead. Richmat's own
-> command map and the beds tested so far both say head plus feet.
+> [bedtech.md](bedtech.md)). That is that vendor's own naming; Richmat's motor
+> numbering above is what the command actually addresses.
 
 #### Presets
 

--- a/docs/beds/richmat.md
+++ b/docs/beds/richmat.md
@@ -140,6 +140,19 @@ Motors 5-7 are only present on select models (e.g., some table/lift actuators).
 | Head Up + Feet Down | `0x21` | Inverse: head up while feet down |
 | Head Down + Feet Up | `0x22` | Inverse: head down while feet up |
 
+`0x29`/`0x2A` are exposed as the `head_feet` cover on remote profiles that
+have both the head and feet motor flags. Confirmed on hardware (#552): on two
+`twrm` beds (`WLT` / `WLT825X_H35_S`) the command raises head and feet at the
+same time, which two sequential cover commands cannot do because each Richmat
+motor command ends with its own STOP frame.
+
+> [!NOTE]
+> The BedTech app calls the same byte pair `bothHeads` (see
+> [bedtech.md](bedtech.md)), which would mean two head actuators rather than
+> head plus feet. No dual-head Richmat bed has been tested, so on a flex-head
+> model this control may drive both head sections instead. Richmat's own
+> command map and the beds tested so far both say head plus feet.
+
 #### Presets
 
 | Command | Byte | Description |

--- a/docs/beds/richmat.md
+++ b/docs/beds/richmat.md
@@ -140,25 +140,21 @@ Motors 5-7 are only present on select models (e.g., some table/lift actuators).
 | Head Up + Feet Down | `0x21` | Inverse: head up while feet down |
 | Head Down + Feet Up | `0x22` | Inverse: head down while feet up |
 
-`0x29`/`0x2A` are exposed as the `head_feet` cover, but only on remote profiles
-listed in `RICHMAT_COMBINED_HEAD_FEET_REMOTES`. The official apps name these
-bytes `com_motor1_2_up` / `com_motor1_2_down`, and the same string tables give
-`k_motor1_up` = `0x24` (head) and `k_motor2_up` = `0x26` (feet), so motor 1 + 2
-is head + feet. Each app ships one `res/layout/f<code>.xml` button map per
-remote code, and only about a third of them bind a button to this pair: 202 of
-the 726 remote surfaces across 75 Richmat OEM apps. The two motor flags alone
-therefore do not imply the combined step exists on a given remote.
+`0x29`/`0x2A` are exposed as the `head_feet` cover, but only for remotes listed
+in `RICHMAT_COMBINED_HEAD_FEET_REMOTE_CODES`, plus `auto`. Confirmed on
+hardware (#552): on two `twrm` beds (`WLT` / `WLT825X_H35_S`) the command
+raises head and feet at the same time, which two sequential cover commands
+cannot do because each Richmat motor command ends with its own STOP frame.
 
-Confirmed on hardware (#552): on two `twrm` beds (`WLT` / `WLT825X_H35_S`) the
-command raises head and feet at the same time, which two sequential cover
-commands cannot do because each Richmat motor command ends with its own STOP
-frame. All 31 apps that ship a `twrm` layout give it the combined button, while
-`qrrm` and the BedTech `bt6500` surface have it in none of them.
+Not every Richmat remote surface has this button, and the head and feet motor
+flags do not say which ones do, so the entity stays opt-in per remote code. Add
+a code to the set when a bed on that profile is confirmed.
 
 > [!NOTE]
 > The BedTech app calls the same byte pair `bothHeads` (see
-> [bedtech.md](bedtech.md)). That is that vendor's own naming; Richmat's motor
-> numbering above is what the command actually addresses.
+> [bedtech.md](bedtech.md)), which would mean two head sections rather than
+> head plus feet. The naming across apps is not settled here; the per-remote
+> allow list is what keeps the control off unconfirmed beds.
 
 #### Presets
 

--- a/docs/beds/richmat.md
+++ b/docs/beds/richmat.md
@@ -141,14 +141,15 @@ Motors 5-7 are only present on select models (e.g., some table/lift actuators).
 | Head Down + Feet Up | `0x22` | Inverse: head down while feet up |
 
 `0x29`/`0x2A` are exposed as the `head_feet` cover, but only for remotes listed
-in `RICHMAT_COMBINED_HEAD_FEET_REMOTE_CODES`, plus `auto`. Confirmed on
-hardware (#552): on two `twrm` beds (`WLT` / `WLT825X_H35_S`) the command
-raises head and feet at the same time, which two sequential cover commands
-cannot do because each Richmat motor command ends with its own STOP frame.
+in `RICHMAT_COMBINED_HEAD_FEET_REMOTE_CODES`. Confirmed on hardware (#552): on
+two `twrm` beds (`WLT` / `WLT825X_H35_S`) the command raises head and feet at
+the same time, which two sequential cover commands cannot do because each
+Richmat motor command ends with its own STOP frame.
 
 Not every Richmat remote surface has this button, and the head and feet motor
 flags do not say which ones do, so the entity stays opt-in per remote code. Add
-a code to the set when a bed on that profile is confirmed.
+a code to the set when a bed on that profile is confirmed. `auto` is excluded
+on purpose: it is the fallback whenever detection cannot name the remote.
 
 > [!NOTE]
 > The BedTech app calls the same byte pair `bothHeads` (see

--- a/tests/test_richmat.py
+++ b/tests/test_richmat.py
@@ -648,12 +648,12 @@ class TestRichmatFeatureDetection:
 
         assert "head_feet" not in [spec.key for spec in controller.motor_control_specs]
 
-    def test_auto_remote_exposes_head_feet_control(self):
-        """An unidentified remote keeps offering everything, as it does elsewhere."""
+    def test_auto_remote_omits_head_feet_control(self):
+        """Auto is the fallback for unidentified beds, so it does not get the combined step."""
         coordinator = MagicMock()
         controller = RichmatController(coordinator, is_wilinke=True, remote_code="auto")
 
-        assert "head_feet" in [spec.key for spec in controller.motor_control_specs]
+        assert "head_feet" not in [spec.key for spec in controller.motor_control_specs]
 
     def test_qrrm_wilinke_supports_rgb_light_and_timer(self):
         """QRRM WiLinke remotes should expose RGB light and timer controls."""

--- a/tests/test_richmat.py
+++ b/tests/test_richmat.py
@@ -591,7 +591,7 @@ class TestRichmatFeatureDetection:
         mock_richmat_config_entry_data: dict,
         mock_coordinator_connected,
     ):
-        """Richmat BT6500 should expose head/feet/head+feet/pillow/lumbar only."""
+        """Richmat BT6500 should expose head/feet/pillow/lumbar only."""
         entry = MockConfigEntry(
             domain=DOMAIN,
             title="BedTech BT6500",
@@ -611,10 +611,11 @@ class TestRichmatFeatureDetection:
         controller = coordinator.controller
 
         assert coordinator.motor_count == 2
+        # The BT6500 remote surface has no combined head+feet button, so the
+        # combined step must not appear even though both motors are present.
         assert [spec.key for spec in controller.motor_control_specs] == [
             "head",
             "feet",
-            "head_feet",
             "pillow",
             "lumbar",
         ]
@@ -632,6 +633,27 @@ class TestRichmatFeatureDetection:
         controller = RichmatController(coordinator, is_wilinke=True, remote_code="aarn")
 
         assert "head_feet" not in [spec.key for spec in controller.motor_control_specs]
+
+    def test_remote_with_combined_button_exposes_head_feet_control(self):
+        """twrm binds a button to 0x29/0x2A, so it gets the combined cover."""
+        coordinator = MagicMock()
+        controller = RichmatController(coordinator, is_wilinke=True, remote_code="twrm")
+
+        assert "head_feet" in [spec.key for spec in controller.motor_control_specs]
+
+    def test_remote_without_combined_button_omits_head_feet_control(self):
+        """virm has both motors but no combined button on its remote surface."""
+        coordinator = MagicMock()
+        controller = RichmatController(coordinator, is_wilinke=True, remote_code="virm")
+
+        assert "head_feet" not in [spec.key for spec in controller.motor_control_specs]
+
+    def test_auto_remote_exposes_head_feet_control(self):
+        """An unidentified remote keeps offering everything, as it does elsewhere."""
+        coordinator = MagicMock()
+        controller = RichmatController(coordinator, is_wilinke=True, remote_code="auto")
+
+        assert "head_feet" in [spec.key for spec in controller.motor_control_specs]
 
     def test_qrrm_wilinke_supports_rgb_light_and_timer(self):
         """QRRM WiLinke remotes should expose RGB light and timer controls."""

--- a/tests/test_richmat.py
+++ b/tests/test_richmat.py
@@ -296,6 +296,41 @@ class TestRichmatMovement:
         expected = coordinator.controller._build_command(RichmatCommands.MOTOR_FEET_UP)
         assert first_command == expected
 
+    async def test_move_head_feet_up_sends_combined_command(
+        self,
+        hass: HomeAssistant,
+        mock_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Head+feet must send the single combined command, not two motor commands."""
+        coordinator = AdjustableBedCoordinator(hass, mock_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.move_head_feet_up()
+
+        calls = mock_bleak_client.write_gatt_char.call_args_list
+        expected = coordinator.controller._build_command(RichmatCommands.MOTOR_HEAD_FEET_UP)
+        assert calls[0][0][1] == expected
+        assert calls[-1][0][1] == coordinator.controller._build_command(RichmatCommands.END)
+
+    async def test_move_head_feet_down_sends_combined_command(
+        self,
+        hass: HomeAssistant,
+        mock_richmat_config_entry,
+        mock_coordinator_connected,
+        mock_bleak_client: MagicMock,
+    ):
+        """Head+feet down uses the paired combined command byte."""
+        coordinator = AdjustableBedCoordinator(hass, mock_richmat_config_entry)
+        await coordinator.async_connect()
+
+        await coordinator.controller.move_head_feet_down()
+
+        calls = mock_bleak_client.write_gatt_char.call_args_list
+        expected = coordinator.controller._build_command(RichmatCommands.MOTOR_HEAD_FEET_DOWN)
+        assert calls[0][0][1] == expected
+
     async def test_stop_all(
         self,
         hass: HomeAssistant,
@@ -556,7 +591,7 @@ class TestRichmatFeatureDetection:
         mock_richmat_config_entry_data: dict,
         mock_coordinator_connected,
     ):
-        """Richmat BT6500 should expose head/feet/pillow/lumbar only."""
+        """Richmat BT6500 should expose head/feet/head+feet/pillow/lumbar only."""
         entry = MockConfigEntry(
             domain=DOMAIN,
             title="BedTech BT6500",
@@ -579,10 +614,24 @@ class TestRichmatFeatureDetection:
         assert [spec.key for spec in controller.motor_control_specs] == [
             "head",
             "feet",
+            "head_feet",
             "pillow",
             "lumbar",
         ]
-        assert controller.stale_motor_entity_keys == {"back", "legs", "pillow", "lumbar"}
+        assert controller.stale_motor_entity_keys == {
+            "back",
+            "legs",
+            "pillow",
+            "lumbar",
+            "head_feet",
+        }
+
+    def test_head_only_remote_omits_combined_head_feet_control(self):
+        """The combined step needs both axes, so a head-only remote must not get it."""
+        coordinator = MagicMock()
+        controller = RichmatController(coordinator, is_wilinke=True, remote_code="aarn")
+
+        assert "head_feet" not in [spec.key for spec in controller.motor_control_specs]
 
     def test_qrrm_wilinke_supports_rgb_light_and_timer(self):
         """QRRM WiLinke remotes should expose RGB light and timer controls."""


### PR DESCRIPTION
## Summary

Richmat already defines `MOTOR_HEAD_FEET_UP` (`0x29`) and `MOTOR_HEAD_FEET_DOWN` (`0x2A`), but nothing in the integration ever sends them. This wires them up as a `head_feet` motor control spec, so Richmat beds get the same combined control that OCTO and SleepStar already have.

This matters because driving the two covers one after the other is not equivalent to the combined command. `_move_with_stop()` ends every motor command with its own STOP frame, so two concurrent commands cut each other short, and running them sequentially means the head only starts once the feet have finished travelling. The physical remote has a single button that raises head and feet together, and until now there was no way to reproduce that from Home Assistant.

The same reasoning is already spelled out in `beds/octo.py` for `CD_MOTOR34`:

> The official 4-motor layout offers motors 3+4 as one hardware synchronised step (CD_MOTOR34), which is not the same as driving the two covers one after the other.

## Changes

- `has_head_feet_support` property, gated on both `MOTOR_HEAD` and `MOTOR_FEET` being present in the detected remote profile, following the existing `has_lumbar_support` / `has_pillow_support` pattern.
- `move_head_feet_up()` / `move_head_feet_down()` / `move_head_feet_stop()` on `RichmatController`.
- A `head_feet` `MotorControlSpec`, which yields a `cover.<bed>_head_feet` entity.

No existing entity ids or behaviour change. The `head_feet` translation key already exists in `strings.json` and `translations/en.json`, so no translation changes were needed.

## Testing

Tested on hardware against two Richmat beds, both detected as the `twrm` remote profile (`WLT` / `WLT825X_H35_S`, split setup, one 2-motor and one 4-motor controller), running on an ESPHome Bluetooth proxy:

- Both `cover.<bed>_head_feet` entities were created after restart, named "Head + Feet".
- `cover.open_cover` on the combined entity raised head and feet **simultaneously**, matching the behaviour of the combined button on the physical remote.
- The four existing `head` / `feet` cover entities kept their entity ids and continued to work unchanged.

Before this change, the only way to approximate it was a script that opened the feet cover, waited, and then opened the head cover, which moves the two axes one after the other rather than together.

*made with the help of AI*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added combined head-and-feet movement controls for compatible Richmat adjustable beds.
  * Raise or lower both sections together using a single control, with support for stopping movement.
  * Combined controls appear only for approved remote profiles that support this capability.
  * Beds without compatible hardware or remote support continue to show their existing controls.
* **Documentation**
  * Added guidance on supported hardware, remote profiles, and combined-motion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->