### PR TITLE
fix: dismiss stale discovery prompts for paired beds

### DIFF
--- a/custom_components/adjustable_bed/__init__.py
+++ b/custom_components/adjustable_bed/__init__.py
@@ -10,7 +10,12 @@ from types import MappingProxyType
 from typing import Any, cast
 
 from homeassistant.components import bluetooth
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry, ConfigEntryDisabler
+from homeassistant.config_entries import (
+    SOURCE_BLUETOOTH,
+    SOURCE_IMPORT,
+    ConfigEntry,
+    ConfigEntryDisabler,
+)
 from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
@@ -73,6 +78,7 @@ from .pairing import (
     inheritable_child_fields,
     is_paired,
     iter_children,
+    pair_member_addresses,
     single_data_from_child,
     single_options_from_child,
     with_updated_child,
@@ -965,6 +971,19 @@ async def async_unpair_entry(hass: HomeAssistant, entry: ConfigEntry) -> list[Co
 
 async def _async_setup_paired_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a paired (Dual Bed 4.0) entry as one logical device."""
+    # HA only clears pending flows matching the new entry's unique_id. A pair's
+    # synthetic ID does not match its members' existing Bluetooth discovery cards.
+    members = set(pair_member_addresses(entry.data))
+    for flow in hass.config_entries.flow.async_progress_by_handler(DOMAIN):
+        context = flow.get("context", {})
+        address = context.get("unique_id")
+        if (
+            context.get("source") == SOURCE_BLUETOOTH
+            and isinstance(address, str)
+            and address.upper() in members
+        ):
+            hass.config_entries.flow.async_abort(flow["flow_id"])
+
     _LOGGER.info(
         "Setting up paired bed %s (pair_id=%s, mode=%s, sides=%s)",
         entry.title,

--- a/custom_components/adjustable_bed/config_flow.py
+++ b/custom_components/adjustable_bed/config_flow.py
@@ -1446,6 +1446,9 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
         assert self._discovery_info is not None
         assert self._disambiguation_types is not None
 
+        if self._is_absorbed_pair_member(self._discovery_info.address):
+            return self.async_abort(reason="already_configured")
+
         if user_input is not None:
             selected = user_input.get("bed_type_choice")
             if selected == "show_all":
@@ -1497,6 +1500,10 @@ class AdjustableBedConfigFlow(BluetoothOperationMixin, ConfigFlow, domain=DOMAIN
     ) -> ConfigFlowResult:
         """Confirm discovery."""
         assert self._discovery_info is not None
+
+        # The bed may have joined a pair while this discovery was awaiting input.
+        if self._is_absorbed_pair_member(self._discovery_info.address):
+            return self.async_abort(reason="already_configured")
 
         # Use detailed detection to get confidence and ambiguity info
         detection_result = detect_bed_type_detailed(self._discovery_info)

--- a/tests/test_paired_setup.py
+++ b/tests/test_paired_setup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from copy import copy
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -155,6 +156,77 @@ def _paired_entry(hass: HomeAssistant) -> MockConfigEntry:
 
 
 class TestPairedSetup:
+    async def test_pair_setup_clears_pending_member_discoveries(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info,
+        mock_coordinator_connected,
+        enable_custom_integrations,
+    ) -> None:
+        """Existing discovery cards disappear when their addresses join a pair."""
+        flows = {}
+        for address in (LEFT_ADDR, RIGHT_ADDR, "AA:BB:CC:DD:EE:03"):
+            info = copy(mock_bluetooth_service_info)
+            info.address = address.lower()
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_BLUETOOTH}, data=info
+            )
+            assert result["type"] == FlowResultType.FORM
+            flows[address] = result["flow_id"]
+
+        entry = _paired_entry(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert entry.state == ConfigEntryState.LOADED
+        remaining = {
+            flow["flow_id"]
+            for flow in hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+        }
+        assert remaining == {flows["AA:BB:CC:DD:EE:03"]}
+
+    @pytest.mark.parametrize("address", [LEFT_ADDR, RIGHT_ADDR])
+    async def test_pending_discovery_rechecks_pair_membership(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info,
+        enable_custom_integrations,
+        address: str,
+    ) -> None:
+        """A discovery opened before pairing must not offer a duplicate afterward."""
+        info = copy(mock_bluetooth_service_info)
+        info.address = address.lower()
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_BLUETOOTH}, data=info
+        )
+        assert result["type"] == FlowResultType.FORM
+        _paired_entry(hass)
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "already_configured"
+
+    @pytest.mark.parametrize("address", [LEFT_ADDR, RIGHT_ADDR])
+    async def test_new_discovery_rejects_pair_members(
+        self,
+        hass: HomeAssistant,
+        mock_bluetooth_service_info,
+        enable_custom_integrations,
+        address: str,
+    ) -> None:
+        """Both sides stay suppressed on fresh Bluetooth discovery."""
+        _paired_entry(hass)
+        info = copy(mock_bluetooth_service_info)
+        info.address = address.lower()
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_BLUETOOTH}, data=info
+        )
+
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "already_configured"
+
     @pytest.mark.parametrize(
         ("resolved_variant", "offers_pairing"),
         [


### PR DESCRIPTION
Discovery cards opened before two beds are combined can remain visible afterward. Clicking Add also continues setup without checking whether the bed now belongs to the pair.

Clear pending Bluetooth discovery flows for member addresses when a paired entry loads, and recheck pair membership on discovery confirmation and disambiguation. Unrelated discovery cards remain available.

Validation: 359 paired-bed and configuration-flow tests passed, including regressions for stale cards and both paired addresses. Ruff, Pyright, and local review passed.

<!-- crq:skip-autoreview -->
