### PR TITLE
fix(okin_cb35): release presets with STOP x3, interrupt a driving preset from stop_all

### DIFF
--- a/custom_components/adjustable_bed/beds/okin_cb35.py
+++ b/custom_components/adjustable_bed/beds/okin_cb35.py
@@ -17,6 +17,13 @@ Uses the same 7-byte command frame as Okin Nordic:
 Identical motor/preset/light/massage command bytes as Okin Nordic, but:
 - Init sequence is only the wake command (5A 0B 00 A5), no Mattress Firm handshake
 - Write-without-response required (Nordic uses write-with-response)
+- Presets are a tap (key x2 at 300 ms) released with STOP x3 at 300 ms. The
+  generic Okin preset path (key x100 at 300 ms, one STOP) leaves this bed
+  armed for ~20 s before it moves; the triple STOP is what commits the move.
+- A preset in flight ignores STOP entirely. Any motor key interrupts it, the
+  same as pressing a button on the handset, so stop_all taps a motor key
+  first while a preset may still be moving.
+  (Verified on a Sealy Element, 2026-09)
 - Additional motors: neck (0x0A/0x0B), hips (0x08/0x09), head+foot simultaneous (0x0C/0x0D)
 - Additional presets: TV/PC, Read, Inverse, Work, Incline, Extension
 - Light brightness and color control
@@ -134,6 +141,61 @@ class OkinCB35Controller(Okin7ByteController):
             cancel_event=effective_cancel,
             response=self._config.write_with_response,
         )
+
+    # ─── Presets and stop ─────────────────────────────────────────────
+    # The CB35 protocol doc records the app's release as STOP sent three times
+    # at 300 ms. On hardware a preset key only arms the bed; the triple STOP is
+    # what commits it. With the generic single STOP the bed sat armed for ~20 s
+    # before moving (Sealy Element, 2026-09). A preset already driving ignores
+    # STOP but is interrupted by any motor key, as on the handset.
+
+    _PRESET_TAP_REPEATS = 2
+    _PRESET_TAP_DELAY_MS = 300
+    _STOP_REPEATS = 3
+    _STOP_DELAY_MS = 300
+    # Longer than any preset's full travel on the tested bed (~30 s).
+    _PRESET_INTERRUPT_WINDOW_S = 45.0
+
+    _preset_started_at: float = 0.0
+
+    async def _send_stop(self) -> None:
+        """Send STOP x3 with a fresh cancel event so a pending cancel cannot suppress it."""
+        await self.write_command(
+            _cmd(0x0F),
+            repeat_count=self._STOP_REPEATS,
+            repeat_delay_ms=self._STOP_DELAY_MS,
+            cancel_event=asyncio.Event(),
+        )
+
+    async def _preset_with_stop(
+        self, command: bytes, repeat_count: int = 2, repeat_delay_ms: int = 300
+    ) -> None:
+        """Tap the preset key, then release it with STOP x3 to commit the move."""
+        self._preset_started_at = asyncio.get_running_loop().time()
+        try:
+            await self.write_command(
+                command,
+                repeat_count=self._PRESET_TAP_REPEATS,
+                repeat_delay_ms=self._PRESET_TAP_DELAY_MS,
+            )
+        finally:
+            try:
+                await self._send_stop()
+            except (BleakError, ConnectionError):
+                _LOGGER.debug("Failed to send preset release", exc_info=True)
+
+    async def stop_all(self) -> None:
+        """Stop all movement.
+
+        A preset that is still driving ignores STOP, so tap a motor key first
+        while one may be in flight. Outside that window send STOP alone so an
+        idle stop does not nudge the bed.
+        """
+        loop = asyncio.get_running_loop()
+        if loop.time() - self._preset_started_at < self._PRESET_INTERRUPT_WINDOW_S:
+            self._preset_started_at = 0.0
+            await self.write_command(_cmd(0x00), repeat_count=1, cancel_event=asyncio.Event())
+        await self._send_stop()
 
     # ─── Extra capability properties ──────────────────────────────────
 

--- a/docs/beds/okin-cb35.md
+++ b/docs/beds/okin-cb35.md
@@ -1,6 +1,6 @@
 # DewertOkin CB35 Star
 
-**Status:** Needs testing
+**Status:** Tested (Sealy Element, ESPHome Bluetooth proxy, 2026-09). Motors, Flat, Memory 1, Zero G, Stop and the under-bed light confirmed on hardware.
 **Protocol version:** CB.35.22.01
 **Ref:** [#310](https://github.com/kristofferR/ha-adjustable-bed/issues/310)
 
@@ -120,6 +120,20 @@ Only a wake command is needed:
 ### Timing
 
 Motor commands repeat every 300ms while held. Stop and massage commands send 3 times (initial + 2 repeats at 300ms).
+
+### Presets and Stop (hardware behaviour)
+
+A preset key on its own only *arms* the bed. The STOP x3 release is what commits the move:
+
+| Sent | Result on the bed |
+|------|-------------------|
+| Preset key x100 at 300ms, then one STOP (generic Okin path) | Bed sits armed for ~20s, then moves |
+| Preset key once, no STOP | Bed sits armed until the link drops, then moves |
+| Preset key x2 at 300ms, then STOP x3 at 300ms | Bed starts within a second (implemented) |
+
+A preset that is already driving **ignores STOP** (three STOP x3 bursts during a Flat had no effect). Any motor key interrupts it, the same as pressing a button on the handset, so `stop_all` sends one motor-key packet before STOP while a preset may still be in flight. Motor holds stop with STOP alone.
+
+The bed accepts only one BLE connection. While the Sealy app is open on a phone (including in the background) the bed stops advertising and the integration cannot connect.
 
 ## Relationship to Other Protocols
 

--- a/tests/test_okin_cb35.py
+++ b/tests/test_okin_cb35.py
@@ -99,3 +99,79 @@ class TestOkinCB35Controller:
         payloads = [call.args[1] for call in mock_cb35_client.write_gatt_char.call_args_list]
         assert _cmd(0x00) not in payloads
         assert payloads[-1] == _cmd(0x0F)
+
+    async def test_preset_is_tap_then_triple_stop(
+        self,
+        hass: HomeAssistant,
+        mock_okin_cb35_config_entry: MockConfigEntry,
+        mock_cb35_client: AsyncMock,
+    ) -> None:
+        """A preset is the key x2 followed by STOP x3; the STOP burst commits the move."""
+        coordinator = AdjustableBedCoordinator(hass, mock_okin_cb35_config_entry)
+        coordinator._client = mock_cb35_client
+        controller = OkinCB35Controller(coordinator)
+        controller._initialized = True
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await controller.preset_flat()
+
+        payloads = [call.args[1] for call in mock_cb35_client.write_gatt_char.call_args_list]
+        assert payloads == [_cmd(0x10)] * 2 + [_cmd(0x0F)] * 3
+
+    async def test_preset_release_survives_cancel(
+        self,
+        hass: HomeAssistant,
+        mock_okin_cb35_config_entry: MockConfigEntry,
+        mock_cb35_client: AsyncMock,
+    ) -> None:
+        """A cancelled preset still sends its STOP x3 release."""
+        coordinator = AdjustableBedCoordinator(hass, mock_okin_cb35_config_entry)
+        coordinator._client = mock_cb35_client
+        controller = OkinCB35Controller(coordinator)
+        controller._initialized = True
+        coordinator.cancel_command.set()
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await controller.preset_memory(1)
+
+        payloads = [call.args[1] for call in mock_cb35_client.write_gatt_char.call_args_list]
+        assert _cmd(0x1A) not in payloads
+        assert payloads == [_cmd(0x0F)] * 3
+
+    async def test_stop_all_interrupts_running_preset_with_motor_tap(
+        self,
+        hass: HomeAssistant,
+        mock_okin_cb35_config_entry: MockConfigEntry,
+        mock_cb35_client: AsyncMock,
+    ) -> None:
+        """While a preset may be driving, stop_all taps a motor key before STOP x3."""
+        coordinator = AdjustableBedCoordinator(hass, mock_okin_cb35_config_entry)
+        coordinator._client = mock_cb35_client
+        controller = OkinCB35Controller(coordinator)
+        controller._initialized = True
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await controller.preset_flat()
+            mock_cb35_client.write_gatt_char.reset_mock()
+            await controller.stop_all()
+
+        payloads = [call.args[1] for call in mock_cb35_client.write_gatt_char.call_args_list]
+        assert payloads == [_cmd(0x00)] + [_cmd(0x0F)] * 3
+
+    async def test_stop_all_is_silent_when_idle(
+        self,
+        hass: HomeAssistant,
+        mock_okin_cb35_config_entry: MockConfigEntry,
+        mock_cb35_client: AsyncMock,
+    ) -> None:
+        """With no recent preset, stop_all sends STOP x3 only, so an idle stop does not nudge the bed."""
+        coordinator = AdjustableBedCoordinator(hass, mock_okin_cb35_config_entry)
+        coordinator._client = mock_cb35_client
+        controller = OkinCB35Controller(coordinator)
+        controller._initialized = True
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await controller.stop_all()
+
+        payloads = [call.args[1] for call in mock_cb35_client.write_gatt_char.call_args_list]
+        assert payloads == [_cmd(0x0F)] * 3


### PR DESCRIPTION

## Summary

First hardware report for the CB35 variant added in #316 for #310 (Sealy Element, ESPHome Bluetooth proxy at -55 dBm, integration 3.7.1, HA 2026.8.3).

Everything worked, with one problem: every preset (Flat, Memory 1, Zero G, TV) started moving about 20 seconds after the button press, cold or warm, while the Sealy app and the RF handset execute the same presets instantly. Motor commands were instant from the integration too. Connects took under a second and the command trace showed the first preset write leaving HA within a second of the press, so this was not the radio.

## Cause

`Okin7ByteController._preset_with_stop` sends the preset key 100x at 300 ms and then a single `0x0F`. On the CB35 the key only arms the bed. The bed's own protocol doc already records the app's release as "Stop and massage commands send 3 times (initial + 2 repeats at 300 ms)". A single STOP is not registered as a release, so the bed sat armed until its own timeout.

## What changed

`beds/okin_cb35.py`

- `_preset_with_stop`: key x2 at 300 ms (a tap), then STOP x3 at 300 ms with a fresh cancel event. Presets now start within a second and run to completion.
- `_send_stop`: STOP x3 at 300 ms on this controller, matching the doc. Motors were unaffected.
- `stop_all`: a preset that is already driving ignores STOP entirely (three STOP x3 bursts during a Flat did nothing), but any motor key interrupts it, the same as pressing a button on the handset. `stop_all` now sends one motor-key packet before STOP if a preset started in the last 45 s. Outside that window it sends STOP alone, so an idle Stop does not nudge the bed. Verified: Stop halts a running preset, and does nothing visible when idle.

`docs/beds/okin-cb35.md`: status set to tested, with a table of the three send patterns tried on hardware and the resulting behaviour, plus a note that the bed stops advertising while the Sealy app holds its single BLE connection.

`tests/test_okin_cb35.py`: four tests covering the tap + STOP x3 sequence, release surviving a cancel, the motor-key interrupt, and the silent idle stop.

## Evidence

Command trace with the tap + STOP x3 send in place and the previous stop behaviour:

```
08:24:01.595 5a0103103010a5 FLAT     rep 2 300
08:24:01.899 5a010310300fa5 STOP     rep 3 300   commit, bed starts moving at once
08:24:05.514 5a010310300fa5 STOP     rep 3 300   Stop button, no effect
08:24:07.881 5a010310300fa5 STOP     rep 3 300   Stop button, no effect
08:24:10.509 5a010310300fa5 STOP     rep 3 300   Stop button, no effect
08:24:47.307 5a0103103000a5 head up  rep 100 300
08:24:50.210 5a010310300fa5 STOP     rep 3 300   Stop button, motor halts
```

With the generic 100x repeat the trace showed the key leaving at t+0 and the bed moving at about t+20 s.

## Test plan

- [x] `pytest tests/test_okin_cb35.py tests/test_okin_7byte.py tests/test_controller_contract.py`
- [x] ruff
- [x] On the bed: Flat, Memory 1 and Zero G start within a second and complete; Stop halts a running preset and a motor hold; idle Stop is silent; motors unchanged.

Thanks for the integration and for adding this bed from the app alone. It has been in nightly use for the newborn feeds since this landed, and the household is going to have a good night's sleep.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added CB35 preset controls with dedicated activation and release behavior.
  - Stop now completes an active preset sequence or interrupts it with a motor command when required.
  - Stop remains quiet when the bed is idle.
- **Documentation**
  - Documented preset, Stop, motor-control, and Bluetooth connection behavior.
  - Updated CB35 support status to tested, including motors, presets, Stop, and under-bed lighting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->